### PR TITLE
fix testrunner integration

### DIFF
--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -42,7 +42,7 @@ function handle_DidOpenTextDocumentNotification(server::Server, msg::DidOpenText
 
     parsed_stream = ParseStream!(textDocument.text)
     fi = cache_file_info!(server.state, uri, textDocument.version, parsed_stream)
-    update_testsetinfos!(server, fi)
+    update_testsetinfos!(server, fi, nothing)
     cache_saved_file_info!(server.state, uri, parsed_stream)
 
     if supports(server, :window, :workDoneProgress)
@@ -66,8 +66,9 @@ function handle_DidChangeTextDocumentNotification(server::Server, msg::DidChange
         @assert contentChange.range === contentChange.rangeLength === nothing # since `change = TextDocumentSyncKind.Full`
     end
     text = last(contentChanges).text
+    prev_fi = server.state.file_cache[uri]
     fi = cache_file_info!(server.state, uri, textDocument.version, text)
-    update_testsetinfos!(server, fi)
+    update_testsetinfos!(server, fi, prev_fi)
 end
 
 function handle_DidSaveTextDocumentNotification(server::Server, msg::DidSaveTextDocumentNotification)
@@ -109,7 +110,7 @@ function handle_DidCloseTextDocumentNotification(server::Server, msg::DidCloseTe
     fi = get(server.state.file_cache, uri, nothing)
     if !isnothing(fi)
         delete!(server.state.file_cache, uri)
-        if clear_extra_diagnostics!(server, fi)
+        if clear_extra_diagnostics!(server, uri)
             notify_diagnostics!(server)
         end
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,26 +1,26 @@
 const SyntaxTree0 = typeof(JS.build_tree(JL.SyntaxTree, JS.parse!(JS.ParseStream(""))))
 
 abstract type ExtraDiagnosticsKey end
-to_file_info(key::ExtraDiagnosticsKey) = to_file_info_impl(key)::FileInfo
+to_uri(key::ExtraDiagnosticsKey) = to_uri_impl(key)::URI
 @eval to_key(key::ExtraDiagnosticsKey) = hash(key, $(rand(UInt)))
 
-struct _TestsetDiagnosticsKey{FileInfo} <: ExtraDiagnosticsKey
+struct TestsetDiagnosticsKey <: ExtraDiagnosticsKey
+    uri::URI
     testset_name::String
-    idx::Int
-    fi::FileInfo
+    testset_index::Int
 end
-to_file_info_impl(key::_TestsetDiagnosticsKey) = key.fi
+to_uri_impl(key::TestsetDiagnosticsKey) = key.uri
 
-struct _TestsetResult{FileInfo}
+struct TestsetResult
     result::TestRunnerResult
-    key::_TestsetDiagnosticsKey{FileInfo}
+    key::TestsetDiagnosticsKey
 end
 
-struct _TestsetInfo{FileInfo}
+struct TestsetInfo
     st0::SyntaxTree0
-    result::_TestsetResult{FileInfo}
-    _TestsetInfo{FileInfo}(st0::SyntaxTree0) where {FileInfo} = new{FileInfo}(st0)
-    _TestsetInfo{FileInfo}(st0::SyntaxTree0, result::_TestsetResult{FileInfo}) where {FileInfo} = new{FileInfo}(st0, result)
+    result::TestsetResult
+    TestsetInfo(st0::SyntaxTree0) = new(st0)
+    TestsetInfo(st0::SyntaxTree0, result::TestsetResult) = new(st0, result)
 end
 
 struct FileInfo
@@ -29,7 +29,7 @@ struct FileInfo
     parsed_stream::JS.ParseStream
     syntax_node::JS.SyntaxNode
     syntax_tree0::SyntaxTree0
-    testsetinfos::Vector{_TestsetInfo{FileInfo}}
+    testsetinfos::Vector{TestsetInfo}
 
     function FileInfo(
             version::Int, parsed_stream::JS.ParseStream, filename::AbstractString,
@@ -54,10 +54,6 @@ function FileInfo( # Constructor for test code (with raw text input and filename
     )
     return FileInfo(version, ParseStream!(s), args...)
 end
-
-const TestsetDiagnosticsKey = _TestsetDiagnosticsKey{FileInfo}
-const TestsetResult = _TestsetResult{FileInfo}
-const TestsetInfo = _TestsetInfo{FileInfo}
 
 struct SavedFileInfo
     parsed_stream::JS.ParseStream

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -147,11 +147,10 @@ function clear_extra_diagnostics!(extra_diagnostics::ExtraDiagnostics, key::Extr
     end
     return false
 end
-function clear_extra_diagnostics!(extra_diagnostics::ExtraDiagnostics, fi::FileInfo) # bulk deletion
+function clear_extra_diagnostics!(extra_diagnostics::ExtraDiagnostics, uri::URI) # bulk deletion
     any_deleted = false
     for key in keys(extra_diagnostics)
-        keyfi = to_file_info(key)
-        if keyfi === fi
+        if to_uri(key) == uri
             delete!(extra_diagnostics, key)
             any_deleted |= true
         end


### PR DESCRIPTION
This commit adapts the testrunner infrastructure to work with the new
immutable `FileInfo` design, where `FileInfo` creates fresh
`testsetinfos` on construction rather than maintaining a mutable
vector. (xref: #229 )

Key changes to `update_testsetinfos!`:
- Now takes `prev_fi` as an explicit parameter instead of relying on
  mutating the existing `FileInfo`'s `testsetinfos`
- Directly modifies `fi.testsetinfos` using `resize!` and indexed
  assignment instead of `push!` operations for better
  understandability
- Early return when `isnothing(prev_fi)` (initial file load) since
  there are no previous test results to preserve
- Returns boolean indicating whether any diagnostics were deleted

The refactored implementation is cleaner and more intuitive:
- `prev_fi` is treated as read-only reference data
- `fi.testsetinfos` is what gets modified directly
- Clear separation between initial load and update scenarios

Additional improvements:
- `TestsetDiagnosticsKey` now holds `uri::URI` instead of `FileInfo`,
  making the key more lightweight and easy to maintain
- `clear_extra_diagnostics!` bulk deletion now works with `URI`
  instead of `FileInfo`, aligning with the new key structure
- Added comprehensive test cases for diagnostic clearance scenarios
  including testset modification, deletion, renaming, and addition

The new tests verify that `update_testsetinfos!` correctly:
- Preserves test results when testsets remain unchanged
- Clears diagnostics when testsets are deleted or renamed
- Maintains results when only minor modifications occur
- Handles addition of new testsets while preserving existing results