### PR TITLE
fix completion request handling for empty files

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -398,8 +398,9 @@ function global_completions!(items::Dict{String, CompletionItem}, state::ServerS
         # check if the cursor is within the macro name context `@xxx|`
         curbyte = xy_to_offset(fi, pos)
         sn = JS.build_tree(JS.SyntaxNode, fi.parsed_stream)
-        if !isempty(sn.children) 
-            curnode = first(byte_ancestors(sn, curbyte-1))
+        ancestors = byte_ancestors(sn, curbyte-1)
+        if !isempty(ancestors) 
+            curnode = first(ancestors)
             is_macro_invoke = JS.kind(curnode) === K"MacroName"
         end
     end

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -398,8 +398,10 @@ function global_completions!(items::Dict{String, CompletionItem}, state::ServerS
         # check if the cursor is within the macro name context `@xxx|`
         curbyte = xy_to_offset(fi, pos)
         sn = JS.build_tree(JS.SyntaxNode, fi.parsed_stream)
-        curnode = first(byte_ancestors(sn, curbyte-1))
-        is_macro_invoke = JS.kind(curnode) === K"MacroName"
+        if !isempty(sn.children) 
+            curnode = first(byte_ancestors(sn, curbyte-1))
+            is_macro_invoke = JS.kind(curnode) === K"MacroName"
+        end
     end
     for name in @invokelatest(names(mod; all=true, imported=true, usings=true))::Vector{Symbol}
         s = String(name)

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -298,6 +298,33 @@ end
     end
 end
 
+# completion for empty program should not crash
+@testset "empty completion" begin
+    state = JETLS.ServerState(identity)
+    filename = "empty.jl"
+    uri = JETLS.URI(filename)
+
+    let text = ""
+        JETLS.cache_file_info!(state, uri, 1, text, filename)
+        params = CompletionParams(;
+            textDocument=TextDocumentIdentifier(string(uri)),
+            position=Position(;line=0,character=0))
+        items = JETLS.get_completion_items(state, uri, params)
+        # should not crash and return something
+        @test length(items) > 0
+    end
+
+    let text = "\n \n \n"
+        JETLS.cache_file_info!(state, uri, 2, text, filename)
+        params = CompletionParams(;
+            textDocument=TextDocumentIdentifier(string(uri)),
+            position=Position(;line=3,character=0))
+        items = JETLS.get_completion_items(state, uri, params)
+        # should not crash and return something
+        @test length(items) > 0
+    end
+end
+
 @testset "macro completion" begin
     state = JETLS.ServerState(identity)
     filename = "filename.jl"


### PR DESCRIPTION
When the user explicitly triggers completion, it's possible that the program is empty. In such cases, attempts to retrieve the current node may fail, so this edge case needs to be handled properly.

