### PR TITLE
Update JuliaLowering branch to master (with SyntaxGraph changes)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 [sources]
 JET = {rev = "master", url = "https://github.com/aviatesk/JET.jl"}
 JSONRPC = {path = "JSONRPC"}
-JuliaLowering = {rev = "jetls-hacking", url = "https://github.com/mlechu/JuliaLowering.jl"}
+JuliaLowering = {rev = "jetls-2", url = "https://github.com/mlechu/JuliaLowering.jl"}
 JuliaSyntax = {rev = "jetls-hacking", url = "https://github.com/JuliaLang/JuliaSyntax.jl"}
 LSP = {path = "LSP"}
 

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -229,7 +229,7 @@ function lowering_diagnostics!(
 
         st0 = without_kinds(st0, JS.KSet"error macrocall")
         try
-            ctx1, st1 = JL.expand_forms_1(mod, st0)
+            ctx1, st1 = JL.expand_forms_1(mod, st0, true)
             _jl_lower_for_scope_resolution(ctx1, st0, st1)
         catch
             # The same error has probably already been handled above

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -57,14 +57,14 @@ function jl_lower_for_scope_resolution(
         st0 = without_kinds(st0, JS.KSet"error")
     end
     ctx1, st1 = try
-        JL.expand_forms_1(mod, st0)
+        JL.expand_forms_1(mod, st0, true)
     catch err
         recover_from_macro_errors || rethrow(err)
         JETLS_DEBUG_LOWERING && @warn "Error in macro expansion; trimming and retrying"
         JETLS_DEBUG_LOWERING && showerror(stderr, err)
         JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
         st0 = without_kinds(st0, JS.KSet"macrocall")
-        JL.expand_forms_1(mod, st0)
+        JL.expand_forms_1(mod, st0, true)
     end
     return _jl_lower_for_scope_resolution(ctx1, st0, st1)
 end

--- a/test/jsjl_utils.jl
+++ b/test/jsjl_utils.jl
@@ -36,7 +36,7 @@ end
 # use `stop` if some lowering pass mutates ctx in a way you don't want
 function jldebug(st0_in::JL.SyntaxTree, stop=5)
     global ctx5, st5, ctx4, st4, ctx3, st3, ctx2, st2, ctx1, st1
-    stop = stop - 1; stop < 0 && return; ctx1, st1 = JL.expand_forms_1(Module(), st0_in)
+    stop = stop - 1; stop < 0 && return; ctx1, st1 = JL.expand_forms_1(Module(), st0_in, true)
     stop = stop - 1; stop < 0 && return; ctx2, st2 = JL.expand_forms_2(ctx1, st1)
     stop = stop - 1; stop < 0 && return; ctx3, st3 = JL.resolve_scopes(ctx2, st2)
     stop = stop - 1; stop < 0 && return; ctx4, st4 = JL.convert_closures(ctx3, st3)


### PR DESCRIPTION
JuliaLowering can run everything in compatibility mode at this point, so we may not even need `jetls-hacking` anymore.  As of writing, this is a version bump to https://github.com/c42f/JuliaLowering.jl/pull/35, which is the master branch plus some syntax graph utilities.  I've still created a separate jetls branch for stability and in case you'd like to apply any changes (@aviatesk)