### PR TITLE
Add source location links to local completions doc and hover

### DIFF
--- a/src/hover.jl
+++ b/src/hover.jl
@@ -37,12 +37,22 @@ function handle_HoverRequest(server::Server, msg::HoverRequest)
         # but for now we'll just show the location of the local binding
         target_binding, definitions = target_binding_definitions
         io = IOBuffer()
-        println(io, "```julia")
-        for definition in definitions
-            JL.showprov(io, definition)
+        n = length(definitions)
+        filepath = uri2filepath(uri)
+        for (i, definition) in enumerate(definitions)
+            println(io, "```julia")
+            JL.showprov(io, definition; include_location=false)
             println(io)
+            println(io, "```")
+            line, character = JS.source_location(definition)
+            showtext = "`@ " * simple_loc_text(filepath; line) * "`"
+            println(io, create_source_location_link(filepath, showtext; line, character))
+            if i ≠ n
+                println(io, "\n---\n") # separator
+            else
+                println(io)
+            end
         end
-        println(io, "```")
         value = String(take!(io))
         contents = MarkupContent(;
             kind = MarkupKind.Markdown,

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -16,7 +16,8 @@ function get_cursor_bindings(s::String, b::Int)
 end
 
 function get_local_completions(s::String, b::Int)
-    return map(o->to_completion(o[1], o[2], o[3]), get_cursor_bindings(s, b))
+    uri = JETLS.URIs2.filepath2uri(@__FILE__)
+    return map(o->to_completion(o[1], o[2], o[3], uri), get_cursor_bindings(s, b))
 end
 
 function cv_has(cs::Vector{CompletionItem}, expected, kind=nothing)


### PR DESCRIPTION
- Include clickable file links in completion documentation
- Show multiple definitions in hover with separators
- Extract location text formatting into utility functions
- Remove location info from `JL.showprov` output to avoid duplication

Requires c42f/JuliaLowering.jl#16 (, which is already merged into our custom JL branch).