### PR TITLE
Add JETLS_DEBUG_LOWERING for JL-related logging

### DIFF
--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -11,8 +11,9 @@ end
 using Preferences: Preferences
 const JETLS_DEV_MODE = Preferences.@load_preference("JETLS_DEV_MODE", false)
 const JETLS_TEST_MODE = Preferences.@load_preference("JETLS_TEST_MODE", false)
+const JETLS_DEBUG_LOWERING = Preferences.@load_preference("JETLS_DEBUG_LOWERING", false)
 push_init_hooks!() do
-    @info "Running JETLS with" JETLS_DEV_MODE JETLS_TEST_MODE
+    @info "Running JETLS with" JETLS_DEV_MODE JETLS_TEST_MODE JETLS_DEBUG_LOWERING
 end
 
 using LSP

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -157,7 +157,9 @@ function lowering_diagnostics(file_info::FileInfo, filename::AbstractString)
         else
             ctx3, st3 = try
                 jl_lower_for_scope_resolution3(st0)
-            catch # err
+            catch err
+                JETLS_DEBUG_LOWERING && @warn "Error in lowering" err
+                JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
                 continue
             end
             analyze_lowered_code!(diagnostics, ctx3, st3, sourcefile)

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -162,7 +162,9 @@ function select_target_binding_definitions(st0_top::JL.SyntaxTree, offset::Int, 
 
     ctx3, st3 = try
         jl_lower_for_scope_resolution3(st0, mod)
-    catch
+    catch err
+        JETLS_DEBUG_LOWERING && @warn "Error in lowering" err
+        JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
         return nothing
     end
     binding = select_target_binding(ctx3, st3, b)

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -48,8 +48,9 @@ function cursor_bindings(st0_top::JL.SyntaxTree, b_top::Int, mod::MaybeLoweringM
     st0, b = @something greatest_local(st0_top, b_top) return nothing # nothing we can lower
     ctx3, st2 = try
         jl_lower_for_scope_resolution2(st0, mod)
-    catch # err
-        # JETLS_DEV_MODE && @warn "Error in lowering" err
+    catch err
+        JETLS_DEBUG_LOWERING && @warn "Error in lowering" err
+        JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
         return nothing # lowering failed, e.g. because of incomplete input
     end
 
@@ -95,7 +96,7 @@ function cursor_bindings(st0_top::JL.SyntaxTree, b_top::Int, mod::MaybeLoweringM
             || bdistances[i] < bdistances[prev]
             || binfo.kind === :static_parameter)
             seen[binfo.name] = i
-        elseif JETLS_DEV_MODE
+        elseif JETLS_DEBUG_LOWERING
             @info "Found two bindings with the same name:" binfo bscopeinfos[prev][1]
         end
     end

--- a/test/jsjl_utils.jl
+++ b/test/jsjl_utils.jl
@@ -14,6 +14,16 @@ jlparse(s::AbstractString; rule::Symbol=:all, kwargs...) = jlparse(parsedstream(
 jlparse(parsed_stream::JS.ParseStream; filename::AbstractString=@__FILE__, first_line::Int=1) =
     JS.build_tree(JL.SyntaxTree, parsed_stream; filename, first_line)
 
+macro expect_jl_err(ex)
+    if JETLS.JETLS_DEBUG_LOWERING
+        esc(:(redirect_stdio(stderr=>devnull) do
+                  $ex
+              end))
+    else
+        esc(ex)
+    end
+end
+
 # For interactive use
 # ===================
 

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -225,7 +225,7 @@ end
 let code = """
     function fo│
     """
-    test_single_cv(code, String[])
+    @expect_jl_err test_single_cv(code, String[])
 end
 let # XXX somehow wrapping within `module A ... end` is necessary to get `xx` completion for this incomplete code
     code = """


### PR DESCRIPTION
Lowering failures shouldn't interfere with the LS running (or even LS development), but they are usually of interest for JL development, where I often end up with a bunch of local logging code.  This change puts lowering backtraces behind another Preferences.jl variable so adding JL-specific logging is less intrusive.