### PR TITLE
diagnostics: report unused bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ the list itself is subject to change.
   - [ ] Cross-server-process cache system
 - Diagnostics
   - [x] Report undefined bindings
+  - [x] Report unused bindings
   - [ ] Report potential `MethodError`
 - Completion
   - [x] Global symbol completion

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -53,6 +53,8 @@ include("utils/server.jl")
 include("analysis/Interpreter.jl")
 using .Interpreter
 
+include("analysis/surface-analysis.jl")
+
 include("document-synchronization.jl")
 include("analysis/full-analysis.jl")
 include("response.jl")

--- a/src/analysis/surface-analysis.jl
+++ b/src/analysis/surface-analysis.jl
@@ -1,0 +1,62 @@
+function analyze_lowered_code!(diagnostics::Vector{Diagnostic},
+                               ctx3::JL.VariableAnalysisContext, st3::JL.SyntaxTree,
+                               sourcefile::JS.SourceFile)
+    binding_usages = compute_binding_usages(ctx3, st3)
+    for (binfo, used) in binding_usages
+        used && continue
+        binding = JL.binding_ex(ctx3, binfo.id)
+        if binfo.kind === :argument
+            message = "Unused argument `$(binfo.name)`"
+        else
+            message = "Unused local binding `$(binfo.name)`"
+        end
+        diagnostic = jsobj_to_diagnostic(binding, sourcefile,
+            message,
+            #=severity=#DiagnosticSeverity.Information,
+            #=source=#LOWERING_DIAGNOSTIC_SOURCE)
+        push!(diagnostics, diagnostic)
+    end
+    return diagnostics
+end
+
+function compute_binding_usages(ctx3::JL.VariableAnalysisContext, st3::JL.SyntaxTree)
+    tracked = Dict{JL.BindingInfo,Bool}()
+
+    for binfo = ctx3.bindings.info
+        binfo.is_internal && continue
+        binfo.kind === :argument || binfo.kind === :local || continue
+        tracked[binfo] = false
+    end
+
+    if isempty(tracked)
+        return tracked
+    end
+
+    stack = [st3]
+    while !isempty(stack)
+        st = pop!(stack)
+        k = JS.kind(st)
+        if k === JS.K"local" # || k === JS.K"function_decl"
+            continue
+        end
+
+        if k === JS.K"BindingId"
+            binfo = JL.lookup_binding(ctx3, st)
+            if haskey(tracked, binfo)
+                tracked[binfo] |= true
+            end
+        end
+
+        i = 1
+        if k === JS.K"lambda"
+            i = 2 # the first block, i.e. the argument declaration does not account for usage
+        elseif k === JS.K"="
+            i = 2 # the left hand side, i.e. "definition", does not account for usage
+        end
+        for j = i:JS.numchildren(st)
+            push!(stack, st[j])
+        end
+    end
+
+    tracked
+end

--- a/src/analysis/surface-analysis.jl
+++ b/src/analysis/surface-analysis.jl
@@ -39,7 +39,8 @@ function compute_binding_usages!(tracked::Dict{JL.BindingInfo,Bool},
                                  ctx3::JL.VariableAnalysisContext, st3::JL.SyntaxTree;
                                  include_decls::Bool = false,
                                  skip_tracking::Union{Nothing,Set{JL.BindingInfo}}=nothing)
-    stack = [st3]
+    stack = JL.SyntaxList(st3)
+    push!(stack, st3)
     infunc = false
     while !isempty(stack)
         st = pop!(stack)

--- a/src/analysis/surface-analysis.jl
+++ b/src/analysis/surface-analysis.jl
@@ -107,6 +107,15 @@ function compute_binding_usages!(tracked::Dict{JL.BindingInfo,Bool},
             end
         elseif k === JS.K"="
             i = 2 # the left hand side, i.e. "definition", does not account for usage
+            if n ≥ 2
+                eq2 = st[2]
+                # In struct definitions, `local struct_name` is somehow introduced,
+                # so special case it here: https://github.com/c42f/JuliaLowering.jl/blob/4b12ab19dad40c64767558be0a8a338eb4cc9172/src/desugaring.jl#L3833
+                # TODO investigate why this local binding introduction is necessary on the JL side
+                if JS.kind(eq2) === JS.K"BindingId" && JL.lookup_binding(ctx3, eq2).name == "struct_type"
+                    i = 1
+                end
+            end
         end
         for j = n:-1:i # since we use `pop!`
             push!(stack, st[j])

--- a/src/analysis/surface-analysis.jl
+++ b/src/analysis/surface-analysis.jl
@@ -10,11 +10,11 @@ function analyze_lowered_code!(diagnostics::Vector{Diagnostic},
         else
             message = "Unused local binding `$(binfo.name)`"
         end
-        diagnostic = jsobj_to_diagnostic(binding, sourcefile,
+        push!(diagnostics, jsobj_to_diagnostic(binding, sourcefile,
             message,
             #=severity=#DiagnosticSeverity.Information,
-            #=source=#LOWERING_DIAGNOSTIC_SOURCE)
-        push!(diagnostics, diagnostic)
+            #=source=#LOWERING_DIAGNOSTIC_SOURCE;
+            tags = DiagnosticTag.Ty[DiagnosticTag.Unnecessary]))
     end
     return diagnostics
 end

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -309,7 +309,7 @@ Examples:
 8. `\\alpha  bet┃a` returns `nothing` (no backslash immediately before token with cursor)
 9. `# \\┃`          returns byte offset of `\\` and `false` or `true` if followed by `:` (comment scope)
 """
-function get_backslash_offset(state::ServerState, fi::FileInfo, pos::Position)
+function get_backslash_offset(fi::FileInfo, pos::Position)
     # Search backwards from cursor position for backslash
     textbuf = fi.parsed_stream.textbuf
     separators = (UInt8(' '), UInt8('\t'), UInt8('\n'), UInt8('"'), UInt8('\''))
@@ -336,7 +336,7 @@ function add_emoji_latex_completions!(items::Dict{String,CompletionItem}, state:
     fi === nothing && return nothing
 
     pos = params.position
-    backslash_offset_emojionly = get_backslash_offset(state, fi, pos)
+    backslash_offset_emojionly = get_backslash_offset(fi, pos)
     backslash_offset_emojionly === nothing && return nothing
     backslash_offset, emojionly = backslash_offset_emojionly
     backslash_pos = offset_to_xy(fi, backslash_offset)

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -27,7 +27,8 @@ end
 function jsobj_to_diagnostic(obj, sourcefile::JS.SourceFile,
                              message::AbstractString,
                              severity::DiagnosticSeverity.Ty,
-                             source::String)
+                             source::String;
+                             tags::Union{Nothing,Vector{DiagnosticTag.Ty}}=nothing)
     sline, scol = JS.source_location(sourcefile, JS.first_byte(obj))
     eline, ecol = JS.source_location(sourcefile, JS.last_byte(obj))
     range = Range(;
@@ -37,7 +38,8 @@ function jsobj_to_diagnostic(obj, sourcefile::JS.SourceFile,
         range,
         severity,
         message,
-        source)
+        source,
+        tags)
 end
 
 # TODO severity

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -15,7 +15,7 @@ module __demo__ end
         end
     """)
     position = only(positions)
-    mktemp() do filename, io
+    mktemp() do filename, _
         uri = filepath2uri(filename)
         @compile_workload let
             state = server.state

--- a/src/response.jl
+++ b/src/response.jl
@@ -22,7 +22,7 @@ function handle_ResponseMessage(server::Server, msg::Dict{Symbol,Any})
     return false
 end
 
-function handle_requested_response(server::Server, msg::Dict{Symbol,Any},
+function handle_requested_response(server::Server, #=msg=#::Dict{Symbol,Any},
                                    @nospecialize request_caller::RequestCaller)
     if request_caller isa RunFullAnalysisCaller
         (; uri, onsave, token) = request_caller

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -239,7 +239,7 @@ function make_siginfo(m::Method, ca::CallArgs, active_arg::Union{Int, Symbol};
     msig = postprocessor(msig)
     mnode = JS.parsestmt(JL.SyntaxTree, msig; ignore_errors=true)
     label = String(msig)
-    documentation = let value
+    documentation = let
         mdl = postprocessor(string(Base.parentmodule(m)))
         file, line = Base.updated_methodloc(m)
         filepath = to_full_path(file)

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -68,7 +68,8 @@ function deduplicate_syntaxlist(sl::JL.SyntaxList)
 end
 
 function traverse(@specialize(callback), st::JL.SyntaxTree)
-    stack = [st]
+    stack = JL.SyntaxList(st)
+    push!(stack, st)
     while !isempty(stack)
         st = pop!(stack)
         if JS.numchildren(st) === 0

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -13,7 +13,7 @@ Note that the byte offset returned in such cases has almost no meaning.
 """
 function xy_to_offset(code::Vector{UInt8}, pos::Position)
     b = 0
-    for z in 1:pos.line
+    for _ in 1:pos.line
         nextb = findnext(isequal(UInt8('\n')), code, b + 1)
         if isnothing(nextb) # guard against invalid `pos`
             break
@@ -24,7 +24,7 @@ function xy_to_offset(code::Vector{UInt8}, pos::Position)
     lend = isnothing(lend) ? lastindex(code) + 1 : lend
     curline = String(code[b+1:lend-1]) # current line, containing no newlines
     line_b = 1
-    for i in 1:pos.character
+    for _ in 1:pos.character
         checkbounds(Bool, curline, line_b) || break # guard against invalid `pos`
         line_b = nextind(curline, line_b)
     end

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -46,7 +46,7 @@ function cursor_bindings(st0_top::JL.SyntaxTree, b_top::Int)
     end
     ctx3, st2 = try
         jl_lower_for_scope_resolution2(st0)
-    catch err
+    catch # err
         # JETLS_DEV_MODE && @warn "Error in lowering" err
         return nothing # lowering failed, e.g. because of incomplete input
     end
@@ -70,7 +70,7 @@ function cursor_bindings(st0_top::JL.SyntaxTree, b_top::Int)
     cursor_scopes = byte_ancestors(st2, b)
 
     # ignore scopes we aren't in
-    filter!(((binfo, _, bs),) -> isnothing(bs) || bs._id in cursor_scopes.ids,
+    filter!(((_, _, bs),) -> isnothing(bs) || bs._id in cursor_scopes.ids,
             bscopeinfos)
 
     # Now eliminate duplicates by name.
@@ -159,7 +159,7 @@ end
 function _lookup_binding_definitions!(sl::JL.SyntaxList, st3::JL.SyntaxTree, binding_id::Int)
     traverse(st3) do st::JL.SyntaxTree
         if JS.kind(st) === JS.K"=" && JS.numchildren(st) ≥ 2
-            lhs, rhs = st[1], st[2]
+            lhs = st[1]
             if is_same_binding(lhs, binding_id)
                 push!(sl, lhs)
             end

--- a/test/jsjl_utils.jl
+++ b/test/jsjl_utils.jl
@@ -37,12 +37,11 @@ end
 function jlnode(g::JL.SyntaxGraph, i::JL.NodeId)
     t = JL.SyntaxTree(g, i)
     # show(stdout, MIME("text/x.sexpression"), t)
-    t
+    return t
 end
 function jlnode(st::JL.SyntaxTree, i::JL.NodeId)
-    t = JL.SyntaxTree(st._graph, i)
-    t
+    return JL.SyntaxTree(st._graph, i)
 end
 function jlnode(ctx::T where {T<:JL.AbstractLoweringContext}, i::JL.NodeId)
-    t = JL.SyntaxTree(ctx.graph, i)
+    return JL.SyntaxTree(ctx.graph, i)
 end

--- a/test/jsjl_utils.jl
+++ b/test/jsjl_utils.jl
@@ -6,13 +6,13 @@ function parsedstream(s::AbstractString, rule::Symbol=:all)
     return stream
 end
 
-function jsparse(s::AbstractString; ignore_errors=true, kws...)
-    JS.build_tree(JS.SyntaxNode, parsedstream(s); filename=@__FILE__, ignore_errors, kws...)
-end
+jsparse(s::AbstractString) = jsparse(parsedstream(s))
+jsparse(parsed_stream::JS.ParseStream; filename::AbstractString=@__FILE__) =
+    JS.build_tree(JS.SyntaxNode, parsed_stream; filename)
 
-function jlparse(s::AbstractString; ignore_errors=true, kws...)
-    JS.build_tree(JL.SyntaxTree, parsedstream(s); filename=@__FILE__, ignore_errors, kws...)
-end
+jlparse(s::AbstractString) = jlparse(parsedstream(s))
+jlparse(parsed_stream::JS.ParseStream; filename::AbstractString=@__FILE__) =
+    JS.build_tree(JL.SyntaxTree, parsed_stream; filename)
 
 # For interactive use
 # ===================

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ end
     @testset "signature help" include("test_signature_help.jl")
     @testset "definition" include("test_definition.jl")
     @testset "hover" include("test_hover.jl")
+    @testset "surface analysis" include("test_surface_analysis.jl")
     @testset "LSAnalyzer" include("test_LSAnalyzer.jl")
     @testset "diagnostics" include("test_diagnostics.jl")
     @testset "full lifecycle" include("test_full_lifecycle.jl")

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -479,7 +479,7 @@ function test_backslash_offset(code::String, expected_result)
     uri = filename2uri(filename)
     fi = JETLS.cache_file_info!(state, uri, 1, text)
 
-    result = JETLS.get_backslash_offset(state, fi, positions[1])
+    result = JETLS.get_backslash_offset(fi, positions[1])
     @test result == expected_result
     return result
 end

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -15,7 +15,7 @@ using JETLS.URIs2
         x = 1
         if x > 0
             println("Positive")
-        # Missing end for the if statement
+        # Missing end
     end
     """
 

--- a/test/test_surface_analysis.jl
+++ b/test/test_surface_analysis.jl
@@ -55,11 +55,11 @@ end
             return x
         end
         """)
-        @test_broken length(diagnostics) == 1
-        # diagnostic = only(diagnostics)
-        # @test diagnostic.message == "Unused argument `y`"
-        # @test diagnostic.range.start.line == 0
-        # @test diagnostic.range.var"end".line == 0
+        @test length(diagnostics) == 1
+        diagnostic = only(diagnostics)
+        @test diagnostic.message == "Unused argument `y`"
+        @test diagnostic.range.start.line == 0
+        @test diagnostic.range.var"end".line == 0
     end
 
     let diagnostics = get_lowered_diagnostics("""
@@ -67,7 +67,7 @@ end
             return x, y
         end
         """)
-        @test_broken isempty(diagnostics)
+        @test isempty(diagnostics)
     end
 
     let diagnostics = get_lowered_diagnostics("""

--- a/test/test_surface_analysis.jl
+++ b/test/test_surface_analysis.jl
@@ -1,0 +1,102 @@
+module test_surface_analysis
+
+using Test
+using JETLS
+using JETLS: JL, JS
+
+include("jsjl_utils.jl")
+
+function get_lowered_diagnostics(text::AbstractString; filename::AbstractString = @__FILE__)
+    return JETLS.lowering_diagnostics(parsedstream(text), filename)
+end
+
+@testset "unused binding detection" begin
+    let diagnostics = get_lowered_diagnostics("""
+        y = let x = 42
+            sin(42)
+        end
+        """)
+        @test length(diagnostics) == 1
+        diagnostic = only(diagnostics)
+        @test diagnostic.message == "Unused local binding `x`"
+        @test diagnostic.range.start.line == 0
+        @test diagnostic.range.start.character == sizeof("y = let ")
+        @test diagnostic.range.var"end".line == 0
+        @test diagnostic.range.var"end".character == sizeof("y = let x")
+    end
+
+    let diagnostics = get_lowered_diagnostics("""
+        function foo(x, y)
+            return x
+        end
+        """)
+        @test length(diagnostics) == 1
+        diagnostic = only(diagnostics)
+        @test diagnostic.message == "Unused argument `y`"
+        @test diagnostic.range.start.line == 0
+        @test diagnostic.range.var"end".line == 0
+    end
+
+    let diagnostics = get_lowered_diagnostics("""
+        function foo(x)
+            local y
+            return x
+        end
+        """)
+        @test length(diagnostics) == 1
+        diagnostic = only(diagnostics)
+        @test diagnostic.message == "Unused local binding `y`"
+        @test diagnostic.range.start.line == 1
+        @test diagnostic.range.var"end".line == 1
+    end
+
+    let diagnostics = get_lowered_diagnostics("""
+        function foo(x; y=nothing)
+            return x
+        end
+        """)
+        @test_broken length(diagnostics) == 1
+        # diagnostic = only(diagnostics)
+        # @test diagnostic.message == "Unused argument `y`"
+        # @test diagnostic.range.start.line == 0
+        # @test diagnostic.range.var"end".line == 0
+    end
+
+    let diagnostics = get_lowered_diagnostics("""
+        function foo(x; y)
+            return x, y
+        end
+        """)
+        @test_broken isempty(diagnostics)
+    end
+
+    let diagnostics = get_lowered_diagnostics("""
+        let x = collect(1:10)
+            ys = [x for (i, x) in enumarate(x)]
+            ys
+        end
+        """)
+        @test length(diagnostics) == 1
+        diagnostic = only(diagnostics)
+        @test diagnostic.message == "Unused local binding `i`"
+        @test diagnostic.range.start.line == 1
+        @test diagnostic.range.var"end".line == 1
+    end
+
+    @testset "module splitter" begin
+        diagnostics = get_lowered_diagnostics("""
+        module TestModuleSplit
+        global y::Float64 = let x = 42
+            sin(42)
+        end
+        end # module TestModuleSplit
+        """)
+        @test length(diagnostics) == 1
+        diagnostic = only(diagnostics)
+        @test diagnostic.message == "Unused local binding `x`"
+        @test diagnostic.range.start.line == 1
+        @test diagnostic.range.var"end".line == 1
+    end
+end
+
+end # module test_surface_analysis


### PR DESCRIPTION
Implements lowering-based diagnostic analysis to detect unused variable bindings. Note that this diagnostics is reported by the pull-model diagnostics, which is synced with syntactic analysis cache.

https://github.com/user-attachments/assets/caa7177a-d7f6-4f43-abe0-6eadd1e1bffd

# TODO
- [x] Keyword arg issue
- [x] Report unused inner function
- [x] Fix false positive warning for `struct` definitions