### PR TITLE
Extract JSONRPC module into separate package

### DIFF
--- a/JSONRPC/.gitignore
+++ b/JSONRPC/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/JSONRPC/Project.toml
+++ b/JSONRPC/Project.toml
@@ -1,0 +1,10 @@
+name = "JSONRPC"
+uuid = "a2756949-8476-49a1-a294-231eace0f283"
+version = "0.1.0"
+authors = ["Shuhei Kadowaki <aviatesk@gmail.com>"]
+
+[deps]
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+
+[compat]
+JSON3 = "1.14.3"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ projects = ["test"]
 [deps]
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+JSONRPC = "a2756949-8476-49a1-a294-231eace0f283"
 JuliaLowering = "f3c80556-a63f-4383-b822-37d64f81a311"
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -19,12 +20,14 @@ StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 
 [sources]
 JET = {rev = "master", url = "https://github.com/aviatesk/JET.jl"}
+JSONRPC = { path = "JSONRPC" }
 JuliaLowering = {rev = "avi/JETLS", url = "https://github.com/aviatesk/JuliaLowering.jl"}
 JuliaSyntax = {rev = "eceaa39", url = "https://github.com/JuliaLang/JuliaSyntax.jl"}
 
 [compat]
 JET = "0.10.5"
 JSON3 = "1.14.1"
+JSONRPC = "0.1"
 JuliaLowering = "1.0.0"
 JuliaSyntax = "1.0"
 Pkg = "1.11.0"

--- a/runserver.jl
+++ b/runserver.jl
@@ -27,7 +27,7 @@ let old_env = Pkg.project().path
     end
 end
 
-let endpoint = Endpoint(stdin, stdout)
+let endpoint = LSEndpoint(stdin, stdout)
     if JETLS.JETLS_DEV_MODE
         server = Server(endpoint) do s::Symbol, x
             @nospecialize x

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -1,6 +1,6 @@
 module JETLS
 
-export Server, Endpoint, runserver
+export Server, LSEndpoint, runserver
 
 const __init__hooks__ = Any[]
 push_init_hooks!(hook) = push!(__init__hooks__, hook)
@@ -20,8 +20,9 @@ using .URIs2
 include("LSP/LSP.jl")
 using .LSP
 
-include("JSONRPC/JSONRPC.jl")
-using .JSONRPC
+using JSONRPC: JSONRPC, Endpoint
+# constructor of `Endpoint` with LSP method dispatcher
+LSEndpoint(args...) = Endpoint(args..., method_dispatcher)
 
 using Pkg
 using JET: CC, JET
@@ -97,7 +98,7 @@ for development purposes only, particularly for inspection or dynamic registrati
 global currently_running::Server
 
 runserver(args...) = runserver(Returns(nothing), args...) # no callback specified
-runserver(callback, in::IO, out::IO) = runserver(callback, Endpoint(in, out))
+runserver(callback, in::IO, out::IO) = runserver(callback, LSEndpoint(in, out))
 runserver(callback, endpoint::Endpoint) = runserver(Server(callback, endpoint))
 function runserver(server::Server)
     shutdown_requested = false

--- a/src/types.jl
+++ b/src/types.jl
@@ -132,7 +132,7 @@ struct Server{Callback}
         )
     end
 end
-Server() = Server(Returns(nothing), Endpoint(IOBuffer(), IOBuffer())) # used for tests
+Server() = Server(Returns(nothing), LSEndpoint(IOBuffer(), IOBuffer())) # used for tests
 
 """
     send(state::ServerState, msg)

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -26,7 +26,7 @@ function withserver(f;
     out = Base.BufferStream()
     received_queue = Channel{Any}(Inf)
     sent_queue = Channel{Any}(Inf)
-    server = Server(Endpoint(in, out)) do s::Symbol, x
+    server = Server(LSEndpoint(in, out)) do s::Symbol, x
         @nospecialize x
         if s === :received
             put!(received_queue, x)
@@ -83,13 +83,13 @@ function withserver(f;
         if read == 0
         elseif read == 1
             raw_res = take_with_timeout!(sent_queue)
-            json_res = JSONRPC.readmsg(out)
+            json_res = JSONRPC.readmsg(out, method_dispatcher)
         else
             raw_res = Any[]
             json_res = Any[]
             for _ = 1:read
                 push!(raw_res, take_with_timeout!(sent_queue))
-                push!(json_res, JSONRPC.readmsg(out))
+                push!(json_res, JSONRPC.readmsg(out, method_dispatcher))
             end
         end
         @test isempty(received_queue) && isempty(sent_queue)
@@ -119,13 +119,13 @@ function withserver(f;
         if read == 0
         elseif read == 1
             raw_msg = take_with_timeout!(sent_queue)
-            json_msg = JSONRPC.readmsg(out)
+            json_msg = JSONRPC.readmsg(out, method_dispatcher)
         else
             raw_msg = Any[]
             json_msg = Any[]
             for _ = 1:read
                 push!(raw_msg, take_with_timeout!(sent_queue))
-                push!(json_msg, JSONRPC.readmsg(out))
+                push!(json_msg, JSONRPC.readmsg(out, method_dispatcher))
             end
         end
         @test isempty(received_queue) && isempty(sent_queue)


### PR DESCRIPTION
Moves JSONRPC functionality from src/JSONRPC/ to a standalone package in JSONRPC/ directory. Updates the main package to depend on the new JSONRPC package and introduces `LSEndpoint` wrapper for LSP-specific method dispatching. JSONRPC is listed in `[sources]` section so it can be used without registering it.