### PR TITLE
use `null` instead of an empty array when no highlights are found

### DIFF
--- a/src/document-highlight.jl
+++ b/src/document-highlight.jl
@@ -44,7 +44,7 @@ function handle_DocumentHighlightRequest(server::Server, msg::DocumentHighlightR
 
     return send(server, DocumentHighlightResponse(;
         id = msg.id,
-        result = highlights
+        result = isempty(highlights) ? null : highlights
     ))
 end
 


### PR DESCRIPTION
Some clients raise an error if an empty array is returned when there are no highlights (confirmed in VSCode). It appears that returning `null` is the expected response.