### PR TITLE
disable `JETLS_DEV_MODE` by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,6 @@ jobs:
         with:
           version: "1.12-nightly" # most stable version
           arch: x64
-      - name: set `JETLS_DEV_MODE=false`
-        working-directory: .
-        run: |
-          echo '[JETLS]
-          JETLS_DEV_MODE = false' >> LocalPreferences.toml
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-buildpkg@latest
       - name: run test

--- a/README.md
+++ b/README.md
@@ -111,16 +111,28 @@ in development:
   each message handler, showing error messages and stack traces in the output
   panel
 
-You can control this setting through Preferences.jl's mechanism:
+You can configure `JETLS_DEV_MODE` using Preferences.jl:
 ```julia-repl
 julia> using Preferences
 
-julia> Preferences.set_preferences!("JETLS", "JETLS_DEV_MODE" => false; force=true) # disable the dev mode
+julia> Preferences.set_preferences!("JETLS", "JETLS_DEV_MODE" => true; force=true) # enable the dev mode
+```
+Alternatively, you can directly edit the LocalPreferences.toml file.
+
+While `JETLS_DEV_MODE` is disabled by default, we _strongly recommend enabling
+it during JETLS development_. For development work, we suggest creating the
+following LocalPreferences.toml file in the root directory of this repository:
+> LocalPreferences.toml
+```toml
+[JETLS] # enable the dev mode of JETLS
+JETLS_DEV_MODE = true
+
+[JET] # additionally, allow JET to be loaded on nightly
+JET_DEV_MODE = true
 ```
 
-`JETLS_DEV_MODE` is enabled by default when running the server at this moment of
-prototyping, but also note that this mode is always disabled during tests to
-ensure that internal errors are not suppressed by the additional `try`/`catch`
+Note that in tests, this mode is always disabled to ensure that internal errors
+are properly raised rather than being suppressed by the additional `try`/`catch`
 block (see [test/LocalPreferences.toml](./test/LocalPreferences.toml)).
 
 ### Dynamic Registration

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -8,9 +8,8 @@ function __init__()
     foreach(hook->hook(), __init__hooks__)
 end
 
-# TODO turn off `JETLS_DEV_MODE` by default when releasing
 using Preferences: Preferences
-const JETLS_DEV_MODE = Preferences.@load_preference("JETLS_DEV_MODE", true)
+const JETLS_DEV_MODE = Preferences.@load_preference("JETLS_DEV_MODE", false)
 push_init_hooks!() do
     @info "Running JETLS with" JETLS_DEV_MODE
 end


### PR DESCRIPTION
One of the issues with aviatesk/JETLS.jl#46 was that `JETLS_DEV_MODE` was enabled by default, while Revise wasn't installed in CI environments.

Initially I thought enabling dev mode by default would be convenient during the current phase of rapid prototyping, but it turns out that that can sometimes be a footgun. I'll now disable it by default, following standard package development practices.

Since `JETLS_DEV_MODE` is still very useful for development, I strongly recommend developers place this LocalPreferences.toml in the directory:
> LocalPreferences.toml
```toml
[JETLS] # enable the dev mode of JETLS
JETLS_DEV_MODE = true

[JET] # additionally, allow JET to be loaded on nightly
JET_DEV_MODE = true
```

cc @abap34 