### PR TITLE
test: refactor completion and signature-help test utilities

### DIFF
--- a/test/test_signature_help.jl
+++ b/test/test_signature_help.jl
@@ -299,6 +299,7 @@ end
         foo(xxx, yyy) = :xxx_yyy
         foo(nothing,│)
         """
+        cnt = 0
         with_signature_help_request(text) do i, result, uri, script_path
             @test length(result.signatures) == 2
             @test any(result.signatures) do siginfo
@@ -315,7 +316,9 @@ end
                 occursin("@ `Main` [$(script_path):2]($(filepath2uri(script_path))#L2)",
                     (siginfo.documentation::MarkupContent).value)
             end
+            cnt += 1
         end
+        @test cnt == 1
     end
 
     # Test with DidChangeTextDocumentNotification (broken test preserved)


### PR DESCRIPTION
I updated the tests for completion and signature help to follow the same approach as the other tests. Some custom utility functions have also been replaced with the shared ones.