### PR TITLE
surface-analysis: improve unused argument handling

### DIFF
--- a/test/test_surface_analysis.jl
+++ b/test/test_surface_analysis.jl
@@ -109,6 +109,35 @@ end
             hasmatch(x::RegexMatch, y::Bool=false) = nothing
             """)
             @test_broken length(diagnostics) == 2
+            @test any(diagnostics) do diagnostic
+                diagnostic.message == "Unused argument `x`" &&
+                diagnostic.range.start.line == 0 &&
+                diagnostic.range.var"end".line == 0
+            end
+            @test any(diagnostics) do diagnostic
+                diagnostic.message == "Unused argument `y`" &&
+                diagnostic.range.start.line == 0 &&
+                diagnostic.range.var"end".line == 0
+            end
+        end
+        let diagnostics = get_lowered_diagnostics("""
+            hasmatch(x::RegexMatch, y::Bool=false) = x
+            """)
+            @test length(diagnostics) == 1
+            diagnostic = only(diagnostics)
+            @test diagnostic.message == "Unused argument `y`"
+            @test diagnostic.range.start.line == 0
+            @test diagnostic.range.var"end".line == 0
+        end
+        let diagnostics = get_lowered_diagnostics("""
+            hasmatch(x::RegexMatch, y::Bool=false) = y
+            """)
+            @test_broken length(diagnostics) == 1
+            @test any(diagnostics) do diagnostic
+                diagnostic.message == "Unused argument `x`" &&
+                diagnostic.range.start.line == 0 &&
+                diagnostic.range.var"end".line == 0
+            end
         end
     end
 


### PR DESCRIPTION
Allows us to get the diagnosics for cases like
```julia
hasmatch(x::RegexMatch, y::Bool=false) = y
```
although this implementation results in duplicated diagnostics.