### PR TITLE
Add guards against invalid positions in xy_to_offset

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -49,25 +49,40 @@ get_fileinfo(s::ServerState, t::TextDocumentIdentifier) = get_fileinfo(s, URI(t.
 # These functions do the conversion.
 
 """
-Convert 0-based `(;line = y, character = x)` to a 1-based byte offset
+    xy_to_offset(code::Vector{UInt8}, pos::Position)
+    xy_to_offset(fi::FileInfo, pos::Position)
+
+Convert 0-based `pos::Position` (equivalent to `(; line = y, character = x)`) to a 1-based byte offset.
+Basically, `pos` is expected to be valid with respect to `code`.
+However, some language server clients sometimes send invalid `Position`s,
+so this function is designed not to error on such invalid `Position`s.
+Note that the byte offset returned in such cases has almost no meaning.
 """
 function xy_to_offset(code::Vector{UInt8}, pos::Position)
     b = 0
     for z in 1:pos.line
-        b = findnext(isequal(UInt8('\n')), code, b + 1)
+        nextb = findnext(isequal(UInt8('\n')), code, b + 1)
+        if isnothing(nextb) # guard against invalid `pos`
+            break
+        end
+        b = nextb
     end
     lend = findnext(isequal(UInt8('\n')), code, b + 1)
     lend = isnothing(lend) ? lastindex(code) + 1 : lend
-    s = String(code[b+1:lend-1]) # current line, containing no newlines
+    curline = String(code[b+1:lend-1]) # current line, containing no newlines
     line_b = 1
     for i in 1:pos.character
-        line_b = nextind(s, line_b)
+        checkbounds(Bool, curline, line_b) || break # guard against invalid `pos`
+        line_b = nextind(curline, line_b)
     end
     return b + line_b
 end
 xy_to_offset(fi::FileInfo, pos::Position) = xy_to_offset(fi.parsed_stream.textbuf, pos)
 
 """
+    offset_to_xy(ps::JS.ParseStream, b::Integer)
+    offset_to_xy(fi::FileInfo, b::Integer)
+
 Convert a 1-based byte offset to a 0-based line and character number
 """
 function offset_to_xy(ps::JS.ParseStream, b::Integer)
@@ -77,7 +92,7 @@ function offset_to_xy(ps::JS.ParseStream, b::Integer)
     l, c = JuliaSyntax.source_location(sf, b)
     return Position(;line = l-1, character = c-1)
 end
-function offset_to_xy(code::Union{AbstractString, Vector{UInt8}}, b::Integer)
+function offset_to_xy(code::Union{AbstractString, Vector{UInt8}}, b::Integer) # used by tests
     ps = JS.parse!(JS.ParseStream(code), rule=:all)
     return offset_to_xy(ps, b)
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -36,4 +36,18 @@ end
     end
 end
 
+@testset "Guard against invalid positions" begin
+    let code = """
+        sin
+        @nospecialize
+        cos(
+        """ |> Vector{UInt8}
+        ok = true
+        for i = 0:10, j = 0:10
+            ok &= JETLS.xy_to_offset(code, JETLS.Position(i, j)) isa Int
+        end
+        @test ok
+    end
+end
+
 end # module test_utils


### PR DESCRIPTION
Prevents errors when language clients send invalid `Position` objects by adding bounds checks and early breaks. Function now gracefully handles out-of-bounds line numbers and character positions.

---

Just for reference:
I particularly found this problem occurring in the Zed editor.
In Zed, such invalid positions are passed especially when completion is triggered after deleting characters, where completion requests with valid and invalid positions seem to be sent in quick succession.
I feel like this is probably a bug on Zed's side, but I think there's no harm in making this function's implementation more robust, so I'm adding this fix.