### PR TITLE
Use typemax(Int32) for last character in range

### DIFF
--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -144,7 +144,7 @@ function jet_to_workspace_diagnostics(result)
             message,
             range = (;
                 start = (; line=report.vst[1].line-1, character=0),
-                var"end" = (; line=report.vst[1].line-1, character=typemax(Int)),
+                var"end" = (; line=report.vst[1].line-1, character=Int(typemax(Int32))),
             )
         ))
     end


### PR DESCRIPTION
I tested out JETLS a bit in neovim, but neovim crashes when trying to display a range with `typemax(Int)` as the last column. This patch uses `typemax(Int32)` instead, which should still be much larger than any line length and serve the same purpose as "end of line" column. Most likely this can/should be fixed in neovim, but seemed easier to change it here for now.