### PR TITLE
Fix configuration key name

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -14,7 +14,7 @@ let traceOutputChannel: vscode.OutputChannel;
 
 function startLanguageServer(context: vscode.ExtensionContext) {
   const config = vscode.workspace.getConfiguration('JETLSClient');
-  const juliaExecutable = config.get<string>('executablePath', 'julia');
+  const juliaExecutable = config.get<string>('juliaExecutablePath', 'julia');
 
   const serverScript = context.asAbsolutePath('runserver.jl');
   const serverArgsToRun = ['--startup-file=no', '--project=.', serverScript];


### PR DESCRIPTION
This PR fixes the key name for the Julia executable path to "juliaExecutablePath" in the server initialization.

In the initialization process:
https://github.com/aviatesk/JETLS.jl/blob/e0a396b8a3d682a171fa4d3fc6df52fea8d9ad18/extension.ts#L17

Other cases:
https://github.com/aviatesk/JETLS.jl/blob/e0a396b8a3d682a171fa4d3fc6df52fea8d9ad18/package.json#L49
https://github.com/aviatesk/JETLS.jl/blob/e0a396b8a3d682a171fa4d3fc6df52fea8d9ad18/extension.ts#L71
