### PR TITLE
diagnostics: fix location info for errors of nested macro call

### DIFF
--- a/test/fixtures/macros.jl
+++ b/test/fixtures/macros.jl
@@ -1,0 +1,7 @@
+macro m_inner_error(x)
+    error("Error in foo")
+end
+
+macro m_outer_error(x)
+    :(@m_inner_error( $x ), @m_inner_error( $nothing ))
+end

--- a/test/fixtures/macros_JL.jl
+++ b/test/fixtures/macros_JL.jl
@@ -1,0 +1,7 @@
+macro m_inner_error_JL(x)
+    error("Error in foo")
+end
+
+macro m_outer_error_JL(x)
+    :(@m_inner_error_JL( $x ), @m_inner_error_JL( $nothing ))
+end


### PR DESCRIPTION
When an error occurs within nested macro calls,
`JS.[first|last]_byte(err.ex)` returns the position of the innermost macro call, but this is not the outermost macro call position that `lowering_diagnostics!` expects. This problem is fixed by using `JL.flattend_provenances`.