### PR TITLE
config: make `throttle` and `debounce` dynamic settings

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -7,15 +7,21 @@ const DEFAULT_CONFIG = ConfigDict(
     "testrunner" => ConfigDict(
         "executable" => "testrunner"
     ),
+    "internal" => ConfigDict(
+        "static_setting" => 0
+    ),
 )
 
 const STATIC_CONFIG = ConfigDict(
     "full_analysis" => ConfigDict(
-        "debounce" => true,
-        "throttle" => true
+        "debounce" => false,
+        "throttle" => false
     ),
     "testrunner" => ConfigDict(
         "executable" => false
+    ),
+    "internal" => ConfigDict(
+        "static_setting" => true
     ),
 )
 


### PR DESCRIPTION
Change `full_analysis.throttle` and `full_analysis.debounce` from static to dynamic settings, allowing them to be updated without server restart. Add `internal.static_setting` for testing static configuration behavior, since the static configuration handling itself would be useful in the future and thus worth the maintenance cost.