### PR TITLE
use "│" as the default cursor marker

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -10,7 +10,7 @@ module __demo__ end
         end
         function getx(bar::Bar)
             out = bar.x
-            #=cursor=#
+            │
             return out
         end
     """)

--- a/src/utils/lsp.jl
+++ b/src/utils/lsp.jl
@@ -80,7 +80,7 @@ function file_cache_error(uri::URI; data=nothing)
         data)
 end
 
-function get_text_and_positions(text::AbstractString, matcher::Regex=r"#=cursor=#")
+function get_text_and_positions(text::AbstractString, matcher::Regex=r"│")
     positions = Position[]
     lines = split(text, '\n')
 

--- a/test/test_definition.jl
+++ b/test/test_definition.jl
@@ -28,8 +28,8 @@ end
 include("setup.jl")
 
 # Helper to run a single global definition test
-function with_definition_request(tester::Function, text::AbstractString)
-    clean_code, positions = JETLS.get_text_and_positions(text, r"│")
+function with_definition_request(tester::Function, text::AbstractString, matcher=r"│")
+    clean_code, positions = JETLS.get_text_and_positions(text, matcher)
 
     withscript(clean_code) do script_path
         uri = filepath2uri(script_path)

--- a/test/test_full_lifecycle.jl
+++ b/test/test_full_lifecycle.jl
@@ -11,7 +11,7 @@ let (pkgcode, positions) = get_text_and_positions("""
     end
 
     function targetfunc(x)
-        #=cursor=#
+        │
     end
 
     end # module TestFullLifecycle

--- a/test/test_hover.jl
+++ b/test/test_hover.jl
@@ -79,7 +79,7 @@ end
         (; pat=string(@doc nothing))
     ]
 
-    clean_code, positions = JETLS.get_text_and_positions(pkg_code, r"│")
+    clean_code, positions = JETLS.get_text_and_positions(pkg_code)
     @assert length(positions) == length(testers)
 
     withpackage("HoverTest", clean_code) do pkg_path
@@ -190,7 +190,7 @@ end
         (; pat="for x in xs") # local source location
     ]
 
-    clean_code, positions = JETLS.get_text_and_positions(script_code, r"│")
+    clean_code, positions = JETLS.get_text_and_positions(script_code)
     @assert length(positions) == length(testers)
 
     withscript(clean_code) do script_path


### PR DESCRIPTION
I’m currently working on unifying the style of the test code. In most cases, the "│" character is used as cursor marker, so it seems reasonable to standardize on this. Of course, since it’s customizable, other styles can still be used as needed.

Similar interface will be introduced for completion as well. The completion system will also be updated to follow the same interface in a future change. (Currently, it uses a custom interface.)
