### PR TITLE
config: simplify schema by removing redundant performance level

### DIFF
--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -20,13 +20,13 @@ function run_full_analysis!(server::Server, uri::URI; throttle::Bool=false, toke
             end
             id = hash(run_full_analysis!, hash(analysis_unit))
             if throttle
-                debounce(id, get_config(server.state.config_manager, "performance", "full_analysis", "debounce")) do
-                    JETLS.throttle(id, get_config(server.state.config_manager, "performance", "full_analysis", "throttle")) do
+                debounce(id, get_config(server.state.config_manager, "full_analysis", "debounce")) do
+                    JETLS.throttle(id, get_config(server.state.config_manager, "full_analysis", "throttle")) do
                         task()
                     end
                 end
             else
-                JETLS.throttle(id, get_config(server.state.config_manager, "performance", "full_analysis", "throttle")) do
+                JETLS.throttle(id, get_config(server.state.config_manager, "full_analysis", "throttle")) do
                     task()
                 end
             end

--- a/src/types.jl
+++ b/src/types.jl
@@ -245,11 +245,9 @@ end
 
 # TODO (later): move this definition to external files
 global DEFAULT_CONFIG::ConfigDict = ConfigDict(
-    "performance" => ConfigDict(
-        "full_analysis" => ConfigDict(
-            "debounce" => 1.0,
-            "throttle" => 5.0
-        )
+    "full_analysis" => ConfigDict(
+        "debounce" => 1.0,
+        "throttle" => 5.0
     ),
     "testrunner" => ConfigDict(
         "executable" => "testrunner"
@@ -257,11 +255,9 @@ global DEFAULT_CONFIG::ConfigDict = ConfigDict(
 )
 
 global CONFIG_RELOAD_REQUIRED::ConfigDict = ConfigDict(
-    "performance" => ConfigDict(
-        "full_analysis" => ConfigDict(
-            "debounce" => true,
-            "throttle" => true
-        )
+    "full_analysis" => ConfigDict(
+        "debounce" => true,
+        "throttle" => true
     ),
     "testrunner" => ConfigDict(
         "executable" => false

--- a/test/test_did-change-watched-files.jl
+++ b/test/test_did-change-watched-files.jl
@@ -16,10 +16,10 @@ const CLIENT_CAPABILITIES = ClientCapabilities(
 )
 
 const DEBOUNCE_DEFAULT = JETLS.access_nested_dict(JETLS.DEFAULT_CONFIG,
-    "performance", "full_analysis", "debounce")
+    "full_analysis", "debounce")
 
 const THROTTLE_DEFAULT = JETLS.access_nested_dict(JETLS.DEFAULT_CONFIG,
-    "performance", "full_analysis", "throttle")
+    "full_analysis", "throttle")
 
 const TESTRUNNER_DEFAULT = JETLS.access_nested_dict(JETLS.DEFAULT_CONFIG,
     "testrunner", "executable")
@@ -38,7 +38,7 @@ const TESTRUNNER_DEFAULT = JETLS.access_nested_dict(JETLS.DEFAULT_CONFIG,
         DEBOUNCE_STARTUP = 100.0
         TESTRUNNER_STARTUP = "testrunner_startup"
         write(config_path, """
-            [performance.full_analysis]
+            [full_analysis]
             debounce = $DEBOUNCE_STARTUP
             [testrunner]
             executable = \"$TESTRUNNER_STARTUP\"
@@ -49,21 +49,21 @@ const TESTRUNNER_DEFAULT = JETLS.access_nested_dict(JETLS.DEFAULT_CONFIG,
 
             # after initialization, manager should have the fixed config for reload required keys
             @test JETLS.access_nested_dict(manager.reload_required_setting,
-                "performance", "full_analysis", "debounce") == DEBOUNCE_STARTUP
+                "full_analysis", "debounce") == DEBOUNCE_STARTUP
             @test JETLS.access_nested_dict(manager.reload_required_setting,
-                "performance", "full_analysis", "throttle") == THROTTLE_DEFAULT
+                "full_analysis", "throttle") == THROTTLE_DEFAULT
 
             @test haskey(manager.watched_files, config_path)
             @test collect(keys(manager.watched_files)) == [config_path, "__DEFAULT_CONFIG__"]
             @test manager.watched_files["__DEFAULT_CONFIG__"] == JETLS.DEFAULT_CONFIG
 
-            @test JETLS.get_config(manager, "performance", "full_analysis", "debounce") == DEBOUNCE_STARTUP
+            @test JETLS.get_config(manager, "full_analysis", "debounce") == DEBOUNCE_STARTUP
             @test JETLS.get_config(manager, "testrunner", "executable") == TESTRUNNER_STARTUP
 
-            # change `performance.full_analysis.debounce` to `DEBOUNCE_V2`
+            # change `full_analysis.debounce` to `DEBOUNCE_V2`
             DEBOUNCE_V2 = 200.0
             write(config_path, """
-                [performance.full_analysis]
+                [full_analysis]
                 debounce = $DEBOUNCE_V2
                 [testrunner]
                 executable = \"$TESTRUNNER_STARTUP\"
@@ -79,18 +79,18 @@ const TESTRUNNER_DEFAULT = JETLS.access_nested_dict(JETLS.DEFAULT_CONFIG,
             @test raw_res isa ShowMessageNotification
             @test raw_res.method == "window/showMessage"
             @test raw_res.params.type == MessageType.Warning
-            @test occursin("performance.full_analysis.debounce", raw_res.params.message)
+            @test occursin("full_analysis.debounce", raw_res.params.message)
             @test occursin("restart", raw_res.params.message)
 
             # Config should not be changed (reload required)
-            @test JETLS.get_config(manager, "performance", "full_analysis", "debounce") == DEBOUNCE_STARTUP
+            @test JETLS.get_config(manager, "full_analysis", "debounce") == DEBOUNCE_STARTUP
             # But config dict should be updated to avoid showing the same message again
-            @test manager.watched_files[config_path]["performance"]["full_analysis"]["debounce"] == DEBOUNCE_V2
+            @test manager.watched_files[config_path]["full_analysis"]["debounce"] == DEBOUNCE_V2
 
             THROTTLE_V2 = 300.0
-            # Add a new key `performance.full_analysis.throttle`
+            # Add a new key `full_analysis.throttle`
             write(config_path, """
-                [performance.full_analysis]
+                [full_analysis]
                 debounce = $DEBOUNCE_V2
                 throttle = $THROTTLE_V2
                 [testrunner]
@@ -111,13 +111,13 @@ const TESTRUNNER_DEFAULT = JETLS.access_nested_dict(JETLS.DEFAULT_CONFIG,
             @test !occursin("debounce", raw_res.params.message)
             @test occursin("restart", raw_res.params.message)
 
-            # `performance.full_analysis.throttle` should not be changed (reload required)
-            @test JETLS.get_config(manager, "performance", "full_analysis", "throttle") == THROTTLE_DEFAULT
+            # `full_analysis.throttle` should not be changed (reload required)
+            @test JETLS.get_config(manager, "full_analysis", "throttle") == THROTTLE_DEFAULT
 
             # Change `testrunner.executable` to "newtestrunner"
             TESTRUNNER_V2 = "testrunner_v2"
             write(config_path, """
-                [performance.full_analysis]
+                [full_analysis]
                 debounce = $DEBOUNCE_V2
                 [testrunner]
                 executable = \"$TESTRUNNER_V2\"
@@ -135,7 +135,7 @@ const TESTRUNNER_DEFAULT = JETLS.access_nested_dict(JETLS.DEFAULT_CONFIG,
 
             # unknown keys should be reported
             write(config_path, """
-                [performance]
+                [full_analysis]
                 ___unknown_key___ = \"value\"
                 """)
 
@@ -149,7 +149,7 @@ const TESTRUNNER_DEFAULT = JETLS.access_nested_dict(JETLS.DEFAULT_CONFIG,
             @test raw_res.method == "window/showMessage"
             @test raw_res.params.type == MessageType.Error
             @test occursin("unknown keys", raw_res.params.message)
-            @test occursin("performance.___unknown_key___", raw_res.params.message)
+            @test occursin("full_analysis.___unknown_key___", raw_res.params.message)
 
             # Delete the config file
             rm(config_path)
@@ -167,7 +167,7 @@ const TESTRUNNER_DEFAULT = JETLS.access_nested_dict(JETLS.DEFAULT_CONFIG,
 
             # After deletion,
             # - for reload required keys, `get_config` should remain unchanged
-            @test JETLS.get_config(manager, "performance", "full_analysis", "debounce") == DEBOUNCE_STARTUP
+            @test JETLS.get_config(manager, "full_analysis", "debounce") == DEBOUNCE_STARTUP
             # -  For non-reload required keys, replace with value from the next highest-priority config file. (`__DEFAULT_CONFIG__`)
             @test JETLS.get_config(manager, "testrunner", "executable") == TESTRUNNER_DEFAULT
 
@@ -179,7 +179,7 @@ const TESTRUNNER_DEFAULT = JETLS.access_nested_dict(JETLS.DEFAULT_CONFIG,
             DEBOUNCE_RECREATE = 400.0
             TESTRUNNER_RECREATE = "testrunner_recreate"
             write(config_path, """
-                [performance.full_analysis]
+                [full_analysis]
                 debounce = $DEBOUNCE_RECREATE
                 [testrunner]
                 executable = \"$TESTRUNNER_RECREATE\"
@@ -200,9 +200,9 @@ const TESTRUNNER_DEFAULT = JETLS.access_nested_dict(JETLS.DEFAULT_CONFIG,
             # `config_path` should be registered again
             @test haskey(manager.watched_files, config_path)
             # reload required keys should not be changed even if higher priority config file is re-created
-            @test JETLS.get_config(manager, "performance", "full_analysis", "debounce") == DEBOUNCE_STARTUP
+            @test JETLS.get_config(manager, "full_analysis", "debounce") == DEBOUNCE_STARTUP
             @test JETLS.access_nested_dict(manager.watched_files[config_path],
-                "performance", "full_analysis", "debounce") == DEBOUNCE_RECREATE
+                "full_analysis", "debounce") == DEBOUNCE_RECREATE
             # non-reload required keys should be updated
             @test JETLS.get_config(manager, "testrunner", "executable") == TESTRUNNER_RECREATE
 
@@ -216,7 +216,7 @@ const TESTRUNNER_DEFAULT = JETLS.access_nested_dict(JETLS.DEFAULT_CONFIG,
             )
             writereadmsg(other_change_notification; read=0)
             # no effect on config
-            @test JETLS.get_config(manager, "performance", "full_analysis", "debounce") == DEBOUNCE_STARTUP
+            @test JETLS.get_config(manager, "full_analysis", "debounce") == DEBOUNCE_STARTUP
             @test JETLS.get_config(manager, "testrunner", "executable") == TESTRUNNER_RECREATE
         end
     end
@@ -236,7 +236,7 @@ end
             DEBOUNCE_RECREATE = 500.0
             TESTRUNNER_RECREATE = "testrunner_recreate"
             write(config_path, """
-                [performance.full_analysis]
+                [full_analysis]
                 debounce = $DEBOUNCE_RECREATE
                 [testrunner]
                 executable = \"$TESTRUNNER_RECREATE\"
@@ -256,7 +256,7 @@ end
 
             # If higher priority config file is created,
             # - reload required keys should not be changed
-            @test JETLS.get_config(manager, "performance", "full_analysis", "debounce") == DEBOUNCE_DEFAULT
+            @test JETLS.get_config(manager, "full_analysis", "debounce") == DEBOUNCE_DEFAULT
             # - non-reload required keys should be updated
             @test JETLS.get_config(manager, "testrunner", "executable") == TESTRUNNER_RECREATE
 
@@ -264,7 +264,7 @@ end
             DEBOUNCE_V2 = 600.0
             TESTRUNNER_V2 = "testrunner_v2"
             write(config_path, """
-                [performance.full_analysis]
+                [full_analysis]
                 debounce = $DEBOUNCE_V2
                 [testrunner]
                 executable = \"$TESTRUNNER_V2\"
@@ -279,9 +279,9 @@ end
             @test raw_res isa ShowMessageNotification
             @test raw_res.method == "window/showMessage"
             @test raw_res.params.type == MessageType.Warning
-            @test occursin("performance.full_analysis.debounce", raw_res.params.message)
+            @test occursin("full_analysis.debounce", raw_res.params.message)
             @test occursin("restart", raw_res.params.message)
-            @test JETLS.get_config(manager, "performance", "full_analysis", "debounce") == DEBOUNCE_DEFAULT
+            @test JETLS.get_config(manager, "full_analysis", "debounce") == DEBOUNCE_DEFAULT
             @test JETLS.get_config(manager, "testrunner", "executable") == TESTRUNNER_V2
         end
     end

--- a/test/utils/test_config.jl
+++ b/test/utils/test_config.jl
@@ -117,16 +117,16 @@ end
 
 @testset "`merge_reload_required_keys`" begin
     dict1 = JETLS.ConfigDict(
-        "performance" => JETLS.ConfigDict("full_analysis" => JETLS.ConfigDict("debounce" => 1.0)))
+        "full_analysis" => JETLS.ConfigDict("debounce" => 1.0))
     dict2 = JETLS.ConfigDict(
-        "performance" => JETLS.ConfigDict("full_analysis" => JETLS.ConfigDict("throttle" => 5.0)),
+        "full_analysis" => JETLS.ConfigDict("throttle" => 5.0),
         "testrunner" => JETLS.ConfigDict("executable" => "testrunner2"))
 
     result = JETLS.merge_reload_required_keys(dict1, dict2)
 
     # Should merge reload-required keys only
-    @test result["performance"]["full_analysis"]["debounce"] == 1.0
-    @test result["performance"]["full_analysis"]["throttle"] == 5.0
+    @test result["full_analysis"]["debounce"] == 1.0
+    @test result["full_analysis"]["throttle"] == 5.0
     # testrunner.executable should NOT be merged (it's false in CONFIG_RELOAD_REQUIRED)
     @test !haskey(result, "testrunner")
 end
@@ -271,13 +271,13 @@ end
     end
 
     # filtering with nested paths
-    let base = JETLS.ConfigDict("performance" => JETLS.ConfigDict("full_analysis" => JETLS.ConfigDict("debounce" => 1.0)))
-        overlay = JETLS.ConfigDict("performance" => JETLS.ConfigDict("full_analysis" => JETLS.ConfigDict("throttle" => 5.0)))
+    let base = JETLS.ConfigDict("full_analysis" => JETLS.ConfigDict("debounce" => 1.0))
+        overlay = JETLS.ConfigDict("full_analysis" => JETLS.ConfigDict("throttle" => 5.0))
         result = JETLS.traverse_merge(base, overlay) do path, v
-            path == ["performance", "full_analysis", "throttle"] ? v : nothing
+            path == ["full_analysis", "throttle"] ? v : nothing
         end
-        @test result["performance"]["full_analysis"]["debounce"] == 1.0
-        @test result["performance"]["full_analysis"]["throttle"] == 5.0
+        @test result["full_analysis"]["debounce"] == 1.0
+        @test result["full_analysis"]["throttle"] == 5.0
     end
 end
 
@@ -285,17 +285,15 @@ end
     default_config_origin = JETLS.CONFIG_RELOAD_REQUIRED
     try
         JETLS.CONFIG_RELOAD_REQUIRED = JETLS.ConfigDict(
-            "performance" => JETLS.ConfigDict(
-                "full_analysis" => JETLS.ConfigDict(
-                    "debounce" => true,
-                    "throttle" => false
-                )
+            "full_analysis" => JETLS.ConfigDict(
+                "debounce" => true,
+                "throttle" => false
             ),
             "simple_key" => true
         )
 
-        @test JETLS.is_reload_required_key("performance", "full_analysis", "debounce") === true
-        @test JETLS.is_reload_required_key("performance", "full_analysis", "throttle") === false
+        @test JETLS.is_reload_required_key("full_analysis", "debounce") === true
+        @test JETLS.is_reload_required_key("full_analysis", "throttle") === false
         @test JETLS.is_reload_required_key("simple_key") === true
         @test JETLS.is_reload_required_key("nonexistent") === false
         @test JETLS.is_reload_required_key("performance", "nonexistent") === false
@@ -400,22 +398,18 @@ end
     is_reload_required_key_origin = JETLS.CONFIG_RELOAD_REQUIRED
     try
         JETLS.DEFAULT_CONFIG = JETLS.ConfigDict(
-            "performance" => JETLS.ConfigDict(
-                "full_analysis" => JETLS.ConfigDict(
-                    "debounce" => 1.0,
-                    "throttle" => 5.0
-                )
+            "full_analysis" => JETLS.ConfigDict(
+                "debounce" => 1.0,
+                "throttle" => 5.0
             ),
             "testrunner" => JETLS.ConfigDict(
                 "executable" => "testrunner"
             )
         )
         JETLS.CONFIG_RELOAD_REQUIRED = JETLS.ConfigDict(
-            "performance" => JETLS.ConfigDict(
-                "full_analysis" => JETLS.ConfigDict(
-                    "debounce" => true,
-                    "throttle" => true
-                )
+            "full_analysis" => JETLS.ConfigDict(
+                "debounce" => true,
+                "throttle" => true
             ),
             "testrunner" => JETLS.ConfigDict(
                 "executable" => false
@@ -425,14 +419,10 @@ end
         # test priority handling
         let manager = JETLS.ConfigManager()
             high_priority_config = JETLS.ConfigDict(
-                "performance" => JETLS.ConfigDict(
-                    "full_analysis" => JETLS.ConfigDict("debounce" => 2.0)
-                )
+                "full_analysis" => JETLS.ConfigDict("debounce" => 2.0)
             )
             low_priority_config = JETLS.ConfigDict(
-                "performance" => JETLS.ConfigDict(
-                    "full_analysis" => JETLS.ConfigDict("debounce" => 999.0)
-                ),
+                "full_analysis" => JETLS.ConfigDict("debounce" => 999.0),
                 "testrunner" => JETLS.ConfigDict("executable" => "custom")
             )
 
@@ -441,7 +431,7 @@ end
             JETLS.fix_reload_required_settings!(manager)
 
             # high priority should win for reload-required keys
-            @test manager.reload_required_setting["performance"]["full_analysis"]["debounce"] == 2.0
+            @test manager.reload_required_setting["full_analysis"]["debounce"] == 2.0
             # testrunner.executable is not reload-required, so should not be in reload_required_setting
             @test !haskey(manager.reload_required_setting, "testrunner")
         end


### PR DESCRIPTION
The config schema had an unnecessary nesting level with `performance` containing only `full_analysis`. This commit flattens the structure to make configuration a bit simpler:

- `performance.full_analysis.debounce` -> `full_analysis.debounce`
- `performance.full_analysis.throttle` -> `full_analysis.throttle`

The simplified structure reduces verbosity while maintaining all functionality, making the configuration easier to understand and use.

🤖 Generated with [Claude Code](https://claude.ai/code)