### PR TITLE
testrunner: use latest TestRunner.jl implementation

### DIFF
--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -151,8 +151,7 @@ function runserver(server::Server)
     return (; exit_code, server.endpoint)
 end
 
-function handle_message(server::Server, msg)
-    @nospecialize msg
+function handle_message(server::Server, @nospecialize msg)
     if !JETLS_TEST_MODE
         try
             if JETLS_DEV_MODE
@@ -178,8 +177,7 @@ function handle_message(server::Server, msg)
     end
 end
 
-function _handle_message(server::Server, msg)
-    @nospecialize msg
+function _handle_message(server::Server, @nospecialize msg)
     if msg isa DidOpenTextDocumentNotification
         return handle_DidOpenTextDocumentNotification(server, msg)
     elseif msg isa DidChangeTextDocumentNotification

--- a/src/testrunner-types.jl
+++ b/src/testrunner-types.jl
@@ -1,3 +1,9 @@
+struct TestRunnerDiagnosticRelatedInformation
+    filename::String
+    line::Int
+    message::String
+end
+
 """
     TestRunnerDiagnostic
 
@@ -13,6 +19,7 @@ struct TestRunnerDiagnostic
     filename::String
     line::Int
     message::String
+    relatedInformation::Union{Nothing,Vector{TestRunnerDiagnosticRelatedInformation}}
 end
 
 """


### PR DESCRIPTION
So that we can see stacktrace from exceptions raised from tests.