### PR TITLE
exclude identifier from bindings when cursor is at its left edge

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -106,7 +106,7 @@ function is_relevant(ctx::JL.AbstractLoweringContext,
                      cursor::Int)
     (;start, stop) = JS.byte_range(JL.binding_ex(ctx, binding.id))
     !binding.is_internal &&
-        !in(cursor, (start+1):(stop+1)) &&
+        !in(cursor, start:(stop+1)) &&
         (binding.kind === :global
          # || we could relax this for locals defined before the end of the
          #    largest for/while containing the cursor

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -172,6 +172,8 @@ end
     test_cv(code, "|", "g1", not="g2")
     code = "function f(); global g1; g|2; end"
     test_cv(code, "|", "g1", not="g g2")
+    code = "function f(); global g1; │g2; end"
+    test_cv(code, "│", "g1", not="g2")
 end
 
 # completion for code including macros


### PR DESCRIPTION
With this change, when `func` is undefined, it will no longer appear as a completion candidate in cases like:

```julia
│func(1.0)
```

Similarly, in Go to Definition, the `func` on the right side of the cursor will no longer be considered as a definition candidate.

ref: https://github.com/aviatesk/JETLS.jl/pull/115#issuecomment-3007784009