### PR TITLE
fix warnings appearing in tests

### DIFF
--- a/test/setup.jl
+++ b/test/setup.jl
@@ -47,7 +47,10 @@ function withserver(f;
                     capabilities=ClientCapabilities(),
                     rootUri,
                     workspaceFolders)))
-        @test take_with_timeout!(sent_queue).id == id
+        req = take_with_timeout!(received_queue)
+        @test req isa InitializeRequest && req.params.workspaceFolders == workspaceFolders
+        res = take_with_timeout!(sent_queue)
+        @test res isa InitializeResponse && res.id == id
     end
     try
         return f(in, out, received_queue, sent_queue, id_counter)


### PR DESCRIPTION
Add a hack to prevent omitting empty `workspaceFolders` in the serialization of `InitializeParams` during the `withserver` test roundtrips, in order to fix the `"No workspaceFolders or rootUri in InitializeRequest"` warnings appearing when `withserver` is called without `workspaceFolders` nor `rootUri` specified.

`InitializeParams` is never serialized during the usual LS lifecycle, so this hack doesn't affect any behavior of the LS for actual usecases.