### PR TITLE
add debounce/throttle mechanism for re-analysis

### DIFF
--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -53,9 +53,6 @@ end
 
 struct ExternalContext end
 
-const DEFAULT_DEBOUNCE_INTERVAL = 1.5
-const DEFAULT_THROTTLE_INTERVAL = 1.5
-
 struct ServerState{F}
     send::F
     workspaceFolders::Vector{URI}
@@ -307,6 +304,41 @@ function parse_file(text::String, uri::URI)
     end
 end
 
+let debounced = Dict{Any,Timer}()
+    global function debounce(f, delay, args...; kwargs...)
+        if haskey(debounced, f)
+            close(debounced[f])
+        end
+        debounced[f] = Timer(delay) do _
+            try
+                f(args...; kwargs...)
+            finally
+                delete!(debounced, f)
+            end
+        end
+        return nothing
+    end
+end
+
+let throttled = Dict{Any, Tuple{Timer, Float64}}()
+    global function throttle(f, delay, args...; kwargs...)
+        last_timer, last_time = get(throttled, f, (nothing, 0.0))
+        if last_timer !== nothing
+            close(last_timer)
+        end
+        delay = max(0.0, delay - (time() - last_time))
+        throttled[f] = Timer(delay) do _
+            try
+                f(args...; kwargs...)
+            finally
+                delete!(throttled, f)
+            end
+        end, time()
+        return nothing
+	end
+end
+
+
 function handle_DidOpenTextDocumentNotification(state::ServerState, msg::DidOpenTextDocumentNotification)
     textDocument = msg.params.textDocument
     @assert textDocument.languageId == "julia"
@@ -350,8 +382,7 @@ function handle_DidChangeTextDocumentNotification(state::ServerState, msg::DidCh
             analysis_context.result.staled = true
         end
         # TODO support multiple analysis contexts, which can happen if this file is included from multiple different contexts
-
-        debounced_reanalyze_with_context!(state, first(contexts))
+        debounce(reanalyze_with_context!, 1.5, state, first(contexts))
     end
     nothing
 end
@@ -708,42 +739,6 @@ function initiate_context!(state::ServerState, uri::URI)
 end
 
 
-function debounce(f::Function; delay::Float64=DEFAULT_DEBOUNCE_INTERVAL)
-    timer = nothing
-    function debounced_func(args...; kwargs...)
-        if timer !== nothing
-            close(timer)
-        end
-        timer = Timer(delay) do timer
-            f(args...; kwargs...)
-            timer = nothing
-        end
-    end
-    return debounced_func
-end
-
-function throttle(f::Function; delay::Float64=DEFAULT_THROTTLE_INTERVAL)
-    last_call = 0.0
-    timer = nothing
-    function throttled_func(args...; kwargs...)
-        now = time()
-        if now - last_call ≥ delay
-            f(args...; kwargs...)
-            last_call = now
-        else
-            if timer !== nothing
-                close(timer)
-            end
-            timer = Timer(delay - (now - last_call)) do timer
-                f(args...; kwargs...)
-                last_call = time()
-                timer = nothing
-            end
-        end
-    end
-    return throttled_func
-end
-
 
 function reanalyze_with_context!(state::ServerState, analysis_context::AnalysisContext)
     analysis_result = analysis_context.result
@@ -807,7 +802,5 @@ function reanalyze_with_context!(state::ServerState, analysis_context::AnalysisC
     notify_diagnostics!(state)
     nothing
 end
-
-debounced_reanalyze_with_context! = debounce(reanalyze_with_context!)
 
 end # module JETLS


### PR DESCRIPTION
Currently, analysis is simply skipped if the interval between requests is less than `analysis_interval` (which is currently set to 5 seconds).  
https://github.com/aviatesk/JETLS.jl/blob/a594087aca4e8928b8fe8faa4cb7e8afee7d3c42/src/JETLS.jl#L728

However, in many cases, it is  inconvenient that fixes to errors are not reflected until the next edit.

This PR changes the behavior so that if a event arrives within a short period, analysis is delayed until the configured interval elapses instead of being skipped like [typescript-language-server](https://github.com/typescript-language-server/typescript-language-server/blob/bb1c105d30a916e92267ce411eed78cdf6ec2980/src/lsp-server.ts#L316), [python-lsp-server](https://github.com/python-lsp/python-lsp-server/blob/cc6d398befddb0c9b0f0a52affade3ca4fbfded4/pylsp/python_lsp.py#L439).