### PR TITLE
ast: remove `include_at_mark` option entirely from `jsobj_to_range`

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -118,7 +118,7 @@ function to_completion(
     JL.showprov(io, st; include_location=false)
     println(io)
     println(io, "``````")
-    (; line, character) = jsobj_to_range(st, fi; include_at_mark=false).start
+    (; line, character) = jsobj_to_range(st, fi).start
     line += 1; character += 1
     showtext = "`@ " * simple_loc_text(uri; line) * "`"
     println(io, create_source_location_link(uri, showtext; line, character))

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -187,8 +187,7 @@ function lowering_diagnostics!(
             end
             push!(diagnostics, jsobj_to_diagnostic(err.ex, fi, msg,
                 #=severity=# DiagnosticSeverity.Error, #=source=# LOWERING_DIAGNOSTIC_SOURCE;
-                relatedInformation,
-                include_at_mark = false))
+                relatedInformation))
         else
             JETLS_DEBUG_LOWERING && @warn "Error in lowering (with macrocall nodes)"
             JETLS_DEBUG_LOWERING && showerror(stderr, err)

--- a/src/hover.jl
+++ b/src/hover.jl
@@ -43,7 +43,7 @@ function handle_HoverRequest(server::Server, msg::HoverRequest)
             JL.showprov(io, definition; include_location=false)
             println(io)
             println(io, "``````")
-            (; line, character) = jsobj_to_range(definition, fi; include_at_mark=false).start
+            (; line, character) = jsobj_to_range(definition, fi).start
             line += 1; character += 1
             showtext = "`@ " * simple_loc_text(uri; line) * "`"
             println(io, create_source_location_link(uri, showtext; line, character))

--- a/test/utils/test_ast.jl
+++ b/test/utils/test_ast.jl
@@ -480,7 +480,7 @@ end
             @test node !== nothing
             @test JS.kind(node) === JS.K"MacroName"
             let range = JETLS.jsobj_to_range(node, fi)
-                @test range.start.line == 0 && range.start.character == 0 # include at mark
+                @test range.start.line == 0 && range.start.character == 1 # not include the @-mark
                 @test range.var"end".line == 0 && range.var"end".character == sizeof("@inline")
             end
         end


### PR DESCRIPTION
This option unnecessarily complicates the meaning of this function, while giving a small benefit.