### PR TITLE
improve completions

### DIFF
--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -241,7 +241,11 @@ function initialize_result()
                 save = SaveOptions(;
                     includeText = true)),
             completionProvider = CompletionOptions(;
-                triggerCharacters = ["\\", "@"],
+                triggerCharacters = [
+                    "@",  # macro completion
+                    "\\", # LaTeX completion
+                    ":",  # emoji completion
+                ],
                 resolveProvider = true,
                 completionItem = (;
                     labelDetailsSupport = true)),

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -241,11 +241,7 @@ function initialize_result()
                 save = SaveOptions(;
                     includeText = true)),
             completionProvider = CompletionOptions(;
-                triggerCharacters = [
-                    "@",  # macro completion
-                    "\\", # LaTeX completion
-                    ":",  # emoji completion
-                ],
+                triggerCharacters = COMPLETION_TRIGGER_CHARACTERS,
                 resolveProvider = true,
                 completionItem = (;
                     labelDetailsSupport = true)),

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -397,7 +397,7 @@ end
 # Latex&emoji
 # ===========
 
-function test_backslash_offset(code::String, expected_offset=nothing)
+function test_backslash_offset(code::String, expected_result)
     text, positions = get_text_and_positions(code, r"#=cursor=#")
     @assert length(positions) == 1 "test_backslash_offset requires exactly one cursor marker"
 
@@ -406,27 +406,28 @@ function test_backslash_offset(code::String, expected_offset=nothing)
     uri = JETLS.URI(filename)
     JETLS.cache_file_info!(state, uri, 1, text, filename)
 
-    offset = JETLS.get_backslash_offset(state, uri, positions[1])
-    @test offset == expected_offset
+    result = JETLS.get_backslash_offset(state, uri, positions[1])
+    @test result == expected_result
+    return result
 end
 @testset "get_backslash_offset" begin
     # Example 1: Current token is backslash
     let code = "\\#=cursor=#"
-        test_backslash_offset(code, 1)
+        test_backslash_offset(code, (1, false))
     end
     let code = "  \\#=cursor=#"
-        test_backslash_offset(code, 3)
+        test_backslash_offset(code, (ncodeunits("  \\"), false))
     end
 
     # Example 2: Previous token is backslash
     let code = "\\alpha#=cursor=#"
-        test_backslash_offset(code, 1)
+        test_backslash_offset(code, (1, false))
     end
     let code = "\\beta#=cursor=#"
-        test_backslash_offset(code, 1)
+        test_backslash_offset(code, (1, false))
     end
     let code = "  \\gamma#=cursor=#"
-        test_backslash_offset(code, 3)
+        test_backslash_offset(code, (ncodeunits("  \\"), false))
     end
     let code = "\\ #=cursor=#"
         test_backslash_offset(code, nothing)
@@ -437,16 +438,16 @@ end
 
     # Example 3: Backslash followed by colon, then cursor
     let code = "\\:#=cursor=#"
-        test_backslash_offset(code, 1)
+        test_backslash_offset(code, (1, true))
     end
     let code = "\\:a#=cursor=#"
-        test_backslash_offset(code, 1)
+        test_backslash_offset(code, (1, true))
     end
     let code = "\\:abc#=cursor=#"
-        test_backslash_offset(code, 1)
+        test_backslash_offset(code, (1, true))
     end
     let code = "  \\:test#=cursor=#"
-        test_backslash_offset(code, 3)
+        test_backslash_offset(code, (ncodeunits("  \\"), true))
     end
 
     # Example 4: No relevant backslash (should return nothing)
@@ -474,101 +475,101 @@ end
 
     # Multiple backslashes - should find the most recent one
     let code = "\\alpha \\beta#=cursor=#"
-        test_backslash_offset(code, 8)
+        test_backslash_offset(code, (ncodeunits("\\alpha \\"), false))
     end
     let code = "\\alpha \\beta \\gamma#=cursor=#"
-        test_backslash_offset(code, 14)
+        test_backslash_offset(code, (ncodeunits("\\alpha \\beta \\"), false))
     end
 
     # In various syntactic contexts
     let code = "f(\\alpha#=cursor=#)"
-        test_backslash_offset(code, 3)
+        test_backslash_offset(code, (ncodeunits("f(\\"), false))
     end
     let code = "[\\beta#=cursor=#]"
-        test_backslash_offset(code, 2)
+        test_backslash_offset(code, (ncodeunits("[\\"), false))
     end
     let code = "{\\gamma#=cursor=#}"
-        test_backslash_offset(code, 2)
+        test_backslash_offset(code, (ncodeunits("{\\"), false))
     end
 
     # With newlines
     let code = "x = 1\n\\alpha#=cursor=#"
-        test_backslash_offset(code, 7)
+        test_backslash_offset(code, (ncodeunits("x = 1\n\\"), false))
     end
     let code = "function f()\n    \\beta#=cursor=#\nend"
-        test_backslash_offset(code, 18)
+        test_backslash_offset(code, (ncodeunits("function f()\n    \\"), false))
     end
 
     # Complex expressions
     let code = "f(x) = x^2 + \\sigma#=cursor=#"
-        test_backslash_offset(code, 14)
+        test_backslash_offset(code, (ncodeunits("f(x) = x^2 + \\"), false))
     end
     let code = "result = compute(\\theta#=cursor=#, y)"
-        test_backslash_offset(code, 18)
+        test_backslash_offset(code, (ncodeunits("result = compute(\\"), false))
     end
 
     # LaTeX-like sequences
     let code = "\\alpha#=cursor=#"
-        test_backslash_offset(code, 1)
+        test_backslash_offset(code, (1, false))
     end
     let code = "\\sum#=cursor=#"
-        test_backslash_offset(code, 1)
+        test_backslash_offset(code, (1, false))
     end
     let code = "\\infty#=cursor=#"
-        test_backslash_offset(code, 1)
+        test_backslash_offset(code, (1, false))
     end
     let code = "\\mathbb#=cursor=#"
-        test_backslash_offset(code, 1)
+        test_backslash_offset(code, (1, false))
     end
 
     # Special colon cases
     let code = "\\:heart#=cursor=#"
-        test_backslash_offset(code, 1)
+        test_backslash_offset(code, (1, true))
     end
     let code = "\\:smile#=cursor=#"
-        test_backslash_offset(code, 1)
+        test_backslash_offset(code, (1, true))
     end
     let code = "\\:+1#=cursor=#"
-        test_backslash_offset(code, 1)
+        test_backslash_offset(code, (1, true))
     end
 
     # Unicode characters in code before backslash
     let code = "α = 1; \\beta#=cursor=#"
-        test_backslash_offset(code, ncodeunits("α = 1; \\"))
+        test_backslash_offset(code, (ncodeunits("α = 1; \\"), false))
     end
     let code = "# 测试\n\\gamma#=cursor=#"
-        test_backslash_offset(code, ncodeunits("# 测试\n\\"))
+        test_backslash_offset(code, (ncodeunits("# 测试\n\\"), false))
     end
 
     # Boundary conditions
     let code = "\\#=cursor=#"
-        test_backslash_offset(code, 1)
+        test_backslash_offset(code, (1, false))
     end
     let code = "\\a#=cursor=#"
-        test_backslash_offset(code, 1)
+        test_backslash_offset(code, (1, false))
     end
     let code = "\\:#=cursor=#"
-        test_backslash_offset(code, 1)
+        test_backslash_offset(code, (1, true))
     end
     let code = "code; \\#=cursor=#"
-        test_backslash_offset(code, 7)
+        test_backslash_offset(code, (ncodeunits("code; \\"), false))
     end
 
     # Real-world usage patterns
     let code = "E = mc^2 + \\hbar#=cursor=#"
-        test_backslash_offset(code, 12)
+        test_backslash_offset(code, (ncodeunits("E = mc^2 + \\"), false))
     end
     let code = "function hermite(n, x)\n    return \\psi#=cursor=#\nend"
-        test_backslash_offset(code, 35)
+        test_backslash_offset(code, (ncodeunits("function hermite(n, x)\n    return \\"), false))
     end
     let code = "struct Particle\n    momentum::\\vec#=cursor=#\nend"
-        test_backslash_offset(code, 31)
+        test_backslash_offset(code, (ncodeunits("struct Particle\n    momentum::\\"), false))
     end
     let code = "[\\theta#=cursor=# for i in 1:n]"
-        test_backslash_offset(code, 2)
+        test_backslash_offset(code, (ncodeunits("[\\"), false))
     end
     let code = "angle = \\phi#=cursor=#"
-        test_backslash_offset(code, 9)
+        test_backslash_offset(code, (ncodeunits("angle = \\"), false))
     end
 end
 
@@ -618,8 +619,9 @@ end
         end
         @test !any(items) do item
             item.label == "foo" || # should not include global completions
-            item.label == "α"      # should not include local completions
-            item.label == "β"      # should not include local completions
+            item.label == "α"   || # should not include local completions
+            item.label == "β"   || # should not include local completions
+            item.label == "\\alpha" # should not even include LaTeX completions
         end
     end
 end


### PR DESCRIPTION
- [x] Don't include latex completion for the emoji completions
- [x] Emoji completion doesn't trigger when typing `\:|`
- [-] Same issue when typing `\:+|`
- [x] For cases like `\alp|`, would like to improve `sortText` so that `\alpha` appears first
- [x] [disallow completion to be triggered by numeric characters](https://github.com/aviatesk/JETLS.jl/pull/41/commits/0666509da19b017635d413e0d256608a565453ff)