### PR TITLE
AGENTS.md: remove custom julia script, use system `julia` directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ node_modules
 out
 Manifest.toml
 Manifest-*.toml
-julia
+.envrc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,9 +57,6 @@
 
 # Running Test Code
 Please make sure to test new code when you wrote.
-When running tests, use the [`./julia`](./julia) script if it exists in the root
-directory of this repository.
-If it doesn't exist, simply use the `julia` command.
 
 If explicit test file or code is provided, prioritize running that.
 Otherwise, you can run the entire test suite for the JETLS project by executing
@@ -68,9 +65,10 @@ Otherwise, you can run the entire test suite for the JETLS project by executing
 For example, if you receive a prompt like this:
 > Improve the error message of diagnostics.
 > Use test/test_diagnostics for the test cases.
-And if `./julia` exists, the command you should run is:
+
+The command you should run is:
 ```
-$ ./julia --startup-file=no -e 'using Test; @testset "test_diagnostics" include("test/test_diagnostics")'
+$ julia --startup-file=no -e 'using Test; @testset "test_diagnostics" include("test/test_diagnostics")'
 ```
 Note that the usage of the `--startup-file=no` flag, which avoids loading
 unnecessary startup utilities.


### PR DESCRIPTION
Update .gitignore to exclude .envrc instead of julia script and remove references to ./julia wrapper from documentation.

The motivation is that instead of each person having to prepare a ./julia script, if we set up technology like [direnv](https://direnv.net/), we can configure the `julia` executable used in this project, so I think it would be good to have CLAUDE utilize that as well.