### PR TITLE
support Go to Definition at the right edge of identifiers

### DIFF
--- a/src/definition.jl
+++ b/src/definition.jl
@@ -41,6 +41,11 @@ refs: https://github.com/rust-lang/rust-analyzer/blob/6acff6c1f8306a0a1d29be8fd1
 function select_target_node(st::JL.SyntaxTree, offset::Int)
     bas = byte_ancestors(st, offset)
 
+    # Support cases like `var│`, `func│(5)` 
+    if length(bas) == 1 || kind(first(bas)) == K"call" && offset > 0
+        bas = byte_ancestors(st, offset - 1)
+    end
+
     (kind(first(bas)) !== K"Identifier") && return nothing
 
     for i in 2:length(bas)

--- a/test/test_definition.jl
+++ b/test/test_definition.jl
@@ -121,6 +121,12 @@ include("setup.jl")
     #=44=#     println("\$s, \$(hello.who)")
     #=45=# end
     #=46=# say_kwar│g
+    #=47=#
+    #=48=# func│(1.0)
+    #=49=# func(│1.0)
+    #=50=# │func(1.0)
+    #=51=# M.m_func│(1.0)
+    #=52=# M.│m_func(1.0)
     """
 
     sin_cand_file, sin_cand_line = functionloc(first(methods(sin, (Float64,))))
@@ -204,6 +210,33 @@ include("setup.jl")
             (length(result) == 1) && # aggregation
             (first(result).uri == uri) &&
             (first(result).range.start.line == 42)
+
+        # func│(1.0)
+        (result, uri) ->
+            (length(result) == 1) &&
+            (first(result).uri == uri) &&
+            (first(result).range.start.line == 0)
+
+        # func(│1.0)
+        (result, uri) -> (result === null)
+
+        # │func(1.0)
+        (result, uri) ->
+            (length(result) == 1) &&
+            (first(result).uri == uri) &&
+            (first(result).range.start.line == 0)
+
+        # M.m_func│(1.0)
+        (result, uri) ->
+            (length(result) == 1) &&
+            (first(result).uri == uri) &&
+            (first(result).range.start.line == 11)
+
+        # M.│m_func(1.0)
+        (result, uri) ->
+            (length(result) == 1) &&
+            (first(result).uri == uri) &&
+            (first(result).range.start.line == 11)
     ]
 
     clean_code, positions = get_text_and_positions(script_code, r"│")


### PR DESCRIPTION
Go to Definition now works even when the cursor is placed just after an identifier, like:

```
func│(x)
```

If there's nothing suitable to the right of the cursor, the position just to the left (i.e., the right edge of `offset - 1`) is also checked.
