### PR TITLE
refactor code architecture to separate `Server` and `ServerState`

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,9 @@ index 29d0db5..728da8f 100644
 > of `_handle_message` that is reachable upon the request handling.
 
 > [!warnng]
-> Note that `currently_running::ServerState` is a global variable that is only
-> defined in `JETLS_DEV_MODE`. The use of this global variable should be limited to such development purposes and should not be included in normal routines.
+> Note that `currently_running::Server` is a global variable that is only
+> defined in `JETLS_DEV_MODE`. The use of this global variable should be limited
+> to such development purposes and should not be included in normal routines.
 
 [^vscode]: Of course, the hack explained here is only possible with clients that
   support dynamic registration. VSCode is currently one of the frontends that

--- a/runserver.jl
+++ b/runserver.jl
@@ -27,7 +27,8 @@ let old_env = Pkg.project().path
     end
 end
 
-let res = runserver(stdin, stdout) do s::Symbol, x
+let endpoint = JETLS.Endpoint(stdin, stdout)
+    server = JETLS.Server(endpoint) do s::Symbol, x
         @nospecialize x
         if JETLS.JETLS_DEV_MODE
             # allow Revise to apply changes with the dev mode enabled
@@ -36,6 +37,10 @@ let res = runserver(stdin, stdout) do s::Symbol, x
             end
         end
     end
+    if JETLS.JETLS_DEV_MODE
+        JETLS.currently_running = server
+    end
+    res = runserver(server)
     @info "JETLS server stopped" res.exit_code
     exit(res.exit_code)
 end

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -566,10 +566,10 @@ function get_completion_items(state::ServerState, uri::URI, params::CompletionPa
         items)))
 end
 
-function handle_CompletionRequest(state::ServerState, msg::CompletionRequest)
+function handle_CompletionRequest(server::Server, msg::CompletionRequest)
     uri = URI(msg.params.textDocument.uri)
-    items = get_completion_items(state, uri, msg.params)
-    return send(state,
+    items = get_completion_items(server.state, uri, msg.params)
+    return send(server,
         ResponseMessage(;
             id = msg.id,
             result = CompletionList(;
@@ -577,9 +577,9 @@ function handle_CompletionRequest(state::ServerState, msg::CompletionRequest)
                 items)))
 end
 
-function handle_CompletionResolveRequest(state::ServerState, msg::CompletionResolveRequest)
-    return send(state,
+function handle_CompletionResolveRequest(server::Server, msg::CompletionResolveRequest)
+    return send(server,
         ResponseMessage(;
             id = msg.id,
-            result = resolve_completion_item(state, msg.params)))
+            result = resolve_completion_item(server.state, msg.params)))
 end

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -124,9 +124,9 @@ function line_range(line::Int)
     return Range(; start, var"end")
 end
 
-function notify_diagnostics!(state::ServerState)
+function notify_diagnostics!(server::Server)
     uri2diagnostics = Dict{URI,Vector{Diagnostic}}()
-    for (uri, contexts) in state.contexts
+    for (uri, contexts) in server.state.contexts
         if contexts isa ExternalContext
             continue
         end
@@ -138,12 +138,12 @@ function notify_diagnostics!(state::ServerState)
             end
         end
     end
-    notify_diagnostics!(state, uri2diagnostics)
+    notify_diagnostics!(server, uri2diagnostics)
 end
 
-function notify_diagnostics!(state::ServerState, uri2diagnostics)
+function notify_diagnostics!(server::Server, uri2diagnostics)
     for (uri, diagnostics) in uri2diagnostics
-        send(state, PublishDiagnosticsNotification(;
+        send(server, PublishDiagnosticsNotification(;
             params = PublishDiagnosticsParams(;
                 uri = string(uri),
                 # version = 0,

--- a/src/registration.jl
+++ b/src/registration.jl
@@ -1,6 +1,7 @@
-register(state::ServerState, registration::Registration) =
-    register(state, Registration[registration])
-function register(state::ServerState, registrations::Vector{Registration})
+register(server::Server, registration::Registration) =
+    register(server, Registration[registration])
+function register(server::Server, registrations::Vector{Registration})
+    state = server.state
     filtered = filter(registrations) do registration
         reg = Registered(registration.id, registration.method)
         if reg ∉ state.currently_registered
@@ -10,25 +11,25 @@ function register(state::ServerState, registrations::Vector{Registration})
             return false
         end
     end
-    send(state, RegisterCapabilityRequest(;
+    send(server, RegisterCapabilityRequest(;
         id = String(gensym(:RegisterCapabilityRequest)),
         params = RegistrationParams(;
             registrations = filtered)))
 end
 
-unregister(state::ServerState, unregistration::Unregistration) =
-    unregister(state, Unregistration[unregistration])
-function unregister(state::ServerState, unregisterations::Vector{Unregistration})
+unregister(server::Server, unregistration::Unregistration) =
+    unregister(server, Unregistration[unregistration])
+function unregister(server::Server, unregisterations::Vector{Unregistration})
     filtered = filter(unregisterations) do unregistration
         reg = Registered(unregistration.id, unregistration.method)
-        if reg ∈ state.currently_registered
-            delete!(state.currently_registered, reg)
+        if reg ∈ server.state.currently_registered
+            delete!(server.state.currently_registered, reg)
             return true
         else
             return false
         end
     end
-    send(state, UnregisterCapabilityRequest(;
+    send(server, UnregisterCapabilityRequest(;
         id = String(gensym(:UnregisterCapabilityRequest)),
         params = UnregistrationParams(;
             unregisterations = filtered)))

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -232,7 +232,7 @@ function get_text_and_positions(text::String, target::Regex=r"#=cursor=#")
 end
 
 @testset "get_completion_items" begin
-    state = JETLS.ServerState(Returns(nothing))
+    state = JETLS.ServerState()
     text, curpos2 = get_text_and_positions("""
     module Foo
 
@@ -300,7 +300,7 @@ end
 
 # completion for empty program should not crash
 @testset "empty completion" begin
-    state = JETLS.ServerState(Returns(nothing))
+    state = JETLS.ServerState()
     filename = "empty.jl"
     uri = JETLS.URI(filename)
 
@@ -326,7 +326,7 @@ end
 end
 
 @testset "macro completion" begin
-    state = JETLS.ServerState(Returns(nothing))
+    state = JETLS.ServerState()
     filename = "filename.jl"
     uri = JETLS.URI(filename)
 
@@ -422,7 +422,7 @@ function test_backslash_offset(code::String, expected_result)
     text, positions = get_text_and_positions(code, r"#=cursor=#")
     @assert length(positions) == 1 "test_backslash_offset requires exactly one cursor marker"
 
-    state = JETLS.ServerState(Returns(nothing))
+    state = JETLS.ServerState()
     filename = "test_backslash.jl"
     uri = JETLS.URI(filename)
     JETLS.cache_file_info!(state, uri, 1, text, filename)
@@ -595,7 +595,7 @@ end
 end
 
 @testset "Latex/emoji completion" begin
-    state = JETLS.ServerState(Returns(nothing))
+    state = JETLS.ServerState()
     filename = "test_latex_emoji.jl"
     uri = JETLS.URI(filename)
 

--- a/test/test_registration.jl
+++ b/test/test_registration.jl
@@ -9,21 +9,22 @@ let capabilities = ClientCapabilities(;
         textDocument = TextDocumentClientCapabilities(;
             completion = CompletionClientCapabilities(;
                 dynamicRegistration = true)))
-    withserver(; capabilities) do (; state, sent_queue)
+    withserver(; capabilities) do (; server, sent_queue)
+        state = server.state
         reg = Registered(JETLS.COMPLETION_REGISTRATION_ID, JETLS.COMPLETION_REGISTRATION_METHOD)
 
         # test the completion is registered dynamically at the initialization
         @test reg in state.currently_registered
 
         # test dynamic unregistration
-        unregister(state, Unregistration(;
+        unregister(server, Unregistration(;
             id=JETLS.COMPLETION_REGISTRATION_ID,
             method=JETLS.COMPLETION_REGISTRATION_METHOD))
         take_with_timeout!(sent_queue)
         @test reg ∉ state.currently_registered
 
         # test dynamic re-registration
-        register(state, JETLS.completion_registration())
+        register(server, JETLS.completion_registration())
         take_with_timeout!(sent_queue)
         @test reg in state.currently_registered
     end


### PR DESCRIPTION
Define a new `Server` struct to make it easier to construct `ServerState` in separation for testing purposes.
It also generally improves the separation between "the internal state" of the server and "the server itself", which interacts with the external world through the endpoint.
`Server` now holds `endpoint`, `callback`, and `state::ServerState` as separate components.
Update all handlers to accept `Server` parameter and access `state` through `server.state`.