### PR TITLE
add more `TokenCursor` utilities

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -182,18 +182,18 @@ function global_completions!(items::Dict{String, CompletionItem}, state::ServerS
 
     # Case: `@│`
     if prev_kind === JS.K"@"
-        edit_start_pos = offset_to_xy(fi, first_byte(prev_token))
+        edit_start_pos = offset_to_xy(fi, JS.first_byte(prev_token))
         is_macro_invoke = true
     # Case: `@macr│`
     elseif prev_kind === JS.K"MacroName"
-        edit_start_pos = offset_to_xy(fi, first_byte(prev_tok(prev_token)))
+        edit_start_pos = offset_to_xy(fi, JS.first_byte(prev_tok(prev_token)))
         is_macro_invoke = true
     # Case `│` (empty program)
     elseif isnothing(prev_token)
         edit_start_pos = Position(; line=0, character=0)
         is_macro_invoke = false
     elseif JS.is_identifier(prev_kind)
-        edit_start_pos = offset_to_xy(fi, first_byte(prev_token))
+        edit_start_pos = offset_to_xy(fi, JS.first_byte(prev_token))
         is_macro_invoke = false
     else
         # When completion is triggered within unknown scope (e.g., comment),

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -178,7 +178,7 @@ function global_completions!(items::Dict{String, CompletionItem}, state::ServerS
     completion_module = mod
 
     prev_token = token_before_offset(fi, pos)
-    prev_kind = isnothing(prev_token) ? nothing : JS.kind(this(prev_token))
+    prev_kind = isnothing(prev_token) ? nothing : JS.kind(prev_token)
 
     # Case: `@│`
     if prev_kind === JS.K"@"

--- a/src/inlay-hint.jl
+++ b/src/inlay-hint.jl
@@ -58,7 +58,7 @@ function syntactic_inlay_hints!(inlay_hints::Vector{InlayHint}, fi::FileInfo, ra
                 nexttc = next_nontrivia(fi.parsed_stream, bstart)
                 if isnothing(nexttc) # no non-trivial token left - include everything left
                     commentrange = bstart:length(fi.parsed_stream.textbuf)
-                elseif JS.kind(this(nexttc)) === JS.K"NewlineWs"
+                elseif JS.kind(nexttc) === JS.K"NewlineWs"
                     commentrange = bstart:length(fi.parsed_stream.textbuf)
                 else
                     commentrange = bstart:JS.first_byte(nexttc)-1

--- a/src/inlay-hint.jl
+++ b/src/inlay-hint.jl
@@ -61,7 +61,7 @@ function syntactic_inlay_hints!(inlay_hints::Vector{InlayHint}, fi::FileInfo, ra
                 elseif JS.kind(this(nexttc)) === JS.K"NewlineWs"
                     commentrange = bstart:length(fi.parsed_stream.textbuf)
                 else
-                    commentrange = bstart:first_byte(nexttc)-1
+                    commentrange = bstart:JS.first_byte(nexttc)-1
                 end
                 commentstr = String(fi.parsed_stream.textbuf[commentrange])
                 if occursin(modname, commentstr)

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -406,7 +406,7 @@ function cursor_call(ps::JS.ParseStream, st0::JL.SyntaxTree, b::Int)
     (isnothing(pnb_line) || pnb_line == b) && return nothing
     # Don't provide completion if the current position is within a newline token and crosses over that newline
     pnt_line = prev_nontrivia(ps, b-1; pass_newlines=false) # include the current token (`strict=false`)
-    if !isnothing(pnt_line) && any(==(UInt8('\n')), @view ps.textbuf[first_byte(pnt_line):b-1])
+    if !isnothing(pnt_line) && any(==(UInt8('\n')), @view ps.textbuf[JS.first_byte(pnt_line):b-1])
         return nothing
     end
     bas = byte_ancestors(st0, pnb_line)

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -363,7 +363,7 @@ cursor would be descendents of it.
 function cursor_call(ps::JS.ParseStream, st0::JL.SyntaxTree, b::Int)
     # disable signature help if invoked within comment scope
     tc = token_before_offset(ps, b)
-    if !isnothing(tc) && JS.kind(this(tc)) === K"Comment"
+    if !isnothing(tc) && JS.kind(tc) === K"Comment"
         return nothing
     end
 

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -171,6 +171,10 @@ Base.IteratorEltype(::Type{TokenCursor}) = Base.HasEltype()
 Base.eltype(::Type{TokenCursor}) = TokenCursor
 Base.IteratorSize(::Type{TokenCursor}) = Base.HasLength()
 Base.length(tc::TokenCursor) = length(tc.tokens)
+function Base.show(io::IO, tc::TokenCursor)
+    print(io, "TokenCursor at position ", tc.position, " ")
+    show(io, this(tc))
+end
 next_tok(tc::TokenCursor) =
     @something(iterate(tc, (tc.position, tc.next_byte)), return nothing)[1]
 prev_tok(tc::TokenCursor) = tc.position <= 1 ? nothing :

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -172,13 +172,14 @@ Base.eltype(::Type{TokenCursor}) = TokenCursor
 Base.IteratorSize(::Type{TokenCursor}) = Base.HasLength()
 Base.length(tc::TokenCursor) = length(tc.tokens)
 next_tok(tc::TokenCursor) =
-    @something(Base.iterate(tc, (tc.position, tc.next_byte)), return nothing)[1]
+    @something(iterate(tc, (tc.position, tc.next_byte)), return nothing)[1]
 prev_tok(tc::TokenCursor) = tc.position <= 1 ? nothing :
     TokenCursor(tc.tokens, tc.position - 1, tc.next_byte - tc.tokens[tc.position].byte_span)
+this(tc::TokenCursor) = tc.tokens[tc.position]
 JS.first_byte(tc::TokenCursor) = tc.position <= 1 ? UInt32(1) : prev_tok(tc).next_byte
 JS.last_byte(tc::TokenCursor) = tc.next_byte - UInt32(1)
 JS.byte_range(tc::TokenCursor) = JS.first_byte(tc):JS.last_byte(tc)
-this(tc::TokenCursor) = tc.tokens[tc.position]
+JS.kind(tc::TokenCursor) = JS.kind(this(tc))
 
 """
     token_at_offset(fi::FileInfo, offset::Int)
@@ -371,7 +372,7 @@ function find_nontrivia(prev_or_next::Bool, ps::JS.ParseStream, b::Int; pass_new
 end
 
 function is_trivia(tc::TokenCursor, pass_newlines::Bool)
-    k = kind(this(tc))
+    k = kind(tc)
     JS.is_whitespace(k) && (pass_newlines || k !== JS.K"NewlineWs")
 end
 

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -175,9 +175,9 @@ next_tok(tc::TokenCursor) =
     @something(Base.iterate(tc, (tc.position, tc.next_byte)), return nothing)[1]
 prev_tok(tc::TokenCursor) = tc.position <= 1 ? nothing :
     TokenCursor(tc.tokens, tc.position - 1, tc.next_byte - tc.tokens[tc.position].byte_span)
-first_byte(tc::TokenCursor) = tc.position <= 1 ? UInt32(1) : prev_tok(tc).next_byte
-last_byte(tc::TokenCursor) = tc.next_byte - UInt32(1)
-byte_range(tc::TokenCursor) = first_byte(tc):last_byte(tc)
+JS.first_byte(tc::TokenCursor) = tc.position <= 1 ? UInt32(1) : prev_tok(tc).next_byte
+JS.last_byte(tc::TokenCursor) = tc.next_byte - UInt32(1)
+JS.byte_range(tc::TokenCursor) = JS.first_byte(tc):JS.last_byte(tc)
 this(tc::TokenCursor) = tc.tokens[tc.position]
 
 """
@@ -245,7 +245,7 @@ prev_nontrivia_byte(ps, 20)  # returns nothing (beyond input)
 ```
 """
 prev_nontrivia_byte(args...; kwargs...) =
-    last_byte(@something prev_nontrivia(args...; kwargs...) return nothing)
+    JS.last_byte(@something prev_nontrivia(args...; kwargs...) return nothing)
 
 """
     prev_nontrivia(ps::JS.ParseStream, b::Int; pass_newlines::Bool=false, strict::Bool=false)
@@ -319,7 +319,7 @@ next_nontrivia_byte(ps, 40)  # returns nothing
 ```
 """
 next_nontrivia_byte(args...; kwargs...) =
-    first_byte(@something next_nontrivia(args...; kwargs...) return nothing)
+    JS.first_byte(@something next_nontrivia(args...; kwargs...) return nothing)
 
 """
     next_nontrivia(ps::JS.ParseStream, b::Int; pass_newlines=false, strict=false)

--- a/test/utils/test_ast.jl
+++ b/test/utils/test_ast.jl
@@ -161,36 +161,36 @@ end
     # Test token_at_offset with simple identifiers
     let code = "alpha beta gamma"
         ps = parsedstream(code)
-        @test String(ps.textbuf[JETLS.byte_range(@something(JETLS.token_at_offset(ps, 1)))]) == "alpha"
-        @test String(ps.textbuf[JETLS.byte_range(@something(JETLS.token_at_offset(ps, 3)))]) == "alpha"
-        @test String(ps.textbuf[JETLS.byte_range(@something(JETLS.token_at_offset(ps, 5)))]) == "alpha"
-        @test String(ps.textbuf[JETLS.byte_range(@something(JETLS.token_at_offset(ps, 6)))]) == " "
-        @test String(ps.textbuf[JETLS.byte_range(@something(JETLS.token_at_offset(ps, 8)))]) == "beta"
+        @test String(ps.textbuf[JS.byte_range(@something(JETLS.token_at_offset(ps, 1)))]) == "alpha"
+        @test String(ps.textbuf[JS.byte_range(@something(JETLS.token_at_offset(ps, 3)))]) == "alpha"
+        @test String(ps.textbuf[JS.byte_range(@something(JETLS.token_at_offset(ps, 5)))]) == "alpha"
+        @test String(ps.textbuf[JS.byte_range(@something(JETLS.token_at_offset(ps, 6)))]) == " "
+        @test String(ps.textbuf[JS.byte_range(@something(JETLS.token_at_offset(ps, 8)))]) == "beta"
         @test isnothing(JETLS.token_at_offset(ps, 100))
     end
     let code = "foo(bar)"
         ps = parsedstream(code)
-        @test String(ps.textbuf[JETLS.byte_range(@something(JETLS.token_at_offset(ps, 2)))]) == "foo"
-        @test String(ps.textbuf[JETLS.byte_range(@something(JETLS.token_at_offset(ps, 4)))]) == "("
-        @test String(ps.textbuf[JETLS.byte_range(@something(JETLS.token_at_offset(ps, 6)))]) == "bar"
+        @test String(ps.textbuf[JS.byte_range(@something(JETLS.token_at_offset(ps, 2)))]) == "foo"
+        @test String(ps.textbuf[JS.byte_range(@something(JETLS.token_at_offset(ps, 4)))]) == "("
+        @test String(ps.textbuf[JS.byte_range(@something(JETLS.token_at_offset(ps, 6)))]) == "bar"
     end
 
     # Test token_before_offset
     let code = "a + b"
         ps = parsedstream(code)
-        @test String(ps.textbuf[JETLS.byte_range(@something(JETLS.token_before_offset(ps, 2)))]) == "a"
-        @test String(ps.textbuf[JETLS.byte_range(@something(JETLS.token_before_offset(ps, 3)))]) == " "
-        @test String(ps.textbuf[JETLS.byte_range(@something(JETLS.token_before_offset(ps, 4)))]) == "+"
+        @test String(ps.textbuf[JS.byte_range(@something(JETLS.token_before_offset(ps, 2)))]) == "a"
+        @test String(ps.textbuf[JS.byte_range(@something(JETLS.token_before_offset(ps, 3)))]) == " "
+        @test String(ps.textbuf[JS.byte_range(@something(JETLS.token_before_offset(ps, 4)))]) == "+"
         @test isnothing(JETLS.token_before_offset(ps, 1))
     end
 
     # Test with multi-byte characters
     let code = "α + β"
         ps = parsedstream(code)
-        @test String(ps.textbuf[JETLS.byte_range(@something(JETLS.token_at_offset(ps, 1)))]) == "α"
-        @test String(ps.textbuf[JETLS.byte_range(@something(JETLS.token_at_offset(ps, sizeof("α"))))]) == "α"
-        @test String(ps.textbuf[JETLS.byte_range(@something(JETLS.token_at_offset(ps, sizeof("α")+1)))]) == " "
-        @test String(ps.textbuf[JETLS.byte_range(@something(JETLS.token_before_offset(ps, sizeof("α")+1)))]) == "α"
+        @test String(ps.textbuf[JS.byte_range(@something(JETLS.token_at_offset(ps, 1)))]) == "α"
+        @test String(ps.textbuf[JS.byte_range(@something(JETLS.token_at_offset(ps, sizeof("α"))))]) == "α"
+        @test String(ps.textbuf[JS.byte_range(@something(JETLS.token_at_offset(ps, sizeof("α")+1)))]) == " "
+        @test String(ps.textbuf[JS.byte_range(@something(JETLS.token_before_offset(ps, sizeof("α")+1)))]) == "α"
     end
 end
 
@@ -202,9 +202,9 @@ end
         ps = parsedstream(code)
         toks = collect(JETLS.TokenCursor(ps))
         @test length(toks) == 3
-        @test String(ps.textbuf[JETLS.byte_range(toks[1])]) == "abc"
-        @test String(ps.textbuf[JETLS.byte_range(toks[2])]) == " "
-        @test String(ps.textbuf[JETLS.byte_range(toks[3])]) == "def"
+        @test String(ps.textbuf[JS.byte_range(toks[1])]) == "abc"
+        @test String(ps.textbuf[JS.byte_range(toks[2])]) == " "
+        @test String(ps.textbuf[JS.byte_range(toks[3])]) == "def"
     end
 end
 
@@ -215,9 +215,9 @@ end
     # Test basic functionality
     let code = "x   y"
         ps = parsedstream(code)
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.prev_nontrivia(ps, 1))]) == "x"
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.prev_nontrivia(ps, 3))]) == "x"
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.prev_nontrivia(ps, 5))]) == "y"
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, 1))]) == "x"
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, 3))]) == "x"
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, 5))]) == "y"
         @test isnothing(JETLS.prev_nontrivia(ps, 0))
         @test isnothing(JETLS.prev_nontrivia(ps, sizeof(code)+1))
         @test isnothing(JETLS.prev_nontrivia(ps, 100))
@@ -227,38 +227,38 @@ end
     let code = "x\n  y"
         ps = parsedstream(code)
         @test JETLS.JS.kind(JETLS.this(@something JETLS.prev_nontrivia(ps, 2))) == JETLS.JS.K"NewlineWs"
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.prev_nontrivia(ps, 2; pass_newlines=true))]) == "x"
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.prev_nontrivia(ps, sizeof(code)))]) == "y"
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, 2; pass_newlines=true))]) == "x"
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, sizeof(code)))]) == "y"
         @test isnothing(JETLS.prev_nontrivia(ps, sizeof(code)+1))  # beyond input
     end
 
     # Test with comments
     let code = "x # comment\ny"
         ps = parsedstream(code)
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.prev_nontrivia(ps, 5))]) == "x"  # from within comment
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, 5))]) == "x"  # from within comment
         @test JETLS.JS.kind(JETLS.this(@something JETLS.prev_nontrivia(ps, sizeof(code)-1))) == JETLS.JS.K"NewlineWs"  # at newline
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.prev_nontrivia(ps, sizeof(code)-1; pass_newlines=true))]) == "x"
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.prev_nontrivia(ps, sizeof(code)))]) == "y"
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, sizeof(code)-1; pass_newlines=true))]) == "x"
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, sizeof(code)))]) == "y"
     end
 
     # Test with block comments
     let code = "x #= block\ncomment =# y"
         ps = parsedstream(code)
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.prev_nontrivia(ps, 15))]) == "x"  # from within block comment
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.prev_nontrivia(ps, sizeof(code)))]) == "y"
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, 15))]) == "x"  # from within block comment
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, sizeof(code)))]) == "y"
         @test isnothing(JETLS.prev_nontrivia(ps, sizeof(code)+1))  # beyond input
     end
 
     # Test at various positions in non-trivia tokens
     let code = "foo(bar)"
         ps = parsedstream(code)
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.prev_nontrivia(ps, 1))]) == "foo"  # at start
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.prev_nontrivia(ps, 2))]) == "foo"  # in middle
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.prev_nontrivia(ps, 3))]) == "foo"  # at end
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.prev_nontrivia(ps, 4))]) == "("
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.prev_nontrivia(ps, 5))]) == "bar"
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.prev_nontrivia(ps, 7))]) == "bar"
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.prev_nontrivia(ps, 8))]) == ")"
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, 1))]) == "foo"  # at start
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, 2))]) == "foo"  # in middle
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, 3))]) == "foo"  # at end
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, 4))]) == "("
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, 5))]) == "bar"
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, 7))]) == "bar"
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, 8))]) == ")"
     end
 
     # Test edge cases
@@ -312,9 +312,9 @@ end
     # Test basic functionality - when starting on a non-trivia token
     let code = "x   y"
         ps = parsedstream(code)
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.next_nontrivia(ps, 1))]) == "x"
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.next_nontrivia(ps, 2))]) == "y"
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.next_nontrivia(ps, sizeof(code)))]) == "y"
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.next_nontrivia(ps, 1))]) == "x"
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.next_nontrivia(ps, 2))]) == "y"
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.next_nontrivia(ps, sizeof(code)))]) == "y"
         @test isnothing(JETLS.next_nontrivia(ps, sizeof(code)+1))
     end
 
@@ -322,26 +322,26 @@ end
     let code = "x\n  y"
         ps = parsedstream(code)
         @test JETLS.JS.kind(JETLS.this(@something JETLS.next_nontrivia(ps, 2))) == JETLS.JS.K"NewlineWs"
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.next_nontrivia(ps, 2; pass_newlines=true))]) == "y"
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.next_nontrivia(ps, 2; pass_newlines=true))]) == "y"
     end
 
     # Test with comments (comments are considered trivia)
     let code = "x # comment\ny"
         ps = parsedstream(code)
         @test JETLS.JS.kind(JETLS.this(@something JETLS.next_nontrivia(ps, sizeof("x #")))) == JETLS.JS.K"NewlineWs"
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.next_nontrivia(ps, sizeof("x #"); pass_newlines=true))]) == "y"
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.next_nontrivia(ps, sizeof("x #"); pass_newlines=true))]) == "y"
 
         code = "x \n#= multi-line\ncomment =#\ny"
         ps = parsedstream(code)
         @test JETLS.JS.kind(JETLS.this(@something JETLS.next_nontrivia(ps, sizeof("x \n#")))) == JETLS.JS.K"NewlineWs"
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.next_nontrivia(ps, sizeof("x \n#"); pass_newlines=true))]) == "y"
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.next_nontrivia(ps, sizeof("x \n#"); pass_newlines=true))]) == "y"
     end
 
     let code = "foo(bar)"
         ps = parsedstream(code)
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.next_nontrivia(ps, 1))]) == "foo"
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.next_nontrivia(ps, 4))]) == "("
-        @test String(ps.textbuf[JETLS.byte_range(@something JETLS.next_nontrivia(ps, 5))]) == "bar"
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.next_nontrivia(ps, 1))]) == "foo"
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.next_nontrivia(ps, 4))]) == "("
+        @test String(ps.textbuf[JS.byte_range(@something JETLS.next_nontrivia(ps, 5))]) == "bar"
     end
 
     let code = "   "

--- a/test/utils/test_ast.jl
+++ b/test/utils/test_ast.jl
@@ -205,6 +205,9 @@ end
         @test String(ps.textbuf[JS.byte_range(toks[1])]) == "abc"
         @test String(ps.textbuf[JS.byte_range(toks[2])]) == " "
         @test String(ps.textbuf[JS.byte_range(toks[3])]) == "def"
+
+        @test startswith(sprint(show, toks[1]), "TokenCursor at position 1 Identifier")
+        @test startswith(sprint(show, toks[2]), "TokenCursor at position 2 Whitespace")
     end
 end
 

--- a/test/utils/test_ast.jl
+++ b/test/utils/test_ast.jl
@@ -226,7 +226,7 @@ end
     # Test with newlines
     let code = "x\n  y"
         ps = parsedstream(code)
-        @test JETLS.JS.kind(JETLS.this(@something JETLS.prev_nontrivia(ps, 2))) == JETLS.JS.K"NewlineWs"
+        @test JS.kind(@something JETLS.prev_nontrivia(ps, 2)) == JS.K"NewlineWs"
         @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, 2; pass_newlines=true))]) == "x"
         @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, sizeof(code)))]) == "y"
         @test isnothing(JETLS.prev_nontrivia(ps, sizeof(code)+1))  # beyond input
@@ -236,7 +236,7 @@ end
     let code = "x # comment\ny"
         ps = parsedstream(code)
         @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, 5))]) == "x"  # from within comment
-        @test JETLS.JS.kind(JETLS.this(@something JETLS.prev_nontrivia(ps, sizeof(code)-1))) == JETLS.JS.K"NewlineWs"  # at newline
+        @test JS.kind(@something JETLS.prev_nontrivia(ps, sizeof(code)-1)) == JS.K"NewlineWs"  # at newline
         @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, sizeof(code)-1; pass_newlines=true))]) == "x"
         @test String(ps.textbuf[JS.byte_range(@something JETLS.prev_nontrivia(ps, sizeof(code)))]) == "y"
     end
@@ -321,19 +321,19 @@ end
     # Test with pass_newlines=true
     let code = "x\n  y"
         ps = parsedstream(code)
-        @test JETLS.JS.kind(JETLS.this(@something JETLS.next_nontrivia(ps, 2))) == JETLS.JS.K"NewlineWs"
+        @test JS.kind(@something JETLS.next_nontrivia(ps, 2)) == JS.K"NewlineWs"
         @test String(ps.textbuf[JS.byte_range(@something JETLS.next_nontrivia(ps, 2; pass_newlines=true))]) == "y"
     end
 
     # Test with comments (comments are considered trivia)
     let code = "x # comment\ny"
         ps = parsedstream(code)
-        @test JETLS.JS.kind(JETLS.this(@something JETLS.next_nontrivia(ps, sizeof("x #")))) == JETLS.JS.K"NewlineWs"
+        @test JS.kind(@something JETLS.next_nontrivia(ps, sizeof("x #"))) == JS.K"NewlineWs"
         @test String(ps.textbuf[JS.byte_range(@something JETLS.next_nontrivia(ps, sizeof("x #"); pass_newlines=true))]) == "y"
 
         code = "x \n#= multi-line\ncomment =#\ny"
         ps = parsedstream(code)
-        @test JETLS.JS.kind(JETLS.this(@something JETLS.next_nontrivia(ps, sizeof("x \n#")))) == JETLS.JS.K"NewlineWs"
+        @test JS.kind(@something JETLS.next_nontrivia(ps, sizeof("x \n#"))) == JS.K"NewlineWs"
         @test String(ps.textbuf[JS.byte_range(@something JETLS.next_nontrivia(ps, sizeof("x \n#"); pass_newlines=true))]) == "y"
     end
 


### PR DESCRIPTION
Allows `TokenCursor` to be used for `jsobj_to_range`.