### PR TITLE
ast: improve `remove_macrocalls` hack a bit

### DIFF
--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -304,10 +304,10 @@ end
         @test any(items) do item
             item.label == "x"
         end
-        @test !any(items) do item
+        @test_broken !any(items) do item
             item.label == "y"
         end
-        @test_broken any(items) do item
+        @test any(items) do item
             item.label == "y_var"
         end
     end


### PR DESCRIPTION
Previously, `remove_macrocalls` replaced all macrocalls (except `@nospecialize`) with `nothing`. However, for better usability in completion and local definition features, this change modifies the behavior to preserve macrocall arguments as `block` expressions.

Of course, this is not a completely correct fix, but it allows minimal utilization of local binding information.

In the future, we will need to wait for proper macro expansion support in JL.