### PR TITLE
LSP: extend ResponseMessage result fields with Nothing

### DIFF
--- a/src/LSP/README.md
+++ b/src/LSP/README.md
@@ -586,6 +586,6 @@ information at a given cursor position.
 end
 
 @interface SignatureHelpResponse @extends ResponseMessage begin
-    result::Union{SignatureHelp, Null}
+    result::Union{SignatureHelp, Null, Nothing}
 end
 ```

--- a/src/LSP/language-features/code-action.jl
+++ b/src/LSP/language-features/code-action.jl
@@ -388,7 +388,7 @@ edits with a code action then that mode should be used.
 end
 
 @interface CodeActionResponse @extends ResponseMessage begin
-    result::Union{Vector{Union{Command, CodeAction}}, Null}
+    result::Union{Vector{Union{Command, CodeAction}}, Null, Nothing}
 end
 
 """
@@ -416,5 +416,5 @@ before it can be applied.
 end
 
 @interface CodeActionResolveResponse @extends ResponseMessage begin
-    result::CodeAction
+    result::Union{CodeAction, Nothing}
 end

--- a/src/LSP/language-features/code-lens.jl
+++ b/src/LSP/language-features/code-lens.jl
@@ -72,7 +72,7 @@ for a given text document.
 end
 
 @interface CodeLensResponse @extends ResponseMessage begin
-    result::Union{Vector{CodeLens}, Null}
+    result::Union{Vector{CodeLens}, Null, Nothing}
 end
 
 """
@@ -85,7 +85,7 @@ command for a given code lens item.
 end
 
 @interface CodeLensResolveResponse @extends ResponseMessage begin
-    result::CodeLens
+    result::Union{CodeLens, Nothing}
 end
 
 """
@@ -106,5 +106,5 @@ is currently not visible.
 end
 
 @interface CodeLensRefreshResponse @extends ResponseMessage begin
-    result::Null
+    result::Union{Null, Nothing}
 end

--- a/src/LSP/language-features/definition.jl
+++ b/src/LSP/language-features/definition.jl
@@ -27,5 +27,5 @@ end
 end
 
 @interface DefinitionResponse @extends ResponseMessage begin
-    result::Union{Location, Vector{Location}, Vector{LocationLink}, Null}
+    result::Union{Location, Vector{Location}, Vector{LocationLink}, Null, Nothing}
 end

--- a/src/LSP/language-features/diagnostics.jl
+++ b/src/LSP/language-features/diagnostics.jl
@@ -505,7 +505,7 @@ end
   'workspace/diagnostic/refresh' request
 """
 @interface WorkspaceDiagnosticRefreshResponse @extends ResponseMessage begin
-    result::Nothing
+    result::Union{Null, Nothing}
 end
 
 # Implementation Considerations

--- a/src/LSP/language-features/hover.jl
+++ b/src/LSP/language-features/hover.jl
@@ -68,5 +68,5 @@ information at a given text document position.
 end
 
 @interface HoverResponse @extends ResponseMessage begin
-    result::Union{Hover, Null}
+    result::Union{Hover, Null, Nothing}
 end

--- a/src/LSP/language-features/signature-help.jl
+++ b/src/LSP/language-features/signature-help.jl
@@ -255,5 +255,5 @@ information at a given cursor position.
 end
 
 @interface SignatureHelpResponse @extends ResponseMessage begin
-    result::Union{SignatureHelp, Null}
+    result::Union{SignatureHelp, Null, Nothing}
 end

--- a/src/LSP/window-features.jl
+++ b/src/LSP/window-features.jl
@@ -181,7 +181,7 @@ particular resource referenced by a URI in the user interface.
 end
 
 @interface ShowDocumentResponse @extends ResponseMessage begin
-    result::ShowDocumentResult
+    result::Union{ShowDocumentResult, Nothing}
 end
 
 # LogMessage Notification
@@ -228,7 +228,7 @@ the client to create a work done progress.
 end
 
 @interface WorkDoneProgressCreateResponse @extends ResponseMessage begin
-    result::Nothing = nothing
+    result::Union{Null, Nothing}
 
     """
     code and message set in case an exception happens during the `window/workDoneProgress/create` request.

--- a/src/LSP/workspace-features/execute-command.jl
+++ b/src/LSP/workspace-features/execute-command.jl
@@ -42,5 +42,5 @@ to the client.
 end
 
 @interface ExecuteCommandResponse @extends ResponseMessage begin
-    result::LSPAny
+    result::Union{LSPAny, Nothing}
 end


### PR DESCRIPTION
Updated all ResponseMessage definitions to include Nothing in their result field Union types, following the pattern shown in the LSP README.md example. This ensures proper handling of cases where the result might be absent in a case when an `error` is set.

🤖 Generated with [Claude Code](https://claude.ai/code)