### PR TITLE
add macro completion support

### DIFF
--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -237,6 +237,7 @@ function initialize_result()
                     includeText = true)),
             completionProvider = CompletionOptions(;
                 resolveProvider = true,
+                triggerCharacters = ["@"],
                 completionItem = (;
                     labelDetailsSupport = true)),
         ),


### PR DESCRIPTION
Configure LSP completion to trigger on "@" character and implement context-aware macro name completion. When triggered by "@" or within macro name context, only show macro names with proper insertText. Otherwise, include both local and global completions as before.

Note that macro completion will not work properly for macros defined in user code like the following:
```julia
macro simplemacro(xs...)
    nothing
end
@|
```
This is because when `@` is typed and the full analysis is performed, errors from undefined macro calls prevent the full analysis from properly recognizing the module context. This issue could be resolved by maintaining a separate file cache of the last successful full analysis, but that will be addressed in a separate PR.