### PR TITLE
synchronize `testsetinfos` by `didChangeDocument` notification

### DIFF
--- a/src/code-action.jl
+++ b/src/code-action.jl
@@ -33,14 +33,8 @@ function handle_CodeActionRequest(server::Server, msg::CodeActionRequest)
                 result = nothing,
                 error = file_cache_error(uri)))
     end
-    testsetinfos = update_testsetinfos!(server, fi)
-    if isempty(testsetinfos)
-        return send(server,
-            CodeActionResponse(;
-                id = msg.id,
-                result = null))
-    end
-    code_actions = testrunner_code_actions(uri, fi, testsetinfos, msg.params.range)
+    code_actions = Union{CodeAction,Command}[]
+    testrunner_code_actions!(code_actions, uri, fi, msg.params.range)
     return send(server,
         CodeActionResponse(;
             id = msg.id,

--- a/src/code-lens.jl
+++ b/src/code-lens.jl
@@ -31,14 +31,8 @@ function handle_CodeLensRequest(server::Server, msg::CodeLensRequest)
                 result = nothing,
                 error = file_cache_error(uri)))
     end
-    testsetinfos = update_testsetinfos!(server, fi)
-    if isempty(testsetinfos)
-        return send(server,
-            CodeLensResponse(;
-                id = msg.id,
-                result = null))
-    end
-    code_lenses = testrunner_code_lenses(uri, fi, testsetinfos)
+    code_lenses = CodeLens[]
+    testrunner_code_lenses!(code_lenses, uri, fi)
     return send(server,
         CodeLensResponse(;
             id = msg.id,

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -124,8 +124,8 @@ function handle_DidChangeTextDocumentNotification(server::Server, msg::DidChange
         @assert contentChange.range === contentChange.rangeLength === nothing # since `change = TextDocumentSyncKind.Full`
     end
     text = last(contentChanges).text
-
-    cache_file_info!(server.state, uri, textDocument.version, text)
+    fi = cache_file_info!(server.state, uri, textDocument.version, text)
+    update_testsetinfos!(server, fi)
 end
 
 function handle_DidSaveTextDocumentNotification(server::Server, msg::DidSaveTextDocumentNotification)

--- a/src/testrunner.jl
+++ b/src/testrunner.jl
@@ -113,9 +113,8 @@ function find_executable_testsets(st0_top::SyntaxTree0)
     return testsets
 end
 
-function testrunner_code_lenses(uri::URI, fi::FileInfo, testsetinfos::Vector{TestsetInfo})
-    code_lenses = CodeLens[]
-    for (idx, testsetinfo) in enumerate(testsetinfos)
+function testrunner_code_lenses!(code_lenses::Vector{CodeLens}, uri::URI, fi::FileInfo)
+    for (idx, testsetinfo) in enumerate(fi.testsetinfos)
         testrunner_code_lenses!(code_lenses, uri, fi, idx, testsetinfo)
     end
     return code_lenses
@@ -165,17 +164,16 @@ function testrunner_code_lenses!(code_lenses::Vector{CodeLens}, uri::URI, fi::Fi
     return code_lenses
 end
 
-function testrunner_code_actions(uri::URI, fi::FileInfo, testsetinfos::Vector{TestsetInfo}, action_range::Range)
-    code_actions = Union{CodeAction,Command}[]
-    testrunner_testset_code_actions!(code_actions, uri, fi, testsetinfos, action_range)
+function testrunner_code_actions!(code_actions::Vector{Union{CodeAction,Command}}, uri::URI, fi::FileInfo, action_range::Range)
+    testrunner_testset_code_actions!(code_actions, uri, fi, action_range)
+    testrunner_testcase_code_actions!(code_actions, uri, fi, action_range)
     return code_actions
 end
 
-function testrunner_testset_code_actions!(code_actions::Vector{Union{CodeAction,Command}}, uri::URI, fi::FileInfo, testsetinfos::Vector{TestsetInfo}, action_range::Range)
-    for (idx, testsetinfo) in enumerate(testsetinfos)
+function testrunner_testset_code_actions!(code_actions::Vector{Union{CodeAction,Command}}, uri::URI, fi::FileInfo, action_range::Range)
+    for (idx, testsetinfo) in enumerate(fi.testsetinfos)
         testrunner_testset_code_actions!(code_actions, uri, fi, idx, testsetinfo, action_range)
     end
-    testrunner_testcase_code_actions!(code_actions, uri, fi, action_range)
     return code_actions
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -29,7 +29,7 @@ mutable struct FileInfo
     # filled after cached
     syntax_node::Dict{Any,JS.SyntaxNode}
     syntax_tree0::Dict{Any,SyntaxTree0}
-    testsetinfos::Vector{_TestsetInfo{FileInfo}} # synced by code lens, or code actions
+    testsetinfos::Vector{_TestsetInfo{FileInfo}}
     FileInfo(version::Int, parsed_stream::JS.ParseStream) =
         new(version, parsed_stream, Dict{Any,JS.SyntaxNode}(), Dict{Any,SyntaxTree0}(), TestsetInfo[])
 end

--- a/test/test_testrunner.jl
+++ b/test/test_testrunner.jl
@@ -90,7 +90,8 @@ end
         @test length(fi.testsetinfos) == 1
         uri = LSP.URI("file:///test.jl")
 
-        code_lenses = JETLS.testrunner_code_lenses(uri, fi, fi.testsetinfos)
+        code_lenses = CodeLens[]
+        JETLS.testrunner_code_lenses!(code_lenses, uri, fi)
 
         @test length(code_lenses) == 1
         first_lens = code_lenses[1]
@@ -121,7 +122,8 @@ end
 
         uri = LSP.URI("file:///test.jl")
 
-        code_lenses = JETLS.testrunner_code_lenses(uri, fi, fi.testsetinfos)
+        code_lenses = CodeLens[]
+        JETLS.testrunner_code_lenses!(code_lenses, uri, fi)
 
         @test length(code_lenses) == 4
 
@@ -178,7 +180,8 @@ end
             start = positions[1],
             var"end" = positions[1])
 
-        code_actions = JETLS.testrunner_code_actions(uri, fi, fi.testsetinfos, first_testset_range)
+        code_actions = Union{CodeAction,Command}[]
+        JETLS.testrunner_code_actions!(code_actions, uri, fi, first_testset_range)
         @test length(code_actions) == 2  # Now includes both @testset and @test actions
         tsn1 = JETLS.testset_name(fi.testsetinfos[1])
         @test code_actions[1].title == "$(JETLS.TESTRUNNER_RUN_TITLE) $tsn1"
@@ -194,7 +197,8 @@ end
             start = positions[2],
             var"end" = positions[2])
 
-        code_actions = JETLS.testrunner_code_actions(uri, fi, fi.testsetinfos, second_testset_range)
+        code_actions = Union{CodeAction,Command}[]
+        JETLS.testrunner_code_actions!(code_actions, uri, fi, second_testset_range)
         @test length(code_actions) == 1
         tsn2 = JETLS.testset_name(fi.testsetinfos[2])
         @test code_actions[1].title == "$(JETLS.TESTRUNNER_RUN_TITLE) $tsn2"
@@ -206,7 +210,8 @@ end
             start = positions[1],
             var"end" = positions[2])
 
-        code_actions = JETLS.testrunner_code_actions(uri, fi, fi.testsetinfos, multi_range)
+        code_actions = Union{CodeAction,Command}[]
+        JETLS.testrunner_code_actions!(code_actions, uri, fi, multi_range)
         @test length(code_actions) == 3  # Two @testset actions and one @test action (true)
         tsn1 = JETLS.testset_name(fi.testsetinfos[1])
         tsn2 = JETLS.testset_name(fi.testsetinfos[2])
@@ -225,7 +230,8 @@ end
             start = positions[3],
             var"end" = positions[3])
 
-        code_actions = JETLS.testrunner_code_actions(uri, fi, fi.testsetinfos, after_end_range)
+        code_actions = Union{CodeAction,Command}[]
+        JETLS.testrunner_code_actions!(code_actions, uri, fi, after_end_range)
         @test length(code_actions) == 1
         tsn2 = JETLS.testset_name(fi.testsetinfos[2])
         @test code_actions[1].title == "$(JETLS.TESTRUNNER_RUN_TITLE) $tsn2"
@@ -237,7 +243,8 @@ end
             start = positions[4],
             var"end" = positions[4])
 
-        code_actions = JETLS.testrunner_code_actions(uri, fi, fi.testsetinfos, no_overlap_range)
+        code_actions = Union{CodeAction,Command}[]
+        JETLS.testrunner_code_actions!(code_actions, uri, fi, no_overlap_range)
         @test isempty(code_actions)
     end
 
@@ -263,7 +270,8 @@ end
             start = positions[1],
             var"end" = positions[1])
 
-        code_actions = JETLS.testrunner_code_actions(uri, fi, fi.testsetinfos, testset_range)
+        code_actions = Union{CodeAction,Command}[]
+        JETLS.testrunner_code_actions!(code_actions, uri, fi, testset_range)
         @test length(code_actions) == 3
 
         tsn = JETLS.testset_name(fi.testsetinfos[1])
@@ -310,7 +318,8 @@ end
         standalone_range = LSP.Range(;
             start = positions[1],
             var"end" = positions[1])
-        code_actions = JETLS.testrunner_code_actions(uri, fi, fi.testsetinfos, standalone_range)
+        code_actions = Union{CodeAction,Command}[]
+        JETLS.testrunner_code_actions!(code_actions, uri, fi, standalone_range)
         @test length(code_actions) == 1
         @test code_actions[1].title == "$(JETLS.TESTRUNNER_RUN_TITLE) `@test 1 == 1`"
         @test code_actions[1].command.command == JETLS.COMMAND_TESTRUNNER_RUN_TESTCASE
@@ -321,7 +330,8 @@ end
         first_test_range = LSP.Range(;
             start = positions[2],
             var"end" = positions[2])
-        code_actions = JETLS.testrunner_code_actions(uri, fi, fi.testsetinfos, first_test_range)
+        code_actions = Union{CodeAction,Command}[]
+        JETLS.testrunner_code_actions!(code_actions, uri, fi, first_test_range)
         @test length(code_actions) == 2  # Both testset and test actions
         # First should be testset action
         @test occursin("tests with multiple @test macros", code_actions[1].title)
@@ -335,7 +345,8 @@ end
         multiline_range = LSP.Range(;
             start = positions[3],
             var"end" = positions[3])
-        code_actions = JETLS.testrunner_code_actions(uri, fi, fi.testsetinfos, multiline_range)
+        code_actions = Union{CodeAction,Command}[]
+        JETLS.testrunner_code_actions!(code_actions, uri, fi, multiline_range)
         @test length(code_actions) == 1
         @test occursin("@test_throws DomainError sin(Inf)", code_actions[1].title)
         @test code_actions[1].command.command == JETLS.COMMAND_TESTRUNNER_RUN_TESTCASE
@@ -344,7 +355,8 @@ end
         multiline_range = LSP.Range(;
             start = positions[4],
             var"end" = positions[4])
-        code_actions = JETLS.testrunner_code_actions(uri, fi, fi.testsetinfos, multiline_range)
+        code_actions = Union{CodeAction,Command}[]
+        JETLS.testrunner_code_actions!(code_actions, uri, fi, multiline_range)
         @test length(code_actions) == 1
         @test occursin("@test begin", code_actions[1].title)
         @test code_actions[1].command.command == JETLS.COMMAND_TESTRUNNER_RUN_TESTCASE


### PR DESCRIPTION
This changes make the `testsetinfos` synchronization a bit more efficient and make it easier to add other code lens/actions.