### PR TITLE
test: split "utils" test

### DIFF
--- a/test/jsjl_utils.jl
+++ b/test/jsjl_utils.jl
@@ -1,18 +1,18 @@
 using JETLS: JS, JL
 
-function parsedstream(s::AbstractString, rule::Symbol=:all)
+function parsedstream(s::AbstractString; rule::Symbol=:all)
     stream = JS.ParseStream(s)
     JS.parse!(stream; rule)
     return stream
 end
 
-jsparse(s::AbstractString) = jsparse(parsedstream(s))
-jsparse(parsed_stream::JS.ParseStream; filename::AbstractString=@__FILE__) =
-    JS.build_tree(JS.SyntaxNode, parsed_stream; filename)
+jsparse(s::AbstractString; rule::Symbol=:all, kwargs...) = jsparse(parsedstream(s; rule); kwargs...)
+jsparse(parsed_stream::JS.ParseStream; filename::AbstractString=@__FILE__, first_line::Int=1) =
+    JS.build_tree(JS.SyntaxNode, parsed_stream; filename, first_line)
 
-jlparse(s::AbstractString) = jlparse(parsedstream(s))
-jlparse(parsed_stream::JS.ParseStream; filename::AbstractString=@__FILE__) =
-    JS.build_tree(JL.SyntaxTree, parsed_stream; filename)
+jlparse(s::AbstractString; rule::Symbol=:all, kwargs...) = jlparse(parsedstream(s; rule); kwargs...)
+jlparse(parsed_stream::JS.ParseStream; filename::AbstractString=@__FILE__, first_line::Int=1) =
+    JS.build_tree(JL.SyntaxTree, parsed_stream; filename, first_line)
 
 # For interactive use
 # ===================

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,8 +7,12 @@ include("setup.jl")
 end
 
 @testset "JETLS" begin
-    @testset "utils" include("test_utils.jl")
-    @testset "binding" include("test_binding.jl")
+    @testset "utils" begin
+        @testset "ast" include("utils/test_ast.jl")
+        @testset "binding" include("utils/test_binding.jl")
+        @testset "lsp" include("utils/test_lsp.jl")
+        @testset "path" include("utils/test_path.jl")
+    end
     @testset "URIs2" include("test_URIs2.jl")
     @testset "registration" include("test_registration.jl")
     @testset "resolver" include("test_resolver.jl")

--- a/test/utils/test_ast.jl
+++ b/test/utils/test_ast.jl
@@ -1,8 +1,10 @@
-module test_utils
+module test_ast
 
 using Test
 using JETLS
 using JETLS: JL, JS
+
+include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
 
 function test_string_positions(s)
     v = Vector{UInt8}(s)
@@ -50,135 +52,6 @@ end
         @test ok
     end
 end
-
-@testset "to_full_path" begin
-    mktempdir() do temp_dir
-        test_file = joinpath(temp_dir, "test_file.jl")
-        touch(test_file)
-        @test isabspath(test_file)
-        result = JETLS.to_full_path(test_file)
-        @test isabspath(result)
-        @test result == test_file
-    end
-
-    # Test with Base function paths
-    @testset "built-in function paths" begin
-        m = only(methods(sin,(Float64,)))
-
-        let file = m.file
-            filepath = JETLS.to_full_path(m.file)
-            @test isabspath(filepath)
-            @test normpath(filepath) == filepath
-            @test isfile(filepath)
-            @test occursin("trig.jl", filepath)
-            # Check that fix_build_path is applied correctly
-            @test !occursin("/usr/share/julia/", filepath)
-        end
-        let (file, line) = Base.updated_methodloc(m)
-            filepath = JETLS.to_full_path(m.file)
-            @test isabspath(filepath)
-            @test normpath(filepath) == filepath
-            @test isfile(filepath)
-            @test occursin("trig.jl", filepath)
-            # Check that fix_build_path is applied correctly
-            @test !occursin("/usr/share/julia/", filepath)
-        end
-    end
-end
-
-@testset "find_env_path" begin
-    # Create a temporary directory structure with Project.toml
-    mktempdir() do temp_root
-        # Create nested directories with Project.toml at different levels
-        proj_dir = joinpath(temp_root, "myproject")
-        src_dir = joinpath(proj_dir, "src")
-        sub_dir = joinpath(src_dir, "submodule")
-
-        mkpath(sub_dir)
-        proj_file = joinpath(proj_dir, "Project.toml")
-        touch(proj_file)
-
-        # Test finding Project.toml from various depths
-        # find_env_path expects a file path, uses dirname to get the directory
-        test_file = joinpath(sub_dir, "test.jl")
-        @test JETLS.find_env_path(test_file) == proj_file
-        @test JETLS.find_env_path(joinpath(src_dir, "file.jl")) == proj_file
-        @test JETLS.find_env_path(joinpath(proj_dir, "file.jl")) == proj_file
-
-        # Test when no Project.toml exists above
-        no_proj_dir = joinpath(temp_root, "no_project", "deep", "path")
-        mkpath(no_proj_dir)
-        @test JETLS.find_env_path(joinpath(no_proj_dir, "file.jl")) === nothing
-    end
-end
-
-@testset "search_up_file" begin
-    mktempdir() do temp_root
-        # Create test structure
-        dir1 = joinpath(temp_root, "level1")
-        dir2 = joinpath(dir1, "level2")
-        mkpath(dir2)
-
-        # Create test files at different levels
-        touch(joinpath(temp_root, "root.txt"))
-        touch(joinpath(dir1, "middle.txt"))
-
-        # Search for files going up the tree
-        @test JETLS.search_up_file(dir2, "middle.txt") == joinpath(dir1, "middle.txt")
-        @test JETLS.search_up_file(dir2, "root.txt") == joinpath(temp_root, "root.txt")
-        @test JETLS.search_up_file(dir2, "nonexistent.txt") === nothing
-
-        # Test with file in the same directory
-        touch(joinpath(dir2, "same.txt"))
-        @test JETLS.search_up_file(joinpath(dir2, "dummy.jl"), "same.txt") == joinpath(dir2, "same.txt")
-    end
-end
-
-@testset "issubdir" begin
-    if Sys.isunix()
-        # Test with absolute paths
-        @test JETLS.issubdir("/home/user/project/src", "/home/user/project")
-        @test JETLS.issubdir("/home/user/project", "/home/user")
-        @test !JETLS.issubdir("/home/user", "/home/user/project")
-        @test !JETLS.issubdir("/home/other", "/home/user")
-
-        # Test with same directory
-        @test JETLS.issubdir("/home/user", "/home/user")
-
-        # Test with trailing slashes
-        @test JETLS.issubdir("/home/user/project/", "/home/user/")
-    end
-
-    # Test with relative paths using temporary directories
-    mktempdir() do temp_root
-        parent = joinpath(temp_root, "parent")
-        child = joinpath(parent, "child")
-        sibling = joinpath(temp_root, "sibling")
-
-        mkpath(child)
-        mkpath(sibling)
-
-        @test JETLS.issubdir(child, parent)
-        @test JETLS.issubdir(child, temp_root)
-        @test !JETLS.issubdir(parent, child)
-        @test !JETLS.issubdir(sibling, parent)
-    end
-end
-
-@testset "create_source_location_link" begin
-    @test JETLS.create_source_location_link("/path/to/file.jl") == "[/path/to/file.jl](file:///path/to/file.jl)"
-    @test JETLS.create_source_location_link("/path/to/file.jl", line=42) == "[/path/to/file.jl:42](file:///path/to/file.jl#L42)"
-    @test JETLS.create_source_location_link("/path/to/file.jl", line=42, character=10) == "[/path/to/file.jl:42](file:///path/to/file.jl#L42C10)"
-end
-
-function _parse(T, code::AbstractString;
-                rule::Symbol=:all, filename::AbstractString=@__FILE__, first_line::Int=1)
-    parsed_stream = JS.ParseStream(code)
-    JS.parse!(parsed_stream; rule)
-    return JS.build_tree(T, parsed_stream; filename, first_line)
-end
-jsparse(args...; kwargs...) = _parse(JS.SyntaxNode, args...; kwargs...)
-jlparse(args...; kwargs...) = _parse(JL.SyntaxTree, args...; kwargs...)
 
 @testset "noparen_macrocall" begin
     @test JETLS.noparen_macrocall(jlparse("@test true"; rule=:statement))
@@ -347,4 +220,4 @@ end
     end
 end
 
-end # module test_utils
+end # module test_ast

--- a/test/utils/test_binding.jl
+++ b/test/utils/test_binding.jl
@@ -3,7 +3,7 @@ module test_binding
 using Test
 using JETLS: JETLS
 
-include("jsjl_utils.jl")
+include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
 
 function with_target_binding_definitions(f, text::AbstractString, matcher::Regex=r"│")
     clean_code, positions = JETLS.get_text_and_positions(text, matcher)

--- a/test/utils/test_lsp.jl
+++ b/test/utils/test_lsp.jl
@@ -1,0 +1,12 @@
+module test_lsp
+
+using Test
+using JETLS: JETLS
+
+@testset "create_source_location_link" begin
+    @test JETLS.create_source_location_link("/path/to/file.jl") == "[/path/to/file.jl](file:///path/to/file.jl)"
+    @test JETLS.create_source_location_link("/path/to/file.jl", line=42) == "[/path/to/file.jl:42](file:///path/to/file.jl#L42)"
+    @test JETLS.create_source_location_link("/path/to/file.jl", line=42, character=10) == "[/path/to/file.jl:42](file:///path/to/file.jl#L42C10)"
+end
+
+end # module test_lsp

--- a/test/utils/test_path.jl
+++ b/test/utils/test_path.jl
@@ -1,0 +1,120 @@
+module test_path
+
+using Test
+using JETLS: JETLS
+
+@testset "to_full_path" begin
+    mktempdir() do temp_dir
+        test_file = joinpath(temp_dir, "test_file.jl")
+        touch(test_file)
+        @test isabspath(test_file)
+        result = JETLS.to_full_path(test_file)
+        @test isabspath(result)
+        @test result == test_file
+    end
+
+    # Test with Base function paths
+    @testset "built-in function paths" begin
+        m = only(methods(sin,(Float64,)))
+
+        let file = m.file
+            filepath = JETLS.to_full_path(m.file)
+            @test isabspath(filepath)
+            @test normpath(filepath) == filepath
+            @test isfile(filepath)
+            @test occursin("trig.jl", filepath)
+            # Check that fix_build_path is applied correctly
+            @test !occursin("/usr/share/julia/", filepath)
+        end
+        let (file, line) = Base.updated_methodloc(m)
+            filepath = JETLS.to_full_path(m.file)
+            @test isabspath(filepath)
+            @test normpath(filepath) == filepath
+            @test isfile(filepath)
+            @test occursin("trig.jl", filepath)
+            # Check that fix_build_path is applied correctly
+            @test !occursin("/usr/share/julia/", filepath)
+        end
+    end
+end
+
+@testset "find_env_path" begin
+    # Create a temporary directory structure with Project.toml
+    mktempdir() do temp_root
+        # Create nested directories with Project.toml at different levels
+        proj_dir = joinpath(temp_root, "myproject")
+        src_dir = joinpath(proj_dir, "src")
+        sub_dir = joinpath(src_dir, "submodule")
+
+        mkpath(sub_dir)
+        proj_file = joinpath(proj_dir, "Project.toml")
+        touch(proj_file)
+
+        # Test finding Project.toml from various depths
+        # find_env_path expects a file path, uses dirname to get the directory
+        test_file = joinpath(sub_dir, "test.jl")
+        @test JETLS.find_env_path(test_file) == proj_file
+        @test JETLS.find_env_path(joinpath(src_dir, "file.jl")) == proj_file
+        @test JETLS.find_env_path(joinpath(proj_dir, "file.jl")) == proj_file
+
+        # Test when no Project.toml exists above
+        no_proj_dir = joinpath(temp_root, "no_project", "deep", "path")
+        mkpath(no_proj_dir)
+        @test JETLS.find_env_path(joinpath(no_proj_dir, "file.jl")) === nothing
+    end
+end
+
+@testset "search_up_file" begin
+    mktempdir() do temp_root
+        # Create test structure
+        dir1 = joinpath(temp_root, "level1")
+        dir2 = joinpath(dir1, "level2")
+        mkpath(dir2)
+
+        # Create test files at different levels
+        touch(joinpath(temp_root, "root.txt"))
+        touch(joinpath(dir1, "middle.txt"))
+
+        # Search for files going up the tree
+        @test JETLS.search_up_file(dir2, "middle.txt") == joinpath(dir1, "middle.txt")
+        @test JETLS.search_up_file(dir2, "root.txt") == joinpath(temp_root, "root.txt")
+        @test JETLS.search_up_file(dir2, "nonexistent.txt") === nothing
+
+        # Test with file in the same directory
+        touch(joinpath(dir2, "same.txt"))
+        @test JETLS.search_up_file(joinpath(dir2, "dummy.jl"), "same.txt") == joinpath(dir2, "same.txt")
+    end
+end
+
+@testset "issubdir" begin
+    if Sys.isunix()
+        # Test with absolute paths
+        @test JETLS.issubdir("/home/user/project/src", "/home/user/project")
+        @test JETLS.issubdir("/home/user/project", "/home/user")
+        @test !JETLS.issubdir("/home/user", "/home/user/project")
+        @test !JETLS.issubdir("/home/other", "/home/user")
+
+        # Test with same directory
+        @test JETLS.issubdir("/home/user", "/home/user")
+
+        # Test with trailing slashes
+        @test JETLS.issubdir("/home/user/project/", "/home/user/")
+    end
+
+    # Test with relative paths using temporary directories
+    mktempdir() do temp_root
+        parent = joinpath(temp_root, "parent")
+        child = joinpath(parent, "child")
+        sibling = joinpath(temp_root, "sibling")
+
+        mkpath(child)
+        mkpath(sibling)
+
+        @test JETLS.issubdir(child, parent)
+        @test JETLS.issubdir(child, temp_root)
+        @test !JETLS.issubdir(parent, child)
+        @test !JETLS.issubdir(sibling, parent)
+    end
+end
+
+end # test_path


### PR DESCRIPTION
Reorganize the monolithic utils test file into focused test modules: - utils/test_ast.jl for AST manipulation functions - utils/test_binding.jl for binding analysis tests - utils/test_lsp.jl for LSP utility functions
- utils/test_path.jl for path manipulation utilities

corresponding to how `src/utils` is organized.