### PR TITLE
surface analysis: fix struct constructors with keyword arguments

### DIFF
--- a/src/analysis/surface-analysis.jl
+++ b/src/analysis/surface-analysis.jl
@@ -95,7 +95,7 @@ function compute_binding_usages!(tracked::Dict{JL.BindingInfo,Bool},
                     end &&
                     JS.kind(arglist[3]) === JS.K"BindingId" &&
                     let arg3info = JL.lookup_binding(ctx3, arglist[3])
-                        arg3info.is_internal && arg3info.name == "#self#"
+                        arg3info.is_internal && (arg3info.name == "#self#" || arg3info.name == "#ctor-self#")
                     end
                 if is_kwcall
                     # This is `kwcall` method -- now need to perform some special case

--- a/test/test_surface_analysis.jl
+++ b/test/test_surface_analysis.jl
@@ -194,6 +194,26 @@ end
             @test diagnostic.message == "Unused argument `y`"
             @test diagnostic.range.start.line == 2
         end
+        # constructor definition with keyword arguments
+        let diagnostics = get_lowered_diagnostics("""
+            struct A{T}
+                x::T
+                A(x::T; override::Union{Nothing,T}) where T = new{T}(@something override x)
+            end
+            """)
+            @test isempty(diagnostics)
+        end
+        let diagnostics = get_lowered_diagnostics("""
+            struct A{T}
+                x::T
+                A(x::T; override::Union{Nothing,T}) where T = new{T}(x)
+            end
+            """)
+            @test length(diagnostics) == 1
+            diagnostic = only(diagnostics)
+            @test diagnostic.message == "Unused argument `override`"
+            @test diagnostic.range.start.line == 2
+        end
     end
 
     @testset "module splitter" begin


### PR DESCRIPTION
Fixes the false positive unused variable diagnostics for cases like:
```julia
struct A{T}
    x::T
    A(x::T; override::Union{Nothing,T}) where T = new{T}(@something override x)
end
```