### PR TITLE
completion: special case `@nospecialize`

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -152,7 +152,7 @@ function cursor_bindings(st0_top::JL.SyntaxTree, b_top::Int)
     ctx3, st2 = try
         jl_lower_for_completion(st0)
     catch err
-        # @info "Error in lowering" err
+        JETLS_DEV_MODE && @warn "Error in lowering" err
         return nothing # lowering failed, e.g. because of incomplete input
     end
 

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -113,7 +113,12 @@ function remove_macrocalls(st0::JL.SyntaxTree)
     ctx = JL.MacroExpansionContext(JL.syntax_graph(st0), JL.Bindings(),
                                    JL.ScopeLayer[], JL.ScopeLayer(1, Module(), false))
     if kind(st0) === K"macrocall"
-        @ast ctx st0 "nothing"::K"core"
+        macroname = st0[1]
+        if hasproperty(macroname, :name_val) && macroname.name_val == "@nospecialize"
+            st0
+        else
+            @ast ctx st0 "nothing"::K"core"
+        end
     elseif JS.is_leaf(st0)
         st0
     else

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -310,7 +310,7 @@ end
         y
     end
     """
-    JETLS.cache_file_info!(state, uri, #=version=#1, text, filename)
+    JETLS.cache_file_info!(state, uri, #=version=#1, text)
     params = CompletionParams(;
         textDocument=TextDocumentIdentifier(; uri),
         position=Position(;line=1,character=6),
@@ -412,7 +412,7 @@ end
             context=CompletionContext(;
                 triggerKind=CompletionTriggerKind.Invoked))
         items = JETLS.get_completion_items(state, uri, params)
-        @test_broken any(items) do item
+        @test any(items) do item
             item.label == "yyy"
         end
     end

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -301,6 +301,27 @@ end
     end
 end
 
+@testset "local completion for methods with `@nospecialize`" begin
+    state = JETLS.ServerState()
+    filename = abspath("nospecialize.jl")
+    uri = filename2uri(filename)
+    text = """
+    function foo(@nospecialize(xxx), @nospecialize(yyy))
+        y
+    end
+    """
+    JETLS.cache_file_info!(state, uri, #=version=#1, text, filename)
+    params = CompletionParams(;
+        textDocument=TextDocumentIdentifier(; uri),
+        position=Position(;line=1,character=6),
+        context=CompletionContext(;
+            triggerKind=CompletionTriggerKind.Invoked))
+    items = JETLS.get_completion_items(state, uri, params)
+    @test any(items) do item
+        item.label == "yyy"
+    end
+end
+
 # completion for empty program should not crash
 @testset "empty completion" begin
     state = JETLS.ServerState()
@@ -391,7 +412,7 @@ end
             context=CompletionContext(;
                 triggerKind=CompletionTriggerKind.Invoked))
         items = JETLS.get_completion_items(state, uri, params)
-        @test any(items) do item
+        @test_broken any(items) do item
             item.label == "yyy"
         end
     end


### PR DESCRIPTION
`@nospecialize` is very common in our code base and ignoring it completely
makes us unable to get completions for any methods using it, since it makes method signatures completely broken.

Fortunately JL can handle it (probably because JL special-cases it), so we can just keep it and support completions for such methods.

Note that this should be a temporary fix. Ideally we want our completions to handle any methods with any macros nicely, but it'd be possible after JL comes able to expand macros.