### PR TITLE
skip `analyze_from_definitions!` when no toplevel signature is present

### DIFF
--- a/src/analysis/Interpreter.jl
+++ b/src/analysis/Interpreter.jl
@@ -56,6 +56,7 @@ function JET.analyze_from_definitions!(interp::LSInterpreter, config::JET.Toplev
     entrypoint = config.analyze_from_definitions
     res = JET.InterpretationState(interp).res
     n = length(res.toplevel_signatures)
+    n == 0 && return
     next_interval = interval = 10 ^ max(round(Int, log10(n)) - 1, 0)
     token = interp.info.token
     if token !== nothing


### PR DESCRIPTION
`n = 0` at https://github.com/aviatesk/JETLS.jl/blob/f1babd40bc79fa66b36842162cfc0515e7688d5f/src/analysis/Interpreter.jl#L58-L59

raises `InexactError: Int64(-Inf)`. This often happen on an empty initial codebase.
This PR  just skips it to prevent the error.