### PR TITLE
LSP: automatically convert `::[DocumentUri|URI]` fields to `URIs2.URI`

### DIFF
--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -278,12 +278,12 @@ function handle_InitializeRequest(server::Server, msg::InitializeRequest)
     workspaceFolders = params.workspaceFolders
     if workspaceFolders !== nothing
         for workspaceFolder in workspaceFolders
-            push!(state.workspaceFolders, URI(workspaceFolder.uri))
+            push!(state.workspaceFolders, workspaceFolder.uri)
         end
     else
         rootUri = params.rootUri
         if rootUri !== nothing
-            push!(state.workspaceFolders, URI(rootUri))
+            push!(state.workspaceFolders, rootUri)
         else
             @warn "No workspaceFolders or rootUri in InitializeRequest - some functionality will be limited"
         end
@@ -383,7 +383,7 @@ function handle_DidOpenTextDocumentNotification(server::Server, msg::DidOpenText
     state = server.state
     textDocument = msg.params.textDocument
     @assert textDocument.languageId == "julia"
-    uri = URI(textDocument.uri)
+    uri = textDocument.uri
     filename = uri2filename(uri)
     @assert filename !== nothing "Unsupported URI: $uri"
     cache_file_info!(state, uri, textDocument.version, textDocument.text, filename)
@@ -420,7 +420,7 @@ end
 function handle_DidChangeTextDocumentNotification(server::Server, msg::DidChangeTextDocumentNotification)
     state = server.state
     (;textDocument,contentChanges) = msg.params
-    uri = URI(textDocument.uri)
+    uri = textDocument.uri
     for contentChange in contentChanges
         @assert contentChange.range === contentChange.rangeLength === nothing # since `change = TextDocumentSyncKind.Full`
     end
@@ -464,7 +464,7 @@ end
 function handle_DidCloseTextDocumentNotification(server::Server, msg::DidCloseTextDocumentNotification)
     state = server.state
     textDocument = msg.params.textDocument
-    uri = URI(textDocument.uri)
+    uri = textDocument.uri
     delete!(state.file_cache, uri)
     return nothing
 end

--- a/src/LSP/LSP.jl
+++ b/src/LSP/LSP.jl
@@ -1,6 +1,7 @@
 module LSP
 
 using StructTypes
+using ..URIs2: URI
 
 const exports = Set{Symbol}()
 const method_dispatcher = Dict{String,DataType}()

--- a/src/LSP/basic-json-structures.jl
+++ b/src/LSP/basic-json-structures.jl
@@ -1,8 +1,31 @@
 # URI
 # ===
 
-const DocumentUri = String
-const URI = String
+const __URI_DOC__ = """
+According to the LSP, any fields declared as `DocumentUri` and `URI` types
+(in the TypeScript definition) are:
+> Over the wire, it will still be transferred as a string, but this guarantees that
+> the contents of that string can be parsed as a valid URI.
+
+In actual language server implementations, the values of such `DocumentUri` and `URI` type
+fields are parsed and used as data structures representing URIs that comply with
+https://datatracker.ietf.org/doc/html/rfc3986,
+having `scheme`, `authority`, `path`, `query`, and `fragment` components.
+
+In JETLS, `URIs2.URI` corresponds to such a data structure.
+
+If we were to strictly adhere to the LSP definition, these fields should be defined as
+`String` type, and `DocumentUri` and `URI` should be aliases to `String`.
+However, in our Julia version of the LSP definition, for implementation simplicity, we
+automatically `convert` URI-representing fields to `URIs2.URI` during JSON3 parsing,
+allowing the language server to directly handle `URIs2.URI`.
+"""
+# const DocumentUri = String
+# const URI = String
+const DocumentUri = URI
+
+@doc __URI_DOC__ DocumentUri
+@doc __URI_DOC__ URI
 
 # Position
 # ========

--- a/src/URIs2/URIs2.jl
+++ b/src/URIs2/URIs2.jl
@@ -69,6 +69,8 @@ else
     end
 end
 
+Base.convert(::Type{URI}, s::AbstractString) = URI(s)
+
 function percent_decode(str::AbstractString)
     return unescapeuri(str)
 end

--- a/src/URIs2/uri_helpers.jl
+++ b/src/URIs2/uri_helpers.jl
@@ -44,11 +44,11 @@ function filename2uri(filename::String)
 end
 
 function filepath2uri(path::String)
-    isabspath(path) || error("Relative path `$path` is not valid.")
+    isabspath(path) || error("Non-absolute path `$path` is not supported.")
 
     path = normpath(path)
 
-    if Sys.iswindows()
+    @static if Sys.iswindows()
         path = replace(path, "\\" => "/")
     end
 

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -567,7 +567,7 @@ function get_completion_items(state::ServerState, uri::URI, params::CompletionPa
 end
 
 function handle_CompletionRequest(server::Server, msg::CompletionRequest)
-    uri = URI(msg.params.textDocument.uri)
+    uri = msg.params.textDocument.uri
     items = get_completion_items(server.state, uri, msg.params)
     return send(server,
         ResponseMessage(;

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -100,7 +100,7 @@ function jet_inference_error_report_to_diagnostic(postprocessor::JET.PostProcess
             message = postprocessor(sprint(JET.print_frame_sig, frame, JET.PrintConfig()))
             DiagnosticRelatedInformation(;
                 location = Location(;
-                    uri = string(filepath2uri(JET.tofullpath(String(frame.file)))),
+                    uri = filepath2uri(JET.tofullpath(String(frame.file))),
                     range = jet_frame_to_range(frame)),
                 message)
         end
@@ -145,7 +145,7 @@ function notify_diagnostics!(server::Server, uri2diagnostics)
     for (uri, diagnostics) in uri2diagnostics
         send(server, PublishDiagnosticsNotification(;
             params = PublishDiagnosticsParams(;
-                uri = string(uri),
+                uri,
                 # version = 0,
                 diagnostics)))
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -52,7 +52,7 @@ end
 Fetch cached FileInfo given an LSclient-provided structure with a URI
 """
 get_fileinfo(s::ServerState, uri::URI) = haskey(s.file_cache, uri) ? s.file_cache[uri] : nothing
-get_fileinfo(s::ServerState, t::TextDocumentIdentifier) = get_fileinfo(s, URI(t.uri))
+get_fileinfo(s::ServerState, t::TextDocumentIdentifier) = get_fileinfo(s, t.uri)
 
 # JuliaLowering uses byte offsets; LSP uses lineno and UTF-* character offset.
 # These functions do the conversion.

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -19,7 +19,7 @@ end
 function withserver(f;
                     capabilities::ClientCapabilities=ClientCapabilities(),
                     workspaceFolders::Union{Nothing,Vector{WorkspaceFolder}}=nothing,
-                    rootUri::Union{Nothing,String}=nothing)
+                    rootUri::Union{Nothing,URI}=nothing)
     in = Base.BufferStream()
     out = Base.BufferStream()
     received_queue = Channel{Any}(Inf)
@@ -38,10 +38,10 @@ function withserver(f;
     root_path = nothing
     if workspaceFolders !== nothing
         if isempty(workspaceFolders)
-            root_path = uri2filepath(URI(first(workspaceFolders).uri))
+            root_path = uri2filepath(first(workspaceFolders).uri)
         end
     elseif rootUri !== nothing
-        root_path = uri2filepath(URI(rootUri))
+        root_path = uri2filepath(rootUri)
     end
     if root_path === nothing
         Pkg.activate(; temp=true, io=devnull)

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -5,6 +5,7 @@ using JETLS
 using JETLS: JL, JS
 using JETLS: cursor_bindings, to_completion, CompletionItem, completion_is
 using JETLS.LSP
+using JETLS.URIs2
 
 function get_cursor_bindings(s::String, b::Int)
     ps = JS.ParseStream(s)
@@ -259,7 +260,7 @@ end
     @test length(curpos2) == 2
     pos1, pos2  = curpos2
     filename = abspath("foo.jl")
-    uri = JETLS.filename2uri(filename)
+    uri = filename2uri(filename)
     JETLS.cache_file_info!(state, uri, #=version=#1, text, filename)
     JETLS.initiate_context!(state, uri)
     let params = CompletionParams(;
@@ -301,8 +302,8 @@ end
 # completion for empty program should not crash
 @testset "empty completion" begin
     state = JETLS.ServerState()
-    filename = "empty.jl"
-    uri = JETLS.URI(filename)
+    filename = abspath("empty.jl")
+    uri = filename2uri(filename)
 
     let text = ""
         JETLS.cache_file_info!(state, uri, 1, text, filename)
@@ -314,7 +315,7 @@ end
         @test length(items) > 0
     end
 
-    let text = "\n \n \n"
+    let text = "\n\n\n"
         JETLS.cache_file_info!(state, uri, 2, text, filename)
         params = CompletionParams(;
             textDocument=TextDocumentIdentifier(string(uri)),
@@ -327,8 +328,8 @@ end
 
 @testset "macro completion" begin
     state = JETLS.ServerState()
-    filename = "filename.jl"
-    uri = JETLS.URI(filename)
+    filename = abspath("macro_completion.jl")
+    uri = filename2uri(filename)
 
     # `@`-mark should trigger completion of macro names
     let text = """
@@ -423,8 +424,8 @@ function test_backslash_offset(code::String, expected_result)
     @assert length(positions) == 1 "test_backslash_offset requires exactly one cursor marker"
 
     state = JETLS.ServerState()
-    filename = "test_backslash.jl"
-    uri = JETLS.URI(filename)
+    filename = abspath("test_backslash.jl")
+    uri = filename2uri(filename)
     JETLS.cache_file_info!(state, uri, 1, text, filename)
 
     result = JETLS.get_backslash_offset(state, uri, positions[1])
@@ -596,8 +597,8 @@ end
 
 @testset "Latex/emoji completion" begin
     state = JETLS.ServerState()
-    filename = "test_latex_emoji.jl"
-    uri = JETLS.URI(filename)
+    filename = abspath("test_latex_emoji.jl")
+    uri = filename2uri(filename)
 
     # `\`-mark should trigger latex completion
     let text = """

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -28,7 +28,7 @@ end
     """
 
     withscript(scriptcode) do script_path
-        uri = string(JETLS.URIs2.filepath2uri(script_path))
+        uri = JETLS.URIs2.filepath2uri(script_path)
         withserver() do (; writereadmsg, id_counter)
             (; raw_res) = writereadmsg(make_DidOpenTextDocumentNotification(uri, scriptcode))
 
@@ -55,7 +55,7 @@ end
 
     # Use withscript to create a temporary file and run the test
     withscript(scriptcode) do script_path
-        uri = string(JETLS.URIs2.filepath2uri(script_path))
+        uri = JETLS.URIs2.filepath2uri(script_path)
         withserver() do (; writereadmsg, id_counter)
             (; raw_res) = writereadmsg(make_DidOpenTextDocumentNotification(uri, scriptcode))
 
@@ -87,7 +87,7 @@ end
 
     # Use withscript to create a temporary file and run the test
     withscript(scriptcode) do script_path
-        uri = string(JETLS.URIs2.filepath2uri(script_path))
+        uri = JETLS.URIs2.filepath2uri(script_path)
         withserver() do (; writereadmsg, id_counter)
             (; raw_res) = writereadmsg(make_DidOpenTextDocumentNotification(uri, scriptcode))
 
@@ -130,9 +130,9 @@ end
     end # module TestPackageAnalysis
     """
     withpackage("TestPackageAnalysis", pkg_code) do pkg_path
-        rootUri = string(JETLS.URIs2.filepath2uri(pkg_path))
+        rootUri = JETLS.URIs2.filepath2uri(pkg_path)
         src_path = normpath(pkg_path, "src", "TestPackageAnalysis.jl")
-        uri = string(JETLS.URIs2.filepath2uri(src_path))
+        uri = JETLS.URIs2.filepath2uri(src_path)
         withserver(; rootUri) do (; writereadmsg, id_counter)
             (; raw_res) = writereadmsg(make_DidOpenTextDocumentNotification(uri, read(src_path, String)))
 

--- a/test/test_full_lifecycle.jl
+++ b/test/test_full_lifecycle.jl
@@ -73,7 +73,7 @@ let (pkgcode, positions) = get_text_and_positions("""
             end
         end
 
-        rootUri = string(JETLS.URIs2.filepath2uri(pkgpath))
+        rootUri = JETLS.URIs2.filepath2uri(pkgpath)
 
         # test clients that give workspaceFolders
         let workspaceFolders = [WorkspaceFolder(; uri=rootUri, name="TestFullLifecycle")]


### PR DESCRIPTION
According to the LSP, any fields declared as `DocumentUri` and `URI` types (in the TypeScript definition) are:
> Over the wire, it will still be transferred as a string, but this guarantees that
> the contents of that string can be parsed as a valid URI.

In actual language server implementations, the values of such `DocumentUri` and `URI` type fields are parsed and used as data structures representing URIs that comply with https://datatracker.ietf.org/doc/html/rfc3986,
having `scheme`, `authority`, `path`, `query`, and `fragment` components.

In JETLS, `URIs2.URI` corresponds to such a data structure.

If we were to strictly adhere to the LSP definition, these fields should be defined as `String` type, and `DocumentUri` and `URI` should be aliases to `String`. However, in our Julia version of the LSP definition, for implementation simplicity, we automatically `convert` URI-representing fields to `URIs2.URI` during JSON3 parsing, allowing the language server to directly handle `URIs2.URI`.

---

/cc @pfitzseb Can I hear your thought on this?