### PR TITLE
fix `lsrender` to take `Markdown.[Table|LaTeX]`

### DIFF
--- a/src/utils/general.jl
+++ b/src/utils/general.jl
@@ -193,5 +193,9 @@ function lsrender(io::IO, code::Markdown.Code)
     println(io, "`" ^ n)
 end
 
+# TODO remove these definitions after JuliaLang/julia#58916.
+lsrender(io::IO, table::Markdown.Table) = Markdown.plain(io, table)
+lsrender(io::IO, latex::Markdown.LaTeX) = Markdown.plain(io, latex)
+
 (processor::LSPostProcessor)(md::Markdown.MD) = processor.inner(lsrender(md))
 (processor::LSPostProcessor)(s::AbstractString) = processor.inner(s)


### PR DESCRIPTION
It turned out that we need these definitions until JuliaLang/julia#58916..