### PR TITLE
LSP: correctly implement the `ResponseMessage.result` field

### DIFF
--- a/src/LSP/base-protocol.jl
+++ b/src/LSP/base-protocol.jl
@@ -201,7 +201,6 @@ end  # @namespace ErrorCodes
     data::Union{Any, Nothing} = nothing
 end
 
-# TODO Revisit this to correctly lower this struct
 """
 A Response Message sent as a result of a request.
 If a request doesn’t provide a result value the receiver of a request still needs to return
@@ -216,8 +215,12 @@ successful request.
     """
     The result of a request. This member is REQUIRED on success.
     This member MUST NOT exist if there was an error invoking the method.
+
+    This means that this field should be non-`nothing` on success (i.e. should be `null`
+    if nothing is specified to be returned as `result`),
+    and should be `nothing` on failure with `error` set to be non-`nothing`.
     """
-    result::Union{Any, Nothing} = nothing
+    result::Union{Any, Null, Nothing}
 
     "The error object in case a request fails."
     error::Union{ResponseError, Nothing} = nothing

--- a/src/LSP/language-features/diagnostics.jl
+++ b/src/LSP/language-features/diagnostics.jl
@@ -188,7 +188,7 @@ is asked to compute the diagnostics for the currently synced version of the docu
 end
 
 @interface DocumentDiagnosticResponse @extends ResponseMessage begin
-    result::Union{DocumentDiagnosticReport, Nothing} = nothing
+    result::Union{DocumentDiagnosticReport, Nothing}
 end
 
 """

--- a/src/LSP/lifecycle-messages/initialize.jl
+++ b/src/LSP/lifecycle-messages/initialize.jl
@@ -142,7 +142,7 @@ end
 end
 
 @interface InitializeResponse @extends ResponseMessage begin
-    result::Union{InitializeResult, Nothing} = nothing
+    result::Union{InitializeResult, Nothing}
     error::Union{InitializeResponseError, Nothing} = nothing
 end
 

--- a/src/LSP/lifecycle-messages/shutdown.jl
+++ b/src/LSP/lifecycle-messages/shutdown.jl
@@ -13,7 +13,6 @@ If a server receives requests after a shutdown request those requests should err
     method::String = "shutdown"
 end
 
-# TODO: Should this also have an `error::ErrorCodes.Ty` field?
 @interface ShutdownResponse @extends ResponseMessage begin
-    result::Union{Null, Nothing} = nothing
+    result::Union{Null, Nothing}
 end

--- a/test/test_runserver.jl
+++ b/test/test_runserver.jl
@@ -127,6 +127,7 @@ withserverprocess() do (; proc, stdin, stdout, stderr)
     shutdown_response === nothing &&
         error("No response received from server (may have terminated)")
     @test occursin("\"id\":2", shutdown_response)
+    @test occursin("\"result\":null", shutdown_response)
     # @info "Server responded to shutdown request"
 
     # Send exit notification


### PR DESCRIPTION
Currently, the `@interface` macro recognizes fields declared with a default value of `= nothing` as "nullable". This works fine in most cases, but causes issues when handling `ResponseMessage`.
```julia
@interface ResponseMessage @extends Message begin
    id::Union{Int, String, Nothing}
    result::Union{Any, Nothing} = nothing
    error::Union{ResponseError, Nothing} = nothing
end
```
According to the LSP specification, the `result` field must not be omitted on success, and even when there's nothing specific to return (like in `ShutdownResponse`), `null` must be explicitly returned.

Instead, `ResponseMessage.result` should not default to `nothing`, and the `result` field in general should be explicitly specified in all `ResponseMessage` instances.

This commit modifies the `@interface` macro to recognize fields as "omittable" only when their declared type includes `Nothing`. It also updates the definitions of `ResponseMessage` and other messages that `@extends` it accordingly.

Now the definition of `ResponseMessage` is:
```julia
"""
A Response Message sent as a result of a request.
If a request doesn’t provide a result value the receiver of a request still needs to return
a response message to conform to the JSON-RPC specification.
The result property of the ResponseMessage should be set to null in this case to signal a
successful request.
"""
@interface ResponseMessage @extends Message begin
    "The request id."
    id::Union{Int, String, Nothing}

    """
    The result of a request. This member is REQUIRED on success.
    This member MUST NOT exist if there was an error invoking the method.

    This means that this field should be non-`nothing` on success (i.e. should be `null`
    if nothing is specified to be returned as `result`),
    and should be `nothing` on failure with `error` set to be non-`nothing`.
    """
    result::Union{Any, Null, Nothing}

    "The error object in case a request fails."
    error::Union{ResponseError, Nothing} = nothing
end
```