### PR TITLE
definition: enhance local binding jump

### DIFF
--- a/src/definition.jl
+++ b/src/definition.jl
@@ -33,7 +33,7 @@ Get the range of a method. (will be deprecated in the future)
 TODO (later): get the correct range of the method definition.
 For now, it just returns the first line of the method
 """
-function get_location(m::Method)
+function LSP.Location(m::Method)
     file, line = functionloc(m)
     file = to_full_path(file)
     return Location(;
@@ -43,7 +43,7 @@ function get_location(m::Method)
             var"end" = Position(; line = line - 1, character = Int(typemax(Int32)))))
 end
 
-function get_location(mod::Module)
+function LSP.Location(mod::Module)
     (; file, line) = Base.moduleloc(mod)
     uri = filename2uri(to_full_path(file))
     return Location(;
@@ -53,35 +53,31 @@ function get_location(mod::Module)
             var"end" = Position(; line = line - 1, character = Int(typemax(Int32)))))
 end
 
-get_location(bind::Tuple{JL.SyntaxTree, URI}) = Location(; uri = bind[2], range = get_source_range(bind[1]))
-
-function definition_target_localbindings(offset, st, node, uri)
+function local_definitions(st0_top::JL.SyntaxTree, offset::Int)
     # We can skip lookups including access of outer modules
     # because we only look for local bindings
-    kind(node) !== K"Identifier" && return nothing
-    cbs = cursor_bindings(st, offset)
-    (cbs === nothing || isempty(cbs)) && return nothing
-    matched_binding = findfirst(b -> b[1].name == node.name_val, cbs)
-    matched_binding === nothing && return nothing
-
-    # Will return multiple results when we support tracking of multiple assignments.
-    # `SyntaxTree` does not retain URI information because `ParseStream` does not store it
-    # so we explicitly keep it.
-    return [(cbs[matched_binding][2], uri)]
-end
-
-function create_definition(obj, origin_range::Range, locationlink_support::Bool)
-    loc = @inline get_location(obj)
-    if locationlink_support
-        LocationLink(;
-            targetUri = loc.uri,
-            targetRange = loc.range,
-            targetSelectionRange = loc.range,
-            originSelectionRange = origin_range)
-    else
-        loc
+    st0, b = greatest_local(st0_top, offset)
+    isnothing(st0) && return nothing
+    ctx3, st3 = try
+        jl_lower_for_scope_resolution3(st0)
+    catch err
+        err
+        return nothing
     end
+    target_binding = select_target_binding(ctx3, st3, b)
+    isnothing(target_binding) && return nothing
+    binfo = JL.lookup_binding(ctx3, target_binding)
+    definitions = lookup_binding_definitions(st3, binfo)
+    isempty(definitions) && return nothing
+    return target_binding, definitions
 end
+
+LSP.LocationLink(loc::Location, originSelectionRange::Range) =
+    LocationLink(;
+        targetUri = loc.uri,
+        targetRange = loc.range,
+        targetSelectionRange = loc.range,
+        originSelectionRange)
 
 function handle_DefinitionRequest(server::Server, msg::DefinitionRequest)
     origin_position = msg.params.position
@@ -98,52 +94,62 @@ function handle_DefinitionRequest(server::Server, msg::DefinitionRequest)
 
     st0 = JS.build_tree(JL.SyntaxTree, fi.parsed_stream)
     offset = xy_to_offset(fi, origin_position)
+
+    locationlink_support = supports(server, :textDocument, :definition, :linkSupport)
+
+    target_binding_definitions = local_definitions(st0, offset)
+    if !isnothing(target_binding_definitions)
+        target_binding, definitions = target_binding_definitions
+        local result = Location[
+            Location(; uri, range = get_source_range(definition))
+            for definition in definitions]
+        if locationlink_support
+            result = LocationLink[
+                LocationLink(loc, get_source_range(target_binding))
+                for loc in result]
+        end
+        return send(server,
+            DefinitionResponse(;
+                id = msg.id,
+                result))
+    end
+
     node = select_target_node(st0, offset)
     if node === nothing
         return send(server, DefinitionResponse(; id = msg.id, result = null))
     end
-
-    locationlink_support = supports(server, :textDocument, :definition, :linkSupport)
-    originSelectionRange = get_source_range(node)
-
-    lbs = definition_target_localbindings(offset, st0, node, uri)
-    if !isnothing(lbs)
-        return send(server,
-            DefinitionResponse(;
-                id = msg.id,
-                result = create_definition.(lbs,
-                    Ref(originSelectionRange),
-                    Ref(locationlink_support))))
-    end
-
     (; mod, analyzer) = get_context_info(server.state, uri, origin_position)
     objtyp = resolve_type(analyzer, mod, node)
-
     objtyp isa Core.Const || return send(server, DefinitionResponse(; id = msg.id, result = null))
 
     objval = objtyp.val
+    originSelectionRange = get_source_range(node)
     if objval isa Module
         if is_location_unknown(objval)
             return send(server, DefinitionResponse(; id = msg.id, result = null))
         else
+            local result = Location(objval)
+            if locationlink_support
+                result = LocationLink(result, originSelectionRange)
+            end
             return send(server,
                 DefinitionResponse(;
                     id = msg.id,
-                    result = create_definition(objval,
-                        originSelectionRange,
-                        locationlink_support)))
+                    result))
         end
     else
         target_methods = filter(!is_location_unknown, unique(Base.updated_methodloc, methods(objtyp.val)))
         if isempty(target_methods)
             return send(server, DefinitionResponse(; id = msg.id, result = null))
         else
+            local result = Location.(target_methods)
+            if locationlink_support
+                result = LocationLink.(result, Ref(originSelectionRange))
+            end
             return send(server,
                 DefinitionResponse(;
                     id = msg.id,
-                    result = create_definition.(target_methods,
-                        Ref(originSelectionRange),
-                        Ref(locationlink_support))))
+                    result))
         end
     end
 end

--- a/src/definition.jl
+++ b/src/definition.jl
@@ -130,7 +130,7 @@ function handle_DefinitionRequest(server::Server, msg::DefinitionRequest)
         else
             local result = Location(objval)
             if locationlink_support
-                result = LocationLink(result, originSelectionRange)
+                result = LocationLink[LocationLink(result, originSelectionRange)] # only `result::Vector{LocationLink}` is supported
             end
             return send(server,
                 DefinitionResponse(;

--- a/test/jsjl_utils.jl
+++ b/test/jsjl_utils.jl
@@ -1,0 +1,15 @@
+using JETLS: JS, JL
+
+function parsedstream(s::AbstractString, rule::Symbol=:all)
+    stream = JS.ParseStream(s)
+    JS.parse!(stream; rule)
+    return stream
+end
+
+function jsparse(s::AbstractString)
+    JS.build_tree(JS.SyntaxNode, parsedstream(s); filename=@__FILE__)
+end
+
+function jlparse(s::AbstractString)
+    JS.build_tree(JL.SyntaxTree, parsedstream(s); filename=@__FILE__)
+end

--- a/test/test_definition.jl
+++ b/test/test_definition.jl
@@ -31,9 +31,9 @@ include("jsjl_utils.jl")
 function with_local_definitions(f, text::AbstractString, matcher::Regex=r"│")
     clean_code, positions = JETLS.get_text_and_positions(text, r"│")
     st0_top = jlparse(clean_code)
-    for pos in positions
+    for (i, pos) in enumerate(positions)
         offset = JETLS.xy_to_offset(Vector{UInt8}(clean_code), pos)
-        f(JETLS.local_definitions(st0_top, offset))
+        f(i, JETLS.local_definitions(st0_top, offset))
     end
 end
 
@@ -43,12 +43,431 @@ end
             Any[Core.Const(x│)
                 for x in xs]
         end
-    """) do res
+    """) do _, res
         @test !isnothing(res)
         binding, defs = res
         @test JS.source_line(JL.sourceref(binding)) == 2
         @test length(defs) == 1
         @test JS.source_line(JL.sourceref(only(defs))) == 3
+    end
+
+    @testset "simple" begin
+        cnt = 0
+        with_local_definitions("""
+            function func(x)
+                y = x│ + 1
+                return y│
+            end
+        """) do i, res
+            if i == 1 # x│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 2
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 1
+                cnt += 1
+            elseif i == 2 # y│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 3
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 2
+                cnt += 1
+            end
+        end
+        @test cnt == 2
+    end
+
+    @testset "parameter shadowing" begin
+        cnt = 0
+        with_local_definitions("""
+            function redef(x)
+                x = 1
+                y = x│ + 1
+                return y│
+            end
+        """) do i, res
+            if i == 1 # x│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 3
+                @test length(defs) == 1
+                # The definition should be x = 1 on line 2, not the parameter x on line 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 2 broken=true
+                cnt += 1
+            elseif i == 2 # y│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 4
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 3
+                cnt += 1
+            end
+        end
+        @test cnt == 2
+    end
+
+    @testset "function self-reference" begin
+        cnt = 0
+        with_local_definitions("""
+            function rec(x)
+                return rec│(x + 1)
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 2
+            @test length(defs) >= 1
+            @test any(defs) do def
+                JS.source_line(JL.sourceref(def)) == 1
+            end
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "closure captures" begin
+        cnt = 0
+        with_local_definitions("""
+            function closure()
+                x = 1
+                function inner(y)
+                    return x│ + y│
+                end
+                return inner
+            end
+        """) do i, res
+            if i == 1 # x│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 4
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 2
+                cnt += 1
+            elseif i == 2 # y│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 4
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 3
+                cnt += 1
+            end
+        end
+        @test cnt == 2
+    end
+
+    @testset "let binding" begin
+        cnt = 0
+        with_local_definitions("""
+            function let_binding()
+                let x = 1
+                    y = x│ + 1
+                    return y│
+                end
+            end
+        """) do i, res
+            if i == 1 # x│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 3
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 2
+                cnt += 1
+            elseif i == 2 # y│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 4
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 3
+                cnt += 1
+            end
+        end
+        @test cnt == 2
+    end
+
+    @testset "for loop variable" begin
+        cnt = 0
+        with_local_definitions("""
+            function loop_var(n)
+                for i in 1:n
+                    println(i│)
+                end
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 3
+            @test length(defs) == 1
+            @test JS.source_line(JL.sourceref(only(defs))) == 2
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "comprehension variable" begin
+        cnt = 0
+        with_local_definitions("""
+            let
+                v = [│xxx^2 for xxx in 1:5]
+                return v
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 2
+            @test length(defs) == 1
+            @test JS.source_line(JL.sourceref(only(defs))) == 2
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "destructuring assignment" begin
+        cnt = 0
+        with_local_definitions("""
+            function destructuring()
+                (a, b) = (1, 2)
+                return a│ + b│
+            end
+        """) do i, res
+            if i == 1 # a│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 3
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 2
+                cnt += 1
+            elseif i == 2 # b│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 3
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 2
+                cnt += 1
+            end
+        end
+        @test cnt == 2
+    end
+
+    @testset "conditional binding" begin
+        cnt = 0
+        with_local_definitions("""
+            function if_branch(x)
+                if x > 0
+                    y = x
+                end
+                return y│
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 5
+            @test length(defs) == 1
+            @test JS.source_line(JL.sourceref(only(defs))) == 3
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "try-catch variable" begin
+        cnt = 0
+        with_local_definitions("""
+            function try_catch()
+                try
+                    error("boom")
+                catch err
+                    return err│
+                end
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 5
+            @test length(defs) == 1
+            @test JS.source_line(JL.sourceref(only(defs))) == 4
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "do block parameter" begin
+        cnt = 0
+        with_local_definitions("""
+            function do_block()
+                map(1:3) do t
+                    t│ + 1
+                end
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 3
+            @test length(defs) == 1
+            @test JS.source_line(JL.sourceref(only(defs))) == 2
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "lambda parameter" begin
+        cnt = 0
+        with_local_definitions("""
+            sq = x -> x│ ^ 2
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 1
+            @test length(defs) == 1
+            @test JS.source_line(JL.sourceref(only(defs))) == 1
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "nested let scopes" begin
+        cnt = 0
+        with_local_definitions("""
+            function nested_let()
+                let x = 1
+                    let x = 2
+                        return x│
+                    end
+                end
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 4
+            @test length(defs) == 1
+            @test JS.source_line(JL.sourceref(only(defs))) == 3
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "for loop shadowing" begin
+        cnt = 0
+        with_local_definitions("""
+            function loop_shadow()
+                x = 0
+                for x = 1:3
+                    println(x│)
+                end
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 4
+            @test length(defs) == 1
+            @test JS.source_line(JL.sourceref(only(defs))) == 3
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "closure recapture" begin
+        cnt = 0
+        with_local_definitions("""
+            function recapture()
+                x = 1
+                f = () -> x│ + 1
+                x = 2
+                return f()
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 3
+            @test length(defs) == 2
+            @test any(def -> JS.source_line(JL.sourceref(def)) == 2, defs)
+            @test any(def -> JS.source_line(JL.sourceref(def)) == 4, defs)
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "keyword arguments" begin
+        cnt = 0
+        with_local_definitions("""
+            function keyword_args(; a = 1, b = 2)
+                a│ + b│
+            end
+        """) do i, res
+            if i == 1 # a│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 2
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 1
+                cnt += 1
+            elseif i == 2 # b│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 2
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 1
+                cnt += 1
+            end
+        end
+        @test cnt == 2
+    end
+
+    @testset "inner function parameter shadowing" begin
+        cnt = 0
+        with_local_definitions("""
+            function outer()
+                x = 1
+                function inner(x)
+                    return x│ + 1
+                end
+                return inner
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 4
+            @test length(defs) == 1
+            @test JS.source_line(JL.sourceref(only(defs))) == 3
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "non-linear control flow" begin
+        cnt = 0
+        with_local_definitions("""
+            function not_linear()
+                finish = false
+                @label l1
+                (!finish) && @goto l2
+                return x│
+                @label l2
+                x = 1
+                finish = true
+                @goto l1
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 5
+            @test length(defs) == 1
+            @test JS.source_line(JL.sourceref(only(defs))) == 7
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "undefined variable" begin
+        cnt = 0
+        with_local_definitions("""
+            function undefined_var()
+                return x│
+            end
+        """) do _, res
+            @test isnothing(res)
+            cnt += 1
+        end
+        @test cnt == 1
     end
 end
 
@@ -276,393 +695,6 @@ include("setup.jl")
                             textDocument = TextDocumentIdentifier(; uri),
                             position = pos)))
                     @test tester(raw_res.result, uri)
-                end
-            end
-        end
-    end
-end
-
-@testset "'Definition' for local bindings request/responce" begin
-    script_code = """
-    #= 1=# function func(x)
-    #= 2=#     y = x│ + 1
-    #= 3=#     return y│
-    #= 4=# end
-    #= 5=#
-    #= 6=# function redef(x)
-    #= 7=#     x = 1
-    #= 8=#     y = x│ + 1
-    #= 9=#     return y│
-    #=10=# end
-    #=11=#
-    #=12=# function rec(x)
-    #=13=#     return rec│(x + 1)
-    #=14=# end
-    #=15=#
-    #=16=# function closure()
-    #=17=#     x = 1
-    #=18=#     function inner(y)
-    #=19=#         return x│ + y│
-    #=20=#     end
-    #=21=#     return inner
-    #=22=# end
-    #=23=#
-    #=24=# function let_binding()
-    #=25=#     let x = 1
-    #=26=#         y = x│ + 1
-    #=27=#         return y│
-    #=28=#     end
-    #=29=# end
-    #=30=#
-    #=31=# function loop_var(n)
-    #=32=#     for i in 1:n
-    #=33=#         println(i│)
-    #=34=#     end
-    #=35=# end
-    #=36=#
-    #=37=# function compre()
-    #=38=#     v = [│x^2 for x in 1:5]
-    #=39=#     return v
-    #=40=# end
-    #=41=#
-    #=42=# function destructuring()
-    #=43=#     (a, b) = (1, 2)
-    #=44=#     return a│ + b
-    #=45=# end
-    #=46=#
-    #=47=# function if_branch(x)
-    #=48=#     if x > 0
-    #=49=#         y = x
-    #=50=#     end
-    #=51=#     return y│
-    #=52=# end
-    #=53=#
-    #=54=# function try_catch()
-    #=55=#     try
-    #=56=#         error("boom")
-    #=57=#     catch err
-    #=58=#         return err│
-    #=59=#     end
-    #=60=# end
-    #=61=#
-    #=62=# function do_block()
-    #=63=#     map(1:3) do t
-    #=64=#         t│ + 1
-    #=65=#     end
-    #=66=# end
-    #=67=#
-    #=68=# sq = x -> x│ ^ 2
-    #=69=#
-    #=70=# function nested_let()
-    #=71=#     let x = 1
-    #=72=#         let x = 2
-    #=73=#             return x│
-    #=74=#         end
-    #=75=#     end
-    #=76=# end
-    #=77=#
-    #=78=# function loop_shadow()
-    #=79=#     x = 0
-    #=80=#     for x = 1:3
-    #=81=#         println(x│)
-    #=82=#     end
-    #=83=# end
-    #=84=#
-    #=85=# function recapture()
-    #=86=#     x = 1
-    #=87=#     f = () -> x│ + 1
-    #=88=#     x = 2
-    #=89=#     return f()
-    #=90=# end
-    #=91=#
-    #=92=# function keyword_args(; a = 1, b = 2)
-    #=93=#     a│ + b│
-    #=94=# end
-    #=95=#
-    #=96=# function outer()
-    #=97=#     x = 1
-    #=98=#     function inner(x)
-    #=99=#         return x│ + 1
-    #=100=#    end
-    #=101=#    return inner
-    #=102=# end
-    #=103=#
-    #=104=# function not_linear()
-    #=105=#     finish = false
-    #=106=#     @label l1
-    #=107=#     (!finish) && @goto l2
-    #=108=#     return x│
-    #=109=#     @label l2
-    #=110=#     x = 1
-    #=111=#     finish = true
-    #=112=#     @goto l1
-    #=113=# end
-    #=114=#
-    #=115=# function undefined_var()
-    #=116=#     return x│
-    #=117=# end
-    """
-
-    testers = [
-        # y = x│ + 1
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 0) &&
-            (first(result).range.start.character == 14) &&
-            (first(result).range.var"end".line == 0) &&
-            (first(result).range.var"end".character == 15)
-
-        # return y│
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 1) &&
-            (first(result).range.start.character == 4) &&
-            (first(result).range.var"end".line == 1) &&
-            (first(result).range.var"end".character == 5)
-
-        # y = x│ + 1 (should be x = 1)
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 6) &&
-            (first(result).range.start.character == 4) &&
-            (first(result).range.var"end".line == 6) &&
-            (first(result).range.var"end".character == 5)
-
-        # return y│
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 7) &&
-            (first(result).range.start.character == 4) &&
-            (first(result).range.var"end".line == 7) &&
-            (first(result).range.var"end".character == 5)
-
-        # #=12=# function rec(x)
-        # #=13=#     return rec│(x + 1)
-        # #=14=# end
-        (result, uri) ->
-            (length(result) >= 1) &&
-            (any(result) do candidate
-                candidate.uri == uri &&
-                candidate.range.start.line == 11 &&
-                candidate.range.start.character == 9 &&
-                candidate.range.var"end".line == 11 &&
-                candidate.range.var"end".character == 12
-            end)
-
-        # return x│ + y│
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 16) &&
-            (first(result).range.start.character == 4) &&
-            (first(result).range.var"end".line == 16) &&
-            (first(result).range.var"end".character == 5)
-
-        # return x│ + y│
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 17) &&
-            (first(result).range.start.character == 19) &&
-            (first(result).range.var"end".line == 17) &&
-            (first(result).range.var"end".character == 20)
-
-        # y = x│ + 1
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 24) &&
-            (first(result).range.start.character == 8) &&
-            (first(result).range.var"end".line == 24) &&
-            (first(result).range.var"end".character == 9)
-
-        # return y│
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 25) &&
-            (first(result).range.start.character == 8) &&
-            (first(result).range.var"end".line == 25) &&
-            (first(result).range.var"end".character == 9)
-
-        # println(i│)
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 31) &&
-            (first(result).range.start.character == 8) &&
-            (first(result).range.var"end".line == 31) &&
-            (first(result).range.var"end".character == 9)
-
-        # v = [│x^2 for x in 1:5]
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 37) &&
-            (first(result).range.start.character == 17) &&
-            (first(result).range.var"end".line == 37) &&
-            (first(result).range.var"end".character == 18)
-
-        # return a│ + b
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 42) &&
-            (first(result).range.start.character == 5) &&
-            (first(result).range.var"end".line == 42) &&
-            (first(result).range.var"end".character == 6)
-
-        # return y│
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 48) &&
-            (first(result).range.start.character == 8) &&
-            (first(result).range.var"end".line == 48) &&
-            (first(result).range.var"end".character == 9)
-
-        # return err│
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 56) &&
-            (first(result).range.start.character == 10) &&
-            (first(result).range.var"end".line == 56) &&
-            (first(result).range.var"end".character == 13)
-
-        # t│ + 1
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 62) &&
-            (first(result).range.start.character == 16) &&
-            (first(result).range.var"end".line == 62) &&
-            (first(result).range.var"end".character == 17)
-
-        # sq = x -> x│ ^ 2 (lambda parameter)
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 67) &&
-            (first(result).range.start.character == 5) &&
-            (first(result).range.var"end".line == 67) &&
-            (first(result).range.var"end".character == 6)
-
-        # return x│
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 71) &&
-            (first(result).range.start.character == 12) &&
-            (first(result).range.var"end".line == 71) &&
-            (first(result).range.var"end".character == 13)
-
-        # println(x│)
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 79) &&
-            (first(result).range.start.character == 8) &&
-            (first(result).range.var"end".line == 79) &&
-            (first(result).range.var"end".character == 9)
-
-        # #=85=# function recapture()
-        # #=86=#     x = 1
-        # #=87=#     f = () -> x│ + 1
-        # #=88=#     x = 2
-        # #=89=#     return f()
-        # #=90=# end
-        (result, uri) ->
-            (length(result) == 2) &&
-            any(result) do res
-                res.uri == uri &&
-                res.range.start.line == 85 &&
-                res.range.start.character == 4 &&
-                res.range.var"end".line == 85 &&
-                res.range.var"end".character == 5
-            end &&
-            any(result) do res
-                res.uri == uri &&
-                res.range.start.line == 87 &&
-                res.range.start.character == 4 &&
-                res.range.var"end".line == 87 &&
-                res.range.var"end".character == 5
-            end
-
-        # return a│ + b
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 91) &&
-            (first(result).range.start.character == 24) &&
-            (first(result).range.var"end".line == 91) &&
-            (first(result).range.var"end".character == 25)
-
-        # return a + b│
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 91) &&
-            (first(result).range.start.character == 31) &&
-            (first(result).range.var"end".line == 91) &&
-            (first(result).range.var"end".character == 32)
-
-        # case 22
-        # return x│ + 1
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 98) &&
-            (first(result).range.start.character == 8) &&
-            (first(result).range.var"end".line == 98) &&
-            (first(result).range.var"end".character == 9)
-
-        # return x│
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 109) &&
-            (first(result).range.start.character == 4) &&
-            (first(result).range.var"end".line == 109) &&
-            (first(result).range.var"end".character == 5)
-
-        # return x│
-        (result, uri) ->
-            (result === null)
-    ]
-
-    # remove prefixes like `#= 1=#` first
-    script_code = join(replace.(split(script_code, '\n'), r"#=\s*\d+\s*=#\s" => ""), '\n')
-    clean_code, positions = JETLS.get_text_and_positions(script_code, r"│")
-    @assert length(positions) == length(testers)
-
-    broken_cases = [
-        3,  # y = x│ + 1 (overwriting `x`)`
-        22, # return x│ + 1 (overwriting `x` in inner function)
-    ]
-
-    withscript(clean_code) do script_path
-        uri = filepath2uri(script_path)
-        withserver() do (; writereadmsg, id_counter)
-            # run the full analysis first
-            (; raw_res) = writereadmsg(make_DidOpenTextDocumentNotification(uri, clean_code))
-            @test raw_res isa PublishDiagnosticsNotification
-            @test raw_res.params.uri == uri
-            for (i, (pos, tester)) in enumerate(zip(positions, testers))
-                @testset let loc = functionloc(only(methods(tester))),
-                             id = id_counter[] += 1,
-                             i = i
-                    (; raw_res) = writereadmsg(DefinitionRequest(;
-                        id,
-                        params = DefinitionParams(;
-                            textDocument = TextDocumentIdentifier(; uri),
-                            position = pos)))
-
-                    @test tester(raw_res.result, uri) broken=(i in broken_cases)
                 end
             end
         end

--- a/test/test_definition.jl
+++ b/test/test_definition.jl
@@ -91,9 +91,10 @@ end
                 @test !isnothing(res)
                 binding, defs = res
                 @test JS.source_line(JL.sourceref(binding)) == 3
-                @test length(defs) == 1
-                # The definition should be x = 1 on line 2, not the parameter x on line 1
-                @test JS.source_line(JL.sourceref(only(defs))) == 2 broken=true
+                @test length(defs) == 2 # Both parameter x and local x = 1
+                # The definitions should include both x = 1 on line 2 and the parameter x on line 1
+                @test any(d -> JS.source_line(JL.sourceref(d)) == 1, defs) # parameter
+                @test any(d -> JS.source_line(JL.sourceref(d)) == 2, defs) # local assignment
                 cnt += 1
             elseif i == 2 # y│
                 @test !isnothing(res)

--- a/test/test_definition.jl
+++ b/test/test_definition.jl
@@ -474,231 +474,285 @@ end
 
 include("setup.jl")
 
-@testset "'Definition' for module, method request/responce" begin
-    script_code = """
-    #= 1=# func(x) = 1
-    #= 2=# fu│nc(1.0)
-    #= 3=# si│n(1.0)
-    #= 4=#
-    #= 5=# Core.Compiler.tm│eet
-    #= 6=# Co│re.Compiler.tmeet
-    #= 7=#
-    #= 8=# func(1.│0)
-    #= 9=# sin(1.│0)
-    #=10=#
-    #=11=# module M
-    #=12=#     m_func(x) = 1
-    #=13=#     m_│func(1.0)
-    #=14=# end
-    #=15=#
-    #=16=# m_│func(1.0)
-    #=17=# M.m_│func(1.0)
-    #=18=#
-    #=19=# module M2
-    #=20=#     m_func(x) = 1
-    #=21=#     m_│func(1.0)
-    #=22=# end
-    #=23=#
-    #=24=# M2.m_│func(1.0)
-    #=25=#
-    #=26=# cos(x) = 1
-    #=27=#
-    #=28=# Base.co│s(x) = 1
-    #=29=#
-    #=30=# struct Hello
-    #=31=#     who::String
-    #=32=#     Hello(who::AbstractString) = new(String(who))
-    #=33=# end
-    #=34=# function say(h::Hel│lo)
-    #=35=#     println("Hello, \$(hello.who)")
-    #=36=# end
-    #=37=#
-    #=38=# function say_defarg(h::Hello, s = "Hello")
-    #=39=#     println("\$s, \$(hello.who)")
-    #=40=# end
-    #=41=# say_defar│g
-    #=42=#
-    #=43=# function say_kwarg(h::Hello; s = "Hello")
-    #=44=#     println("\$s, \$(hello.who)")
-    #=45=# end
-    #=46=# say_kwar│g
-    #=47=#
-    #=48=# func│
-    #=49=# func│(1.0)
-    #=50=# func(│1.0)
-    #=51=# │func(1.0)
-    #=52=# M.m_func│(1.0)
-    #=53=# M.│m_func(1.0)
-    #=54=# let; func│; end
-    #=55=#
-    #=56=# 1 +│ 2
-    #=57=#
-    #=58=# M2│.m_func(1.0)
-    #=58=# Core│.isdefined
-    """
-
-    sin_cand_file, sin_cand_line = functionloc(first(methods(sin, (Float64,))))
-    sin_cand_file = JETLS.to_full_path(sin_cand_file)
-
-    testers = [
-        # fu│nc(1.0)
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 0)
-
-        # si│n(x)
-        (result, uri) ->
-            (length(result) >= 1) &&
-            (any(result) do candidate
-                JETLS.uri2filepath(candidate.uri) == sin_cand_file &&
-                candidate.range.start.line == (sin_cand_line - 1)
-            end)
-
-        # Core.Compiler.tm│eet
-        (result, uri) ->
-            (length(result) >= 1)
-
-        # Co│re.Compiler.tmeet
-        (result, uri) -> (result === null)
-
-        # func(1.│0)
-        (result, uri) -> (result === null)
-
-        # sin(1.│0)
-        (result, uri) -> (result === null)
-
-        # m_│func(1.0) in module M
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 11)
-
-        # m_│func(1.0)
-        (result, uri) -> (result === null)
-
-        # M.m_│func(1.0)
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 11)
-
-        # m_│func(1.0) in module M2
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 19)
-
-        # M2.m_│func(1.0)
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 19)
-
-        # Base.co│s(x)
-        (result, uri) ->
-            (length(result) >= 1) &&
-            (all(result) do candidate
-                candidate.uri.path != uri # in `Base`, not `cos(x) = 1`
-            end)
-
-        # function say(h::Hel|lo)
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 31)
-
-        # say_defar│g
-        (result, uri) ->
-            (length(result) == 1) && # aggregation
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 37)
-
-        # say_kwar│g
-        (result, uri) ->
-            (length(result) == 1) && # aggregation
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 42)
-
-        # func│
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 0)
-
-        # func│(1.0)
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 0)
-
-        # func(│1.0)
-        (result, uri) -> (result === null)
-
-        # │func(1.0)
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 0) &&
-            (first(result).range.start.character == 0)
-
-
-        # M.m_func│(1.0)
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 11)
-
-        # M.│m_func(1.0)
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 11)
-
-        # let; func│; end
-        (result, uri) ->
-            (length(result) == 1) &&
-            (first(result).uri == uri) &&
-            (first(result).range.start.line == 0)
-
-        # 1 +│ 2
-        (result, uri) ->
-            (length(result) >= 1)
-
-        # M2│.m_func(1.0)
-        (result, uri) ->
-            (result isa Location) &&
-            (result.uri == uri) &&
-            (result.range.start.line == 18)
-
-        # Core│.isdefined
-        (result, uri) -> (result === null) # `Base.moduleloc(Core)` doesn't return anything meaningful
-    ]
-
-    clean_code, positions = JETLS.get_text_and_positions(script_code, r"│")
-    @assert length(positions) == length(testers)
+# Helper to run a single global definition test
+function test_global_definition(text::AbstractString, tester::Function)
+    clean_code, positions = JETLS.get_text_and_positions(text, r"│")
 
     withscript(clean_code) do script_path
         uri = filepath2uri(script_path)
         withserver() do (; writereadmsg, id_counter)
             # run the full analysis first
-            (; raw_res) = writereadmsg(make_DidOpenTextDocumentNotification(uri, read(script_path, String)))
+            (; raw_res) = writereadmsg(make_DidOpenTextDocumentNotification(uri, clean_code))
             @test raw_res isa PublishDiagnosticsNotification
             @test raw_res.params.uri == uri
 
-            for (i, (pos, tester)) in enumerate(zip(positions, testers))
-                @testset let loc = functionloc(only(methods(tester))),
-                             id = id_counter[] += 1,
-                             i = i
-                    (; raw_res) = writereadmsg(DefinitionRequest(;
-                        id,
-                        params = DefinitionParams(;
-                            textDocument = TextDocumentIdentifier(; uri),
-                            position = pos)))
-                    @test tester(raw_res.result, uri)
-                end
+            for (i, pos) in enumerate(positions)
+                (; raw_res) = writereadmsg(DefinitionRequest(;
+                    id = id_counter[] += 1,
+                    params = DefinitionParams(;
+                        textDocument = TextDocumentIdentifier(; uri),
+                        position = pos)))
+                tester(i, raw_res.result, uri)
             end
         end
+    end
+end
+
+@testset "'Definition' for module, method request/responce" begin
+    @testset "function definition" begin
+        cnt = 0
+        test_global_definition("""
+            func(x) = 1
+            fu│nc(1.0)
+        """, (i, result, uri) -> begin
+            @test length(result) == 1
+            @test first(result).uri == uri
+            @test first(result).range.start.line == 0
+            cnt += 1
+        end)
+        @test cnt == 1
+    end
+
+    @testset "Base functions" begin
+        cnt = 0
+        test_global_definition("""
+            Base.Compiler.tm│eet
+        """, (i, result, uri) -> begin
+            @test length(result) >= 1
+            cnt += 1
+        end)
+        @test cnt == 1
+
+        sin_cand_file, sin_cand_line = functionloc(first(methods(sin, (Float64,))))
+        sin_cand_file = JETLS.to_full_path(sin_cand_file)
+
+        cnt = 0
+        test_global_definition("""
+            si│n(1.0)
+        """, (i, result, uri) -> begin
+            @test length(result) >= 1
+            @test any(result) do candidate
+                JETLS.uri2filepath(candidate.uri) == sin_cand_file &&
+                candidate.range.start.line == (sin_cand_line - 1)
+            end
+            cnt += 1
+        end)
+        @test cnt == 1
+    end
+    @testset "Base function with invalid location" begin
+        cnt = 0
+        test_global_definition("""
+            1 +│ 2
+        """, (i, result, uri) -> begin
+            @test length(result) >= 1
+            cnt += 1
+        end)
+        @test cnt == 1
+    end
+
+    @testset "function argument position" begin
+        cnt = 0
+        test_global_definition("""
+            func(x) = 1
+            func(1.│0)
+        """, (i, result, uri) -> begin
+            @test result === null
+            cnt += 1
+        end)
+        @test cnt == 1
+    end
+
+    @testset "function in module" begin
+        cnt = 0
+        test_global_definition("""
+            module M
+                m_func(x) = 1
+                m_│func(1.0)
+            end
+            m_│func(1.0)
+            M.m_│func(1.0)
+        """, (i, result, uri) -> begin
+            if i == 1
+                @test length(result) == 1
+                @test first(result).uri == uri
+                @test first(result).range.start.line == 1
+                cnt += 1
+            elseif i == 2
+                @test result === null
+                cnt += 1
+            elseif i == 3
+                @test length(result) == 1
+                @test first(result).uri == uri
+                @test first(result).range.start.line == 1
+                cnt += 1
+            end
+        end)
+        @test cnt == 3
+    end
+
+    @testset "Base override" begin
+        cnt = 0
+        test_global_definition("""
+            cos(x) = 1
+            Base.co│s(x) = 1
+        """, (i, result, uri) -> begin
+            @test length(result) >= 1
+            @test all(result) do candidate
+                candidate.uri.path != uri # in `Base`, not `cos(x) = 1`
+            end
+            cnt += 1
+        end)
+        @test cnt == 1
+    end
+
+    @testset "struct type in function signature" begin
+        cnt = 0
+        test_global_definition("""
+            struct Hello
+                who::String
+                Hello(who::AbstractString) = new(String(who))
+            end
+            function say(h::Hel│lo)
+                println("Hello, \$(h.who)")
+            end
+        """, (i, result, uri) -> begin
+            @test length(result) == 1
+            @test first(result).uri == uri
+            @test first(result).range.start.line == 2
+            cnt += 1
+        end)
+        @test cnt == 1
+    end
+
+    @testset "function with default arguments (should be aggregated)" begin
+        cnt = 0
+        test_global_definition("""
+            struct Hello
+                who::String
+            end
+            function say_defarg(h::Hello, s = "Hello")
+                println("\$s, \$(h.who)")
+            end
+            say_defar│g
+        """, (i, result, uri) -> begin
+            @test length(result) == 1
+            @test first(result).uri == uri
+            @test first(result).range.start.line == 3
+            cnt += 1
+        end)
+        @test cnt == 1
+    end
+
+    @testset "function with keyword arguments (should be aggregated)" begin
+        cnt = 0
+        test_global_definition("""
+            struct Hello
+                who::String
+            end
+            function say_kwarg(h::Hello; s = "Hello")
+                println("\$s, \$(h.who)")
+            end
+            say_kwar│g
+        """, (i, result, uri) -> begin
+            @test length(result) == 1
+            @test first(result).uri == uri
+            @test first(result).range.start.line == 3
+            cnt += 1
+        end)
+        @test cnt == 1
+    end
+
+    @testset "target node selection" begin
+        local cnt = 0
+        test_global_definition("""
+            func(x) = 1
+            func│ # bare function
+            func│(1.0) # right edge
+            │func(1.0) # left edge
+        """, (i, result, uri) -> begin
+            if i == 1
+                @test length(result) == 1
+                @test first(result).uri == uri
+                @test first(result).range.start.line == 0
+                cnt += 1
+            elseif i == 2
+                @test length(result) == 1
+                @test first(result).uri == uri
+                @test first(result).range.start.line == 0
+                cnt += 1
+            elseif i == 3
+                @test length(result) == 1
+                @test first(result).uri == uri
+                @test first(result).range.start.line == 0
+                cnt += 1
+            end
+        end)
+        @test cnt == 3
+    end
+
+    @testset "target node selection (qualified function)" begin
+        cnt = 0
+        test_global_definition("""
+            module M
+                m_func(x) = 1
+            end
+            M.m_func│(1.0)
+            M.│m_func(1.0)
+        """, (i, result, uri) -> begin
+            if i == 1
+                @test length(result) == 1
+                @test first(result).uri == uri
+                @test first(result).range.start.line == 1
+                cnt += 1
+            elseif i == 2
+                @test length(result) == 1
+                @test first(result).uri == uri
+                @test first(result).range.start.line == 1
+                cnt += 1
+            end
+        end)
+        @test cnt == 2
+    end
+
+    @testset "function in let block" begin
+        cnt = 0
+        test_global_definition("""
+            func(x) = 1
+            let; func│; end
+        """, (i, result, uri) -> begin
+            @test length(result) == 1
+            @test first(result).uri == uri
+            @test first(result).range.start.line == 0
+            cnt += 1
+        end)
+        @test cnt == 1
+    end
+
+    @testset "module location" begin
+        cnt = 0
+        test_global_definition("""
+            module M2
+                m_func(x) = 1
+            end
+            M2│.m_func(1.0)
+        """, (i, result, uri) -> begin
+            @test result isa Location
+            @test result.uri == uri
+            @test result.range.start.line == 0
+            cnt += 1
+        end)
+        @test cnt == 1
+    end
+
+    @testset "invalid module location" begin
+        cnt = 0
+        test_global_definition("""
+            Core│.isdefined
+        """, (i, result, uri) -> begin
+            @test result === null # `Base.moduleloc(Core)` doesn't return anything meaningful
+            cnt += 1
+        end)
+        @test cnt == 1
     end
 end
 


### PR DESCRIPTION
This change enhances the local binding jump functionality to support multiple assignment operations and enables jumps from target bindings that are positioned before the definition.

@abap34 Sorry for immediately fixing the code that was reviewed and merged. There were reasons for making the changes, so I'll explain it in inline comments. I would appreciate it if you could review it.