### PR TITLE
definition: handle methods with unknown locations

### DIFF
--- a/src/definition.jl
+++ b/src/definition.jl
@@ -61,6 +61,8 @@ function select_target_node(st::JL.SyntaxTree, offset::Int)
     return nothing
 end
 
+is_location_unknown(m) = Base.updated_methodloc(m)[2] <= 0
+
 """
 Get the range of a method. (will be deprecated in the future)
 
@@ -97,7 +99,7 @@ function definition_target_methods(state::ServerState, uri::URI, pos::Position, 
     objtyp isa Core.Const || return empty_methods
 
     # TODO modify this aggregation logic when we start to use more precise location informaiton
-    return unique(functionloc, methods(objtyp.val))
+    return filter(!is_location_unknown, unique(Base.updated_methodloc, methods(objtyp.val)))
 end
 
 function handle_DefinitionRequest(server::Server, msg::DefinitionRequest)

--- a/test/test_definition.jl
+++ b/test/test_definition.jl
@@ -129,6 +129,8 @@ include("setup.jl")
     #=52=# M.m_func│(1.0)
     #=53=# M.│m_func(1.0)
     #=54=# let; func│; end
+    #=55=#
+    #=56=# 1 +│ 2
     """
 
     sin_cand_file, sin_cand_line = functionloc(first(methods(sin, (Float64,))))
@@ -251,6 +253,10 @@ include("setup.jl")
             (length(result) == 1) &&
             (first(result).uri == uri) &&
             (first(result).range.start.line == 0)
+
+        # 1 +│ 2
+        (result, uri) ->
+            (length(result) >= 1)
     ]
 
     clean_code, positions = get_text_and_positions(script_code, r"│")


### PR DESCRIPTION
Currently, Go to Definition fails for `+` because of:

```julia
julia> m = methods(+, (LinearAlgebra.UniformScaling, LinearAlgebra.Diagonal))[1]
+(B::UniformScaling, A::Diagonal)
     @ LinearAlgebra none:0

julia> functionloc(m)
ERROR: could not determine location of method definition
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:44
 [2] functionloc(m::Method)
   @ Base ./methodshow.jl:173
 [3] top-level scope
   @ REPL[30]:1
```

(https://github.com/JuliaLang/LinearAlgebra.jl/blob/c5d712277675649d79fd8921eec0b78587e7f72b/src/special.jl#L271-L273)

This change skips such methods instead of throwing them as errors. This lookup strategy will be removed in the future, but it will remain for a while, so I made a simple fix.

(I'm now using `+` as an example of a case where it fails,  but let me know if there’s a more appropriate one that is likely to remain with a unknown location for a longer time)