### PR TITLE
improve error handling and make `local_completions!` more robust

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,19 +12,15 @@ JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 JuliaLowering = "f3c80556-a63f-4383-b822-37d64f81a311"
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
-[sources.JET]
-url = "https://github.com/aviatesk/JET.jl"
-rev = "avi/analyzed-file-contexts"
-[sources.JuliaLowering]
-url = "https://github.com/mlechu/JuliaLowering.jl"
-rev = "fix-nightly"
-[sources.JuliaSyntax]
-url = "https://github.com/JuliaLang/JuliaSyntax.jl"
-rev = "main"
+[sources]
+JET = {rev = "avi/analyzed-file-contexts", url = "https://github.com/aviatesk/JET.jl"}
+JuliaLowering = {rev = "fix-nightly", url = "https://github.com/mlechu/JuliaLowering.jl"}
+JuliaSyntax = {rev = "main", url = "https://github.com/JuliaLang/JuliaSyntax.jl"}
 
 [compat]
 JET = "0.10.5"
@@ -32,6 +28,7 @@ JSON3 = "1.14.1"
 JuliaLowering = "1.0.0"
 JuliaSyntax = "1.0"
 Pkg = "1.11.0"
+Preferences = "1.4.3"
 REPL = "1.11.0"
 StructTypes = "1.11.0"
 URIs = "1.5"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Minimal Emacs (eglot client) setup:
 
 ### Notes
 
+#### `[sources]` dependencies
+
 In JETLS, since we need to use packages that aren’t yet registered
 (e.g., [JuliaLowering.jl](https://github.com/c42f/JuliaLowering.jl)) or specific branches of
 [JET.jl](https://github.com/c42f/JuliaLowering.jl) and [JuliaSyntax.jl](https://github.com/JuliaLang/JuliaSyntax.jl),
@@ -60,6 +62,26 @@ To workaround this, you can temporarily comment out the `[sources]` section and 
 This lets you use any local JET implementation. After running `Pkg.develop("JET")`,
 you can restore the `[sources]` section, and perform any most of `Pkg` operations without any issues onward.
 The same applies to the other packages listed in `[sources]`.
+
+#### `JETLS_DEV_MODE`
+
+JETLS has a development mode that can be enabled through the `JETLS_DEV_MODE`
+[preference](https://github.com/JuliaPackaging/Preferences.jl).
+When this mode is enabled, the language server enables several features to aid in development:
+- Automatic loading of Revise when starting the server, allowing changes to be applied without restarting
+- `try`/`catch` block is added for the top-level handler of non-lifecycle-related messages,
+  allowing the server to continue running even if an error occurs in each message handler,
+  showing error messages and stack traces in the output panel
+
+You can control this setting through Preferences.jl's mechanism:
+```julia
+using Preferences
+# Disable development mode
+Preferences.set_preferences!("JETLS", "JETLS_DEV_MODE" => false; force=true)
+```
+
+`JETLS_DEV_MODE` is enabled by default when running the server at this moment of prototyping,
+but also note that it is enabled when running the test suite.
 
 ## Structure
 

--- a/runserver.jl
+++ b/runserver.jl
@@ -6,6 +6,7 @@ let old_env = Pkg.project().path
     try
         Pkg.activate(@__DIR__)
 
+        # TODO load Revise only when `JETLS_DEV_MODE` is true
         # load Revise with JuliaInterpreter used by JETLS
         try
             using Revise
@@ -26,7 +27,7 @@ let old_env = Pkg.project().path
     end
 end
 
-function in_callback(@nospecialize msg)
-    revise() # TODO only in debug mode
+function in_callback(@nospecialize(msg),)
+    JETLS.JETLS_DEV_MODE && Revise.revise()
 end
 runserver(stdin, stdout; in_callback)

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -1,5 +1,13 @@
 module JETLS
 
+using Preferences: Preferences
+# TODO turn off `JETLS_DEV_MODE` by default when releasing
+const JETLS_DEV_MODE = Preferences.@load_preference("JETLS_DEV_MODE", true)
+
+function __init__()
+    @info "Running JETLS with" JETLS_DEV_MODE
+end
+
 export runserver
 function runserver end
 
@@ -112,7 +120,12 @@ function runserver(callback, in::IO, out::IO;
     try
         for msg in endpoint
             in_callback(msg)
-            if msg isa ShutdownRequest
+            # handle lifecycle-related messages
+            if msg isa InitializeRequest
+                handle_InitializeRequest(state, msg)
+            elseif msg isa InitializedNotification
+                continue
+            elseif msg isa ShutdownRequest
                 shutdown_requested = true
                 send(ShutdownResponse(; id = msg.id, result = null))
             elseif msg isa ExitNotification
@@ -124,6 +137,7 @@ function runserver(callback, in::IO, out::IO;
                     code=ErrorCodes.InvalidRequest,
                     message="Received request after a shutdown request requested")))
             else
+                # handle general messages
                 @invokelatest handle_message(state, msg)
             end
         end
@@ -140,11 +154,21 @@ function runserver(callback, in::IO, out::IO;
 end
 
 function handle_message(state::ServerState, msg)
-    if msg isa InitializeRequest
-        return handle_InitializeRequest(state, msg)
-    elseif msg isa InitializedNotification
-        return nothing
-    elseif msg isa DidOpenTextDocumentNotification
+    if JETLS_DEV_MODE
+        try
+            return _handle_message(state, msg)
+        catch err
+            @error "Message handling failed for" typeof(err)
+            Base.display_error(stderr, err, catch_backtrace())
+            return nothing
+        end
+    else
+        return _handle_message(state, msg)
+    end
+end
+
+function _handle_message(state::ServerState, msg)
+    if msg isa DidOpenTextDocumentNotification
         return handle_DidOpenTextDocumentNotification(state, msg)
     elseif msg isa DidChangeTextDocumentNotification
         return handle_DidChangeTextDocumentNotification(state, msg)
@@ -155,21 +179,9 @@ function handle_message(state::ServerState, msg)
     elseif msg isa DocumentDiagnosticRequest || msg isa WorkspaceDiagnosticRequest
         @assert false "Document and workspace diagnostics are not enabled"
     elseif msg isa CompletionRequest
-        try
-            return handle_CompletionRequest(state, msg)
-        catch e
-            @info "Completion request failed:"
-            Base.display_error(stderr, e, catch_backtrace())
-        end
-        return nothing
+        return handle_CompletionRequest(state, msg)
     elseif msg isa CompletionResolveRequest
-        try
-            return handle_CompletionResolveRequest(state, msg)
-        catch e
-            @info "Completion resolve request failed:"
-            Base.display_error(stderr, e, catch_backtrace())
-        end
-        return nothing
+        return handle_CompletionResolveRequest(state, msg)
     else
         @warn "Unhandled message" msg
         return nothing

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -138,7 +138,7 @@ function runserver(callback, in::IO, out::IO;
                     message="Received request after a shutdown request requested")))
             else
                 # handle general messages
-                @invokelatest handle_message(state, msg)
+                handle_message(state, msg)
             end
         end
     catch err
@@ -156,7 +156,9 @@ end
 function handle_message(state::ServerState, msg)
     if JETLS_DEV_MODE
         try
-            return _handle_message(state, msg)
+            # `@invokelatest` for allowing changes maded by Revise to be reflected without
+            # terminating the `runserver` loop
+            return @invokelatest _handle_message(state, msg)
         catch err
             @error "Message handling failed for" typeof(err)
             Base.display_error(stderr, err, catch_backtrace())

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -193,7 +193,7 @@ function cursor_bindings(st0_top::JL.SyntaxTree, b_top::Int)
             || bdistances[i] < bdistances[prev]
             || binfo.kind === :static_parameter)
             seen[binfo.name] = i
-        else
+        elseif JETLS_DEV_MODE
             @info "Found two bindings with the same name:" binfo bscopeinfos[prev][1]
         end
     end

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -16,8 +16,8 @@ let sort_texts = Dict{Int, String}()
         sort_texts[i] = lpad(i, 4, '0')
     end
     _, max_sort_text = maximum(sort_texts)
-    global function get_sort_text(ckind::Symbol, offset::Int)
-        if ckind === :global
+    global function get_sort_text(offset::Int, isglobal::Bool)
+        if isglobal
             return max_sort_text
         end
         return get(sort_texts, offset, max_sort_text)
@@ -122,6 +122,15 @@ function remove_macrocalls(st0::JL.SyntaxTree)
     end
 end
 
+let lowering_module = Module()
+    global function jl_lower_for_completion(st0)
+        ctx1, st1 = JL.expand_forms_1(lowering_module, remove_macrocalls(st0));
+        ctx2, st2 = JL.expand_forms_2(ctx1, st1);
+        ctx3, st3 = JL.resolve_scopes(ctx2, st2);
+        return ctx3, st2
+    end
+end
+
 """
 Find the list of (BindingInfo, SyntaxTree, distance::Int) to suggest as
 completions given a parsed SyntaxTree and a cursor position.
@@ -135,9 +144,12 @@ function cursor_bindings(st0_top::JL.SyntaxTree, b_top::Int)
     if isnothing(st0)
         return nothing # nothing we can lower
     end
-    ctx1, st1 = JL.expand_forms_1(Module(), remove_macrocalls(st0));
-    ctx2, st2 = JL.expand_forms_2(ctx1, st1);
-    ctx3, st3 = JL.resolve_scopes(ctx2, st2);
+    ctx3, st2 = try
+        jl_lower_for_completion(st0)
+    catch err
+        # @info "Error in lowering" err
+        return nothing # lowering failed, e.g. because of incomplete input
+    end
 
     # Note that ctx.bindings are only available after resolve_scopes, and
     # scope-blocks are not present in st3 after resolve_scopes.
@@ -253,7 +265,7 @@ function to_completion(binding::JL.BindingInfo,
         kind = label_kind,
         detail,
         documentation,
-        sortText = get_sort_text(:local, sort_offset),
+        sortText = get_sort_text(sort_offset, #=isglobal=#false),
         data = CompletionData(#=needs_resolve=#false))
 end
 
@@ -261,6 +273,8 @@ function local_completions!(items::Dict{String, CompletionItem},
                             s::ServerState, uri::URI, pos::Position)
     fi = get_fileinfo(s, uri)
     fi === nothing && return items
+    # NOTE don't bail out even if `length(fi.parsed_stream.diagnostics) ≠ 0`
+    # so that we can get some completions even for incomplete code
     st0 = JS.build_tree(JL.SyntaxTree, fi.parsed_stream)
     cbs = cursor_bindings(st0, xy_to_offset(fi, pos))
     cbs === nothing && return items
@@ -317,7 +331,7 @@ function global_completions!(items::Dict{String, CompletionItem}, state::ServerS
                 description = "global"),
             kind = CompletionItemKind.Variable,
             documentation = nothing,
-            sortText = get_sort_text(:global, 0),
+            sortText = get_sort_text(0, #=isglobal=#true),
             data = CompletionData(#=needs_resolve=#true))
     end
     return items

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -322,7 +322,7 @@ end
 
 function global_completions!(items::Dict{String, CompletionItem}, state::ServerState, uri::URI, pos::Position)
     mod = find_file_module!(state, uri, pos)
-    for name in names(mod; all=true, imported=true, usings=true)
+    for name in @invokelatest(names(mod; all=true, imported=true, usings=true))::Vector{Symbol}
         s = String(name)
         startswith(s, "#") && continue
         items[s] = CompletionItem(;

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,1 @@
+!LocalPreferences.toml

--- a/test/LocalPreferences.toml
+++ b/test/LocalPreferences.toml
@@ -1,0 +1,3 @@
+# disable the `try/catch` in `handle_message` when testing
+[JETLS]
+JETLS_DEV_MODE = false

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -5,12 +5,15 @@ using JETLS
 using JETLS: JL, JS
 using JETLS: cursor_bindings, to_completion, CompletionItem, completion_is
 
-function get_local_completions(s::String, b::Int)
+function get_cursor_bindings(s::String, b::Int)
     ps = JS.ParseStream(s)
     JS.parse!(ps; rule=:all)
     st0 = JS.build_tree(JL.SyntaxTree, ps)
-    out = cursor_bindings(st0, b)
-    map(o->to_completion(o[1], o[2], o[3]), out)
+    return cursor_bindings(st0, b)
+end
+
+function get_local_completions(s::String, b::Int)
+    return map(o->to_completion(o[1], o[2], o[3]), get_cursor_bindings(s, b))
 end
 
 function cv_has(cs::Vector{CompletionItem}, expected, kind=nothing)
@@ -177,6 +180,23 @@ let code = """
     end
     """
     test_cv(code, "#=cursor=#", "x")
+end
+
+# local completion for incomplete code shouldn't crash
+let code = """
+    function fo#=cursor=#
+    """
+    b = first(findfirst("#=cursor=#", code))
+    @test get_cursor_bindings(code, b) === nothing
+end
+let # XXX somehow wrapping within `module A ... end` is necessary to get `xx` completion for this incomplete code
+    s = """
+    module A
+    function foo(xx, y=x#=cursor=#)
+    end
+    """
+    b = first(findfirst("#=cursor=#", s))
+    test_cv(s, b, "xx", kind=:local)
 end
 
 # get_completion_items

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -249,8 +249,7 @@ end
     uri = JETLS.filename2uri(filename)
     JETLS.cache_file_info!(state, uri, #=version=#1, text, filename)
     JETLS.initiate_context!(state, uri)
-    # XXX `@invokelatest` is required for `names` to return all the symbols of the `Foo`, in particular `:Bar`
-    let items = @invokelatest JETLS.get_completion_items(state, uri, pos1)
+    let items = JETLS.get_completion_items(state, uri, pos1)
         @test any(items) do item
             item.label == "bar"
         end


### PR DESCRIPTION
Extend the `try`/`catch` currently only enabled for completions to all
other handlers so the server won’t crash immediately during development.

In tests, disable the `try`/`catch` block to allow immediate detection
of message handler errors.

Note: Once merged, run `Pkg.instantiate()` again for installing Preferences.jl into JETLS environment.