### PR TITLE
surface-analysis: fix issues with werid `@nospecialize` expand

### DIFF
--- a/src/analysis/surface-analysis.jl
+++ b/src/analysis/surface-analysis.jl
@@ -10,6 +10,9 @@ function analyze_lowered_code!(diagnostics::Vector{Diagnostic},
         else
             message = "Unused local binding `$(binfo.name)`"
         end
+        if iszero(JS.first_byte(binding)) || iszero(JS.last_byte(binding))
+            continue
+        end
         push!(diagnostics, jsobj_to_diagnostic(binding, sourcefile,
             message,
             #=severity=#DiagnosticSeverity.Information,

--- a/test/test_surface_analysis.jl
+++ b/test/test_surface_analysis.jl
@@ -177,6 +177,22 @@ end
         @test diagnostic.range.var"end".line == 1
     end
 
+    @testset "macro compatibility issue" begin
+        diagnostics = get_lowered_diagnostics("""
+        function kwargs_dict(@nospecialize configs)
+            return ()
+        end
+        """)
+        isone = length(diagnostics) == 1
+        @test_broken isone
+        if isone
+            diagnostic = only(diagnostics)
+            @test diagnostic.message == "Unused local binding `configs`"
+            @test diagnostic.range.start.line == 1
+            @test diagnostic.range.var"end".line == 1
+        end
+    end
+
     @testset "Edge case" begin
         diagnostics = get_lowered_diagnostics("""
         func(::Nothing, x) = x


### PR DESCRIPTION
Currently we remove all macro calls due to the JL's macro compat issue, but we treat `@nospecialize` specially and keep it during lowering. However, for some reason there are cases where `JS.first_byte` becomes 0 after `@nospecialize` is applied, so we're adding that special case to surface-analysis.jl. This is expected to be resolved by aviatesk/JETLS.jl#180.