### PR TITLE
rename `AnalysisContext` to `AnalysisUnit`

### DIFF
--- a/src/analysis/resolver.jl
+++ b/src/analysis/resolver.jl
@@ -19,7 +19,7 @@ end
 ```
 
 For this reason, significant changes are expected in the near future.
-Specifically, `AnalysisContext` will store type inference results for each method analyzed by `LSAnalyzer`,
+Specifically, `AnalysisUnit` will store type inference results for each method analyzed by `LSAnalyzer`,
 and `resolve_type` will be implemented as a query against these type inference results.
 However, this implementation requires JL to be able to lower arbitrary user code,
 which first requires integration of JL into Base.

--- a/src/definition.jl
+++ b/src/definition.jl
@@ -86,8 +86,8 @@ function definition_target_methods(state::ServerState, uri::URI, pos::Position, 
     node === nothing && return empty_methods
 
     mod = find_file_module(state, uri, pos)
-    context = find_context_for_uri(state, uri)
-    analyzer = isnothing(context) ? LSAnalyzer(uri) : context.result.analyzer
+    analysis_unit = find_analysis_unit_for_uri(state, uri)
+    analyzer = isnothing(analysis_unit) ? LSAnalyzer(uri) : analysis_unit.result.analyzer
     objtyp = resolve_type(analyzer, mod, node)
     objtyp isa Core.Const || return empty_methods
 

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -127,13 +127,13 @@ end
 
 function notify_full_diagnostics!(server::Server)
     uri2diagnostics = Dict{URI,Vector{Diagnostic}}()
-    for (uri, contexts) in server.state.contexts
-        if contexts isa ExternalContext
+    for (uri, analysis_units) in server.state.analysis_units
+        if analysis_units isa ExternalUnit
             continue
         end
         diagnostics = get!(Vector{Diagnostic}, uri2diagnostics, uri)
-        for analysis_context in contexts
-            full_diagnostics = get(analysis_context.result.uri2diagnostics, uri, nothing)
+        for analysis_unit in analysis_units
+            full_diagnostics = get(analysis_unit.result.uri2diagnostics, uri, nothing)
             if full_diagnostics !== nothing
                 append!(diagnostics, full_diagnostics)
             end

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -127,12 +127,12 @@ end
 
 function notify_full_diagnostics!(server::Server)
     uri2diagnostics = Dict{URI,Vector{Diagnostic}}()
-    for (uri, analysis_units) in server.state.analysis_units
-        if analysis_units isa ExternalUnit
+    for (uri, analysis_info) in server.state.analysis_cache
+        if analysis_info isa OutOfScope
             continue
         end
         diagnostics = get!(Vector{Diagnostic}, uri2diagnostics, uri)
-        for analysis_unit in analysis_units
+        for analysis_unit in analysis_info
             full_diagnostics = get(analysis_unit.result.uri2diagnostics, uri, nothing)
             if full_diagnostics !== nothing
                 append!(diagnostics, full_diagnostics)

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -362,9 +362,9 @@ function handle_SignatureHelpRequest(server::Server, msg::SignatureHelpRequest)
                 error = file_cache_error(uri)))
     end
     mod = find_file_module(state, uri, msg.params.position)
-    context = find_context_for_uri(state, uri)
-    postprocessor = JET.PostProcessor(isnothing(context) ? nothing : context.result.actual2virtual)
-    analyzer = isnothing(context) ? LSAnalyzer(uri) : context.result.analyzer
+    analysis_unit = find_analysis_unit_for_uri(state, uri)
+    postprocessor = JET.PostProcessor(isnothing(analysis_unit) ? nothing : analysis_unit.result.actual2virtual)
+    analyzer = isnothing(analysis_unit) ? LSAnalyzer(uri) : analysis_unit.result.analyzer
     b = xy_to_offset(fi, msg.params.position)
     signatures = cursor_siginfos(mod, fi.parsed_stream, b, analyzer; postprocessor)
     activeSignature = nothing

--- a/src/types.jl
+++ b/src/types.jl
@@ -62,7 +62,9 @@ function successfully_analyzed_file_info(analysis_unit::AnalysisUnit, uri::URI)
     return get(analysis_unit.result.successfully_analyzed_file_infos, uri, nothing)
 end
 
-struct ExternalUnit end
+struct OutOfScope end
+
+const AnalysisInfo = Union{Set{AnalysisUnit},OutOfScope}
 
 abstract type RequestCaller end
 
@@ -81,7 +83,7 @@ mutable struct ServerState
     const workspaceFolders::Vector{URI}
     const file_cache::Dict{URI,FileInfo} # syntactic analysis cache (synced with `textDocument/didChange`)
     const saved_file_cache::Dict{URI,SavedFileInfo} # syntactic analysis cache (synced with `textDocument/didSave`)
-    const analysis_units::Dict{URI,Union{Set{AnalysisUnit},ExternalUnit}} # entry points for the full analysis (currently not cached really)
+    const analysis_cache::Dict{URI,AnalysisInfo} # entry points for the full analysis (currently not cached really)
     const currently_requested::Dict{String,RequestCaller}
     const currently_registered::Set{Registered}
     root_path::String
@@ -93,7 +95,7 @@ mutable struct ServerState
             #=workspaceFolders=# URI[],
             #=file_cache=# Dict{URI,FileInfo}(),
             #=saved_file_cache=# Dict{URI,SavedFileInfo}(),
-            #=analysis_units=# Dict{URI,Union{Set{AnalysisUnit},ExternalUnit}}(),
+            #=analysis_cache=# Dict{URI,AnalysisInfo}(),
             #=currently_requested=# Dict{String,RequestCaller}(),
             #=currently_registered=# Set{Registered}(),
         )

--- a/src/types.jl
+++ b/src/types.jl
@@ -51,18 +51,18 @@ mutable struct FullAnalysisResult
     const successfully_analyzed_file_infos::Dict{URI,JET.AnalyzedFileInfo}
 end
 
-struct AnalysisContext
+struct AnalysisUnit
     entry::AnalysisEntry
     result::FullAnalysisResult
 end
 
-analyzed_file_uris(context::AnalysisContext) = keys(context.result.analyzed_file_infos)
+analyzed_file_uris(analysis_unit::AnalysisUnit) = keys(analysis_unit.result.analyzed_file_infos)
 
-function successfully_analyzed_file_info(context::AnalysisContext, uri::URI)
-    return get(context.result.successfully_analyzed_file_infos, uri, nothing)
+function successfully_analyzed_file_info(analysis_unit::AnalysisUnit, uri::URI)
+    return get(analysis_unit.result.successfully_analyzed_file_infos, uri, nothing)
 end
 
-struct ExternalContext end
+struct ExternalUnit end
 
 abstract type RequestCaller end
 
@@ -81,7 +81,7 @@ mutable struct ServerState
     const workspaceFolders::Vector{URI}
     const file_cache::Dict{URI,FileInfo} # syntactic analysis cache (synced with `textDocument/didChange`)
     const saved_file_cache::Dict{URI,SavedFileInfo} # syntactic analysis cache (synced with `textDocument/didSave`)
-    const contexts::Dict{URI,Union{Set{AnalysisContext},ExternalContext}} # entry points for the full analysis (currently not cached really)
+    const analysis_units::Dict{URI,Union{Set{AnalysisUnit},ExternalUnit}} # entry points for the full analysis (currently not cached really)
     const currently_requested::Dict{String,RequestCaller}
     const currently_registered::Set{Registered}
     root_path::String
@@ -93,7 +93,7 @@ mutable struct ServerState
             #=workspaceFolders=# URI[],
             #=file_cache=# Dict{URI,FileInfo}(),
             #=saved_file_cache=# Dict{URI,SavedFileInfo}(),
-            #=contexts=# Dict{URI,Union{Set{AnalysisContext},ExternalContext}}(),
+            #=analysis_units=# Dict{URI,Union{Set{AnalysisUnit},ExternalUnit}}(),
             #=currently_requested=# Dict{String,RequestCaller}(),
             #=currently_registered=# Set{Registered}(),
         )

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -27,9 +27,9 @@ function find_file_module!(state::ServerState, uri::URI, pos::Position)
     return mod
 end
 function find_file_module(state::ServerState, uri::URI, pos::Position)
-    context = find_context_for_uri(state, uri)
-    context === nothing && return Main
-    safi = successfully_analyzed_file_info(context, uri)
+    analysis_unit = find_analysis_unit_for_uri(state, uri)
+    analysis_unit === nothing && return Main
+    safi = successfully_analyzed_file_info(analysis_unit, uri)
     isnothing(safi) && return Main
     curline = Int(pos.line) + 1
     curmod = Main
@@ -40,17 +40,17 @@ function find_file_module(state::ServerState, uri::URI, pos::Position)
     return curmod
 end
 
-function find_context_for_uri(state::ServerState, uri::URI)
-    haskey(state.contexts, uri) || return nothing
-    contexts = state.contexts[uri]
-    contexts isa ExternalContext && return nothing
-    context = first(contexts)
-    for ctx in contexts
+function find_analysis_unit_for_uri(state::ServerState, uri::URI)
+    haskey(state.analysis_units, uri) || return nothing
+    analysis_units = state.analysis_units[uri]
+    analysis_units isa ExternalUnit && return nothing
+    analysis_unit = first(analysis_units)
+    for analysis_unit′ in analysis_units
         # prioritize `PackageSourceAnalysisEntry` if exists
-        if isa(context.entry, PackageSourceAnalysisEntry)
-            context = ctx
+        if isa(analysis_unit.entry, PackageSourceAnalysisEntry)
+            analysis_unit = analysis_unit′
             break
         end
     end
-    return context
+    return analysis_unit
 end

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -41,11 +41,11 @@ function find_file_module(state::ServerState, uri::URI, pos::Position)
 end
 
 function find_analysis_unit_for_uri(state::ServerState, uri::URI)
-    haskey(state.analysis_units, uri) || return nothing
-    analysis_units = state.analysis_units[uri]
-    analysis_units isa ExternalUnit && return nothing
-    analysis_unit = first(analysis_units)
-    for analysis_unit′ in analysis_units
+    haskey(state.analysis_cache, uri) || return nothing
+    analysis_info = state.analysis_cache[uri]
+    analysis_info isa OutOfScope && return nothing
+    analysis_unit = first(analysis_info)
+    for analysis_unit′ in analysis_info
         # prioritize `PackageSourceAnalysisEntry` if exists
         if isa(analysis_unit.entry, PackageSourceAnalysisEntry)
             analysis_unit = analysis_unit′

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -264,7 +264,7 @@ end
     uri = filename2uri(filename)
     JETLS.cache_file_info!(state, uri, #=version=#1, text)
     JETLS.cache_saved_file_info!(state, uri, text)
-    JETLS.initiate_context!(server, uri)
+    JETLS.initiate_analysis_unit!(server, uri)
     let params = CompletionParams(;
             textDocument=TextDocumentIdentifier(; uri),
             position=pos1)

--- a/test/test_resolver.jl
+++ b/test/test_resolver.jl
@@ -13,8 +13,8 @@ function analyze_and_resolve(s::AbstractString;
     mktemp() do filename, io
         uri = filename2uri(filename)
         fileinfo = JETLS.cache_file_info!(state, uri, 1, text)
-        context = JETLS.initiate_context!(server, uri)
-        analyzer = context.result.analyzer
+        analysis_unit = JETLS.initiate_analysis_unit!(server, uri)
+        analyzer = analysis_unit.result.analyzer
 
         mod = JETLS.find_file_module(state, uri, position)
 


### PR DESCRIPTION
Which seems more appropriate.

Also includes a fix to `record_reverse_map!`, where it may raise exception when previously `OutOfScope` files turns out to be analyzable by some unit later.