### PR TITLE
full-analysis: force concretization of `Base.Docs.doc!` calls

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -9,6 +9,14 @@ end
 
 entryuri(entry::AnalysisEntry) = entryuri_impl(entry)::URI
 entrykind(entry::AnalysisEntry) = entrykind_impl(entry)::String
+entryjetconfigs(entry::AnalysisEntry) = entryjetconfigs_impl(entry)::Dict{Symbol,Any}
+
+let default_jetconfigs = Dict{Symbol,Any}(
+        :toplevel_logger => nothing,
+        # force concretization of documentation
+        :concretization_patterns => [:($(Base.Docs.doc!)(xs__))])
+    global entryjetconfigs_impl(::AnalysisEntry) = default_jetconfigs
+end
 
 struct ScriptAnalysisEntry <: AnalysisEntry
     uri::URI
@@ -28,6 +36,12 @@ struct PackageSourceAnalysisEntry <: AnalysisEntry
 end
 entryuri_impl(entry::PackageSourceAnalysisEntry) = entry.pkgfileuri
 entrykind_impl(entry::PackageSourceAnalysisEntry) = "pkg src"
+let jetconfigs = Dict{Symbol,Any}(
+        :toplevel_logger => nothing,
+        :analyze_from_definitions => true,
+        :concretization_patterns => [:(x_)])
+    global entryjetconfigs_impl(entry::PackageSourceAnalysisEntry) = jetconfigs
+end
 struct PackageTestAnalysisEntry <: AnalysisEntry
     env_path::String
     runtestsuri::URI

--- a/test/test_hover.jl
+++ b/test/test_hover.jl
@@ -138,10 +138,10 @@ end
         (;)
 
         # func│(42)
-        (; pat="Documented method.", brokens=(2,))
+        (; pat="Documented method.")
 
         # M_doc.func│(42)
-        (; pat="Documented method.", brokens=(2,))
+        (; pat="Documented method.")
     ]
 
     clean_code, positions = JETLS.get_text_and_positions(script_code, r"│")


### PR DESCRIPTION
For allowing LSP features like hover to retrieve documentation on objects analyzed by virtual process.