### PR TITLE
ast: remove the second return value of `greatest_local`

### DIFF
--- a/src/document-highlight.jl
+++ b/src/document-highlight.jl
@@ -51,7 +51,7 @@ end
 function lowering_document_highlights!(highlights::Vector{DocumentHighlight}, fi::FileInfo, offset::Int, mod::Module)
     st0_top = build_tree!(JL.SyntaxTree, fi)
 
-    st0, _ = @something greatest_local(st0_top, offset) return highlights
+    st0 = @something greatest_local(st0_top, offset) return highlights
     (; ctx3, st3) = try
         jl_lower_for_scope_resolution(mod, st0)
     catch err

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -125,13 +125,13 @@ end
 byte_ancestors(flt, sn::JS.SyntaxNode, byte::Integer) = byte_ancestors(flt, sn, byte:byte)
 
 """
-    greatest_local(st0, b) -> (st::Union{SyntaxTree, Nothing}, b::Int)
+    greatest_local(st0::JL.SyntaxTree, offset::Int) -> st::Union{JL.SyntaxTree, Nothing}
 
-Return the largest tree that can introduce local bindings that are visible to
-the cursor (if any such tree exists), and the cursor's position within it.
+Return the largest tree that can introduce local bindings that are visible to the cursor
+(if any such tree exists).
 """
-function greatest_local(st0::JL.SyntaxTree, b::Int)
-    bas = byte_ancestors(st0, b)
+function greatest_local(st0::JL.SyntaxTree, offset::Int)
+    bas = byte_ancestors(st0, offset)
     first_global = findfirst(st::JL.SyntaxTree -> JL.kind(st) in JS.KSet"toplevel module", bas)
     isnothing(first_global) && return nothing
 
@@ -146,8 +146,7 @@ function greatest_local(st0::JL.SyntaxTree, b::Int)
         i -= 1
         i < 1 && return nothing
     end
-
-    return bas[i], (b - (JS.first_byte(st0) - 1))
+    return bas[i]
 end
 
 """


### PR DESCRIPTION
Currently all the callers of `greatest_local(st0, offset)` pass `st0` of the toplevel syntax tree, so the second return value is always same as `offset`. They can calculate the local offset information within non-toplevel syntax tree on their side when necessary.