### PR TITLE
fix up `throttle` implementation and use it for `reanalyze_with_context!`

### DIFF
--- a/runserver.jl
+++ b/runserver.jl
@@ -1,18 +1,29 @@
 @info "Running JETLS with Julia version" VERSION
 
-try
-    using Revise
-catch err
-    @warn "Revise not found"
-end
+using Pkg
 
-@info "Loading JETLS..."
+let old_env = Pkg.project().path
+    try
+        Pkg.activate(@__DIR__)
 
-try
-    using JETLS
-catch
-    @error "JETLS not found"
-    exit(1)
+        # load Revise with JuliaInterpreter used by JETLS
+        try
+            using Revise
+        catch err
+            @warn "Revise not found"
+        end
+
+        @info "Loading JETLS..."
+
+        try
+            using JETLS
+        catch
+            @error "JETLS not found"
+            exit(1)
+        end
+    finally
+        Pkg.activate(old_env)
+    end
 end
 
 function in_callback(@nospecialize msg)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,40 @@
+# TODO Need to make them thread safe when making the message handling multithreaded
+
+let debounced = Dict{UInt,Timer}()
+    global function debounce(f, id::UInt, delay)
+        if haskey(debounced, id)
+            close(debounced[id])
+        end
+        debounced[id] = Timer(delay) do _
+            try
+                f()
+            finally
+                delete!(debounced, id)
+            end
+        end
+        nothing
+    end
+end
+
+let throttled = Dict{UInt, Tuple{Union{Nothing,Timer}, Float64}}()
+    global function throttle(f, id::UInt, interval)
+        if !haskey(throttled, id)
+            f()
+            throttled[id] = (nothing, time())
+            return nothing
+        end
+        last_timer, last_time = throttled[id]
+        if last_timer !== nothing
+            close(last_timer)
+        end
+        delay = max(0.0, interval - (time() - last_time))
+        throttled[id] = (Timer(delay) do _
+            try
+                f()
+            finally
+                throttled[id] = (nothing, time())
+            end
+        end, last_time)
+        nothing
+    end
+end


### PR DESCRIPTION
Also changes `debounce` and `throttle` to take `id` object that is used to identify the callback, rather than using the function object as the key.

/cc @abap34 