### PR TITLE
config: make DEFAULT_CONFIG and CONFIG_RELOAD_REQUIRED constants

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -244,7 +244,7 @@ struct WatchedConfigFiles
 end
 
 # TODO (later): move this definition to external files
-global DEFAULT_CONFIG::ConfigDict = ConfigDict(
+const DEFAULT_CONFIG = ConfigDict(
     "full_analysis" => ConfigDict(
         "debounce" => 1.0,
         "throttle" => 5.0
@@ -254,7 +254,7 @@ global DEFAULT_CONFIG::ConfigDict = ConfigDict(
     ),
 )
 
-global CONFIG_RELOAD_REQUIRED::ConfigDict = ConfigDict(
+const CONFIG_RELOAD_REQUIRED = ConfigDict(
     "full_analysis" => ConfigDict(
         "debounce" => true,
         "throttle" => true


### PR DESCRIPTION
These global configuration dictionaries are never modified during runtime and should be treated as constants. This change:

- Makes `DEFAULT_CONFIG` and `CONFIG_RELOAD_REQUIRED` `const` 
- Simplifies tests that previously modified these globals 

The constants provide the baseline configuration that should never change during the language server's lifetime. User interactions only affect the ConfigManager's watched files, not these base definitions.