### PR TITLE
allow method lines appearing in signature help jumpable

### DIFF
--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -317,7 +317,7 @@ function handle_InitializeRequest(server::Server, msg::InitializeRequest)
         # leave Refs undefined
     end
 
-    if getpath(params.capabilities,
+    if getobjpath(params.capabilities,
         :textDocument, :completion, :dynamicRegistration) !== true
         completionProvider = completion_options()
         if JETLS_DEV_MODE
@@ -327,7 +327,7 @@ function handle_InitializeRequest(server::Server, msg::InitializeRequest)
         completionProvider = nothing # will be registered dynamically
     end
 
-    if getpath(params.capabilities,
+    if getobjpath(params.capabilities,
         :textDocument, :signatureHelp, :dynamicRegistration) !== true
         signatureHelpProvider = signature_help_options()
         if JETLS_DEV_MODE
@@ -371,7 +371,7 @@ function handle_InitializedNotification(server::Server)
 
     registrations = Registration[]
 
-    if getpath(state.init_params.capabilities,
+    if getobjpath(state.init_params.capabilities,
         :textDocument, :completion, :dynamicRegistration) === true
         push!(registrations, completion_registration())
         if JETLS_DEV_MODE
@@ -383,7 +383,7 @@ function handle_InitializedNotification(server::Server)
         # since `CompletionRegistrationOptions` does not extend `StaticRegistrationOptions`.
     end
 
-    if getpath(state.init_params.capabilities,
+    if getobjpath(state.init_params.capabilities,
         :textDocument, :signatureHelp, :dynamicRegistration) === true
         push!(registrations, signature_help_registration())
         if JETLS_DEV_MODE

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -46,7 +46,7 @@ function jet_result_to_diagnostics!(uri2diagnostics::Dict{URI,Vector{Diagnostic}
         if startswith(filename, "Untitled")
             uri = filename2uri(filename)
         else
-            uri = filepath2uri(JET.tofullpath(filename))
+            uri = filepath2uri(to_full_path(filename))
         end
         push!(uri2diagnostics[uri], diagnostic)
     end
@@ -63,7 +63,7 @@ function jet_result_to_diagnostics!(uri2diagnostics::Dict{URI,Vector{Diagnostic}
         if startswith(filename, "Untitled")
             uri = filename2uri(filename)
         else
-            uri = filepath2uri(JET.tofullpath(filename))
+            uri = filepath2uri(to_full_path(filename))
         end
         push!(uri2diagnostics[uri], diagnostic)
     end
@@ -100,7 +100,7 @@ function jet_inference_error_report_to_diagnostic(postprocessor::JET.PostProcess
             message = postprocessor(sprint(JET.print_frame_sig, frame, JET.PrintConfig()))
             DiagnosticRelatedInformation(;
                 location = Location(;
-                    uri = filepath2uri(JET.tofullpath(String(frame.file))),
+                    uri = filepath2uri(to_full_path(frame.file)),
                     range = jet_frame_to_range(frame)),
                 message)
         end

--- a/test/test_signature_help.jl
+++ b/test/test_signature_help.jl
@@ -210,13 +210,15 @@ include("setup.jl")
                     siginfo.label == "foo(xxx)" &&
                     # this also tests that JETLS doesn't show the nonsensical `var"..."`
                     # string caused by JET's internal details
-                    occursin("@ Main $(script_path):1", siginfo.documentation)
+                    occursin("@ `Main` [$(script_path):1]($(filepath2uri(script_path))#L1)",
+                        (siginfo.documentation::MarkupContent).value)
                 end
                 @test any(raw_res.result.signatures) do siginfo
                     siginfo.label == "foo(xxx, yyy)" &&
                     # this also tests that JETLS doesn't show the nonsensical `var"..."`
                     # string caused by JET's internal details
-                    occursin("@ Main $(script_path):2", siginfo.documentation)
+                    occursin("@ `Main` [$(script_path):2]($(filepath2uri(script_path))#L2)",
+                        (siginfo.documentation::MarkupContent).value)
                 end
             end
         end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -50,4 +50,16 @@ end
     end
 end
 
+@testset "to_full_path" begin
+    m = only(methods(sin,(Float64,)))
+    file, line = Base.updated_methodloc(m)
+    filepath = JETLS.to_full_path(file)
+    @test isabspath(filepath) && isfile(filepath)
+end
+@testset "create_source_location_link" begin
+    @test JETLS.create_source_location_link("/path/to/file.jl") == "[/path/to/file.jl](file:///path/to/file.jl)"
+    @test JETLS.create_source_location_link("/path/to/file.jl", line=42) == "[/path/to/file.jl:42](file:///path/to/file.jl#L42)"
+    @test JETLS.create_source_location_link("/path/to/file.jl", line=42, character=10) == "[/path/to/file.jl:42](file:///path/to/file.jl#L42C10)"
+end
+
 end # module test_utils


### PR DESCRIPTION
This is not explicitly stated in the LSP specification, but most clients seem to support URI links in the format of
`"[show text](file://path#L#C)"`,
so let's use this to make the method line information displayed in signature help jumpable.