### PR TITLE
full-analysis: Remove `staled` field from `FullAnalysisResult`

### DIFF
--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -1,4 +1,4 @@
-function run_full_analysis!(server::Server, uri::URI; onsave::Bool=false, token::Union{Nothing,ProgressToken}=nothing)
+function run_full_analysis!(server::Server, uri::URI; throttle::Bool=false, token::Union{Nothing,ProgressToken}=nothing)
     if !haskey(server.state.analysis_cache, uri)
         res = initiate_analysis_unit!(server, uri; token)
         if res isa AnalysisUnit
@@ -19,7 +19,7 @@ function run_full_analysis!(server::Server, uri::URI; onsave::Bool=false, token:
                 end
             end
             id = hash(run_full_analysis!, hash(analysis_unit))
-            if onsave
+            if throttle
                 debounce(id, get_config(server.state.config_manager, "performance", "full_analysis", "debounce")) do
                     throttle(id, get_config(server.state.config_manager, "performance", "full_analysis", "throttle")) do
                         task()

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -11,9 +11,7 @@ function run_full_analysis!(server::Server, uri::URI; onsave::Bool=false, token:
         else
             # TODO support multiple analysis units, which can happen if this file is included from multiple different analysis_units
             analysis_unit = first(analysis_info)
-            if onsave
-                analysis_unit.result.staled = true
-            end
+
             function task()
                 res = reanalyze!(server, analysis_unit; token)
                 if res isa AnalysisUnit
@@ -106,7 +104,7 @@ function new_analysis_unit(entry::AnalysisEntry, result)
     successfully_analyzed_file_infos = copy(analyzed_file_infos)
     is_full_analysis_successful(result) || empty!(successfully_analyzed_file_infos)
     analysis_result = FullAnalysisResult(
-        #=staled=#false, result.res.actual2virtual::JET.Actual2Virtual, update_analyzer_world(result.analyzer),
+        result.res.actual2virtual::JET.Actual2Virtual, update_analyzer_world(result.analyzer),
         uri2diagnostics, analyzed_file_infos, successfully_analyzed_file_infos)
     return AnalysisUnit(entry, analysis_result)
 end
@@ -133,7 +131,6 @@ function update_analysis_unit!(analysis_unit::AnalysisUnit, result)
         empty!(get!(()->Diagnostic[], uri2diagnostics, new_file_uri))
     end
     jet_result_to_diagnostics!(uri2diagnostics, result)
-    analysis_unit.result.staled = false
     if is_full_analysis_successful(result)
         analysis_unit.result.actual2virtual = result.res.actual2virtual
         analysis_unit.result.analyzer = update_analyzer_world(result.analyzer)
@@ -266,10 +263,6 @@ end
 
 function reanalyze!(server::Server, analysis_unit::AnalysisUnit; token::Union{Nothing,ProgressToken}=nothing)
     state = server.state
-    analysis_result = analysis_unit.result
-    if !(analysis_result.staled)
-        return nothing
-    end
 
     any_parse_failed = any(analyzed_file_uris(analysis_unit)) do uri::URI
         fi = get_saved_file_info(state, uri)

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -48,7 +48,7 @@ function handle_DidOpenTextDocumentNotification(server::Server, msg::DidOpenText
     if supports(server, :window, :workDoneProgress)
         id = String(gensym(:WorkDoneProgressCreateRequest_run_full_analysis!))
         token = String(gensym(:WorkDoneProgressCreateRequest_run_full_analysis!))
-        addrequest!(server, id=>RunFullAnalysisCaller(uri, #=onsave=#false, token))
+        addrequest!(server, id=>RunFullAnalysisCaller(uri, #=throttle=#false, token))
         send(server,
             WorkDoneProgressCreateRequest(;
                 id,
@@ -93,14 +93,14 @@ function handle_DidSaveTextDocumentNotification(server::Server, msg::DidSaveText
     if supports(server, :window, :workDoneProgress)
         id = String(gensym(:WorkDoneProgressCreateRequest_run_full_analysis!))
         token = String(gensym(:WorkDoneProgressCreateRequest_run_full_analysis!))
-        addrequest!(server, id=>RunFullAnalysisCaller(uri, #=onsave=#true, token))
+        addrequest!(server, id=>RunFullAnalysisCaller(uri, #=throttle=#true, token))
         send(server,
             WorkDoneProgressCreateRequest(;
                 id,
                 params = WorkDoneProgressCreateParams(;
                     token = token)))
     else
-        run_full_analysis!(server, uri; onsave=true)
+        run_full_analysis!(server, uri; throttle=true)
     end
 end
 

--- a/src/response.jl
+++ b/src/response.jl
@@ -59,8 +59,8 @@ function handle_requested_response(server::Server, msg::Dict{Symbol,Any},
 end
 
 function handle_run_full_analysis_response(server::Server, msg::Dict{Symbol,Any}, request_caller::RunFullAnalysisCaller)
-    (; uri, onsave, token) = request_caller
-    run_full_analysis!(server, uri; onsave, token)
+    (; uri, throttle, token) = request_caller
+    run_full_analysis!(server, uri; throttle, token)
 end
 
 function handle_show_document_response(server::Server, msg::Dict{Symbol,Any}, request_caller::ShowDocumentRequestCaller)

--- a/src/types.jl
+++ b/src/types.jl
@@ -132,7 +132,6 @@ end
 const URI2Diagnostics = Dict{URI,Vector{Diagnostic}}
 
 mutable struct FullAnalysisResult
-    staled::Bool
     actual2virtual::JET.Actual2Virtual
     analyzer::LSAnalyzer
     const uri2diagnostics::URI2Diagnostics

--- a/src/types.jl
+++ b/src/types.jl
@@ -162,7 +162,7 @@ abstract type RequestCaller end
 
 struct RunFullAnalysisCaller <: RequestCaller
     uri::URI
-    onsave::Bool
+    throttle::Bool
     token::ProgressToken
 end
 


### PR DESCRIPTION
The `staled` tracking mechanism was removed from analysis units,
simplifying the reanalysis logic and struct definition.

When the reanalysis is requested, which is hooked with the `didSave`
notification, the analysis result should be staled always under the
current implementation.