### PR TITLE
LSInterpreter: sync file cache to `textDocument/didSave`

### DIFF
--- a/src/Analysis/Interpreter.jl
+++ b/src/Analysis/Interpreter.jl
@@ -3,20 +3,20 @@ module Interpreter
 export LSInterpreter
 
 using JET: JET
-using ..JETLS: AnalysisEntry, FileInfo, ServerState
+using ..JETLS: AnalysisEntry, SavedFileInfo, ServerState
 using ..JETLS.URIs2
 using ..JETLS.Analyzer
 
 struct LSInterpreter <: JET.ConcreteInterpreter
-    file_cache::Dict{URI,FileInfo}
+    file_cache::Dict{URI,SavedFileInfo}
     analyzer::LSAnalyzer
     state::JET.InterpretationState
-    LSInterpreter(file_cache::Dict{URI,FileInfo}, analyzer::LSAnalyzer) = new(file_cache, analyzer)
-    LSInterpreter(file_cache::Dict{URI,FileInfo}, analyzer::LSAnalyzer, state::JET.InterpretationState) = new(file_cache, analyzer, state)
+    LSInterpreter(file_cache::Dict{URI,SavedFileInfo}, analyzer::LSAnalyzer) = new(file_cache, analyzer)
+    LSInterpreter(file_cache::Dict{URI,SavedFileInfo}, analyzer::LSAnalyzer, state::JET.InterpretationState) = new(file_cache, analyzer, state)
 end
 
 # The main constructor
-LSInterpreter(state::ServerState, entry::AnalysisEntry) = LSInterpreter(state.file_cache, LSAnalyzer(entry))
+LSInterpreter(state::ServerState, entry::AnalysisEntry) = LSInterpreter(state.saved_file_cache, LSAnalyzer(entry))
 
 # `JET.ConcreteInterpreter` interface
 JET.InterpretationState(interp::LSInterpreter) = interp.state
@@ -33,7 +33,7 @@ JET.ToplevelAbstractAnalyzer(interp::LSInterpreter) = interp.analyzer
 function JET.try_read_file(interp::LSInterpreter, include_context::Module, filepath::AbstractString)
     uri = filepath2uri(filepath)
     if haskey(interp.file_cache, uri)
-        return interp.file_cache[uri].text # TODO use `parsed` instead of `text`?
+        return interp.file_cache[uri].text # TODO use `parsed_stream` instead of `text`?
     end
     # fallback to the default file-system-based include
     return read(filepath, String)

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -43,6 +43,12 @@ struct FileInfo
     parsed_stream::JS.ParseStream
 end
 
+struct SavedFileInfo
+    text::String
+    filename::String
+    parsed_stream::JS.ParseStream
+end
+
 entryuri(entry::AnalysisEntry) = entryuri_impl(entry)::URI
 
 struct ScriptAnalysisEntry <: AnalysisEntry
@@ -95,7 +101,8 @@ end
 
 mutable struct ServerState
     const workspaceFolders::Vector{URI}
-    const file_cache::Dict{URI,FileInfo} # syntactic analysis cache
+    const file_cache::Dict{URI,FileInfo} # syntactic analysis cache (synced with `textDocument/didChange`)
+    const saved_file_cache::Dict{URI,SavedFileInfo} # syntactic analysis cache (synced with `textDocument/didSave`)
     const contexts::Dict{URI,Union{Set{AnalysisContext},ExternalContext}} # entry points for the full analysis (currently not cached really)
     const currently_registered::Set{Registered}
     root_path::String
@@ -106,6 +113,7 @@ mutable struct ServerState
         return new(
             URI[],
             Dict{URI,FileInfo}(),
+            Dict{URI,SavedFileInfo}(),
             Dict{URI,Union{Set{AnalysisContext},ExternalContext}}(),
             Set{Registered}(),
         )
@@ -384,7 +392,7 @@ function handle_InitializeRequest(server::Server, msg::InitializeRequest)
                 openClose = true,
                 change = TextDocumentSyncKind.Full,
                 save = SaveOptions(;
-                    includeText = false)),
+                    includeText = true)),
             completionProvider,
             signatureHelpProvider,
             definitionProvider,
@@ -472,6 +480,18 @@ function parsefile(version::Int, text::String, filename::String)
     return FileInfo(version, text, filename, stream)
 end
 
+function cache_saved_file_info!(state::ServerState, uri::URI, text::String, filename::String)
+    return cache_saved_file_info!(state, uri, parsesavedfile(text, filename))
+end
+function cache_saved_file_info!(state::ServerState, uri::URI, file_info::SavedFileInfo)
+    return state.saved_file_cache[uri] = file_info
+end
+function parsesavedfile(text::String, filename::String)
+    stream = JS.ParseStream(text)
+    JS.parse!(stream; rule=:all)
+    return SavedFileInfo(text, filename, stream)
+end
+
 const FULL_ANALYSIS_THROTTLE = 3.0
 const FULL_ANALYSIS_DEBOUNCE = 1.0
 const SYNTACTIC_ANALYSIS_DEBOUNCE = 0.5
@@ -520,7 +540,8 @@ function handle_DidOpenTextDocumentNotification(server::Server, msg::DidOpenText
     @assert filename !== nothing "Unsupported URI: $uri"
 
     state = server.state
-    file_info = cache_file_info!(state, uri, textDocument.version, textDocument.text, filename)
+    cache_file_info!(state, uri, textDocument.version, textDocument.text, filename)
+    cache_saved_file_info!(state, uri, textDocument.text, filename)
 
     run_full_analysis!(server, uri; reanalyze=false)
 end
@@ -540,26 +561,39 @@ end
 
 function handle_DidSaveTextDocumentNotification(server::Server, msg::DidSaveTextDocumentNotification)
     uri = msg.params.textDocument.uri
-    if !haskey(server.state.file_cache, uri)
+    if !haskey(server.state.saved_file_cache, uri)
         # Some language client implementations (in this case Zed) appear to be
         # sending `textDocument/didSave` notifications for arbitrary text documents,
         # so we add a save guard for such cases.
         JETLS_DEV_MODE && @warn "Received textDocument/didSave for unopened or unsupported document" uri
         return nothing
     end
+    text = msg.params.text
+    if !(text isa String)
+        @warn """
+        The client is not respecting the `capabilities.textDocumentSync.save.includeText`
+        option specified by this server during initialization. Without the document text
+        content in save notifications, the diagnostics feature cannot function properly.
+        """
+        return nothing
+    end
+    filename = uri2filename(uri)
+    @assert filename !== nothing "Unsupported URI: $uri"
+    cache_saved_file_info!(server.state, uri, text, filename)
     run_full_analysis!(server, uri; reanalyze=true)
 end
 
 function handle_DidCloseTextDocumentNotification(server::Server, msg::DidCloseTextDocumentNotification)
     delete!(server.state.file_cache, msg.params.textDocument.uri)
+    delete!(server.state.saved_file_cache, msg.params.textDocument.uri)
     nothing
 end
 
 function analyze_parsed_if_exist(state::ServerState, entry::AnalysisEntry, args...;
                                  toplevel_logger = nothing, kwargs...)
     uri = entryuri(entry)
-    if haskey(state.file_cache, uri)
-        file_info = state.file_cache[uri]
+    if haskey(state.saved_file_cache, uri)
+        file_info = state.saved_file_cache[uri]
         parsed_stream = file_info.parsed_stream
         filename = uri2filename(uri)::String
         parsed = JS.build_tree(JS.SyntaxNode, parsed_stream; filename)
@@ -712,7 +746,7 @@ function find_package_directory(path::String, env_path::String)
 end
 
 function initiate_context!(state::ServerState, uri::URI)
-    file_info = state.file_cache[uri]
+    file_info = state.saved_file_cache[uri]
     parsed_stream = file_info.parsed_stream
     if !isempty(parsed_stream.diagnostics)
         return nothing
@@ -823,8 +857,8 @@ function reanalyze_with_context!(state::ServerState, analysis_context::AnalysisC
     end
 
     any_parse_failed = any(analyzed_file_uris(analysis_context)) do uri::URI
-        if haskey(state.file_cache, uri)
-            file_info = state.file_cache[uri]
+        if haskey(state.saved_file_cache, uri)
+            file_info = state.saved_file_cache[uri]
             if !isempty(file_info.parsed_stream.diagnostics)
                 return true
             end

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -262,6 +262,7 @@ end
     filename = abspath("foo.jl")
     uri = filename2uri(filename)
     JETLS.cache_file_info!(state, uri, #=version=#1, text, filename)
+    JETLS.cache_saved_file_info!(state, uri, text, filename)
     JETLS.initiate_context!(state, uri)
     let params = CompletionParams(;
             textDocument=TextDocumentIdentifier(; uri),


### PR DESCRIPTION
Since aviatesk/JETLS.jl#73, the full analysis is synced to `textDocument/didSave`, so the file cache used by `LSInterpreter` also needs to be synced to that notification.

With this change, even if the user continues editing after saving, as long as the last saved state is valid, the full analysis will be performed appropriately.

The downside of this approach is that `ServerState` will manage two separate file caches, which may introduce code complexity, but that's probably unavoidable.

Related to this, in the future we will also need to properly update `server.state.successfully_analyzed_file_infos` in response to `textDocument/didChange` (for more accurate definition and completion), but we'll leave that as a future task.