### PR TITLE
completion: simplify backslash completion implementation

### DIFF
--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -615,12 +615,18 @@ end
         test_backslash_offset(code, (sizeof("angle = \\"), false))
     end
 
-    # within comment scope
+    # within comment/string scope
     let code = "# this is a single line comment \\phi#=cursor=#"
         test_backslash_offset(code, (sizeof("# this is a single line comment \\"), false))
     end
+    let code = "# this is a single line comment \\:#=cursor=#"
+        test_backslash_offset(code, (sizeof("# this is a single line comment \\"), true))
+    end
     let code = "#=\nthis is a multi line comment \\phi#=cursor=#\n=#"
         test_backslash_offset(code, (sizeof("#=\nthis is a multi line comment \\"), false))
+    end
+    let code = "\"\\phi#=cursor=#\""
+        test_backslash_offset(code, (sizeof("\"\\"), false))
     end
 end
 


### PR DESCRIPTION
After reconsidering the discussion at https://github.com/aviatesk/JETLS.jl/pull/103#pullrequestreview-2943628486, now I think it's better to have this completion even inside string scopes. If the completion shows up, you can just ignore it, so it'd be better than not having it available.

My previous comment was based on the fact that implementing general completion features like `global_completions!` requires tokenization, but for this specific backslash completion, I believe tokenization is not really needed.