### PR TITLE
test: avoid using `take_with_timeout!` in `withserver` callbacks

### DIFF
--- a/runserver.jl
+++ b/runserver.jl
@@ -27,20 +27,20 @@ let old_env = Pkg.project().path
     end
 end
 
-let endpoint = JETLS.Endpoint(stdin, stdout)
-    server = JETLS.Server(endpoint) do s::Symbol, x
-        @nospecialize x
-        if JETLS.JETLS_DEV_MODE
+let endpoint = Endpoint(stdin, stdout)
+    if JETLS.JETLS_DEV_MODE
+        server = Server(endpoint) do s::Symbol, x
+            @nospecialize x
             # allow Revise to apply changes with the dev mode enabled
             if s === :received
                 Revise.revise()
             end
         end
-    end
-    if JETLS.JETLS_DEV_MODE
         JETLS.currently_running = server
+        res = runserver(server)
+    else
+        res = runserver(endpoint)
     end
-    res = runserver(server)
     @info "JETLS server stopped" res.exit_code
     exit(res.exit_code)
 end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -3,7 +3,7 @@ using Pkg
 using JETLS
 using JETLS.LSP
 using JETLS.URIs2
-using JETLS.JSONRPC: JSON3, readmsg, writemsg
+using JETLS: JSONRPC
 
 function take_with_timeout!(chn::Channel; interval=1, limit=60)
     while limit > 0
@@ -24,7 +24,7 @@ function withserver(f;
     out = Base.BufferStream()
     received_queue = Channel{Any}(Inf)
     sent_queue = Channel{Any}(Inf)
-    server = JETLS.Server(JETLS.JSONRPC.Endpoint(in, out)) do s::Symbol, x
+    server = Server(Endpoint(in, out)) do s::Symbol, x
         @nospecialize x
         if s === :received
             put!(received_queue, x)
@@ -52,9 +52,87 @@ function withserver(f;
         workspaceFolders = WorkspaceFolder[] # initialize empty workspace by default
     end
 
+    """
+        writereadmsg(@nospecialize(msg); read::Int=1)
+
+    Write a message to the language server via JSON-RPC, read the server's received message,
+    and read the server's response(s).
+    This function also asserts that no messages remain in the queue after reading the
+    expected number of responses.
+
+    # Arguments
+    - `msg`: The message to send to the server
+    - `read::Int=1`: Number of responses to read from the server:
+      - `0`: Don't read any responses
+      - `1`: Read a single response (default)
+      - `>1`: Read multiple responses and return them as arrays
+
+    # Returns
+    A named tuple containing:
+    - `raw_msg`: The message received by the server
+    - `raw_res`: The raw response(s) sent by the server (or `nothing` if `read=0`)
+    - `json_res`: The JSON-parsed response(s) from the server (or `nothing` if `read=0`)
+    """
+    function writereadmsg(@nospecialize(msg); read::Int=1)
+        @assert read ≥ 0 "`read::Int` must not be negative"
+        JSONRPC.writemsg(in, msg)
+        raw_msg = take_with_timeout!(received_queue)
+        raw_res = json_res = nothing
+        if read == 0
+        elseif read == 1
+            raw_res = take_with_timeout!(sent_queue)
+            json_res = JSONRPC.readmsg(out)
+        else
+            raw_res = Any[]
+            json_res = Any[]
+            for _ = 1:read
+                push!(raw_res, take_with_timeout!(sent_queue))
+                push!(json_res, JSONRPC.readmsg(out))
+            end
+        end
+        @test isempty(received_queue) && isempty(sent_queue)
+        return (; raw_msg, raw_res, json_res)
+    end
+
+    """
+        readmsg(; read::Int=1)
+
+    Read response messages from the language server without sending a request.
+    Similar to `writereadmsg` but only reads responses from the server.
+
+    # Arguments
+    - `read::Int=1`: Number of responses to read from the server:
+      - `0`: Don't read any responses
+      - `1`: Read a single response (default)
+      - `>1`: Read multiple responses and return them as arrays
+
+    # Returns
+    A named tuple containing:
+    - `raw_msg`: The raw response(s) sent by the server (or `nothing` if `read=0`)
+    - `json_msg`: The JSON-parsed response(s) from the server (or `nothing` if `read=0`)
+    """
+    function readmsg(; read::Int=1)
+        @assert read ≥ 0 "`read::Int` must not be negative"
+        raw_msg = json_msg = nothing
+        if read == 0
+        elseif read == 1
+            raw_msg = take_with_timeout!(sent_queue)
+            json_msg = JSONRPC.readmsg(out)
+        else
+            raw_msg = Any[]
+            json_msg = Any[]
+            for _ = 1:read
+                push!(raw_msg, take_with_timeout!(sent_queue))
+                push!(json_msg, JSONRPC.readmsg(out))
+            end
+        end
+        @test isempty(received_queue) && isempty(sent_queue)
+        return (; raw_msg, json_msg)
+    end
+
     # do the server initialization
     let id = id_counter[] += 1
-        writemsg(in,
+        (; raw_msg, raw_res, json_res) = writereadmsg(
             InitializeRequest(;
                 id,
                 params=InitializeParams(;
@@ -62,37 +140,30 @@ function withserver(f;
                     capabilities,
                     rootUri,
                     workspaceFolders)))
-        req = take_with_timeout!(received_queue)
-        @test req isa InitializeRequest && req.params.workspaceFolders == workspaceFolders
-        res = take_with_timeout!(sent_queue)
-        @test res isa InitializeResponse && res.id == id
+        @test raw_msg isa InitializeRequest && raw_msg.params.workspaceFolders == workspaceFolders
+        @test raw_res isa InitializeResponse && raw_res.id == id
 
-        writemsg(in, InitializedNotification())
-        @test take_with_timeout!(received_queue) isa InitializedNotification
-        res = take_with_timeout!(sent_queue)
-        @test res isa RegisterCapabilityRequest && res.id isa String
+        (; raw_msg, raw_res) = writereadmsg(InitializedNotification())
+        @test raw_msg isa InitializedNotification
+        @test raw_res isa RegisterCapabilityRequest && raw_res.id isa String
     end
 
-    argnt = (; in, out, server, received_queue, sent_queue, id_counter)
+    argnt = (; server, writereadmsg, readmsg, id_counter)
     try
         # do the main callback
         return f(argnt)
     finally
         Pkg.activate(old_env; io=devnull)
         let id = id_counter[] += 1
-            writemsg(in,
-                ShutdownRequest(;
-                    id))
-            res = take_with_timeout!(sent_queue)
-            @test res.id == id
+            (; raw_res, json_res) = writereadmsg(ShutdownRequest(; id))
+            @test raw_res isa ShutdownResponse && raw_res.id == id
             # make sure the `ShutdownResponse` follows the `ResponseMessage` specification:
             # https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#responseMessage
-            roundtrip = JSON3.read(JSON3.write(res))
-            @test haskey(roundtrip, :result)
-            @test roundtrip[:result] === nothing
+            @test json_res isa Dict{Symbol,Any} &&
+                haskey(json_res, :result) &&
+                json_res[:result] === nothing
         end
-        writemsg(in,
-            ExitNotification())
+        writereadmsg(ExitNotification(); read=0)
         result = fetch(t)
         @test result isa @NamedTuple{exit_code::Int, endpoint::JETLS.JSONRPC.Endpoint}
         @test result.exit_code == 0

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -29,15 +29,14 @@ end
 
     withscript(scriptcode) do script_path
         uri = string(JETLS.URIs2.filepath2uri(script_path))
-        withserver() do (; in, sent_queue, id_counter)
-            writemsg(in, make_DidOpenTextDocumentNotification(uri, scriptcode))
+        withserver() do (; writereadmsg, id_counter)
+            (; raw_res) = writereadmsg(make_DidOpenTextDocumentNotification(uri, scriptcode))
 
-            out = take_with_timeout!(sent_queue)
-            @test out isa PublishDiagnosticsNotification
-            @test out.params.uri == uri
+            @test raw_res isa PublishDiagnosticsNotification
+            @test raw_res.params.uri == uri
 
             found_diagnostic = false
-            for diag in out.params.diagnostics
+            for diag in raw_res.params.diagnostics
                 if diag.source == JETLS.SYNTAX_DIAGNOSTIC_SOURCE
                     found_diagnostic = true
                     break
@@ -57,15 +56,14 @@ end
     # Use withscript to create a temporary file and run the test
     withscript(scriptcode) do script_path
         uri = string(JETLS.URIs2.filepath2uri(script_path))
-        withserver() do (; in, sent_queue, id_counter)
-            writemsg(in, make_DidOpenTextDocumentNotification(uri, scriptcode))
+        withserver() do (; writereadmsg, id_counter)
+            (; raw_res) = writereadmsg(make_DidOpenTextDocumentNotification(uri, scriptcode))
 
-            out = take_with_timeout!(sent_queue)
-            @test out isa PublishDiagnosticsNotification
-            @test out.params.uri == uri
+            @test raw_res isa PublishDiagnosticsNotification
+            @test raw_res.params.uri == uri
 
             found_diagnostic = false
-            for diag in out.params.diagnostics
+            for diag in raw_res.params.diagnostics
                 if diag.source == JETLS.TOPLEVEL_DIAGNOSTIC_SOURCE
                     found_diagnostic = true
                     break
@@ -90,15 +88,14 @@ end
     # Use withscript to create a temporary file and run the test
     withscript(scriptcode) do script_path
         uri = string(JETLS.URIs2.filepath2uri(script_path))
-        withserver() do (; in, sent_queue, id_counter)
-            writemsg(in, make_DidOpenTextDocumentNotification(uri, scriptcode))
+        withserver() do (; writereadmsg, id_counter)
+            (; raw_res) = writereadmsg(make_DidOpenTextDocumentNotification(uri, scriptcode))
 
-            out = take_with_timeout!(sent_queue)
-            @test out isa PublishDiagnosticsNotification
-            @test out.params.uri == uri
+            @test raw_res isa PublishDiagnosticsNotification
+            @test raw_res.params.uri == uri
 
             found_diagnostic = false
-            for diag in out.params.diagnostics
+            for diag in raw_res.params.diagnostics
                 if diag.source == JETLS.INFERENCE_DIAGNOSTIC_SOURCE
                     found_diagnostic = true
                     break
@@ -136,16 +133,15 @@ end
         rootUri = string(JETLS.URIs2.filepath2uri(pkg_path))
         src_path = normpath(pkg_path, "src", "TestPackageAnalysis.jl")
         uri = string(JETLS.URIs2.filepath2uri(src_path))
-        withserver(; rootUri) do (; in, sent_queue, id_counter)
-            writemsg(in, make_DidOpenTextDocumentNotification(uri, read(src_path, String)))
+        withserver(; rootUri) do (; writereadmsg, id_counter)
+            (; raw_res) = writereadmsg(make_DidOpenTextDocumentNotification(uri, read(src_path, String)))
 
-            out = take_with_timeout!(sent_queue; limit=300) # wait for 5 minutes
-            @test out isa PublishDiagnosticsNotification
-            @test out.params.uri == uri
-            # @test out.params.version == 1
+            @test raw_res isa PublishDiagnosticsNotification
+            @test raw_res.params.uri == uri
+            # @test raw_res.params.version == 1
 
             found_diagnostic = false
-            for diag in out.params.diagnostics
+            for diag in raw_res.params.diagnostics
                 if (diag.source == JETLS.INFERENCE_DIAGNOSTIC_SOURCE &&
                     # this also tests that JETLS doesn't show the nonsensical `var"..."`
                     # string caused by JET's internal details

--- a/test/test_full_lifecycle.jl
+++ b/test/test_full_lifecycle.jl
@@ -23,30 +23,30 @@ let (pkgcode, positions) = get_text_and_positions("""
         filepath = normpath(pkgpath, "src", "TestFullLifecycle.jl")
         uri = string(JETLS.URIs2.filepath2uri(filepath))
 
-        test_full_cycle = function ((; in, sent_queue, id_counter),)
+        test_full_cycle = function ((; writereadmsg, id_counter),)
             # open the file, and fill in the file cache
-            writemsg(in,
-                DidOpenTextDocumentNotification(;
-                    params = DidOpenTextDocumentParams(;
-                        textDocument = TextDocumentItem(;
-                            uri,
-                            languageId = "julia",
-                            version = 1,
-                            text = read(filepath, String)))))
-            out = take_with_timeout!(sent_queue; limit=300) # wait for 5 minutes
-            @test out isa PublishDiagnosticsNotification
+            let (; raw_res) = writereadmsg(
+                    DidOpenTextDocumentNotification(;
+                            params = DidOpenTextDocumentParams(;
+                            textDocument = TextDocumentItem(;
+                                uri,
+                                languageId = "julia",
+                                version = 1,
+                                text = read(filepath, String)))))
+                @test raw_res isa PublishDiagnosticsNotification
+            end
 
-            id = id_counter[] += 1
-            writemsg(in,
-                CompletionRequest(;
-                    id,
-                    params = CompletionParams(;
-                        textDocument = TextDocumentIdentifier(; uri),
-                        position = pos1)))
-            out = take_with_timeout!(sent_queue)
-            @test out isa ResponseMessage
-            @test out.id == id
-            result = out.result
+            result = let id = id_counter[] += 1
+                (; raw_res) = writereadmsg(
+                    CompletionRequest(;
+                        id,
+                        params = CompletionParams(;
+                            textDocument = TextDocumentIdentifier(; uri),
+                            position = pos1)))
+                @test raw_res isa ResponseMessage
+                @test raw_res.id == id
+                result = raw_res.result
+            end
             @test result isa CompletionList
             idx = findfirst(x -> x.label == "hello", result.items)
             @test !isnothing(idx)
@@ -56,15 +56,14 @@ let (pkgcode, positions) = get_text_and_positions("""
                 @test data isa CompletionData && data.needs_resolve
                 @test isnothing(item.documentation)
 
-                let id = id_counter[] += 1, out, result
-                    writemsg(in,
+                let id = id_counter[] += 1, raw_res, result
+                    (; raw_res) = writereadmsg(
                         CompletionResolveRequest(;
                             id,
                             params =  item))
-                    out = take_with_timeout!(sent_queue)
-                    @test out isa ResponseMessage
-                    @test out.id == id
-                    result = out.result
+                    @test raw_res isa ResponseMessage
+                    @test raw_res.id == id
+                    result = raw_res.result
                     @test result isa CompletionItem
                     documentation = result.documentation
                     @test documentation isa MarkupContent &&

--- a/test/test_registration.jl
+++ b/test/test_registration.jl
@@ -9,7 +9,7 @@ let capabilities = ClientCapabilities(;
         textDocument = TextDocumentClientCapabilities(;
             completion = CompletionClientCapabilities(;
                 dynamicRegistration = true)))
-    withserver(; capabilities) do (; server, sent_queue)
+    withserver(; capabilities) do (; server, readmsg, id_counter)
         state = server.state
         reg = Registered(JETLS.COMPLETION_REGISTRATION_ID, JETLS.COMPLETION_REGISTRATION_METHOD)
 
@@ -20,12 +20,14 @@ let capabilities = ClientCapabilities(;
         unregister(server, Unregistration(;
             id=JETLS.COMPLETION_REGISTRATION_ID,
             method=JETLS.COMPLETION_REGISTRATION_METHOD))
-        take_with_timeout!(sent_queue)
+        (; raw_msg) = readmsg()
+        @test raw_msg isa UnregisterCapabilityRequest
         @test reg ∉ state.currently_registered
 
         # test dynamic re-registration
         register(server, JETLS.completion_registration())
-        take_with_timeout!(sent_queue)
+        (; raw_msg) = readmsg()
+        @test raw_msg isa RegisterCapabilityRequest
         @test reg in state.currently_registered
     end
 end


### PR DESCRIPTION
Previously, tests using `withserver` followed this pattern:
```julia
withserver() do (; in, sent_queue)
    writemsg(in, ...)
    out = take_with_timeout!(sent_queue)
    ... test with out

    writemsg(in, ...)
    out = take_with_timeout!(sent_queue)
    ... test with out
end
```
This pattern is risky because it creates implicit dependencies between test cases regarding messages in the `sent_queue`.

Therefore, I've created the following utilities to use in tests:
```julia
"""
    writereadmsg(@nospecialize(msg); read::Int=1)

Write a message to the language server via JSON-RPC, read the server's received message,
and read the server's response(s).
This function also asserts that no messages remain in the queue after reading the
expected number of responses.

- `msg`: The message to send to the server
- `read::Int=1`: Number of responses to read from the server:
    - `0`: Don't read any responses
    - `1`: Read a single response (default)
    - `>1`: Read multiple responses and return them as arrays

A named tuple containing:
- `raw_msg`: The message received by the server
- `raw_res`: The raw response(s) sent by the server (or `nothing` if `read=0`)
- `json_res`: The JSON-parsed response(s) from the server (or `nothing` if `read=0`)
"""
function writereadmsg(@nospecialize(msg); read::Int=1)

"""
    readmsg(; read::Int=1)

Read response messages from the language server without sending a request.
Similar to `writereadmsg` but only reads responses from the server.

- `read::Int=1`: Number of responses to read from the server:
    - `0`: Don't read any responses
    - `1`: Read a single response (default)
    - `>1`: Read multiple responses and return them as arrays

A named tuple containing:
- `raw_res`: The raw response(s) sent by the server (or `nothing` if `read=0`)
- `json_res`: The JSON-parsed response(s) from the server (or `nothing` if `read=0`)
"""
function readmsg(; read::Int=1)
```