### PR TITLE
use temporary combined JL branch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [sources]
 JET = { rev = "master", url = "https://github.com/aviatesk/JET.jl" }
-JuliaLowering = { rev = "fix-nightly", url = "https://github.com/mlechu/JuliaLowering.jl" }
+JuliaLowering = { rev = "avi/JETLS", url = "https://github.com/aviatesk/JuliaLowering.jl" }
 JuliaSyntax = { rev = "eceaa39", url = "https://github.com/JuliaLang/JuliaSyntax.jl" }
 
 [compat]


### PR DESCRIPTION
Use the `aviatesk/JuliaLowering.jl#avi/JETLS` branch which combines the following JL branches:
- [`mlechu:fix-nightly`](https://github.com/c42f/JuliaLowering.jl/pull/10)
- [`aviatesk:avi/precompile`](https://github.com/c42f/JuliaLowering.jl/pull/14)

This is a temporary solution until these branches are merged into JL#master.

This enables JL precompilation and significantly improves JETLS startup time (even when JETLS `precompile_workload` is set to `false`).