### PR TITLE
fix filtering ambiguity in LaTeX and emoji completion

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -439,6 +439,7 @@ function add_emoji_latex_completions!(items::Dict{String,CompletionItem}, state:
             kind=CompletionItemKind.Snippet,
             documentation=val,
             sortText,
+            filterText = key,
             textEdit=TextEdit(;
                 range = Range(;
                     start = backslash_pos,


### PR DESCRIPTION
Some clients (e.g., VSCode) seem to discard completion items when filterText is not explicitly set and the beginning of the label does not match the current input.

This change explicitly sets `filterText`, and I have confirmed that it works both in VSCode and in editors where it previously worked.