### PR TITLE
minor refactoring on `byte_ancestors`

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -11,17 +11,20 @@ function completion_is(ci::CompletionItem, ckind::Symbol)
         (ci.labelDetails.description === "argument" && ckind === :local)
 end
 
-let sort_texts = Dict{Int, String}()
+# TODO use `let` block when Revise can handle it...
+const sort_texts, max_sort_text = let
+    sort_texts = Dict{Int, String}()
     for i = 1:1000
         sort_texts[i] = lpad(i, 4, '0')
     end
     _, max_sort_text = maximum(sort_texts)
-    global function get_sort_text(offset::Int, isglobal::Bool)
-        if isglobal
-            return max_sort_text
-        end
-        return get(sort_texts, offset, max_sort_text)
+    sort_texts, max_sort_text
+end
+function get_sort_text(offset::Int, isglobal::Bool)
+    if isglobal
+        return max_sort_text
     end
+    return get(sort_texts, offset, max_sort_text)
 end
 
 # local completions
@@ -44,31 +47,34 @@ function deduplicate_syntaxlist(sl::JL.SyntaxList)
 end
 
 """
-Get a list of `SyntaxTree`s containing certain bytes.  Output should be
-topologically sorted, children first.
+    byte_ancestors(st::JL.SyntaxTree, rng::UnitRange{Int})
+    byte_ancestors(st::JL.SyntaxTree, byte::Int)
+
+Get a list of `SyntaxTree`s containing certain bytes.
+Output should be topologically sorted, children first.
 
 If we know that parent ranges contain all child ranges, and that siblings don't
 have overlapping ranges (this is not true after lowering, but appear to be true
 after parsing), each tree in the result will be a child of the next.
 """
-function byte_ancestors(st::JL.SyntaxTree, b::Int, b2::Int=b)
+function byte_ancestors(st0::JL.SyntaxTree, r::UnitRange{Int})
     function byte_ancestors_(st::JL.SyntaxTree, l::JL.SyntaxList)
         (JS.numchildren(st) === 0) && return l
-        cis = findall(ci -> (b in JS.byte_range(ci) && b2 in JS.byte_range(ci)),
-                      JS.children(st))
-        append!(l, map(ci -> st[ci], cis))
+        for ci in JS.children(st)
+            if r ⊆ JS.byte_range(ci)
+                push!(l, ci)
+            end
+        end
         for c in JS.children(st)
             var"#self#"(c, l)
         end
         return l
     end
-
     # delete later duplicates when sorted parent->child
-    out = deduplicate_syntaxlist(byte_ancestors_(st, JL.SyntaxList(st._graph, [st._id])))
-    return reverse(out)
+    out = deduplicate_syntaxlist(byte_ancestors_(st0, JL.SyntaxList(st0._graph, [st0._id])))
+    return reverse!(out)
 end
-
-byte_ancestors(st0::JL.SyntaxTree, r::UnitRange{Int}) = byte_ancestors(st0, r.start, r.stop)
+byte_ancestors(st0::JL.SyntaxTree, byte::Int) = byte_ancestors(st0, byte:byte)
 
 """
 Find any largest lowerable tree containing the cursor and the cursor's position


### PR DESCRIPTION
- Changed the algorithm to mainly work on `byte_range::UnitRange{Int}` rather than checking on the first and last byte of the range.
- Some performance improvements by avoidng allocations
- Make Revise work on this file
- Avoid recursion to be able to handle possibilities of encountering huge AST