### PR TITLE
Small completion fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ A new language server for the Julia programming language. In a nascent stage of 
 - Press `▷` to run the launch configuration (<kbd>F5</kbd>).
 - In the [Extension Development Host](https://code.visualstudio.com/api/get-started/your-first-extension#:~:text=Then%2C%20inside%20the%20editor%2C%20press%20F5.%20This%20will%20compile%20and%20run%20the%20extension%20in%20a%20new%20Extension%20Development%20Host%20window.) instance of VSCode, open a Julia file.
 
+#### Other editors
+
+Minimal Emacs (eglot client) setup:
+```lisp
+(add-to-list 'eglot-server-programs
+             '(((julia-mode :language-id "julia")
+                (julia-ts-mode :language-id "julia"))
+               "julia"
+               "--startup-file=no"
+               "--project=/path/to/JETLS.jl"
+               "/path/to/JETLS.jl/runserver.jl"))
+```
+
 ### Notes
 
 In JETLS, since we need to use packages that aren’t yet registered

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -11,10 +11,17 @@ function completion_is(ci::CompletionItem, ckind::Symbol)
         (ci.labelDetails.description === "argument" && ckind === :local)
 end
 
-function get_sort_text(ckind::Symbol, offset::Int)
-    # show non-global completions first in the list
-    n = ckind === :global ? (10000000 + offset) : offset
-    lpad(n, 8, '0')
+let sort_texts = Dict{Int, String}()
+    for i = 1:1000
+        sort_texts[i] = lpad(i, 4, '0')
+    end
+    _, max_sort_text = maximum(sort_texts)
+    global function get_sort_text(ckind::Symbol, offset::Int)
+        if ckind === :global
+            return max_sort_text
+        end
+        return get(sort_texts, offset, max_sort_text)
+    end
 end
 
 # local completions

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -1,7 +1,5 @@
 using .JS: @K_str, @KSet_str
-
-const SORT_TEXT_0 = "00000000"
-const SORT_TEXT_1 = "00000001"
+using .JL: @ast
 
 # completion utils
 # ================
@@ -11,6 +9,12 @@ function completion_is(ci::CompletionItem, ckind::Symbol)
     # to change with changes to the information we put in CompletionItem.
     ci.labelDetails.description === String(ckind) ||
         (ci.labelDetails.description === "argument" && ckind === :local)
+end
+
+function get_sort_text(ckind::Symbol, offset::Int)
+    # show non-global completions first in the list
+    n = ckind === :global ? (10000000 + offset) : offset
+    lpad(n, 8, '0')
 end
 
 # local completions
@@ -96,9 +100,24 @@ function is_relevant(ctx::JL.AbstractLoweringContext,
          || cursor > start)
 end
 
+# TODO: Macro expansion requires we know the module we're lowering in, and that
+# JuliaLowering sees the macro definition.  Ignore them in local completions for now.
+function remove_macrocalls(st0::JL.SyntaxTree)
+    ctx = JL.MacroExpansionContext(JL.syntax_graph(st0), JL.Bindings(),
+                                   JL.ScopeLayer[], JL.ScopeLayer(1, Module(), false))
+    if kind(st0) === K"macrocall"
+        @ast ctx st0 "nothing"::K"core"
+    elseif JS.is_leaf(st0)
+        st0
+    else
+        k = kind(st0)
+        @ast ctx st0 [k (map(remove_macrocalls, JS.children(st0)))...]
+    end
+end
+
 """
-Find the list of (JL.BindingInfo, JL.LambdaBindingInfo|nothing, SyntaxTree)
-to suggest as completions given a parsed SyntaxTree and a cursor position.
+Find the list of (BindingInfo, SyntaxTree, distance::Int) to suggest as
+completions given a parsed SyntaxTree and a cursor position.
 
 JuliaLowering throws away the mapping from scopes to bindings (scopes are stored
 as an ephemeral stack.)  We work around this by taking all available bindings
@@ -109,9 +128,7 @@ function cursor_bindings(st0_top::JL.SyntaxTree, b_top::Int)
     if isnothing(st0)
         return nothing # nothing we can lower
     end
-    # julia does require knowing what module we're lowering in, but it isn't
-    # needed for reasonable completions
-    ctx1, st1 = JL.expand_forms_1(Module(), st0);
+    ctx1, st1 = JL.expand_forms_1(Module(), remove_macrocalls(st0));
     ctx2, st2 = JL.expand_forms_2(ctx1, st1);
     ctx3, st3 = JL.resolve_scopes(ctx2, st2);
 
@@ -162,16 +179,11 @@ function cursor_bindings(st0_top::JL.SyntaxTree, b_top::Int)
         end
     end
 
-    # TODO sort by bdistance?
-
     return map(values(seen)) do i
-        (binfo, bas, _) = bscopeinfos[i]
-
-        # Get LambdaBindingInfo from nearest lambda, if any
-        ba_lam = findfirst(st -> kind(st) === K"lambda", bas)
-        lbs = isnothing(ba_lam) ? nothing : get(bas[ba_lam], :lambda_bindings, nothing)
-        lb = isnothing(lbs)     ? nothing : get(lbs.bindings, binfo.id, nothing)
-        return (binfo, JL.binding_ex(ctx3, binfo.id), lb)
+        (binfo, _, _) = bscopeinfos[i]
+        # distance from the cursor
+        dist = abs(b - JS.last_byte(JL.binding_ex(ctx3, binfo.id)))
+        return (binfo, JL.binding_ex(ctx3, binfo.id), dist)
     end
 end
 
@@ -189,7 +201,7 @@ to|
 (1) Icon corresponding to CompletionItem's `ci.kind`
 (2) `ci.labelDetails.detail`
 (3) `ci.labelDetails.description`
-(4) `ci.detail`
+(4) `ci.detail` (possibly at (3))
 (5) `ci.documentation`
 
 Sending (4) and (5) to the client can happen eagerly in response to <TAB>
@@ -199,7 +211,7 @@ in later versions.
 """
 function to_completion(binding::JL.BindingInfo,
                        st::JL.SyntaxTree,
-                       lb::Union{Nothing, JL.LambdaBindingInfo}=nothing)
+                       sort_offset::Int=0)
     label_kind = CompletionItemKind.Variable
     label_detail = nothing
     label_desc = nothing
@@ -222,11 +234,9 @@ function to_completion(binding::JL.BindingInfo,
         label_detail = "::" * JL.sourcetext(binding.type)
     end
 
-    if !isnothing(lb) && lb.is_called
-        label_kind = CompletionItemKind.Function
-    end
-
-    detail = sprint(JL.showprov, st)
+    documentation = MarkupContent(;
+        kind = MarkupKind.Markdown,
+        value = "```julia\n" * sprint(JL.showprov, st) * "\n```")
 
     CompletionItem(;
         label = binding.name,
@@ -236,7 +246,7 @@ function to_completion(binding::JL.BindingInfo,
         kind = label_kind,
         detail,
         documentation,
-        sortText = SORT_TEXT_0, # show local completions first
+        sortText = get_sort_text(:local, sort_offset),
         data = CompletionData(#=needs_resolve=#false))
 end
 
@@ -247,8 +257,8 @@ function local_completions!(items::Dict{String, CompletionItem},
     st0 = JS.build_tree(JL.SyntaxTree, fi.parsed_stream)
     cbs = cursor_bindings(st0, xy_to_offset(fi, pos))
     cbs === nothing && return items
-    for (bi, st, lb) in cbs
-        ci = to_completion(bi, st, lb)
+    for (bi, st, dist) in cbs
+        ci = to_completion(bi, st, dist)
         prev_ci = get(items, ci.label, nothing)
         # Name collisions: overrule existing global completions with our own,
         # unless our completion is also a global, in which case the existing
@@ -300,7 +310,7 @@ function global_completions!(items::Dict{String, CompletionItem}, state::ServerS
                 description = "global"),
             kind = CompletionItemKind.Variable,
             documentation = nothing,
-            sortText = SORT_TEXT_1,
+            sortText = get_sort_text(:global, 0),
             data = CompletionData(#=needs_resolve=#true))
     end
     return items


### PR DESCRIPTION
- Sort locals by distance from the cursor
- HACK: We can't expand macros through JuliaLowering yet---even if we grab the
  module context, JuliaLowering needs to see the macro definition.  To fix local
  completions not working when macrocalls are around the cursor, trim macrocalls
  from the tree before lowering.
- Remove code attempting to find LambdaBindingInfo for completions (I was
  mistakenly searching our pre-scope-resolution data structures, so the result
  was always nothing).  This was just to give locals a "function" type if we can
  see that they're called, so probably not worth maintaining that much code for.
- Move the `showprov` on local completions from ci.detail to ci.documentation
  (after figuring out where different clients put these in the UI).

Also add a snippet to the setup instructions for the emacs LSP client