### PR TITLE
ast: Fix scope analysis for blocks containing `local` statements

### DIFF
--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -182,8 +182,13 @@ function greatest_local(st0::JL.SyntaxTree, offset::Int)
 
     i = first_global - 1
     while JL.kind(bas[i]) === JS.K"block"
-        # bas[i] is a block within a global scope, so can't introduce local
-        # bindings.  Shrink the tree (mostly for performance).
+        if any(j::Int -> JS.kind(bas[i][j]) === JS.K"local", 1:JS.numchildren(bas[i]))
+            # If this `block` contains `local`, it may introduce local bindings.
+            # For correct scope analysis, we need to analyze this entire block
+            break
+        end
+        # `bas[i]` is a block within a global scope, so can't introduce local bindings.
+        # Shrink the tree (mostly for performance).
         i -= 1
         i < 1 && return nothing
     end

--- a/test/utils/test_binding.jl
+++ b/test/utils/test_binding.jl
@@ -83,6 +83,29 @@ end
         end
         @test cnt == 4
     end
+
+    # Perform analysis on a `block` unit containing `local`
+    let cnt = 0
+        local binfo = nothing
+        _with_target_binding("""
+            begin
+                local │xxx│ = 42
+                getxxx() = │xxx│
+            end
+            """) do i, (; ctx3, binding)
+            if i in (1, 2)
+                @test JS.sourcetext(binding) == "xxx"
+                @test JS.source_line(binding) == 2
+                binfo = JL.lookup_binding(ctx3, binding)
+            else
+                @test JS.sourcetext(binding) == "xxx"
+                @test JS.source_line(binding) == 3
+                @test JL.lookup_binding(ctx3, binding).id == binfo.id
+            end
+            cnt += 1
+        end
+        @test cnt == 4
+    end
 end
 
 function with_target_binding_definitions(f, text::AbstractString; kwargs...)


### PR DESCRIPTION
Previously, blocks within top-level scope were always shrunk, but this incorrectly excluded blocks that contained `local` statements which can introduce local bindings.