### PR TITLE
binding: re-implement `remove_macrocalls`

### DIFF
--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -186,8 +186,9 @@ function _select_target_binding(st0_top::JL.SyntaxTree, offset::Int, mod::Module
         return nothing
     end
 
+    st0′ = remove_macrocalls(st0)
     (; ctx3, st3) = try
-        jl_lower_for_scope_resolution(mod, st0)
+        jl_lower_for_scope_resolution(mod, st0′)
     catch err
         JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
         JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
@@ -348,7 +349,7 @@ function compute_binding_occurrences(
             occurrences[ctx3.bindings.info[idx]] = newoccurrences
         end
     end
-    
+
     # The same goes for static parameter bindings
     for (_, idxs) in same_sparam_bindings
         length(idxs) == 1 && continue

--- a/test/test_document_highlight.jl
+++ b/test/test_document_highlight.jl
@@ -87,6 +87,30 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
             end
         end
 
+        @testset "highlight with macrocalls" begin
+            code = """
+            func(│xxx│) = @something rand((│xxx│, nothing)) return nothing
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 4
+            fi = JETLS.FileInfo(#=version=#0, parsedstream(clean_code))
+            @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
+            for pos in positions
+                highlights = JETLS.lowering_document_highlights(fi, pos, @__MODULE__)
+                @test length(highlights) == 2
+                @test any(highlights) do highlight
+                    highlight.range.start == positions[1] &&
+                    highlight.range.var"end" == positions[2] &&
+                    highlight.kind == DocumentHighlightKind.Write
+                end
+                @test any(highlights) do highlight
+                    highlight.range.start == positions[3] &&
+                    highlight.range.var"end" == positions[4] &&
+                    highlight.kind == DocumentHighlightKind.Read
+                end
+            end
+        end
+
         let code = """
             let │xxx│, │yyy│ = :yyy
                 │xxx│ = :xxx


### PR DESCRIPTION
The LSP features like "rename" use binding information resolved by JL to analyze local variables, requiring to go through
`JL.expand_forms_[1|2]`. However in the current compat macro expansion mode, precise provenance information within `macrocall` contexts is lost, preventing LSP features from working on local variables inside `macrocall`s that cannot use new macro definitions.

These features primarily operate on surface AST and rarely need analysis on fully lowered AST. What's needed is binding information, which works fine in most cases even when ignoring `macrocall`s.

This commit thus re-implements `remove_macrocalls`. Unlike the previous version that completely trimmed `macrocall` trees like `without_kinds(st0, JS.KSet"macrocall")`, this implementation converts `macrocalls children...` to `block children...`, preserving the binding provenance information contained within expressions passed as arguments to macrocalls.

As a result, LSP features that rely on binding source information (primarily using surface AST level information) can work in many cases based on binding resolution performed on the transformed tree. This enables various LSP features including definition, hover, highlight, and rename to function correctly with local variables inside macrocalls.