### PR TITLE
use `Threads.@spawn` instead of `@async`

### DIFF
--- a/JSONRPC/src/JSONRPC.jl
+++ b/JSONRPC/src/JSONRPC.jl
@@ -15,7 +15,7 @@ mutable struct Endpoint
         in_msg_queue = Channel{Any}(Inf)
         out_msg_queue = Channel{Any}(Inf)
 
-        read_task = @async try
+        read_task = Threads.@spawn try
             while true
                 msg = @something readmsg(in, method_dispatcher) break
                 put!(in_msg_queue, msg)
@@ -24,7 +24,7 @@ mutable struct Endpoint
             err_handler(#=isread=#true, err, catch_backtrace())
         end
 
-        write_task = @async try
+        write_task = Threads.@spawn try
             for msg in out_msg_queue
                 if isopen(out)
                     writemsg(out, msg)

--- a/src/formatting.jl
+++ b/src/formatting.jl
@@ -48,7 +48,7 @@ function handle_DocumentFormattingRequest(server::Server, msg::DocumentFormattin
 
     workDoneToken = msg.params.workDoneToken
     if workDoneToken !== nothing && supports(server, :window, :workDoneProgress)
-        @async do_format_with_progress(server, uri, msg.id, workDoneToken)
+        Threads.@spawn do_format_with_progress(server, uri, msg.id, workDoneToken)
     elseif supports(server, :window, :workDoneProgress)
         id = String(gensym(:WorkDoneProgressCreateRequest_formatting))
         token = String(gensym(:FormattingProgress))
@@ -56,7 +56,7 @@ function handle_DocumentFormattingRequest(server::Server, msg::DocumentFormattin
         params = WorkDoneProgressCreateParams(; token)
         send(server, WorkDoneProgressCreateRequest(; id, params))
     else
-        @async do_format(server, uri, msg.id)
+        Threads.@spawn do_format(server, uri, msg.id)
     end
 
     return nothing
@@ -106,7 +106,7 @@ function handle_DocumentRangeFormattingRequest(server::Server, msg::DocumentRang
 
     workDoneToken = msg.params.workDoneToken
     if workDoneToken !== nothing && supports(server, :window, :workDoneProgress)
-        @async do_range_format_with_progress(server, uri, range, msg.id, workDoneToken)
+        Threads.@spawn do_range_format_with_progress(server, uri, range, msg.id, workDoneToken)
     elseif supports(server, :window, :workDoneProgress)
         id = String(gensym(:WorkDoneProgressCreateRequest_rangeFormatting))
         token = String(gensym(:RangeFormattingProgress))
@@ -114,7 +114,7 @@ function handle_DocumentRangeFormattingRequest(server::Server, msg::DocumentRang
         params = WorkDoneProgressCreateParams(; token)
         send(server, WorkDoneProgressCreateRequest(; id, params))
     else
-        @async do_range_format(server, uri, range, msg.id)
+        Threads.@spawn do_range_format(server, uri, range, msg.id)
     end
 
     return nothing

--- a/src/response.jl
+++ b/src/response.jl
@@ -143,7 +143,7 @@ function handle_testrunner_testset_progress_response(server::Server, msg::Dict{S
         return
     end
     (; uri, fi, idx, testset_name, filepath, token) = request_caller
-    @async testrunner_run_testset(server, uri, fi, idx, testset_name, filepath; token)
+    Threads.@spawn testrunner_run_testset(server, uri, fi, idx, testset_name, filepath; token)
 end
 
 function handle_testrunner_testcase_progress_response(server::Server, msg::Dict{Symbol,Any}, request_caller::TestRunnerTestcaseProgressCaller)
@@ -151,7 +151,7 @@ function handle_testrunner_testcase_progress_response(server::Server, msg::Dict{
         return
     end
     (; uri, testcase_line, testcase_text, filepath, token) = request_caller
-    @async testrunner_run_testcase(server, uri, testcase_line, testcase_text, filepath; token)
+    Threads.@spawn testrunner_run_testcase(server, uri, testcase_line, testcase_text, filepath; token)
 end
 
 function handle_code_lens_refresh_response(server::Server, msg::Dict{Symbol,Any}, ::CodeLensRefreshRequestCaller)
@@ -166,7 +166,7 @@ function handle_formatting_progress_response(server::Server, msg::Dict{Symbol,An
         return
     end
     (; uri, msg_id, token) = request_caller
-    @async do_format_with_progress(server, uri, msg_id, token)
+    Threads.@spawn do_format_with_progress(server, uri, msg_id, token)
 end
 
 function handle_range_formatting_progress_response(server::Server, msg::Dict{Symbol,Any}, request_caller::RangeFormattingProgressCaller)
@@ -174,5 +174,5 @@ function handle_range_formatting_progress_response(server::Server, msg::Dict{Sym
         return
     end
     (; uri, range, msg_id, token) = request_caller
-    @async do_range_format_with_progress(server, uri, range, msg_id, token)
+    Threads.@spawn do_range_format_with_progress(server, uri, range, msg_id, token)
 end

--- a/src/testrunner.jl
+++ b/src/testrunner.jl
@@ -513,7 +513,7 @@ function _testrunner_run_testcase(server::Server, executable::AbstractString, ur
     # Show error information to the user as temporary diagnostics.
     uri2diagnostics = testrunner_result_to_diagnostics(result)
     notify_temporary_diagnostics!(server, uri2diagnostics)
-    @async begin
+    Threads.@spawn begin
         sleep(10)
         notify_diagnostics!(server) # refresh diagnostics after 5 sec
     end
@@ -608,7 +608,7 @@ function testrunner_run_testset_from_uri(server::Server, uri::URI, idx::Int, tsn
         params = WorkDoneProgressCreateParams(; token)
         send(server, WorkDoneProgressCreateRequest(; id, params))
     else
-        @async testrunner_run_testset(server, uri, fi, idx, tsn, filepath)
+        Threads.@spawn testrunner_run_testset(server, uri, fi, idx, tsn, filepath)
     end
     return nothing
 end
@@ -640,7 +640,7 @@ function testrunner_run_testcase_from_uri(server::Server, uri::URI, tcl::Int, tc
         params = WorkDoneProgressCreateParams(; token)
         send(server, WorkDoneProgressCreateRequest(; id, params))
     else
-        @async testrunner_run_testcase(server, uri, tcl, tct, filepath)
+        Threads.@spawn testrunner_run_testcase(server, uri, tcl, tct, filepath)
     end
     return nothing
 end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -34,7 +34,7 @@ function withserver(f;
             put!(sent_queue, x)
         end
     end
-    t = @async runserver(server)
+    t = Threads.@spawn runserver(server)
     id_counter = Ref(0)
     old_env = Pkg.project().path
     root_path = nothing


### PR DESCRIPTION
use `Threads.@spawn` instead of `@async`

As suggested by the docstring of `@async`:
> │ Warning
> │ It is strongly encouraged to favor `Threads.@spawn` over 
> │ `@async` always even when no parallelism is required 
> │ especially in publicly distributed libraries. This is because 
> │ a use of `@async` disables the migration of the parent task 
> │ across worker threads in the current implementation of Julia. 
> │ Thus, seemingly innocent use of `@async` in a library function 
> │ can have a large impact on the performance of very different 
> │ parts of user applications.

---

Separated from #195 .