### PR TITLE
server: add test mode for error handling

### DIFF
--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -10,8 +10,9 @@ end
 
 using Preferences: Preferences
 const JETLS_DEV_MODE = Preferences.@load_preference("JETLS_DEV_MODE", false)
+const JETLS_TEST_MODE = Preferences.@load_preference("JETLS_TEST_MODE", false)
 push_init_hooks!() do
-    @info "Running JETLS with" JETLS_DEV_MODE
+    @info "Running JETLS with" JETLS_DEV_MODE JETLS_TEST_MODE
 end
 
 include("URIs2/URIs2.jl")
@@ -143,7 +144,7 @@ end
 
 function handle_message(server::Server, msg)
     @nospecialize msg
-    if JETLS_DEV_MODE
+    if JETLS_DEV_MODE || !JETLS_TEST_MODE
         try
             # `@invokelatest` for allowing changes maded by Revise to be reflected without
             # terminating the `runserver` loop

--- a/test/LocalPreferences.toml
+++ b/test/LocalPreferences.toml
@@ -1,3 +1,3 @@
-# disable the `try/catch` in `handle_message` when testing
 [JETLS]
-JETLS_DEV_MODE = false
+JETLS_DEV_MODE = false  # disable server logs
+JETLS_TEST_MODE = false # disable the `try/catch` in `handle_message` when testing


### PR DESCRIPTION
Currently, we have no expectations for anyone other than developers to use this LS, but there seem to be cases where interested users want to utilize it. Particularly since the current `resolve_type` implementation is fragile, killing the server loop due to a single failure would not be good for demo purposes. Until we make a release, we will enable unlimited server loop failure handling via `JETLS_DEV_MODE`.

However, as a mechanism to catch critical errors in testing, this commit will add and utilize a new `JETLS_TEST_MODE`. `JETLS_TEST_MODE` will only be enabled during testing.