### PR TITLE
diagnostics: separate syntactic and full analysis

### DIFF
--- a/src/definition.jl
+++ b/src/definition.jl
@@ -1,6 +1,6 @@
 using .JS
 
-const DEFINITION_REGISTRATION_ID = "textDocument-definition"
+const DEFINITION_REGISTRATION_ID = "jetls-definition"
 const DEFINITION_REGISTRATION_METHOD = "textDocument/definition"
 
 function definition_options()
@@ -25,7 +25,7 @@ end
 
 # TODO: memorize this?
 is_definition_links_supported(server::Server) =
-        getobjpath(server.state.init_params.capabilities,
+    getobjpath(server.state.init_params.capabilities,
         :textDocument, :definition, :linkSupport) === true
 
 """

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -347,8 +347,8 @@ function cursor_siginfos(mod::Module, ps::JS.ParseStream, b::Int, analyzer::LSAn
 end
 
 """
-textDocument/signatureHelp is requested when one of the negotiated trigger
-characters is typed.  Eglot (emacs) requests it more frequently.
+`textDocument/signatureHelp` is requested when one of the negotiated trigger characters is typed.
+Some clients, e.g. Eglot (emacs), requests it more frequently.
 """
 function handle_SignatureHelpRequest(server::Server, msg::SignatureHelpRequest)
     state = server.state


### PR DESCRIPTION
This commit fixes poor diagnostics UX where syntax errors don't disappear immediately and JET analysis blocks real-time features like completion.

The issue was that both lightweight syntactic analysis and heavy JET-based full analysis ran on every `textDocument/didChange` notification. When full analysis took too long, it blocked subsequent request processing.

This commit separates the two analysis types:

- Syntactic analysis: Runs on `textDocument/diagnostic` requests and returns results via pull model diagnostics. This provides real-time feedback for syntax errors.
- Full analysis: Runs only on `textDocument/didSave` notifications and publishes results via `textDocument/publishDiagnostics` (push model). This prevents blocking during active editing.

This approach ensures syntactic diagnostics update in real-time while full analysis happens on save, similar to when rust-analyzer runs `cargo build` analysis. LSP features like completion remain responsive even during active editing.

Using different diagnostic models (pull for syntactic, push for full) has an additional benefit: it avoids complex line number adjustments when new syntactic diagnostics appear after full diagnostics are published. The client handles line number updates reasonably well in most cases, eliminating the need for manual incremental adjustments on the server side.

---

- removed no longer necessary `IncludeCallback`
- removed no longer necessary `last_analysis` field
- run syntactic analysis with `textDocument/diagnostic`
- fixed up test cases