### PR TITLE
Bump JuliaSyntax and JuliaLowering for macro support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,8 +21,8 @@ REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 [sources]
 JET = {rev = "master", url = "https://github.com/aviatesk/JET.jl"}
 JSONRPC = {path = "JSONRPC"}
-JuliaLowering = {rev = "avi/JETLS", url = "https://github.com/aviatesk/JuliaLowering.jl"}
-JuliaSyntax = {rev = "eceaa39", url = "https://github.com/JuliaLang/JuliaSyntax.jl"}
+JuliaLowering = {rev = "jetls-hacking", url = "https://github.com/mlechu/JuliaLowering.jl"}
+JuliaSyntax = {rev = "e02f29f", url = "https://github.com/JuliaLang/JuliaSyntax.jl"}
 LSP = {path = "LSP"}
 
 [compat]

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -300,16 +300,14 @@ Return the last byte at or before `b` that isn't in whitespace or a comment (or
 if `pass_newlines=false`, also isn't a newline).
 """
 function prev_nontrivia_byte(ps::JS.ParseStream, b::Int; pass_newlines=false)
-    ti = get_current_token_idx(ps, min(JS.last_byte(ps), b))
-    isnothing(ti) && return nothing
-    skip = (i::Int) -> let tok = ps.tokens[i]; k = kind(tok)
-        b < tok.next_byte || JS.is_whitespace(k) && (pass_newlines || k != K"NewlineWs")
+    tc = token_at_offset(ps, min(JS.last_byte(ps), b))
+    isnothing(tc) && return nothing
+    while (JS.is_whitespace(kind(this(tc))) && (pass_newlines || kind(this(tc)) != K"NewlineWs"))
+        b < tc.next_byte && return b # in the middle of a token
+        tc = prev_tok(tc)
+        isnothing(tc) && return nothing
     end
-    while skip(ti)
-        ti -= 1
-        ti < 1 && return nothing
-    end
-    return ps.tokens[ti].next_byte - 1
+    return Int(last_byte(tc))
 end
 
 function is_relevant_call(call::JL.SyntaxTree)
@@ -329,7 +327,7 @@ function call_is_decl(_bas::JL.SyntaxList, i::Int, _basᵢ::JL.SyntaxTree = _bas
     return j <= lastindex(_bas) &&
         kind(_bas[j]) in JS.KSet"macro function" &&
         # in `f(x) = g(x)`, return true in `f`, false in `g`
-        _bas[j - 1] === _bas[j][1]
+        _bas[j - 1]._id === _bas[j][1]._id
 end
 
 # Find cases where a macro call is not surrounded by parentheses
@@ -352,8 +350,8 @@ cursor would be descendents of it.
 """
 function cursor_call(ps::JS.ParseStream, st0::JL.SyntaxTree, b::Int)
     # disable signature help if invoked within comment scope
-    prev_token_idx = get_prev_token_idx(ps, b)
-    if !isnothing(prev_token_idx) && JS.kind(ps.tokens[prev_token_idx]) === K"Comment"
+    tc = token_before_offset(ps, b)
+    if !isnothing(tc) && JS.kind(this(tc)) === K"Comment"
         return nothing
     end
 

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -327,7 +327,7 @@ function call_is_decl(_bas::JL.SyntaxList, i::Int, _basᵢ::JL.SyntaxTree = _bas
     return j <= lastindex(_bas) &&
         kind(_bas[j]) in JS.KSet"macro function" &&
         # in `f(x) = g(x)`, return true in `f`, false in `g`
-        _bas[j - 1]._id === _bas[j][1]._id
+        _bas[j - 1]._id == _bas[j][1]._id
 end
 
 # Find cases where a macro call is not surrounded by parentheses

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,4 +1,4 @@
-const SyntaxTree0 = typeof(JS.build_tree(JL.SyntaxTree, JS.ParseStream("")))
+const SyntaxTree0 = typeof(JS.build_tree(JL.SyntaxTree, JS.parse!(JS.ParseStream(""))))
 
 abstract type ExtraDiagnosticsKey end
 to_file_info(key::ExtraDiagnosticsKey) = to_file_info_impl(key)::FileInfo

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -234,7 +234,6 @@ function token_at_offset(ps::JS.ParseStream, offset::Int)
 end
 
 function token_at_offset(fi::FileInfo, pos::Position)
-    fi === nothing && return nothing
     token_at_offset(fi.parsed_stream, xy_to_offset(fi, pos))
 end
 
@@ -245,7 +244,6 @@ function token_before_offset(ps::JS.ParseStream, offset::Int)
     token_at_offset(ps, offset - 1)
 end
 function token_before_offset(fi::FileInfo, pos::Position)
-    fi === nothing && return nothing
     token_before_offset(fi.parsed_stream, xy_to_offset(fi, pos))
 end
 


### PR DESCRIPTION
Main change: ParseStream no longer holds a flat token list; we need to do
     something to get it.  Arguably we should do something smarter than seeking
     through the tokens but I've left that for later.

TODO: preparing a commit where I try to delete the macro hack