### PR TITLE
enable `[sources]` section in Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,8 +16,8 @@ StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [sources]
-# JET = {url = "https://github.com/aviatesk/JET.jl#master"}
-# JuliaLowering = {url = "https://github.com/mlechu/JuliaLowering.jl#fix-nightly"}
+JET = {url = "https://github.com/aviatesk/JET.jl", rev = "master"}
+JuliaLowering = {url = "https://github.com/mlechu/JuliaLowering.jl", rev = "fix-nightly"}
 
 [compat]
 JET = "0.10.5"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A new language server for the Julia programming language. In a nascent stage of 
 
 ### Steps
 
+- Run `julia --project=. -e 'using Pkg; Pkg.instantiate()'` in this folder to install all necessary Julia packages.
 - Run `npm install` in this folder to install all necessary node modules for the client.
 - Open this folder in VSCode.
 - Press <kbd>Ctrl+Shift+B</kbd> to start compiling the client and server in [watch mode](https://code.visualstudio.com/docs/editor/tasks#:~:text=The%20first%20entry%20executes,the%20HelloWorld.js%20file.).
@@ -22,6 +23,22 @@ A new language server for the Julia programming language. In a nascent stage of 
 - Select `Launch Client` from the drop-down menu (if it is not already selected).
 - Press `▷` to run the launch configuration (<kbd>F5</kbd>).
 - In the [Extension Development Host](https://code.visualstudio.com/api/get-started/your-first-extension#:~:text=Then%2C%20inside%20the%20editor%2C%20press%20F5.%20This%20will%20compile%20and%20run%20the%20extension%20in%20a%20new%20Extension%20Development%20Host%20window.) instance of VSCode, open a Julia file.
+
+### Notes
+
+In JETLS, since we need to use packages that aren’t yet registered
+(e.g., [JuliaLowering.jl](https://github.com/c42f/JuliaLowering.jl)) or specific branches of
+[JET.jl](https://github.com/c42f/JuliaLowering.jl) and [JuliaSyntax.jl](https://github.com/JuliaLang/JuliaSyntax.jl),
+the [Project.toml](./Project.toml) includes a `[sources]` section.
+The `[sources]` section allows simply running `Pkg.instantiate()` to install the required
+versions of these packages on any environment.
+
+However, when developing JETLS while making changes on the packages listed in `[sources]`,
+it can be more convenient to use the local package directory (especially in order to reflect
+changes immediately with Revise). In that case, temporarily comment out the `[sources]`
+section and run `Pkg.develop("JET")`. This lets you use any local JET implementation.
+After running `develop`, you can restore the `[sources]` section without issues.
+The same applies to the other packages listed in `[sources]`.
 
 ## Structure
 


### PR DESCRIPTION
So that everyone can instantiate dependency of expected versions by
running `Pkg.instantiate()`, and more importantly, to allow tests to
pass with custom versions of JET and JuliaLowering.

A drawback of this method is then we can't use packages installed in our
local package directory with simply running `pkg> dev JET JuliaLowering`.
The workaround is to temporarily comment out the `[sources]` section,
and then we can `pkg> dev JET JuliaLowering` and specify any checkout.
We'll need to use this method if we need to make changes to JET or JL
and test them against JETLS.

Another option is to use `git submodule`, but I think the solution with
`[sources]` is a bit simpler than managing `git submodule`, which is
known to be complex and tedious in general.
