### PR TITLE
file-cache: remove AST caching and make `FileInfo` immutable

### DIFF
--- a/src/analysis/Interpreter.jl
+++ b/src/analysis/Interpreter.jl
@@ -6,7 +6,7 @@ using JuliaSyntax: JuliaSyntax as JS
 using JET: CC, JET
 using ..JETLS:
     AnalysisEntry, FullAnalysisInfo, SavedFileInfo, Server,
-    JETLS_DEV_MODE, build_tree!, get_saved_file_info, yield_to_endpoint, send
+    JETLS_DEV_MODE, get_saved_file_info, yield_to_endpoint, send
 using ..JETLS.URIs2
 using ..JETLS.LSP
 using ..JETLS.Analyzer
@@ -137,7 +137,7 @@ function JET.try_read_file(interp::LSInterpreter, include_context::Module, filen
     if !isnothing(fi)
         parsed_stream = fi.parsed_stream
         if isempty(parsed_stream.diagnostics)
-            return build_tree!(JS.SyntaxNode, fi; filename)
+            return fi.syntax_node
         else
             return String(JS.sourcetext(parsed_stream))
         end

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -68,7 +68,7 @@ function analyze_parsed_if_exist(server::Server, info::FullAnalysisInfo, args...
     fi = get_saved_file_info(server.state, uri)
     if !isnothing(fi)
         filename = @something uri2filename(uri) error(lazy"Unsupported URI: $uri")
-        parsed = build_tree!(JS.SyntaxNode, fi; filename)
+        parsed = fi.syntax_node
         begin_full_analysis_progress(server, info)
         try
             return JET.analyze_and_report_expr!(LSInterpreter(server, info), parsed, filename, args...; jetconfigs...)

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -147,7 +147,7 @@ function local_completions!(items::Dict{String, CompletionItem},
     fi = @something get_file_info(s, uri) return nothing
     # NOTE don't bail out even if `length(fi.parsed_stream.diagnostics) ≠ 0`
     # so that we can get some completions even for incomplete code
-    st0 = build_tree!(JL.SyntaxTree, fi)
+    st0 = fi.syntax_tree0
     (; mod) = get_context_info(s, uri, params.position)
     cbs = @something cursor_bindings(st0, xy_to_offset(fi, params.position), mod) return nothing
     for (bi, st, dist) in cbs
@@ -207,7 +207,7 @@ function global_completions!(items::Dict{String, CompletionItem}, state::ServerS
     # since macros are always defined top-level
     is_completed = is_macro_invoke
 
-    st = build_tree!(JL.SyntaxTree, fi)
+    st = fi.syntax_tree0
     offset = xy_to_offset(fi, pos)
     dotprefix = select_dotprefix_node(st, offset)
     if !isnothing(dotprefix)

--- a/src/definition.jl
+++ b/src/definition.jl
@@ -73,7 +73,7 @@ function handle_DefinitionRequest(server::Server, msg::DefinitionRequest)
                 error = file_cache_error(uri)))
     end
 
-    st0 = build_tree!(JL.SyntaxTree, fi)
+    st0 = fi.syntax_tree0
     offset = xy_to_offset(fi, origin_position)
     (; mod, analyzer) = get_context_info(server.state, uri, origin_position)
 

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -68,7 +68,7 @@ function jet_toplevel_error_report_to_diagnostic(
     )
     if report isa JET.ParseErrorReport
         # TODO: Pass correct encoding here
-        fi = FileInfo(#=version=#0, ParseStream!(report.source.code), PositionEncodingKind.UTF16)
+        fi = FileInfo(#=version=#0, report.source.code, JS.filename(report.source), PositionEncodingKind.UTF16)
         return jsdiag_to_lspdiag(report.diagnostic, fi)
     end
     message = JET.with_bufferring(:limit=>true) do io
@@ -246,8 +246,7 @@ lowering_diagnostics(args...) = lowering_diagnostics!(Diagnostic[], args...) # u
 function toplevel_lowering_diagnostics(server::Server, uri::URI)
     diagnostics = Diagnostic[]
     file_info = get_file_info(server.state, uri)
-    filename = @something uri2filename(uri) error(lazy"Unsupported URI: $uri")
-    st0_top = build_tree!(JL.SyntaxTree, file_info; filename)
+    st0_top = file_info.syntax_tree0
     sl = JL.SyntaxList(st0_top)
     push!(sl, st0_top)
     while !isempty(sl)

--- a/src/document-highlight.jl
+++ b/src/document-highlight.jl
@@ -49,7 +49,7 @@ function handle_DocumentHighlightRequest(server::Server, msg::DocumentHighlightR
 end
 
 function lowering_document_highlights!(highlights::Vector{DocumentHighlight}, fi::FileInfo, offset::Int, mod::Module)
-    st0_top = build_tree!(JL.SyntaxTree, fi)
+    st0_top = fi.syntax_tree0
 
     (; ctx3, st3, binding) = @something begin
         _select_target_binding(st0_top, offset, mod; caller="lowering_document_highlights!")

--- a/src/hover.jl
+++ b/src/hover.jl
@@ -66,7 +66,7 @@ function handle_HoverRequest(server::Server, msg::HoverRequest)
                 error = file_cache_error(uri)))
     end
 
-    st0_top = build_tree!(JL.SyntaxTree, fi)
+    st0_top = fi.syntax_tree0
     offset = xy_to_offset(fi, pos)
     (; mod, analyzer, postprocessor) = get_context_info(server.state, uri, pos)
 

--- a/src/inlay-hint.jl
+++ b/src/inlay-hint.jl
@@ -43,7 +43,7 @@ function handle_InlayHintRequest(server::Server, msg::InlayHintRequest)
 end
 
 function syntactic_inlay_hints!(inlay_hints::Vector{InlayHint}, fi::FileInfo, range::Range)
-    traverse(build_tree!(JL.SyntaxTree, fi)) do st::SyntaxTree0
+    traverse(fi.syntax_tree0) do st::SyntaxTree0
         if JS.kind(st) === JS.K"module" && JS.numchildren(st) ≥ 2
             modrange = jsobj_to_range(st, fi)
             endpos = modrange.var"end"

--- a/src/rename.jl
+++ b/src/rename.jl
@@ -46,7 +46,7 @@ function handle_PrepareRenameRequest(server::Server, msg::PrepareRenameRequest)
 end
 
 function local_binding_rename_preparation(fi::FileInfo, pos::Position, mod::Module)
-    st0_top = build_tree!(JL.SyntaxTree, fi)
+    st0_top = fi.syntax_tree0
     offset = xy_to_offset(fi, pos)
 
     (; ctx3, binding) = @something begin
@@ -82,7 +82,7 @@ function handle_RenameRequest(server::Server, msg::RenameRequest)
 end
 
 function local_binding_rename(uri::URI, fi::FileInfo, pos::Position, mod::Module, newName::String)
-    st0_top = build_tree!(JL.SyntaxTree, fi)
+    st0_top = fi.syntax_tree0
     offset = xy_to_offset(fi, pos)
 
     (; ctx3, st3, binding) = @something begin

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -416,7 +416,7 @@ end
 
 function cursor_siginfos(mod::Module, fi::FileInfo, b::Int, analyzer::LSAnalyzer;
                          postprocessor::LSPostProcessor=LSPostProcessor())
-    st0 = build_tree!(JL.SyntaxTree, fi)
+    st0 = fi.syntax_tree0
     call = cursor_call(fi.parsed_stream, st0, b)
     isnothing(call) && return empty_siginfos
     after_semicolon = let

--- a/src/testrunner.jl
+++ b/src/testrunner.jl
@@ -36,7 +36,7 @@ testset_line(testsetinfo::TestsetInfo) = testset_line(testsetinfo.st0)
 testset_line(testset::JL.SyntaxTree) = JS.source_line(testset[2])
 
 function update_testsetinfos!(server::Server, fi::FileInfo; notify_server::Bool=true)
-    st0_top = build_tree!(JL.SyntaxTree, fi)
+    st0_top = fi.syntax_tree0
     testsets = find_executable_testsets(st0_top)
     m, n = length(testsets), length(fi.testsetinfos)
     if m == n == 0
@@ -235,7 +235,7 @@ end
 function testrunner_testcase_code_actions!(
         code_actions::Vector{Union{CodeAction, Command}}, uri::URI, fi::FileInfo, action_range::Range
     )
-    st0_top = build_tree!(JL.SyntaxTree, fi)
+    st0_top = fi.syntax_tree0
     traverse_skip_func_scope(st0_top) do st0::SyntaxTree0
         if JS.kind(st0) === JS.K"macrocall" && JS.numchildren(st0) ≥ 1
             macroname = st0[1]

--- a/src/utils/string.jl
+++ b/src/utils/string.jl
@@ -66,9 +66,9 @@ function xy_to_offset end
 
 xy_to_offset(fi::FileInfo, pos::Position) = _xy_to_offset(fi.parsed_stream.textbuf, pos, fi.encoding)
 xy_to_offset( # used by tests
-    s::Union{Vector{UInt8},AbstractString}, pos::Position,
+    s::Union{Vector{UInt8},AbstractString}, pos::Position, filename::AbstractString,
     encoding::PositionEncodingKind.Ty = PositionEncodingKind.UTF16
-) = xy_to_offset(FileInfo(#=version=#0, ParseStream!(s), encoding), pos)
+) = xy_to_offset(FileInfo(#=version=#0, s, filename, encoding), pos)
 
 function _xy_to_offset(textbuf::Vector{UInt8}, pos::Position, encoding::PositionEncodingKind.Ty)
     b = 0
@@ -108,9 +108,9 @@ function offset_to_xy end
 
 offset_to_xy(fi::FileInfo, byte::Integer) = _offset_to_xy(fi.parsed_stream.textbuf, byte, fi.encoding)
 offset_to_xy( # used by tests
-    s::Union{Vector{UInt8},AbstractString}, byte::Integer,
+    s::Union{Vector{UInt8},AbstractString}, byte::Integer, filename::AbstractString,
     encoding::PositionEncodingKind.Ty = PositionEncodingKind.UTF16
-) = offset_to_xy(FileInfo(#=version=#0, ParseStream!(s), encoding), byte)
+) = offset_to_xy(FileInfo(#=version=#0, s, filename, encoding), byte)
 
 function _offset_to_xy(textbuf::Vector{UInt8}, byte::Integer, encoding::PositionEncodingKind.Ty)
     if byte < 1

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -11,15 +11,14 @@ include("jsjl_utils.jl")
 
 global lowering_module::Module = Module()
 function get_cursor_bindings(fi::JETLS.FileInfo, b::Int)
-    st0 = JETLS.build_tree!(JL.SyntaxTree, fi)
+    st0 = fi.syntax_tree0
     cb = JETLS.cursor_bindings(st0, b, lowering_module)
     return isnothing(cb) ? [] : cb
 end
 
 function get_local_completions(s::AbstractString, b::Int)
     uri = JETLS.URIs2.filepath2uri(@__FILE__)
-    ps = JETLS.ParseStream!(s)
-    fi = JETLS.FileInfo(#=version=#0, ps)
+    fi = JETLS.FileInfo(#=version=#0, s, @__FILE__)
     return map(get_cursor_bindings(fi, b)) do ((bi, st, dist))
         JETLS.to_completion(bi, st, dist, uri, fi)
     end
@@ -51,7 +50,7 @@ end
 function with_completion(f, text::String; kwargs...)
     clean_code, positions = JETLS.get_text_and_positions(text; kwargs...)
     for (i, pos) in enumerate(positions)
-        cv = get_local_completions(clean_code, JETLS.xy_to_offset(clean_code, pos))
+        cv = get_local_completions(clean_code, JETLS.xy_to_offset(clean_code, pos, @__FILE__))
         f(i, cv)
     end
 end

--- a/test/test_document_highlight.jl
+++ b/test/test_document_highlight.jl
@@ -16,7 +16,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
             """
             clean_code, positions = JETLS.get_text_and_positions(code)
             @test length(positions) == 6
-            fi = JETLS.FileInfo(#=version=#0, parsedstream(clean_code))
+            fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
             @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
             for pos in positions
                 highlights = JETLS.lowering_document_highlights(fi, pos, @__MODULE__)
@@ -41,7 +41,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
             """
             clean_code, positions = JETLS.get_text_and_positions(code)
             @test length(positions) == 4
-            fi = JETLS.FileInfo(#=version=#0, parsedstream(clean_code))
+            fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
             @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
             for pos in positions
                 highlights = JETLS.lowering_document_highlights(fi, pos, @__MODULE__)
@@ -65,7 +65,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
             """
             clean_code, positions = JETLS.get_text_and_positions(code)
             @test length(positions) == 6
-            fi = JETLS.FileInfo(#=version=#0, parsedstream(clean_code))
+            fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
             @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
             for pos in positions
                 highlights = JETLS.lowering_document_highlights(fi, pos, @__MODULE__)
@@ -93,7 +93,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
             """
             clean_code, positions = JETLS.get_text_and_positions(code)
             @test length(positions) == 4
-            fi = JETLS.FileInfo(#=version=#0, parsedstream(clean_code))
+            fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
             @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
             for pos in positions
                 highlights = JETLS.lowering_document_highlights(fi, pos, @__MODULE__)
@@ -119,7 +119,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
             """
             clean_code, positions = JETLS.get_text_and_positions(code)
             @test length(positions) == 10
-            fi = JETLS.FileInfo(#=version=#0, parsedstream(clean_code))
+            fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
             @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
             for i = (1,2,5,6,7,8) # x
                 pos = positions[i]
@@ -167,7 +167,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
         """
         clean_code, positions = JETLS.get_text_and_positions(code)
         @test length(positions) == 2
-        fi = JETLS.FileInfo(#=version=#0, parsedstream(clean_code))
+        fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
         for pos in positions
             highlights = JETLS.lowering_document_highlights(fi, pos, @__MODULE__)
             @test length(highlights) == 0

--- a/test/test_hover.jl
+++ b/test/test_hover.jl
@@ -243,10 +243,9 @@ end
 module lowering_module end
 get_local_hover(args...; kwargs...) = get_local_hover(lowering_module, args...; kwargs...)
 function get_local_hover(mod::Module, text::AbstractString, pos::Position; filename::AbstractString=@__FILE__)
-    ps = JETLS.ParseStream!(text)
-    fi = JETLS.FileInfo(#=version=#0, ps)
+    fi = JETLS.FileInfo(#=version=#0, text, filename)
     uri = filename2uri(filename)
-    st0_top = JETLS.build_tree!(JL.SyntaxTree, fi)
+    st0_top = fi.syntax_tree0
     @assert JS.kind(st0_top) === JS.K"toplevel"
     offset = JETLS.xy_to_offset(fi, pos)
     return JETLS.local_binding_hover(fi, uri, st0_top, offset, mod)

--- a/test/test_inlay_hint.jl
+++ b/test/test_inlay_hint.jl
@@ -14,7 +14,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
             x = 1
             end
             """
-            fi = JETLS.FileInfo(1, parsedstream(code))
+            fi = JETLS.FileInfo(1, code, @__FILE__)
             range = Range(; start = Position(; line = 0, character = 0),
                             var"end" = Position(; line = 3, character = 0))
             inlay_hints = JETLS.syntactic_inlay_hints(fi, range)
@@ -29,7 +29,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
             y = 2
             end # module TestModule
             """
-            fi = JETLS.FileInfo(1, parsedstream(code))
+            fi = JETLS.FileInfo(1, code, @__FILE__)
             range = Range(; start = Position(; line = 0, character = 0),
                             var"end" = Position(; line = 4, character = 0))
             inlay_hints = JETLS.syntactic_inlay_hints(fi, range)
@@ -41,7 +41,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
             x = 1
             end #= module TestModule =#
             """
-            fi = JETLS.FileInfo(1, parsedstream(code))
+            fi = JETLS.FileInfo(1, code, @__FILE__)
             range = Range(; start = Position(; line = 0, character = 0),
                             var"end" = Position(; line = 3, character = 0))
             inlay_hints = JETLS.syntactic_inlay_hints(fi, range)
@@ -52,7 +52,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
             let code = """
                 module TestModule end
                 """
-                fi = JETLS.FileInfo(1, parsedstream(code))
+                fi = JETLS.FileInfo(1, code, @__FILE__)
                 range = Range(; start = Position(; line = 0, character = 0),
                                 var"end" = Position(; line = 1, character = 0))
                 inlay_hints = JETLS.syntactic_inlay_hints(fi, range)
@@ -68,7 +68,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
                 end
                 end
                 """
-                fi = JETLS.FileInfo(1, parsedstream(code))
+                fi = JETLS.FileInfo(1, code, @__FILE__)
                 range = Range(; start = Position(; line = 0, character = 0),
                                 var"end" = Position(; line = 5, character = 0))
                 inlay_hints = JETLS.syntactic_inlay_hints(fi, range)
@@ -88,7 +88,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
                 x = 1
                 end
                 """
-                fi = JETLS.FileInfo(1, parsedstream(code))
+                fi = JETLS.FileInfo(1, code, @__FILE__)
                 range = Range(; start = Position(; line = 0, character = 0),
                                 var"end" = Position(; line = 1, character = 0))
                 inlay_hints = JETLS.syntactic_inlay_hints(fi, range)
@@ -102,7 +102,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
                 x = 1
                 end    # some comment
                 """
-                fi = JETLS.FileInfo(1, parsedstream(code))
+                fi = JETLS.FileInfo(1, code, @__FILE__)
                 range = Range(; start = Position(; line = 0, character = 0),
                                 var"end" = Position(; line = 3, character = 0))
                 inlay_hints = JETLS.syntactic_inlay_hints(fi, range)

--- a/test/test_lowering_diagnostics.jl
+++ b/test/test_lowering_diagnostics.jl
@@ -11,9 +11,8 @@ module lowering_module end
 
 get_lowered_diagnostics(text::AbstractString) = get_lowered_diagnostics(lowering_module, text)
 function get_lowered_diagnostics(mod::Module, text::AbstractString)
-    ps = JETLS.ParseStream!(text)
-    fi = JETLS.FileInfo(#=version=#0, ps)
-    st0 = JETLS.build_tree!(JL.SyntaxTree, fi)
+    fi = JETLS.FileInfo(#=version=#0, text, @__FILE__)
+    st0 = fi.syntax_tree0
     @assert JS.kind(st0) === JS.K"toplevel"
     return JETLS.lowering_diagnostics(st0[1], mod, fi)
 end

--- a/test/test_rename.jl
+++ b/test/test_rename.jl
@@ -15,7 +15,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
         """
         clean_code, positions = JETLS.get_text_and_positions(code)
         @test length(positions) == 9
-        fi = JETLS.FileInfo(#=version=#0, parsedstream(clean_code))
+        fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
         @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
         for (i, pos) in enumerate(positions)
             if i in (4,5,6) # println
@@ -34,7 +34,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
         """
         clean_code, positions = JETLS.get_text_and_positions(code)
         @test length(positions) == 1
-        fi = JETLS.FileInfo(#=version=#0, parsedstream(clean_code))
+        fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
         rename_prep = JETLS.local_binding_rename_preparation(fi, only(positions), @__MODULE__)
         @test isnothing(rename_prep)
     end
@@ -45,7 +45,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
             """
             clean_code, positions = JETLS.get_text_and_positions(code)
             @test length(positions) == 6
-            fi = JETLS.FileInfo(#=version=#0, parsedstream(clean_code))
+            fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
             @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
             for (i, pos) in enumerate(positions)
                 rename_prep = JETLS.local_binding_rename_preparation(fi, pos, @__MODULE__)
@@ -61,7 +61,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
             """
             clean_code, positions = JETLS.get_text_and_positions(code)
             @test length(positions) == 4
-            fi = JETLS.FileInfo(#=version=#0, parsedstream(clean_code))
+            fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
             @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
             for (i, pos) in enumerate(positions)
                 rename_prep = JETLS.local_binding_rename_preparation(fi, pos, @__MODULE__)
@@ -80,7 +80,7 @@ end
         """
         clean_code, positions = JETLS.get_text_and_positions(code)
         @test length(positions) == 9
-        fi = JETLS.FileInfo(#=version=#0, parsedstream(clean_code))
+        fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
         @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
         furi = filename2uri("Untitled" * @__FILE__)
         for (i, pos) in enumerate(positions)
@@ -110,7 +110,7 @@ end
     let code = "func(xx│x, yyy) = println(xxx, yyy)"
         clean_code, positions = JETLS.get_text_and_positions(code)
         @test length(positions) == 1
-        fi = JETLS.FileInfo(#=version=#0, parsedstream(clean_code))
+        fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
         furi = filename2uri("Untitled" * @__FILE__)
         let
             (; result, error) = JETLS.local_binding_rename(furi, fi, only(positions), @__MODULE__, "zzz zzz")
@@ -130,7 +130,7 @@ end
     let code = """func(var"│xxx│") = println(var"│xxx│")"""
         clean_code, positions = JETLS.get_text_and_positions(code)
         @test length(positions) == 4
-        fi = JETLS.FileInfo(#=version=#0, parsedstream(clean_code))
+        fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
         @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
         furi = filename2uri("Untitled" * @__FILE__)
         for pos in positions
@@ -157,7 +157,7 @@ end
             """
             clean_code, positions = JETLS.get_text_and_positions(code)
             @test length(positions) == 6
-            fi = JETLS.FileInfo(#=version=#0, parsedstream(clean_code))
+            fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
             @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
             furi = filename2uri("Untitled" * @__FILE__)
             for (i, pos) in enumerate(positions)
@@ -189,7 +189,7 @@ end
             """
             clean_code, positions = JETLS.get_text_and_positions(code)
             @test length(positions) == 4
-            fi = JETLS.FileInfo(#=version=#0, parsedstream(clean_code))
+            fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
             @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
             furi = filename2uri("Untitled" * @__FILE__)
             for (i, pos) in enumerate(positions)

--- a/test/test_signature_help.jl
+++ b/test/test_signature_help.jl
@@ -13,9 +13,8 @@ function siginfos(mod::Module, code::AbstractString; kwargs...)
     clean_code, positions = JETLS.get_text_and_positions(code; kwargs...)
     @assert length(positions) == 1 "siginfos requires exactly one cursor marker"
     position = only(positions)
-    b = JETLS.xy_to_offset(clean_code, position)
-    ps = JS.ParseStream(clean_code); JS.parse!(ps)
-    fi = JETLS.FileInfo(0, ps)
+    fi = JETLS.FileInfo(0, clean_code, @__FILE__)
+    b = JETLS.xy_to_offset(fi, position)
     return JETLS.cursor_siginfos(mod, fi, b, LSAnalyzer())
 end
 

--- a/test/utils/test_ast.jl
+++ b/test/utils/test_ast.jl
@@ -14,7 +14,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
         end
         """
         clean_code, positions = JETLS.get_text_and_positions(code)
-        return_pos = JETLS.xy_to_offset(clean_code, positions[1])
+        return_pos = JETLS.xy_to_offset(clean_code, positions[1], @__FILE__)
 
         st = jlparse(clean_code)
         let ancestors = JETLS.byte_ancestors(st, 1)
@@ -57,8 +57,8 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
         """
         clean_code, positions = JETLS.get_text_and_positions(code)
         @assert length(positions) == 2
-        hello_start = JETLS.xy_to_offset(clean_code, positions[1])
-        hello_end = JETLS.xy_to_offset(clean_code, positions[2]) - 1
+        hello_start = JETLS.xy_to_offset(clean_code, positions[1], @__FILE__)
+        hello_end = JETLS.xy_to_offset(clean_code, positions[2], @__FILE__) - 1
 
         let st = jlparse(clean_code),
             ancestors = JETLS.byte_ancestors(st, hello_start:hello_end)
@@ -82,7 +82,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
         │x = 1
         """
         clean_code, positions = JETLS.get_text_and_positions(code)
-        x_pos = JETLS.xy_to_offset(clean_code, positions[1])
+        x_pos = JETLS.xy_to_offset(clean_code, positions[1], @__FILE__)
 
         st = jlparse(clean_code)
         sn = jsparse(clean_code)
@@ -105,7 +105,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
         """
         clean_code, positions = JETLS.get_text_and_positions(code)
         @test length(positions) == 1
-        c_pos = JETLS.xy_to_offset(clean_code, positions[1])
+        c_pos = JETLS.xy_to_offset(clean_code, positions[1], @__FILE__)
 
         let st = jlparse(clean_code),
             ancestors = JETLS.byte_ancestors(st, c_pos)
@@ -122,7 +122,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
     let code = "α = β + │γ"
         clean_code, positions = JETLS.get_text_and_positions(code)
         @test length(positions) == 1
-        γ_pos = JETLS.xy_to_offset(clean_code, positions[1])
+        γ_pos = JETLS.xy_to_offset(clean_code, positions[1], @__FILE__)
         @test γ_pos == sizeof("α = β + ")+1
 
         let st = jlparse(clean_code),
@@ -143,10 +143,10 @@ include(normpath(pkgdir(JETLS), "test", "jsjl_utils.jl"))
         clean_code, positions = JETLS.get_text_and_positions(code)
         @test length(positions) == 2
 
-        pos1 = JETLS.xy_to_offset(clean_code, positions[1])
+        pos1 = JETLS.xy_to_offset(clean_code, positions[1], @__FILE__)
         @test pos1 == sizeof("αβγ = ")+1
 
-        pos2 = JETLS.xy_to_offset(clean_code, positions[2])
+        pos2 = JETLS.xy_to_offset(clean_code, positions[2], @__FILE__)
         @test pos2 == sizeof("αβγ = δεζ + ηθι")+1
 
         st = jlparse(clean_code)
@@ -406,8 +406,8 @@ select_target_node(::Type{JS.SyntaxNode}, code::AbstractString, pos::Int) = JETL
 function get_target_node(::Type{T}, code::AbstractString; kwargs...) where T
     clean_code, positions = JETLS.get_text_and_positions(code; kwargs...)
     @assert length(positions) == 1
-    fi = JETLS.FileInfo(1, parsedstream(clean_code))
-    target_node = select_target_node(T, clean_code, JETLS.xy_to_offset(clean_code, positions[1]))
+    fi = JETLS.FileInfo(1, clean_code, @__FILE__)
+    target_node = select_target_node(T, clean_code, JETLS.xy_to_offset(fi, positions[1]))
     return fi, target_node
 end
 
@@ -532,7 +532,7 @@ get_dotprefix_node(code::AbstractString, pos::Int) = JETLS.select_dotprefix_node
 function get_dotprefix_node(code::AbstractString; kwargs...)
     clean_code, positions = JETLS.get_text_and_positions(code; kwargs...)
     @assert length(positions) == 1
-    return get_dotprefix_node(clean_code, JETLS.xy_to_offset(clean_code, positions[1]))
+    return get_dotprefix_node(clean_code, JETLS.xy_to_offset(clean_code, positions[1], @__FILE__))
 end
 @testset "`select_dotprefix_node`" begin
     @test isnothing(get_dotprefix_node("isnothing│"))

--- a/test/utils/test_binding.jl
+++ b/test/utils/test_binding.jl
@@ -11,7 +11,7 @@ function with_target_binding(f, text::AbstractString; kwargs...)
     clean_code, positions = JETLS.get_text_and_positions(text; kwargs...)
     st0_top = jlparse(clean_code)
     for (i, pos) in enumerate(positions)
-        offset = JETLS.xy_to_offset(clean_code, pos)
+        offset = JETLS.xy_to_offset(clean_code, pos, @__FILE__)
         f(i, JETLS.select_target_binding(st0_top, offset, lowering_module))
     end
 end
@@ -20,7 +20,7 @@ function _with_target_binding(f, text::AbstractString; kwargs...)
     clean_code, positions = JETLS.get_text_and_positions(text; kwargs...)
     st0_top = jlparse(clean_code)
     for (i, pos) in enumerate(positions)
-        offset = JETLS.xy_to_offset(clean_code, pos)
+        offset = JETLS.xy_to_offset(clean_code, pos, @__FILE__)
         f(i, JETLS._select_target_binding(st0_top, offset, lowering_module))
     end
 end
@@ -89,7 +89,7 @@ function with_target_binding_definitions(f, text::AbstractString; kwargs...)
     clean_code, positions = JETLS.get_text_and_positions(text; kwargs...)
     st0_top = jlparse(clean_code)
     for (i, pos) in enumerate(positions)
-        offset = JETLS.xy_to_offset(clean_code, pos)
+        offset = JETLS.xy_to_offset(clean_code, pos, @__FILE__)
         f(i, JETLS.select_target_binding_definitions(st0_top, offset, lowering_module))
     end
 end

--- a/test/utils/test_string.jl
+++ b/test/utils/test_string.jl
@@ -79,9 +79,9 @@ end
 
         # All encodings should produce same results for ASCII
         for offset in [1, 3, 6]  # start, middle, end+1
-            pos_utf8 = offset_to_xy(textbuf, offset, UTF8)
-            pos_utf16 = offset_to_xy(textbuf, offset, UTF16)
-            pos_utf32 = offset_to_xy(textbuf, offset, UTF32)
+            pos_utf8 = offset_to_xy(textbuf, offset, @__FILE__, UTF8)
+            pos_utf16 = offset_to_xy(textbuf, offset, @__FILE__, UTF16)
+            pos_utf32 = offset_to_xy(textbuf, offset, @__FILE__, UTF32)
 
             @test pos_utf8.line == 0
             @test pos_utf8.character == offset - 1
@@ -94,15 +94,15 @@ end
         textbuf = Vector{UInt8}(text)
 
         # Test line boundaries
-        @test offset_to_xy(textbuf, 1).line == 0  # Start of line 1
-        @test offset_to_xy(textbuf, 6).line == 0  # End of line 1
-        @test offset_to_xy(textbuf, 7).line == 1  # Start of line 2
-        @test offset_to_xy(textbuf, 12).line == 1  # End of line 2
-        @test offset_to_xy(textbuf, 13).line == 2  # Start of line 3
+        @test offset_to_xy(textbuf, 1, @__FILE__).line == 0  # Start of line 1
+        @test offset_to_xy(textbuf, 6, @__FILE__).line == 0  # End of line 1
+        @test offset_to_xy(textbuf, 7, @__FILE__).line == 1  # Start of line 2
+        @test offset_to_xy(textbuf, 12, @__FILE__).line == 1  # End of line 2
+        @test offset_to_xy(textbuf, 13, @__FILE__).line == 2  # Start of line 3
 
         # Character positions reset on new lines
-        @test offset_to_xy(textbuf, 7).character == 0  # Start of line 2
-        @test offset_to_xy(textbuf, 8).character == 1  # 'i' in line2
+        @test offset_to_xy(textbuf, 7, @__FILE__).character == 0  # Start of line 2
+        @test offset_to_xy(textbuf, 8, @__FILE__).character == 1  # 'i' in line2
     end
 
     @testset "BMP characters (café)" begin
@@ -110,9 +110,9 @@ end
         textbuf = Vector{UInt8}(text)
 
         # After 'é' at byte 6
-        pos_utf8 = offset_to_xy(textbuf, 6, UTF8)
-        pos_utf16 = offset_to_xy(textbuf, 6, UTF16)
-        pos_utf32 = offset_to_xy(textbuf, 6, UTF32)
+        pos_utf8 = offset_to_xy(textbuf, 6, @__FILE__, UTF8)
+        pos_utf16 = offset_to_xy(textbuf, 6, @__FILE__, UTF16)
+        pos_utf32 = offset_to_xy(textbuf, 6, @__FILE__, UTF32)
 
         @test pos_utf8.character == 4  # 4 characters
         @test pos_utf16.character == 4  # 4 UTF-16 units
@@ -124,9 +124,9 @@ end
         textbuf = Vector{UInt8}(text)
 
         # After emoji at byte 6
-        pos_utf8 = offset_to_xy(textbuf, 6, UTF8)
-        pos_utf16 = offset_to_xy(textbuf, 6, UTF16)
-        pos_utf32 = offset_to_xy(textbuf, 6, UTF32)
+        pos_utf8 = offset_to_xy(textbuf, 6, @__FILE__, UTF8)
+        pos_utf16 = offset_to_xy(textbuf, 6, @__FILE__, UTF16)
+        pos_utf32 = offset_to_xy(textbuf, 6, @__FILE__, UTF32)
 
         @test pos_utf8.character == 2  # 'a' + '😀'
         @test pos_utf16.character == 3  # 'a' + 2 units for '😀'
@@ -138,15 +138,15 @@ end
         textbuf = Vector{UInt8}(text)
 
         # After "Hi " (byte 4)
-        @test offset_to_xy(textbuf, 4, UTF8).character == 3
+        @test offset_to_xy(textbuf, 4, @__FILE__, UTF8).character == 3
 
         # After "世" (byte 7)
-        @test offset_to_xy(textbuf, 7, UTF8).character == 4
-        @test offset_to_xy(textbuf, 7, UTF16).character == 4
+        @test offset_to_xy(textbuf, 7, @__FILE__, UTF8).character == 4
+        @test offset_to_xy(textbuf, 7, @__FILE__, UTF16).character == 4
 
         # After "😊" (byte 15)
-        @test offset_to_xy(textbuf, 15, UTF8).character == 7
-        @test offset_to_xy(textbuf, 15, UTF16).character == 8  # Extra unit for emoji
+        @test offset_to_xy(textbuf, 15, @__FILE__, UTF8).character == 7
+        @test offset_to_xy(textbuf, 15, @__FILE__, UTF16).character == 8  # Extra unit for emoji
     end
 
     @testset "Edge cases" begin
@@ -154,16 +154,16 @@ end
         textbuf = Vector{UInt8}(text)
 
         # Invalid offset before start
-        @test_throws ArgumentError offset_to_xy(textbuf, 0)
+        @test_throws ArgumentError offset_to_xy(textbuf, 0, @__FILE__)
 
         # Beyond end gets clamped
-        pos = offset_to_xy(textbuf, 100)
+        pos = offset_to_xy(textbuf, 100, @__FILE__)
         @test pos.line == 0
         @test pos.character == 4
 
         # Empty string
         empty_buf = Vector{UInt8}("")
-        @test offset_to_xy(empty_buf, 1).character == 0
+        @test offset_to_xy(empty_buf, 1, @__FILE__).character == 0
     end
 end
 
@@ -174,9 +174,9 @@ end
 
         # All encodings same for ASCII
         pos = Position(; line=0, character=6)
-        @test xy_to_offset(textbuf, pos, UTF8) == 7
-        @test xy_to_offset(textbuf, pos, UTF16) == 7
-        @test xy_to_offset(textbuf, pos, UTF32) == 7
+        @test xy_to_offset(textbuf, pos, @__FILE__, UTF8) == 7
+        @test xy_to_offset(textbuf, pos, @__FILE__, UTF16) == 7
+        @test xy_to_offset(textbuf, pos, @__FILE__, UTF32) == 7
     end
 
     @testset "Multi-line navigation" begin
@@ -184,16 +184,16 @@ end
         textbuf = Vector{UInt8}(text)
 
         # Line 0, char 0 -> byte 1
-        @test xy_to_offset(textbuf, Position(; line=0, character=0)) == 1
+        @test xy_to_offset(textbuf, Position(; line=0, character=0), @__FILE__) == 1
 
         # Line 1, char 0 -> byte 7 (after "first\n")
-        @test xy_to_offset(textbuf, Position(; line=1, character=0)) == 7
+        @test xy_to_offset(textbuf, Position(; line=1, character=0), @__FILE__) == 7
 
         # Line 1, char 3 -> byte 10 ("sec" in second)
-        @test xy_to_offset(textbuf, Position(; line=1, character=3)) == 10
+        @test xy_to_offset(textbuf, Position(; line=1, character=3), @__FILE__) == 10
 
         # Line 2, char 2 -> byte 16 ("th" in third)
-        @test xy_to_offset(textbuf, Position(; line=2, character=2)) == 16
+        @test xy_to_offset(textbuf, Position(; line=2, character=2), @__FILE__) == 16
     end
 
     @testset "BMP characters" begin
@@ -202,9 +202,9 @@ end
 
         # Position after 'é' - all encodings count it as 1 unit
         pos = Position(; line=0, character=4)
-        @test xy_to_offset(textbuf, pos, UTF8) == 6
-        @test xy_to_offset(textbuf, pos, UTF16) == 6
-        @test xy_to_offset(textbuf, pos, UTF32) == 6
+        @test xy_to_offset(textbuf, pos, @__FILE__, UTF8) == 6
+        @test xy_to_offset(textbuf, pos, @__FILE__, UTF16) == 6
+        @test xy_to_offset(textbuf, pos, @__FILE__, UTF32) == 6
     end
 
     @testset "Emoji with UTF-16 surrogate pairs" begin
@@ -213,15 +213,15 @@ end
 
         # Position 2: UTF-8/32 -> after emoji, UTF-16 -> middle of emoji
         pos = Position(; line=0, character=2)
-        @test xy_to_offset(textbuf, pos, UTF8) == 6   # After emoji
-        @test xy_to_offset(textbuf, pos, UTF16) == 2  # Middle of emoji!
-        @test xy_to_offset(textbuf, pos, UTF32) == 6  # After emoji
+        @test xy_to_offset(textbuf, pos, @__FILE__, UTF8) == 6   # After emoji
+        @test xy_to_offset(textbuf, pos, @__FILE__, UTF16) == 2  # Middle of emoji!
+        @test xy_to_offset(textbuf, pos, @__FILE__, UTF32) == 6  # After emoji
 
         # Position 3: UTF-8/32 -> after 'b', UTF-16 -> after emoji
         pos = Position(; line=0, character=3)
-        @test xy_to_offset(textbuf, pos, UTF8) == 7   # After 'b'
-        @test xy_to_offset(textbuf, pos, UTF16) == 6  # After emoji
-        @test xy_to_offset(textbuf, pos, UTF32) == 7  # After 'b'
+        @test xy_to_offset(textbuf, pos, @__FILE__, UTF8) == 7   # After 'b'
+        @test xy_to_offset(textbuf, pos, @__FILE__, UTF16) == 6  # After emoji
+        @test xy_to_offset(textbuf, pos, @__FILE__, UTF32) == 7  # After 'b'
     end
 
     @testset "Complex Unicode" begin
@@ -230,15 +230,15 @@ end
 
         # After α (2 bytes)
         pos = Position(; line=0, character=1)
-        @test xy_to_offset(textbuf, pos, UTF8) == 3
+        @test xy_to_offset(textbuf, pos, @__FILE__, UTF8) == 3
 
         # After ⊕ (3 bytes total from start: α=2 + ⊕=3)
         pos = Position(; line=0, character=2)
-        @test xy_to_offset(textbuf, pos, UTF8) == 6
+        @test xy_to_offset(textbuf, pos, @__FILE__, UTF8) == 6
 
         # After 😀 with UTF-16 (needs 4 character units: α=1 + ⊕=1 + 😀=2)
         pos = Position(; line=0, character=4)
-        @test xy_to_offset(textbuf, pos, UTF16) == 10
+        @test xy_to_offset(textbuf, pos, @__FILE__, UTF16) == 10
     end
 
     @testset "Beyond line end" begin
@@ -247,11 +247,11 @@ end
 
         # Character position beyond line end
         pos = Position(; line=0, character=100)
-        @test xy_to_offset(textbuf, pos) == 6  # End of "short"
+        @test xy_to_offset(textbuf, pos, @__FILE__) == 6  # End of "short"
 
         # Line beyond file
         pos = Position(; line=100, character=0)
-        @test xy_to_offset(textbuf, pos) == sizeof(text)  # End of file
+        @test xy_to_offset(textbuf, pos, @__FILE__) == sizeof(text)  # End of file
     end
 
     @testset "Guard against invalid positions" begin
@@ -262,7 +262,7 @@ end
             """ |> Vector{UInt8}
             ok = true
             for i = 0:10, j = 0:10
-                ok &= xy_to_offset(code, Position(i, j)) isa Int
+                ok &= xy_to_offset(code, Position(i, j), @__FILE__) isa Int
             end
             @test ok
         end
@@ -302,8 +302,8 @@ end
             push!(test_positions, sizeof(text) + 1)
 
             for byte in test_positions
-                pos = offset_to_xy(textbuf, byte, encoding)
-                recovered = xy_to_offset(textbuf, pos, encoding)
+                pos = offset_to_xy(textbuf, byte, @__FILE__, encoding)
+                recovered = xy_to_offset(textbuf, pos, @__FILE__, encoding)
                 @test recovered == byte
             end
         end
@@ -313,14 +313,14 @@ end
 function test_string_positions(s)
     v = Vector{UInt8}(s)
     for b in eachindex(s)
-        pos = JETLS.offset_to_xy(v, b)
-        b2 =  JETLS.xy_to_offset(v, pos)
+        pos = JETLS.offset_to_xy(v, b, @__FILE__)
+        b2 =  JETLS.xy_to_offset(v, pos, @__FILE__)
         @test b === b2
     end
     # One past the last byte is a valid position in an editor
     b = length(v) + 1
-    pos = JETLS.offset_to_xy(v, b)
-    b2 =  JETLS.xy_to_offset(v, pos)
+    pos = JETLS.offset_to_xy(v, b, @__FILE__)
+    b2 =  JETLS.xy_to_offset(v, pos, @__FILE__)
     @test b === b2
 end
 @testset "Cursor file position <-> byte" begin


### PR DESCRIPTION
This simplification is based on the analysis documented at: 
https://publish.obsidian.md/jetls/work/JETLS/%60JS.build_tree%60+vs.+%22JL.lower%60+performance+observations

Based on the performance observations showing that AST construction 
(~1ms) is significantly faster than lowering (~40ms), this commit 
removes the unnecessary caching of syntax trees. The `build_tree!` 
function and its associated `Dict`-based caching mechanism have been 
eliminated in favor of pre-computing syntax trees during `FileInfo` 
construction.

Key changes:
- Make `FileInfo` struct immutable (was mutable struct)
- Remove `build_tree!` and `clear_file_info_cache!` functions
- Pre-compute `syntax_node` and `syntax_tree0` in `FileInfo` 
  constructors
- Update all call sites to use direct field access (e.g., 
  `fi.syntax_tree0`)

The immutable `FileInfo` design serves as a foundation for future 
work on:
1. Caching lowering and type inference results (the actual 
   bottlenecks)
3. Multithreading support for the language server

The immutability ensures thread safety for concurrent access to 
`FileInfo` instances, while the removal of unnecessary AST caching 
reduces complexity and memory overhead (maybe).

Future work will focus on implementing caches for expensive 
operations (lowering and type inference) with proper multithreading 
considerations.