### PR TITLE
config: rename "reload required" to "static" settings

### DIFF
--- a/src/did-change-watched-files.jl
+++ b/src/did-change-watched-files.jl
@@ -38,7 +38,7 @@ function initialize_config!(server::Server)
         end
     end
 
-    fix_reload_required_settings!(server.state.config_manager)
+    fix_static_settings!(server.state.config_manager)
 end
 
 """
@@ -48,7 +48,7 @@ If the file does not exist or cannot be parsed, current configuration remains un
 When there are unknown keys in the config file, send error by `workspace/showMessage`
 and **current configuration is not changed.**
 """
-function load_config!(on_reload_required, server::Server, path::AbstractString)
+function load_config!(on_static_setting, server::Server, path::AbstractString)
     isfile(path) || return
     parsed = TOML.tryparsefile(path)
     parsed isa TOML.ParserError && return # just skip to reduce noise while typing
@@ -64,7 +64,7 @@ function load_config!(on_reload_required, server::Server, path::AbstractString)
         return
     end
 
-    merge_config!(on_reload_required,
+    merge_config!(on_static_setting,
                   server.state.config_manager,
                   path,
                   config_dict)

--- a/src/types.jl
+++ b/src/types.jl
@@ -254,7 +254,7 @@ const DEFAULT_CONFIG = ConfigDict(
     ),
 )
 
-const CONFIG_RELOAD_REQUIRED = ConfigDict(
+const STATIC_CONFIG = ConfigDict(
     "full_analysis" => ConfigDict(
         "debounce" => true,
         "throttle" => true
@@ -313,7 +313,7 @@ end
 
 struct ConfigFileOrder <: Base.Ordering end
 mutable struct ConfigManager
-    reload_required_setting::ConfigDict     # settings that are not changed during the server lifetime
+    static_settings::ConfigDict             # settings that should be static throughout the server lifetime
     const watched_files::WatchedConfigFiles # watched configuration files
 end
 ConfigManager() = ConfigManager(ConfigDict(), WatchedConfigFiles())


### PR DESCRIPTION
The previous "reload required" naming was misleading and I think "static settings" make more sense since they are fixed at server startup and cannot be changed during server lifetime.