### PR TITLE
hover: Add local variable hover

### DIFF
--- a/src/hover.jl
+++ b/src/hover.jl
@@ -15,22 +15,6 @@ function hover_registration()
     )
 end
 
-function local_hover(st0_top::JL.SyntaxTree, offset::Int)
-    st0, b = greatest_local(st0_top, offset)
-    isnothing(st0) && return nothing
-    ctx3, st3 = try
-        jl_lower_for_scope_resolution3(st0)
-    catch
-        return nothing
-    end
-    binding = select_target_binding(ctx3, st3, b)
-    isnothing(binding) && return nothing
-    binfo = JL.lookup_binding(ctx3, binding)
-    definitions = lookup_binding_definitions(st3, binfo)
-    isempty(definitions) && return nothing
-    return binding, definitions
-end
-
 function handle_HoverRequest(server::Server, msg::HoverRequest)
     pos = msg.params.position
     uri = msg.params.textDocument.uri
@@ -47,7 +31,7 @@ function handle_HoverRequest(server::Server, msg::HoverRequest)
     st0_top = JS.build_tree(JL.SyntaxTree, fi.parsed_stream)
     offset = xy_to_offset(fi, pos)
 
-    target_binding_definitions = local_hover(st0_top, offset)
+    target_binding_definitions = select_target_binding_definitions(st0_top, offset)
     if !isnothing(target_binding_definitions)
         # TODO Ideally we would want to show the type of this local binding,
         # but for now we'll just show the location of the local binding

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ end
 
 @testset "JETLS" begin
     @testset "utils" include("test_utils.jl")
+    @testset "binding" include("test_binding.jl")
     @testset "URIs2" include("test_URIs2.jl")
     @testset "registration" include("test_registration.jl")
     @testset "resolver" include("test_resolver.jl")

--- a/test/test_binding.jl
+++ b/test/test_binding.jl
@@ -1,0 +1,452 @@
+module test_binding
+
+using Test
+using JETLS: JETLS
+
+include("jsjl_utils.jl")
+
+function with_target_binding_definitions(f, text::AbstractString, matcher::Regex=r"│")
+    clean_code, positions = JETLS.get_text_and_positions(text, matcher)
+    st0_top = jlparse(clean_code)
+    for (i, pos) in enumerate(positions)
+        offset = JETLS.xy_to_offset(Vector{UInt8}(clean_code), pos)
+        f(i, JETLS.select_target_binding_definitions(st0_top, offset))
+    end
+end
+
+@testset "`select_target_binding_definitions" begin
+    with_target_binding_definitions("""
+        function mapfunc(xs)
+            Any[Core.Const(x│)
+                for x in xs]
+        end
+    """) do _, res
+        @test !isnothing(res)
+        binding, defs = res
+        @test JS.source_line(JL.sourceref(binding)) == 2
+        @test length(defs) == 1
+        @test JS.source_line(JL.sourceref(only(defs))) == 3
+    end
+
+    @testset "simple" begin
+        cnt = 0
+        with_target_binding_definitions("""
+            function func(x)
+                y = x│ + 1
+                return y│
+            end
+        """) do i, res
+            if i == 1 # x│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 2
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 1
+                cnt += 1
+            elseif i == 2 # y│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 3
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 2
+                cnt += 1
+            end
+        end
+        @test cnt == 2
+    end
+
+    @testset "parameter shadowing" begin
+        cnt = 0
+        with_target_binding_definitions("""
+            function redef(x)
+                x = 1
+                y = x│ + 1
+                return y│
+            end
+        """) do i, res
+            if i == 1 # x│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 3
+                @test length(defs) == 2 # Both parameter x and local x = 1
+                # The definitions should include both x = 1 on line 2 and the parameter x on line 1
+                @test any(d -> JS.source_line(JL.sourceref(d)) == 1, defs) # parameter
+                @test any(d -> JS.source_line(JL.sourceref(d)) == 2, defs) # local assignment
+                cnt += 1
+            elseif i == 2 # y│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 4
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 3
+                cnt += 1
+            end
+        end
+        @test cnt == 2
+    end
+
+    @testset "function self-reference" begin
+        cnt = 0
+        with_target_binding_definitions("""
+            function rec(x)
+                return rec│(x + 1)
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 2
+            @test length(defs) >= 1
+            @test any(defs) do def
+                JS.source_line(JL.sourceref(def)) == 1
+            end
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "closure captures" begin
+        cnt = 0
+        with_target_binding_definitions("""
+            function closure()
+                x = 1
+                function inner(y)
+                    return x│ + y│
+                end
+                return inner
+            end
+        """) do i, res
+            if i == 1 # x│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 4
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 2
+                cnt += 1
+            elseif i == 2 # y│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 4
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 3
+                cnt += 1
+            end
+        end
+        @test cnt == 2
+    end
+
+    @testset "let binding" begin
+        cnt = 0
+        with_target_binding_definitions("""
+            function let_binding()
+                let x = 1
+                    y = x│ + 1
+                    return y│
+                end
+            end
+        """) do i, res
+            if i == 1 # x│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 3
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 2
+                cnt += 1
+            elseif i == 2 # y│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 4
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 3
+                cnt += 1
+            end
+        end
+        @test cnt == 2
+    end
+
+    @testset "for loop variable" begin
+        cnt = 0
+        with_target_binding_definitions("""
+            function loop_var(n)
+                for i in 1:n
+                    println(i│)
+                end
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 3
+            @test length(defs) == 1
+            @test JS.source_line(JL.sourceref(only(defs))) == 2
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "comprehension variable" begin
+        cnt = 0
+        with_target_binding_definitions("""
+            let
+                v = [│xxx^2 for xxx in 1:5]
+                return v
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 2
+            @test length(defs) == 1
+            @test JS.source_line(JL.sourceref(only(defs))) == 2
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "destructuring assignment" begin
+        cnt = 0
+        with_target_binding_definitions("""
+            function destructuring()
+                (a, b) = (1, 2)
+                return a│ + b│
+            end
+        """) do i, res
+            if i == 1 # a│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 3
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 2
+                cnt += 1
+            elseif i == 2 # b│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 3
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 2
+                cnt += 1
+            end
+        end
+        @test cnt == 2
+    end
+
+    @testset "conditional binding" begin
+        cnt = 0
+        with_target_binding_definitions("""
+            function if_branch(x)
+                if x > 0
+                    y = x
+                end
+                return y│
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 5
+            @test length(defs) == 1
+            @test JS.source_line(JL.sourceref(only(defs))) == 3
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "try-catch variable" begin
+        cnt = 0
+        with_target_binding_definitions("""
+            function try_catch()
+                try
+                    error("boom")
+                catch err
+                    return err│
+                end
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 5
+            @test length(defs) == 1
+            @test JS.source_line(JL.sourceref(only(defs))) == 4
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "do block parameter" begin
+        cnt = 0
+        with_target_binding_definitions("""
+            function do_block()
+                map(1:3) do t
+                    t│ + 1
+                end
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 3
+            @test length(defs) == 1
+            @test JS.source_line(JL.sourceref(only(defs))) == 2
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "lambda parameter" begin
+        cnt = 0
+        with_target_binding_definitions("""
+            sq = x -> x│ ^ 2
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 1
+            @test length(defs) == 1
+            @test JS.source_line(JL.sourceref(only(defs))) == 1
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "nested let scopes" begin
+        cnt = 0
+        with_target_binding_definitions("""
+            function nested_let()
+                let x = 1
+                    let x = 2
+                        return x│
+                    end
+                end
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 4
+            @test length(defs) == 1
+            @test JS.source_line(JL.sourceref(only(defs))) == 3
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "for loop shadowing" begin
+        cnt = 0
+        with_target_binding_definitions("""
+            function loop_shadow()
+                x = 0
+                for x = 1:3
+                    println(x│)
+                end
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 4
+            @test length(defs) == 1
+            @test JS.source_line(JL.sourceref(only(defs))) == 3
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "closure recapture" begin
+        cnt = 0
+        with_target_binding_definitions("""
+            function recapture()
+                x = 1
+                f = () -> x│ + 1
+                x = 2
+                return f()
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 3
+            @test length(defs) == 2
+            @test any(def -> JS.source_line(JL.sourceref(def)) == 2, defs)
+            @test any(def -> JS.source_line(JL.sourceref(def)) == 4, defs)
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "keyword arguments" begin
+        cnt = 0
+        with_target_binding_definitions("""
+            function keyword_args(; a = 1, b = 2)
+                a│ + b│
+            end
+        """) do i, res
+            if i == 1 # a│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 2
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 1
+                cnt += 1
+            elseif i == 2 # b│
+                @test !isnothing(res)
+                binding, defs = res
+                @test JS.source_line(JL.sourceref(binding)) == 2
+                @test length(defs) == 1
+                @test JS.source_line(JL.sourceref(only(defs))) == 1
+                cnt += 1
+            end
+        end
+        @test cnt == 2
+    end
+
+    @testset "inner function parameter shadowing" begin
+        cnt = 0
+        with_target_binding_definitions("""
+            function outer()
+                x = 1
+                function inner(x)
+                    return x│ + 1
+                end
+                return inner
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 4
+            @test length(defs) == 1
+            @test JS.source_line(JL.sourceref(only(defs))) == 3
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "non-linear control flow" begin
+        cnt = 0
+        with_target_binding_definitions("""
+            function not_linear()
+                finish = false
+                @label l1
+                (!finish) && @goto l2
+                return x│
+                @label l2
+                x = 1
+                finish = true
+                @goto l1
+            end
+        """) do _, res
+            @test !isnothing(res)
+            binding, defs = res
+            @test JS.source_line(JL.sourceref(binding)) == 5
+            @test length(defs) == 1
+            @test JS.source_line(JL.sourceref(only(defs))) == 7
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "undefined variable" begin
+        cnt = 0
+        with_target_binding_definitions("""
+            function undefined_var()
+                return x│
+            end
+        """) do _, res
+            @test isnothing(res)
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+end
+
+end # module test_binding

--- a/test/test_definition.jl
+++ b/test/test_definition.jl
@@ -2,7 +2,6 @@ module test_definition
 
 using Test
 using JETLS
-using JETLS: JS, JL
 
 @testset "method location" begin
     linenum = @__LINE__; method_for_test_method_definition_range() = 1
@@ -26,456 +25,10 @@ const LINE_TestModuleDefinitionRange = (@__LINE__) - 3
     @test loc.range.start.line == LINE_TestModuleDefinitionRange-1
 end
 
-include("jsjl_utils.jl")
-
-function with_local_definitions(f, text::AbstractString, matcher::Regex=r"│")
-    clean_code, positions = JETLS.get_text_and_positions(text, matcher)
-    st0_top = jlparse(clean_code)
-    for (i, pos) in enumerate(positions)
-        offset = JETLS.xy_to_offset(Vector{UInt8}(clean_code), pos)
-        f(i, JETLS.local_definitions(st0_top, offset))
-    end
-end
-
-@testset "local definitions" begin
-    with_local_definitions("""
-        function mapfunc(xs)
-            Any[Core.Const(x│)
-                for x in xs]
-        end
-    """) do _, res
-        @test !isnothing(res)
-        binding, defs = res
-        @test JS.source_line(JL.sourceref(binding)) == 2
-        @test length(defs) == 1
-        @test JS.source_line(JL.sourceref(only(defs))) == 3
-    end
-
-    @testset "simple" begin
-        cnt = 0
-        with_local_definitions("""
-            function func(x)
-                y = x│ + 1
-                return y│
-            end
-        """) do i, res
-            if i == 1 # x│
-                @test !isnothing(res)
-                binding, defs = res
-                @test JS.source_line(JL.sourceref(binding)) == 2
-                @test length(defs) == 1
-                @test JS.source_line(JL.sourceref(only(defs))) == 1
-                cnt += 1
-            elseif i == 2 # y│
-                @test !isnothing(res)
-                binding, defs = res
-                @test JS.source_line(JL.sourceref(binding)) == 3
-                @test length(defs) == 1
-                @test JS.source_line(JL.sourceref(only(defs))) == 2
-                cnt += 1
-            end
-        end
-        @test cnt == 2
-    end
-
-    @testset "parameter shadowing" begin
-        cnt = 0
-        with_local_definitions("""
-            function redef(x)
-                x = 1
-                y = x│ + 1
-                return y│
-            end
-        """) do i, res
-            if i == 1 # x│
-                @test !isnothing(res)
-                binding, defs = res
-                @test JS.source_line(JL.sourceref(binding)) == 3
-                @test length(defs) == 2 # Both parameter x and local x = 1
-                # The definitions should include both x = 1 on line 2 and the parameter x on line 1
-                @test any(d -> JS.source_line(JL.sourceref(d)) == 1, defs) # parameter
-                @test any(d -> JS.source_line(JL.sourceref(d)) == 2, defs) # local assignment
-                cnt += 1
-            elseif i == 2 # y│
-                @test !isnothing(res)
-                binding, defs = res
-                @test JS.source_line(JL.sourceref(binding)) == 4
-                @test length(defs) == 1
-                @test JS.source_line(JL.sourceref(only(defs))) == 3
-                cnt += 1
-            end
-        end
-        @test cnt == 2
-    end
-
-    @testset "function self-reference" begin
-        cnt = 0
-        with_local_definitions("""
-            function rec(x)
-                return rec│(x + 1)
-            end
-        """) do _, res
-            @test !isnothing(res)
-            binding, defs = res
-            @test JS.source_line(JL.sourceref(binding)) == 2
-            @test length(defs) >= 1
-            @test any(defs) do def
-                JS.source_line(JL.sourceref(def)) == 1
-            end
-            cnt += 1
-        end
-        @test cnt == 1
-    end
-
-    @testset "closure captures" begin
-        cnt = 0
-        with_local_definitions("""
-            function closure()
-                x = 1
-                function inner(y)
-                    return x│ + y│
-                end
-                return inner
-            end
-        """) do i, res
-            if i == 1 # x│
-                @test !isnothing(res)
-                binding, defs = res
-                @test JS.source_line(JL.sourceref(binding)) == 4
-                @test length(defs) == 1
-                @test JS.source_line(JL.sourceref(only(defs))) == 2
-                cnt += 1
-            elseif i == 2 # y│
-                @test !isnothing(res)
-                binding, defs = res
-                @test JS.source_line(JL.sourceref(binding)) == 4
-                @test length(defs) == 1
-                @test JS.source_line(JL.sourceref(only(defs))) == 3
-                cnt += 1
-            end
-        end
-        @test cnt == 2
-    end
-
-    @testset "let binding" begin
-        cnt = 0
-        with_local_definitions("""
-            function let_binding()
-                let x = 1
-                    y = x│ + 1
-                    return y│
-                end
-            end
-        """) do i, res
-            if i == 1 # x│
-                @test !isnothing(res)
-                binding, defs = res
-                @test JS.source_line(JL.sourceref(binding)) == 3
-                @test length(defs) == 1
-                @test JS.source_line(JL.sourceref(only(defs))) == 2
-                cnt += 1
-            elseif i == 2 # y│
-                @test !isnothing(res)
-                binding, defs = res
-                @test JS.source_line(JL.sourceref(binding)) == 4
-                @test length(defs) == 1
-                @test JS.source_line(JL.sourceref(only(defs))) == 3
-                cnt += 1
-            end
-        end
-        @test cnt == 2
-    end
-
-    @testset "for loop variable" begin
-        cnt = 0
-        with_local_definitions("""
-            function loop_var(n)
-                for i in 1:n
-                    println(i│)
-                end
-            end
-        """) do _, res
-            @test !isnothing(res)
-            binding, defs = res
-            @test JS.source_line(JL.sourceref(binding)) == 3
-            @test length(defs) == 1
-            @test JS.source_line(JL.sourceref(only(defs))) == 2
-            cnt += 1
-        end
-        @test cnt == 1
-    end
-
-    @testset "comprehension variable" begin
-        cnt = 0
-        with_local_definitions("""
-            let
-                v = [│xxx^2 for xxx in 1:5]
-                return v
-            end
-        """) do _, res
-            @test !isnothing(res)
-            binding, defs = res
-            @test JS.source_line(JL.sourceref(binding)) == 2
-            @test length(defs) == 1
-            @test JS.source_line(JL.sourceref(only(defs))) == 2
-            cnt += 1
-        end
-        @test cnt == 1
-    end
-
-    @testset "destructuring assignment" begin
-        cnt = 0
-        with_local_definitions("""
-            function destructuring()
-                (a, b) = (1, 2)
-                return a│ + b│
-            end
-        """) do i, res
-            if i == 1 # a│
-                @test !isnothing(res)
-                binding, defs = res
-                @test JS.source_line(JL.sourceref(binding)) == 3
-                @test length(defs) == 1
-                @test JS.source_line(JL.sourceref(only(defs))) == 2
-                cnt += 1
-            elseif i == 2 # b│
-                @test !isnothing(res)
-                binding, defs = res
-                @test JS.source_line(JL.sourceref(binding)) == 3
-                @test length(defs) == 1
-                @test JS.source_line(JL.sourceref(only(defs))) == 2
-                cnt += 1
-            end
-        end
-        @test cnt == 2
-    end
-
-    @testset "conditional binding" begin
-        cnt = 0
-        with_local_definitions("""
-            function if_branch(x)
-                if x > 0
-                    y = x
-                end
-                return y│
-            end
-        """) do _, res
-            @test !isnothing(res)
-            binding, defs = res
-            @test JS.source_line(JL.sourceref(binding)) == 5
-            @test length(defs) == 1
-            @test JS.source_line(JL.sourceref(only(defs))) == 3
-            cnt += 1
-        end
-        @test cnt == 1
-    end
-
-    @testset "try-catch variable" begin
-        cnt = 0
-        with_local_definitions("""
-            function try_catch()
-                try
-                    error("boom")
-                catch err
-                    return err│
-                end
-            end
-        """) do _, res
-            @test !isnothing(res)
-            binding, defs = res
-            @test JS.source_line(JL.sourceref(binding)) == 5
-            @test length(defs) == 1
-            @test JS.source_line(JL.sourceref(only(defs))) == 4
-            cnt += 1
-        end
-        @test cnt == 1
-    end
-
-    @testset "do block parameter" begin
-        cnt = 0
-        with_local_definitions("""
-            function do_block()
-                map(1:3) do t
-                    t│ + 1
-                end
-            end
-        """) do _, res
-            @test !isnothing(res)
-            binding, defs = res
-            @test JS.source_line(JL.sourceref(binding)) == 3
-            @test length(defs) == 1
-            @test JS.source_line(JL.sourceref(only(defs))) == 2
-            cnt += 1
-        end
-        @test cnt == 1
-    end
-
-    @testset "lambda parameter" begin
-        cnt = 0
-        with_local_definitions("""
-            sq = x -> x│ ^ 2
-        """) do _, res
-            @test !isnothing(res)
-            binding, defs = res
-            @test JS.source_line(JL.sourceref(binding)) == 1
-            @test length(defs) == 1
-            @test JS.source_line(JL.sourceref(only(defs))) == 1
-            cnt += 1
-        end
-        @test cnt == 1
-    end
-
-    @testset "nested let scopes" begin
-        cnt = 0
-        with_local_definitions("""
-            function nested_let()
-                let x = 1
-                    let x = 2
-                        return x│
-                    end
-                end
-            end
-        """) do _, res
-            @test !isnothing(res)
-            binding, defs = res
-            @test JS.source_line(JL.sourceref(binding)) == 4
-            @test length(defs) == 1
-            @test JS.source_line(JL.sourceref(only(defs))) == 3
-            cnt += 1
-        end
-        @test cnt == 1
-    end
-
-    @testset "for loop shadowing" begin
-        cnt = 0
-        with_local_definitions("""
-            function loop_shadow()
-                x = 0
-                for x = 1:3
-                    println(x│)
-                end
-            end
-        """) do _, res
-            @test !isnothing(res)
-            binding, defs = res
-            @test JS.source_line(JL.sourceref(binding)) == 4
-            @test length(defs) == 1
-            @test JS.source_line(JL.sourceref(only(defs))) == 3
-            cnt += 1
-        end
-        @test cnt == 1
-    end
-
-    @testset "closure recapture" begin
-        cnt = 0
-        with_local_definitions("""
-            function recapture()
-                x = 1
-                f = () -> x│ + 1
-                x = 2
-                return f()
-            end
-        """) do _, res
-            @test !isnothing(res)
-            binding, defs = res
-            @test JS.source_line(JL.sourceref(binding)) == 3
-            @test length(defs) == 2
-            @test any(def -> JS.source_line(JL.sourceref(def)) == 2, defs)
-            @test any(def -> JS.source_line(JL.sourceref(def)) == 4, defs)
-            cnt += 1
-        end
-        @test cnt == 1
-    end
-
-    @testset "keyword arguments" begin
-        cnt = 0
-        with_local_definitions("""
-            function keyword_args(; a = 1, b = 2)
-                a│ + b│
-            end
-        """) do i, res
-            if i == 1 # a│
-                @test !isnothing(res)
-                binding, defs = res
-                @test JS.source_line(JL.sourceref(binding)) == 2
-                @test length(defs) == 1
-                @test JS.source_line(JL.sourceref(only(defs))) == 1
-                cnt += 1
-            elseif i == 2 # b│
-                @test !isnothing(res)
-                binding, defs = res
-                @test JS.source_line(JL.sourceref(binding)) == 2
-                @test length(defs) == 1
-                @test JS.source_line(JL.sourceref(only(defs))) == 1
-                cnt += 1
-            end
-        end
-        @test cnt == 2
-    end
-
-    @testset "inner function parameter shadowing" begin
-        cnt = 0
-        with_local_definitions("""
-            function outer()
-                x = 1
-                function inner(x)
-                    return x│ + 1
-                end
-                return inner
-            end
-        """) do _, res
-            @test !isnothing(res)
-            binding, defs = res
-            @test JS.source_line(JL.sourceref(binding)) == 4
-            @test length(defs) == 1
-            @test JS.source_line(JL.sourceref(only(defs))) == 3
-            cnt += 1
-        end
-        @test cnt == 1
-    end
-
-    @testset "non-linear control flow" begin
-        cnt = 0
-        with_local_definitions("""
-            function not_linear()
-                finish = false
-                @label l1
-                (!finish) && @goto l2
-                return x│
-                @label l2
-                x = 1
-                finish = true
-                @goto l1
-            end
-        """) do _, res
-            @test !isnothing(res)
-            binding, defs = res
-            @test JS.source_line(JL.sourceref(binding)) == 5
-            @test length(defs) == 1
-            @test JS.source_line(JL.sourceref(only(defs))) == 7
-            cnt += 1
-        end
-        @test cnt == 1
-    end
-
-    @testset "undefined variable" begin
-        cnt = 0
-        with_local_definitions("""
-            function undefined_var()
-                return x│
-            end
-        """) do _, res
-            @test isnothing(res)
-            cnt += 1
-        end
-        @test cnt == 1
-    end
-end
-
 include("setup.jl")
 
 # Helper to run a single global definition test
-function test_global_definition(tester::Function, text::AbstractString)
+function with_definition_request(tester::Function, text::AbstractString)
     clean_code, positions = JETLS.get_text_and_positions(text, r"│")
 
     withscript(clean_code) do script_path
@@ -501,7 +54,7 @@ end
 @testset "'Definition' for module, method request/responce" begin
     @testset "function definition" begin
         cnt = 0
-        test_global_definition("""
+        with_definition_request("""
             func(x) = 1
             fu│nc(1.0)
         """) do i, result, uri
@@ -515,7 +68,7 @@ end
 
     @testset "Base functions" begin
         cnt = 0
-        test_global_definition("""
+        with_definition_request("""
             Base.Compiler.tm│eet
         """) do i, result, uri
             @test length(result) >= 1
@@ -527,7 +80,7 @@ end
         sin_cand_file = JETLS.to_full_path(sin_cand_file)
 
         cnt = 0
-        test_global_definition("""
+        with_definition_request("""
             si│n(1.0)
         """) do i, result, uri
             @test length(result) >= 1
@@ -541,7 +94,7 @@ end
     end
     @testset "Base function with invalid location" begin
         cnt = 0
-        test_global_definition("""
+        with_definition_request("""
             1 +│ 2
         """) do i, result, uri
             @test length(result) >= 1
@@ -552,7 +105,7 @@ end
 
     @testset "function argument position" begin
         cnt = 0
-        test_global_definition("""
+        with_definition_request("""
             func(x) = 1
             func(1.│0)
         """) do i, result, uri
@@ -564,7 +117,7 @@ end
 
     @testset "function in module" begin
         cnt = 0
-        test_global_definition("""
+        with_definition_request("""
             module M
                 m_func(x) = 1
                 m_│func(1.0)
@@ -592,7 +145,7 @@ end
 
     @testset "Base override" begin
         cnt = 0
-        test_global_definition("""
+        with_definition_request("""
             cos(x) = 1
             Base.co│s(x) = 1
         """) do i, result, uri
@@ -607,7 +160,7 @@ end
 
     @testset "struct type in function signature" begin
         cnt = 0
-        test_global_definition("""
+        with_definition_request("""
             struct Hello
                 who::String
                 Hello(who::AbstractString) = new(String(who))
@@ -626,7 +179,7 @@ end
 
     @testset "function with default arguments (should be aggregated)" begin
         cnt = 0
-        test_global_definition("""
+        with_definition_request("""
             struct Hello
                 who::String
             end
@@ -645,7 +198,7 @@ end
 
     @testset "function with keyword arguments (should be aggregated)" begin
         cnt = 0
-        test_global_definition("""
+        with_definition_request("""
             struct Hello
                 who::String
             end
@@ -664,7 +217,7 @@ end
 
     @testset "target node selection" begin
         local cnt = 0
-        test_global_definition("""
+        with_definition_request("""
             func(x) = 1
             func│ # bare function
             func│(1.0) # right edge
@@ -692,7 +245,7 @@ end
 
     @testset "target node selection (qualified function)" begin
         cnt = 0
-        test_global_definition("""
+        with_definition_request("""
             module M
                 m_func(x) = 1
             end
@@ -716,7 +269,7 @@ end
 
     @testset "function in let block" begin
         cnt = 0
-        test_global_definition("""
+        with_definition_request("""
             func(x) = 1
             let; func│; end
         """) do i, result, uri
@@ -730,7 +283,7 @@ end
 
     @testset "module location" begin
         cnt = 0
-        test_global_definition("""
+        with_definition_request("""
             module M2
                 m_func(x) = 1
             end
@@ -746,10 +299,37 @@ end
 
     @testset "invalid module location" begin
         cnt = 0
-        test_global_definition("""
+        with_definition_request("""
             Core│.isdefined
         """) do i, result, uri
             @test result === null # `Base.moduleloc(Core)` doesn't return anything meaningful
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    @testset "local definition" begin
+        local cnt = 0
+        with_definition_request("""
+            function func(x, y)
+                if rand(Bool)
+                    z = x
+                else
+                    z = y
+                end
+                return z│
+            end
+        """) do _, results, uri
+            @test results isa Vector{Location}
+            @test length(results) == 2
+            @test any(results) do result
+                result.uri == uri &&
+                result.range.start.line == 2
+            end
+            @test any(results) do result
+                result.uri == uri &&
+                result.range.start.line == 4
+            end
             cnt += 1
         end
         @test cnt == 1


### PR DESCRIPTION
Implement local_hover function to provide hover information for local bindings by looking up their definitions and showing their source locations in markdown format.

The information shown by this feature is essentially duplication of the "definition" feature.
In the future, we would want to show the type of this local binding, but that is only possible after the full JL integration. For now we'll just show the location of the local binding