### PR TITLE
Refactor `JS.build_tree` calls and add syntax node/tree caching mechanism

### DIFF
--- a/src/analysis/Interpreter.jl
+++ b/src/analysis/Interpreter.jl
@@ -6,7 +6,7 @@ using JuliaSyntax: JuliaSyntax as JS
 using JET: CC, JET
 using ..JETLS:
     AnalysisEntry, FullAnalysisInfo, SavedFileInfo, Server,
-    JETLS_DEV_MODE, get_saved_file_info, yield_to_endpoint, send
+    JETLS_DEV_MODE, build_tree!, get_saved_file_info, yield_to_endpoint, send
 using ..JETLS.URIs2
 using ..JETLS.LSP
 using ..JETLS.Analyzer
@@ -136,7 +136,7 @@ function JET.try_read_file(interp::LSInterpreter, include_context::Module, filen
     if !isnothing(fi)
         parsed_stream = fi.parsed_stream
         if isempty(parsed_stream.diagnostics)
-            return JS.build_tree(JS.SyntaxNode, parsed_stream; filename)
+            return build_tree!(JS.SyntaxNode, fi)
         else
             return String(JS.sourcetext(parsed_stream))
         end

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -76,10 +76,9 @@ function analyze_parsed_if_exist(server::Server, info::FullAnalysisInfo, args...
     jetconfigs = entryjetconfigs(info.entry)
     fi = get_saved_file_info(server.state, uri)
     if !isnothing(fi)
-        parsed_stream = fi.parsed_stream
         filename = uri2filename(uri)
         @assert !isnothing(filename) "Unsupported URI: $uri"
-        parsed = JS.build_tree(JS.SyntaxNode, parsed_stream; filename)
+        parsed = build_tree!(JS.SyntaxNode, fi; filename)
         begin_full_analysis_progress(server, info)
         try
             return JET.analyze_and_report_expr!(LSInterpreter(server, info), parsed, filename, args...; jetconfigs...)

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -148,7 +148,7 @@ function local_completions!(items::Dict{String, CompletionItem},
     fi === nothing && return nothing
     # NOTE don't bail out even if `length(fi.parsed_stream.diagnostics) ≠ 0`
     # so that we can get some completions even for incomplete code
-    st0 = JS.build_tree(JL.SyntaxTree, fi.parsed_stream)
+    st0 = build_tree!(JL.SyntaxTree, fi)
     cbs = cursor_bindings(st0, xy_to_offset(fi, params.position))
     cbs === nothing && return nothing
     for (bi, st, dist) in cbs
@@ -210,7 +210,7 @@ function global_completions!(items::Dict{String, CompletionItem}, state::ServerS
     # since macros are always defined top-level
     is_completed = is_macro_invoke
 
-    st = JS.build_tree(JL.SyntaxTree, fi.parsed_stream)
+    st = build_tree!(JL.SyntaxTree, fi)
     offset = xy_to_offset(fi, pos)
     dotprefix = select_dotprefix_node(st, offset)
     if !isnothing(dotprefix)

--- a/src/definition.jl
+++ b/src/definition.jl
@@ -73,7 +73,7 @@ function handle_DefinitionRequest(server::Server, msg::DefinitionRequest)
                 error = file_cache_error(uri)))
     end
 
-    st0 = JS.build_tree(JL.SyntaxTree, fi.parsed_stream)
+    st0 = build_tree!(JL.SyntaxTree, fi)
     offset = xy_to_offset(fi, origin_position)
 
     locationlink_support = supports(server, :textDocument, :definition, :linkSupport)

--- a/src/hover.jl
+++ b/src/hover.jl
@@ -28,7 +28,7 @@ function handle_HoverRequest(server::Server, msg::HoverRequest)
                 error = file_cache_error(uri)))
     end
 
-    st0_top = JS.build_tree(JL.SyntaxTree, fi.parsed_stream)
+    st0_top = build_tree!(JL.SyntaxTree, fi)
     offset = xy_to_offset(fi, pos)
 
     target_binding_definitions = select_target_binding_definitions(st0_top, offset)

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -400,10 +400,10 @@ function cursor_call(ps::JS.ParseStream, st0::JL.SyntaxTree, b::Int)
     return isnothing(i) ? nothing : bas[i]
 end
 
-function cursor_siginfos(mod::Module, ps::JS.ParseStream, b::Int, analyzer::LSAnalyzer;
+function cursor_siginfos(mod::Module, fi::FileInfo, b::Int, analyzer::LSAnalyzer;
                          postprocessor::JET.PostProcessor=JET.PostProcessor())
-    st0 = JS.build_tree(JL.SyntaxTree, ps; ignore_errors=true)
-    call = cursor_call(ps, st0, b)
+    st0 = build_tree!(JL.SyntaxTree, fi)
+    call = cursor_call(fi.parsed_stream, st0, b)
     isnothing(call) && return empty_siginfos
     after_semicolon = let
         params_i = findfirst(st -> kind(st) === K"parameters", JS.children(call))
@@ -466,7 +466,7 @@ function handle_SignatureHelpRequest(server::Server, msg::SignatureHelpRequest)
     end
     (; mod, analyzer, postprocessor) = get_context_info(state, uri, msg.params.position)
     b = xy_to_offset(fi, msg.params.position)
-    signatures = cursor_siginfos(mod, fi.parsed_stream, b, analyzer; postprocessor)
+    signatures = cursor_siginfos(mod, fi, b, analyzer; postprocessor)
     activeSignature = nothing
     activeParameter = nothing
     return send(server,

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,11 +1,27 @@
-struct FileInfo
+const SyntaxTree0 = typeof(JS.build_tree(JL.SyntaxTree, JS.ParseStream("")))
+
+# TODO separate cache by `kwargs`?
+
+mutable struct FileInfo
     version::Int
     parsed_stream::JS.ParseStream
+    # filled after cached
+    syntax_node::Dict{Any,JS.SyntaxNode}
+    syntax_tree0::Dict{Any,SyntaxTree0}
+    FileInfo(version::Int, parsed_stream::JS.ParseStream) =
+        new(version, parsed_stream, Dict{Any,JS.SyntaxNode}(), Dict{Any,SyntaxTree0}())
 end
 
-struct SavedFileInfo
+mutable struct SavedFileInfo
     parsed_stream::JS.ParseStream
+    # filled after cached
+    syntax_node::Dict{Any,JS.SyntaxNode}
+    syntax_tree0::Dict{Any,SyntaxTree0}
+    SavedFileInfo(parsed_stream::JS.ParseStream) =
+        new(parsed_stream, Dict{Any,JS.SyntaxNode}(), Dict{Any,SyntaxTree0}())
 end
+
+function build_tree! end
 
 entryuri(entry::AnalysisEntry) = entryuri_impl(entry)::URI
 entrykind(entry::AnalysisEntry) = entrykind_impl(entry)::String

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -21,7 +21,7 @@ end
 
 Fetch cached FileInfo given an LSclient-provided structure with a URI
 """
-get_file_info(s::ServerState, uri::URI) = haskey(s.file_cache, uri) ? s.file_cache[uri] : nothing
+get_file_info(s::ServerState, uri::URI) = get(s.file_cache, uri, nothing)
 get_file_info(s::ServerState, t::TextDocumentIdentifier) = get_file_info(s, t.uri)
 
 """
@@ -30,7 +30,7 @@ get_file_info(s::ServerState, t::TextDocumentIdentifier) = get_file_info(s, t.ur
 
 Fetch cached saved FileInfo given an LSclient-provided structure with a URI
 """
-get_saved_file_info(s::ServerState, uri::URI) = haskey(s.saved_file_cache, uri) ? s.saved_file_cache[uri] : nothing
+get_saved_file_info(s::ServerState, uri::URI) = get(s.saved_file_cache, uri, nothing)
 get_saved_file_info(s::ServerState, t::TextDocumentIdentifier) = get_saved_file_info(s, t.uri)
 
 """

--- a/test/test_signature_help.jl
+++ b/test/test_signature_help.jl
@@ -16,7 +16,8 @@ function siginfos(mod::Module, code::AbstractString, cursor::Regex=r"│")
     position = only(positions)
     b = JETLS.xy_to_offset(Vector{UInt8}(clean_code), position)
     ps = JS.ParseStream(clean_code); JS.parse!(ps)
-    return cursor_siginfos(mod, ps, b, LSAnalyzer())
+    fi = JETLS.FileInfo(0, ps)
+    return cursor_siginfos(mod, fi, b, LSAnalyzer())
 end
 
 n_si(args...) = length(siginfos(args...))


### PR DESCRIPTION
Add mutable syntax tree cache fields to `FileInfo`/`SavedFileInfo` and replace direct `JS.build_tree` calls with `build_tree!` wrapper that caches results. Update cache functions to clear cached trees when file content changes.

Now we generally should use `build_tree!` when constructing syntax node or syntax tree from (saved) file info.