### PR TITLE
inlay-hints: show `end module` suffix

### DIFF
--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -68,6 +68,7 @@ include("hover.jl")
 include("diagnostics.jl")
 include("code-lens.jl")
 include("code-action.jl")
+include("inlay-hint.jl")
 include("testrunner.jl")
 include("response.jl")
 include("lifecycle.jl")
@@ -198,6 +199,8 @@ function _handle_message(server::Server, msg)
         return handle_CodeActionRequest(server, msg)
     elseif msg isa ExecuteCommandRequest
         return handle_ExecuteCommandRequest(server, msg)
+    elseif msg isa InlayHintRequest
+        return handle_InlayHintRequest(server, msg)
     elseif msg isa Dict{Symbol,Any} # response message
         if handle_ResponseMessage(server, msg)
             return nothing

--- a/src/inlay-hint.jl
+++ b/src/inlay-hint.jl
@@ -1,0 +1,91 @@
+const INLAY_HINT_REGISTRATION_ID = "jetls-inlay-hint"
+const INLAY_HINT_REGISTRATION_METHOD = "textDocument/inlayHint"
+
+function inlay_hint_options()
+    return InlayHintOptions(;
+        resolveProvider = false)
+end
+
+function inlay_hint_registration(static::Bool)
+    return Registration(;
+        id = INLAY_HINT_REGISTRATION_ID,
+        method = INLAY_HINT_REGISTRATION_METHOD,
+        registerOptions = InlayHintRegistrationOptions(;
+            documentSelector = DEFAULT_DOCUMENT_SELECTOR,
+            resolveProvider = false,
+            id = static ? INLAY_HINT_REGISTRATION_ID : nothing))
+end
+
+# For dynamic registrations during development
+# unregister(currently_running, Unregistration(;
+#     id = INLAY_HINT_REGISTRATION_ID,
+#     method = INLAY_HINT_REGISTRATION_METHOD))
+# register(currently_running, inlay_hint_registration(#=static=#true))
+
+function handle_InlayHintRequest(server::Server, msg::InlayHintRequest)
+    uri = msg.params.textDocument.uri
+    range = msg.params.range
+
+    fi = get_file_info(server.state, uri)
+    if fi === nothing
+        return send(server,
+            InlayHintResponse(;
+                id = msg.id,
+                result = nothing,
+                error = file_cache_error(uri)))
+    end
+
+    inlay_hints = InlayHint[]
+    syntactic_inlay_hints!(inlay_hints, fi, range)
+
+    return send(server, InlayHintResponse(;
+        id = msg.id,
+        result = isempty(inlay_hints) ? null : inlay_hints))
+end
+
+function syntactic_inlay_hints!(inlay_hints::Vector{InlayHint}, fi::FileInfo, range::Range)
+    traverse(build_tree!(JL.SyntaxTree, fi)) do st::SyntaxTree0
+        if JS.kind(st) === JS.K"module" && JS.numchildren(st) ≥ 2
+            modrange = get_source_range(st)
+            endpos = modrange.var"end"
+            if endpos ∉ range
+                return # this inlay hint isn't visible
+            elseif modrange.start.line == endpos.line
+                return # don't add module inlay hint when module is defined as one linear
+            else
+                # If there's already a comment like `end # module ModName`, don't display the inlay hint
+                modname = JS.sourcetext(st[1])
+                bstart = xy_to_offset(fi, endpos) + 1
+                nexttc = next_nontrivia(fi.parsed_stream, bstart)
+                if isnothing(nexttc) # no non-trivial token left - include everything left
+                    commentrange = bstart:length(fi.parsed_stream.textbuf)
+                elseif JS.kind(this(nexttc)) === JS.K"NewlineWs"
+                    commentrange = bstart:length(fi.parsed_stream.textbuf)
+                else
+                    commentrange = bstart:first_byte(nexttc)-1
+                end
+                commentstr = String(fi.parsed_stream.textbuf[commentrange])
+                if occursin(modname, commentstr)
+                    return
+                elseif startswith(lstrip(commentstr), "# module")
+                    return
+                elseif startswith(lstrip(commentstr), "#= module")
+                    return
+                end
+                label = " #= module $modname =#"
+                offset = sizeof(label)
+                textEdits = TextEdit[TextEdit(;
+                    range = Range(;
+                        start = Position(endpos; character = endpos.character+1),
+                        var"end" = Position(endpos; character = endpos.character+1+offset)),
+                    newText = label)]
+                push!(inlay_hints, InlayHint(;
+                    position = endpos,
+                    textEdits,
+                    label))
+            end
+        end
+    end
+    return inlay_hints
+end
+syntactic_inlay_hints(args...) = syntactic_inlay_hints!(InlayHint[], args...) # used by tests

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -10,10 +10,12 @@ function yield_to_endpoint(interval=DEFAULT_FLUSH_INTERVAL)
 end
 
 # TODO memomize computed results?
-supports(server::Server, paths::Symbol...) = supports(server.state, paths...)
-function supports(state::ServerState, paths::Symbol...)
+supports(args...) = getcapability(args...) === true
+
+getcapability(server::Server, paths::Symbol...) = getcapability(server.state, paths...)
+function getcapability(state::ServerState, paths::Symbol...)
     return isdefined(state, :init_params) &&
-        getobjpath(state.init_params.capabilities, paths...) === true
+        getobjpath(state.init_params.capabilities, paths...)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ end
     @testset "signature help" include("test_signature_help.jl")
     @testset "definition" include("test_definition.jl")
     @testset "hover" include("test_hover.jl")
+    @testset "inlay hint" include("test_inlay_hint.jl")
     @testset "surface analysis" include("test_surface_analysis.jl")
     @testset "LSAnalyzer" include("test_LSAnalyzer.jl")
     @testset "diagnostics" include("test_diagnostics.jl")

--- a/test/test_inlay_hint.jl
+++ b/test/test_inlay_hint.jl
@@ -1,0 +1,117 @@
+module test_inlay_hint
+
+using Test
+using JETLS
+using JETLS.LSP
+
+include("setup.jl")
+include("jsjl_utils.jl")
+
+@testset "syntactic_inlay_hints!" begin
+    @testset "module inlay hints" begin
+        let code = """
+            module TestModule
+            x = 1
+            end
+            """
+            fi = JETLS.FileInfo(1, parsedstream(code))
+            range = Range(; start = Position(; line = 0, character = 0),
+                            var"end" = Position(; line = 3, character = 0))
+            inlay_hints = JETLS.syntactic_inlay_hints(fi, range)
+            @test length(inlay_hints) == 1
+            @test inlay_hints[1].position == Position(; line = 2, character = 3)
+            @test inlay_hints[1].label == " #= module TestModule =#"
+        end
+
+        let code = """
+            module TestModule
+            x = 1
+            y = 2
+            end # module TestModule
+            """
+            fi = JETLS.FileInfo(1, parsedstream(code))
+            range = Range(; start = Position(; line = 0, character = 0),
+                            var"end" = Position(; line = 4, character = 0))
+            inlay_hints = JETLS.syntactic_inlay_hints(fi, range)
+            @test isempty(inlay_hints)
+        end
+
+        let code = """
+            module TestModule
+            x = 1
+            end #= module TestModule =#
+            """
+            fi = JETLS.FileInfo(1, parsedstream(code))
+            range = Range(; start = Position(; line = 0, character = 0),
+                            var"end" = Position(; line = 3, character = 0))
+            inlay_hints = JETLS.syntactic_inlay_hints(fi, range)
+            @test isempty(inlay_hints)
+        end
+
+        @testset "one-liner modules" begin
+            let code = """
+                module TestModule end
+                """
+                fi = JETLS.FileInfo(1, parsedstream(code))
+                range = Range(; start = Position(; line = 0, character = 0),
+                                var"end" = Position(; line = 1, character = 0))
+                inlay_hints = JETLS.syntactic_inlay_hints(fi, range)
+                @test isempty(inlay_hints)
+            end
+        end
+
+        @testset "nested modules" begin
+            let code = """
+                module Outer
+                module Inner
+                x = 1
+                end
+                end
+                """
+                fi = JETLS.FileInfo(1, parsedstream(code))
+                range = Range(; start = Position(; line = 0, character = 0),
+                                var"end" = Position(; line = 5, character = 0))
+                inlay_hints = JETLS.syntactic_inlay_hints(fi, range)
+                @test length(inlay_hints) == 2
+                # The order depends on the tree traversal, so we sort by line number
+                sort!(inlay_hints, by = hint -> hint.position.line)
+                @test inlay_hints[1].position == Position(; line = 3, character = 3)
+                @test inlay_hints[1].label == " #= module Inner =#"
+                @test inlay_hints[2].position == Position(; line = 4, character = 3)
+                @test inlay_hints[2].label == " #= module Outer =#"
+            end
+        end
+
+        @testset "range filtering" begin
+            let code = """
+                module TestModule
+                x = 1
+                end
+                """
+                fi = JETLS.FileInfo(1, parsedstream(code))
+                range = Range(; start = Position(; line = 0, character = 0),
+                                var"end" = Position(; line = 1, character = 0))
+                inlay_hints = JETLS.syntactic_inlay_hints(fi, range)
+                @test isempty(inlay_hints)
+            end
+        end
+
+        @testset "whitespace before comment" begin
+            let code = """
+                module TestModule
+                x = 1
+                end    # some comment
+                """
+                fi = JETLS.FileInfo(1, parsedstream(code))
+                range = Range(; start = Position(; line = 0, character = 0),
+                                var"end" = Position(; line = 3, character = 0))
+                inlay_hints = JETLS.syntactic_inlay_hints(fi, range)
+                @test length(inlay_hints) == 1
+                @test inlay_hints[1].position == Position(; line = 2, character = 3)
+                @test inlay_hints[1].label == " #= module TestModule =#"
+            end
+        end
+    end
+end
+
+end # module test_inlay_hint


### PR DESCRIPTION
As we begin full-scale use of JL in the future, we will make extensive use of inlay-hints for features like inline type annotations. To build the infrastructure for that purpose, I have implemented a simple `end-module` suffix inlay-hint based on syntactic analysis.

For code patterns like: 
```julia
module A
...
end
```

This automatically displays `#= module A =#` after the `end`. If there is already a comment after `end`, the inlay hint is not displayed.