### PR TITLE
config: refactor to use immutable data structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out
 Manifest.toml
 Manifest-*.toml
 .envrc
+**/.JETLSConfig.toml

--- a/src/types.jl
+++ b/src/types.jl
@@ -236,37 +236,39 @@ struct LSPostProcessor
 end
 LSPostProcessor() = LSPostProcessor(JET.PostProcessor())
 
+const ConfigDict = Base.PersistentDict{String, Any}
+
 struct WatchedConfigFiles
     files::Vector{String}
-    configs::Vector{Dict{String,Any}}
+    configs::Vector{ConfigDict}
 end
 
 # TODO (later): move this definition to external files
-global DEFAULT_CONFIG::Dict{String,Any} = Dict{String,Any}(
-    "performance" => Dict{String,Any}(
-        "full_analysis" => Dict{String,Any}(
+global DEFAULT_CONFIG::ConfigDict = ConfigDict(
+    "performance" => ConfigDict(
+        "full_analysis" => ConfigDict(
             "debounce" => 1.0,
             "throttle" => 5.0
         )
     ),
-    "testrunner" => Dict{String,Any}(
+    "testrunner" => ConfigDict(
         "executable" => "testrunner"
     ),
 )
 
-global CONFIG_RELOAD_REQUIRED::Dict{String,Any} = Dict{String,Any}(
-    "performance" => Dict{String,Any}(
-        "full_analysis" => Dict{String,Any}(
+global CONFIG_RELOAD_REQUIRED::ConfigDict = ConfigDict(
+    "performance" => ConfigDict(
+        "full_analysis" => ConfigDict(
             "debounce" => true,
             "throttle" => true
         )
     ),
-    "testrunner" => Dict{String,Any}(
+    "testrunner" => ConfigDict(
         "executable" => false
     ),
 )
 
-WatchedConfigFiles() = WatchedConfigFiles(String["__DEFAULT_CONFIG__"], Dict{String,Any}[DEFAULT_CONFIG])
+WatchedConfigFiles() = WatchedConfigFiles(String["__DEFAULT_CONFIG__"], ConfigDict[DEFAULT_CONFIG])
 
 function _file_idx(watched_files::WatchedConfigFiles, file::String)
     idx = searchsortedfirst(watched_files.files, file, ConfigFileOrder())
@@ -290,7 +292,7 @@ function Base.delete!(watched_files::WatchedConfigFiles, file::String)
     return watched_files
 end
 
-function Base.setindex!(watched_files::WatchedConfigFiles, config::Dict{String,Any}, file::String)
+function Base.setindex!(watched_files::WatchedConfigFiles, config::ConfigDict, file::String)
     idx = searchsortedfirst(watched_files.files, file, ConfigFileOrder())
     if 1 <= idx <= length(watched_files.files) && watched_files.files[idx] == file
         watched_files.configs[idx] = config
@@ -314,11 +316,11 @@ function Base.get(watched_files::WatchedConfigFiles, file::String, default)
 end
 
 struct ConfigFileOrder <: Base.Ordering end
-struct ConfigManager
-    reload_required_setting::Dict{String,Any} # settings that are not changed during the server lifetime
-    watched_files::WatchedConfigFiles               # watched configuration files
+mutable struct ConfigManager
+    reload_required_setting::ConfigDict     # settings that are not changed during the server lifetime
+    const watched_files::WatchedConfigFiles # watched configuration files
 end
-ConfigManager() = ConfigManager(Dict{String,Any}(), WatchedConfigFiles())
+ConfigManager() = ConfigManager(ConfigDict(), WatchedConfigFiles())
 
 mutable struct ServerState
     const workspaceFolders::Vector{URI}


### PR DESCRIPTION
This is a major refactoring of the configuration system to use Base's immutable `Base.PersistentDict` instead of mutable `Dict{String,Any}`. This change prepares the language server for the incoming safe parallelization (#241) by eliminating mutation possibilities within the configuration system.

Key changes:
- Introduced `ConfigDict` type alias for `Base.PersistentDict{String,Any}`
- Converted all configuration data structures to use immutable `ConfigDict`
- Replaced mutating operations with functional, immutable equivalents:
- Added `to_config_dict` helper for converting TOML parse results

The only place where `Dict{String,Any}` is still used is at the TOML parser boundary, where `to_config_dict` converts it to the immutable structure.

This refactoring also improves code clarity by making data flow more explicit through immutable transformations rather than hidden mutations, and aligns with future plans to introduce schema validation, which is likely implemented with a custom immutable data structure.