### PR TITLE
test: add tests for runserver.jl script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
           # - version: '1' # current stable
           #   os: ubuntu-latest
           #   arch: x64
-          - version: '1.12-nightly' # minimum version supported
+          - version: "1.12-nightly" # minimum version supported
             os: ubuntu-latest
             arch: x64
-          - version: '1.13-nightly' # next release
+          - version: "1.13-nightly" # next release
             os: ubuntu-latest
             arch: x64
-          - version: 'nightly' # dev
+          - version: "nightly" # dev
             os: ubuntu-latest
             arch: x64
           # - version: '1' # x86 ubuntu
@@ -53,3 +53,18 @@ jobs:
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
+
+  # Not working on CI for some reason, so commented out
+  # test_runserver:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: julia-actions/setup-julia@v1
+  #       with:
+  #         version: "1.12-nightly" # most stable version
+  #         arch: x64
+  #     - uses: julia-actions/julia-buildpkg@latest
+  #     - uses: julia-actions/julia-buildpkg@latest
+  #     - name: run test
+  #       run: |
+  #         julia --startup-file=no --project=./test ./test/test_runserver.jl

--- a/runserver.jl
+++ b/runserver.jl
@@ -4,7 +4,7 @@ using Pkg
 
 let old_env = Pkg.project().path
     try
-        Pkg.activate(@__DIR__)
+        Pkg.activate(@__DIR__; io=devnull)
 
         # TODO load Revise only when `JETLS_DEV_MODE` is true
         try
@@ -23,7 +23,7 @@ let old_env = Pkg.project().path
             exit(1)
         end
     finally
-        Pkg.activate(old_env)
+        Pkg.activate(old_env; io=devnull)
     end
 end
 

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -169,12 +169,16 @@ for development purposes only, particularly for inspection or dynamic registrati
 """
 global currently_running::Server
 
-runserver(args...) = runserver(Returns(nothing), args...) # no callback specified
-runserver(callback, in::IO, out::IO) = runserver(callback, Endpoint(in, out))
-runserver(callback, endpoint::Endpoint) = runserver(Server(callback, endpoint))
-function runserver(server::Server)
+const SERVER_LOOP_STARTUP_MSG = "Running JETLS server loop"
+const SERVER_LOOP_EXIT_MSG    = "Exited JETLS server loop"
+
+runserver(args...; kwarg...) = runserver(Returns(nothing), args...; kwarg...) # no callback specified
+runserver(callback, in::IO, out::IO; kwarg...) = runserver(callback, Endpoint(in, out); kwarg...)
+runserver(callback, endpoint::Endpoint; kwarg...) = runserver(Server(callback, endpoint); kwarg...)
+function runserver(server::Server; server_loop_log::Bool=true)
     shutdown_requested = false
     local exit_code::Int = 1
+    server_loop_log && @info SERVER_LOOP_STARTUP_MSG
     try
         for msg in server.endpoint
             server.callback !== nothing && server.callback(:received, msg)
@@ -206,6 +210,7 @@ function runserver(server::Server)
     finally
         close(server.endpoint)
     end
+    server_loop_log && @info SERVER_LOOP_EXIT_MSG
     return (; exit_code, server.endpoint)
 end
 

--- a/test/test_runserver.jl
+++ b/test/test_runserver.jl
@@ -1,0 +1,206 @@
+module test_runserver
+
+"""
+Test file for exercising runserver.jl with raw JSON communication.
+
+This test spawns actual server processes using runserver.jl and communicates
+with them via stdin/stdout using raw JSON-RPC messages, testing:
+
+1. Server startup and basic lifecycle (initialize, shutdown, exit)
+2. Process management and graceful termination
+
+To run this test independently:
+    julia --startup-file=no -e 'using Test; @testset "runserver" include("test/test_runserver.jl")'
+"""
+
+using Test
+using JETLS
+
+# Test configuration
+const JULIA_CMD = normpath(Sys.BINDIR, "julia")
+const JETLS_DIR = pkgdir(JETLS)
+const SERVER_SCRIPT = normpath(JETLS_DIR, "runserver.jl")
+
+function withserverprocess(f)
+    cmd = `$JULIA_CMD --project=$JETLS_DIR $SERVER_SCRIPT`
+    stdin = Base.BufferStream()
+    stdout = Base.BufferStream()
+    stderr = Base.BufferStream()
+    pipe = pipeline(cmd; stdin, stdout, stderr)
+    proc = run(pipe; wait=false)
+
+    try
+        return f((; proc, stdin, stdout, stderr))
+    catch e
+        rethrow(e)
+    finally
+        close(stdin)
+        close(stdout)
+        close(stderr)
+        if !process_exited(proc)
+            @error "Server process did not exit gracefully, killing it"
+            kill(proc)
+        end
+    end
+end
+
+function with_timeout(f, timeout, timeout_message)
+    elapsed = 0.0
+    while true
+        elapsed > timeout && error(timeout_message)
+        res = f(elapsed)
+        if res !== nothing
+            @info "Resolved within timeout" timeout_message elapsed
+            return res
+        end
+        sleep(1.0)
+        elapsed += 1.0
+    end
+end
+
+function write_lsp_message(io, message)
+    response_utf8 = transcode(UInt8, message)
+    var"Content-Length" = length(response_utf8)
+    write(io, "Content-Length: $(var"Content-Length")\r\n\r\n")
+    write(io, message)
+    flush(io)
+    return nothing
+end
+
+function read_lsp_message(io, timeout, message_kind)
+    # Read headers with timeout
+    var"Content-Length" = with_timeout(timeout, "Timeout waiting for reading `Content-Length` of '$message_kind' message") do elapsed
+        bytesavailable(io) > 0 || return nothing
+        line = readline(io) # XXX may block
+        startswith(line, "Content-Length:") || return nothing
+        readline(io) # read the extra line break
+        return parse(Int, strip(split(line, ":")[2]))
+    end
+    return with_timeout(timeout, "Timeout waiting for reading body of '$message_kind' message") do elapsed
+        bytesavailable(io) >= var"Content-Length" || return nothing
+        return String(read(io, var"Content-Length"))
+    end
+end
+
+const DEFAULT_TIMEOUT = 10
+const STARTUP_TIMEOUT = 60
+
+# test a very simple, normal server lifecycle
+withserverprocess() do (; proc, stdin, stdout, stderr)
+    @test with_timeout(#=timeout=#STARTUP_TIMEOUT, "Timeout waiting for the server to startup") do elapsed
+        bytesavailable(stderr) > 0 || return nothing
+        log = String(readavailable(stderr))
+        occursin(JETLS.SERVER_LOOP_STARTUP_MSG, log) || return nothing
+        return true
+    end
+    # @info "The server loop started successfully"
+
+    # Send initialization request
+    initialize_msg = """{
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "processId": $(getpid()),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": []
+        }
+    }"""
+    write_lsp_message(stdin, initialize_msg)
+    initialization_response = read_lsp_message(stdout, #=timeout=#DEFAULT_TIMEOUT, "initialize request")
+    initialization_response === nothing &&
+        error("No response received from server (may have terminated)")
+    @test occursin("\"id\":1", initialization_response)
+    @test occursin("\"result\"", initialization_response)
+    # @info "Server responded to initialize request successfully"
+
+    # Send shutdown request
+    shutdown_msg = """{
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "shutdown",
+        "params": null
+    }"""
+    write_lsp_message(stdin, shutdown_msg)
+    shutdown_response = read_lsp_message(stdout, #=timeout=#DEFAULT_TIMEOUT, "shutdown request")
+    shutdown_response === nothing &&
+        error("No response received from server (may have terminated)")
+    @test occursin("\"id\":2", shutdown_response)
+    # @info "Server responded to shutdown request"
+
+    # Send exit notification
+    exit_msg = """{
+        "jsonrpc": "2.0",
+        "method": "exit",
+        "params": null
+    }"""
+    write_lsp_message(stdin, exit_msg)
+    @test with_timeout(#=timeout=#DEFAULT_TIMEOUT, "Timeout waiting for the server to exit the loop") do elapsed
+        bytesavailable(stderr) > 0 || return nothing
+        log = String(readavailable(stderr))
+        occursin(JETLS.SERVER_LOOP_EXIT_MSG, log) || return nothing
+        return true
+    end
+    # @info "The server loop exited successfully"
+
+    @test with_timeout(#=timeout=#DEFAULT_TIMEOUT, "Timeout waiting for the server process to shutdown") do elapsed
+        process_running(proc) && return nothing
+        return true
+    end
+    @test process_exited(proc) && proc.exitcode == 0
+end
+
+# test a very simple, abnormal server lifecycle
+withserverprocess() do (; proc, stdin, stdout, stderr)
+    @test with_timeout(#=timeout=#STARTUP_TIMEOUT, "Timeout waiting for the server to startup") do elapsed
+        bytesavailable(stderr) > 0 || return nothing
+        log = String(readavailable(stderr))
+        occursin(JETLS.SERVER_LOOP_STARTUP_MSG, log) || return nothing
+        return true
+    end
+    # @info "The server loop started successfully"
+
+    # Send initialization request
+    initialize_msg = """{
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "processId": $(getpid()),
+            "rootUri": null,
+            "capabilities": {},
+            "workspaceFolders": []
+        }
+    }"""
+    write_lsp_message(stdin, initialize_msg)
+    initialization_response = read_lsp_message(stdout, #=timeout=#DEFAULT_TIMEOUT, "initialize request")
+    initialization_response === nothing &&
+        error("No response received from server (may have terminated)")
+    @test occursin("\"id\":1", initialization_response)
+    @test occursin("\"result\"", initialization_response)
+    # @info "Server responded to initialize request successfully"
+
+    # Send exit notification, before requesting shutdown request (invalid)
+    exit_msg = """{
+        "jsonrpc": "2.0",
+        "method": "exit",
+        "params": null
+    }"""
+    write_lsp_message(stdin, exit_msg)
+    @test with_timeout(#=timeout=#DEFAULT_TIMEOUT, "Timeout waiting for the server to exit the loop") do elapsed
+        bytesavailable(stderr) > 0 || return nothing
+        log = String(readavailable(stderr))
+        occursin(JETLS.SERVER_LOOP_EXIT_MSG, log) || return nothing
+        return true
+    end
+    # @info "The server loop exited successfully"
+
+    @test with_timeout(#=timeout=#DEFAULT_TIMEOUT, "Timeout waiting for the server process to shutdown") do elapsed
+        process_running(proc) && return nothing
+        return true
+    end
+    @test process_exited(proc) && proc.exitcode == 1
+end
+
+end # module test_runserver


### PR DESCRIPTION
Add simple tests for the runserver.jl script.
These tests are somewhat hacky but also added timeouts to try to ensure that no dead processes remain when tests finish, even in a case when problems occur during execution.