### PR TITLE
make `byte_ancestors` return empty list for out-of-range positions

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -346,9 +346,7 @@ function add_emoji_latex_completions!(items::Dict{String,CompletionItem}, state:
     fi === nothing && return nothing
 
     pos = params.position
-    backslash_offset_emojionly = get_backslash_offset(fi, pos)
-    backslash_offset_emojionly === nothing && return nothing
-    backslash_offset, emojionly = backslash_offset_emojionly
+    backslash_offset, emojionly = @something get_backslash_offset(fi, pos) return nothing
     backslash_pos = offset_to_xy(fi, backslash_offset)
 
     # HACK Certain clients cannot properly sort/filter completion items that contain

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -41,10 +41,7 @@ as an ephemeral stack.)  We work around this by taking all available bindings
 and filtering out any that aren't declared in a scope containing the cursor.
 """
 function cursor_bindings(st0_top::JL.SyntaxTree, b_top::Int)
-    st0, b = greatest_local(st0_top, b_top)
-    if isnothing(st0)
-        return nothing # nothing we can lower
-    end
+    st0, b = @something greatest_local(st0_top, b_top) return nothing # nothing we can lower
     ctx3, st2 = try
         jl_lower_for_scope_resolution2(st0)
     catch # err
@@ -148,8 +145,7 @@ has no definitions. Otherwise returns a tuple of `(binding, definitions)` where:
 - `definitions` is a `JL.SyntaxList` containing all definition sites for that binding
 """
 function select_target_binding_definitions(st0_top::JL.SyntaxTree, offset::Int)
-    st0, b = greatest_local(st0_top, offset)
-    isnothing(st0) && return nothing
+    st0, b = @something greatest_local(st0_top, offset) return nothing # nothing we can lower
     ctx3, st3 = try
         jl_lower_for_scope_resolution3(st0)
     catch


### PR DESCRIPTION
Initialize empty result containers and add range checks before adding root nodes. Also updates `select_target_node` accordingly. I think other places where `byte_ancestors` is used handle empty anscestor list case.