### PR TITLE
Bump JuliaLowering version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 [sources]
 JET = {rev = "master", url = "https://github.com/aviatesk/JET.jl"}
 JSONRPC = {path = "JSONRPC"}
-JuliaLowering = {rev = "jetls-2", url = "https://github.com/mlechu/JuliaLowering.jl"}
+JuliaLowering = {rev = "jetls-hacking", url = "https://github.com/mlechu/JuliaLowering.jl"}
 JuliaSyntax = {rev = "jetls-hacking", url = "https://github.com/JuliaLang/JuliaSyntax.jl"}
 LSP = {path = "LSP"}
 

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -262,7 +262,7 @@ function lowering_diagnostics!(
 
         st0 = without_kinds(st0, JS.KSet"error macrocall")
         try
-            ctx1, st1 = JL.expand_forms_1(mod, st0, true)
+            ctx1, st1 = JL.expand_forms_1(mod, st0, true, Base.get_world_counter())
             _jl_lower_for_scope_resolution(ctx1, st0, st1)
         catch
             # The same error has probably already been handled above

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -57,7 +57,7 @@ function jl_lower_for_scope_resolution(
         st0 = without_kinds(st0, JS.KSet"error")
     end
     ctx1, st1 = try
-        JL.expand_forms_1(mod, st0, true)
+        JL.expand_forms_1(mod, st0, true, Base.get_world_counter())
     catch err
         recover_from_macro_errors || rethrow(err)
         JETLS_DEBUG_LOWERING && @warn "Error in macro expansion; trimming and retrying"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -10,7 +10,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [sources]
 JET = {rev = "master", url = "https://github.com/aviatesk/JET.jl"}
 JETLS = {path = "."}
-JuliaLowering = {rev = "jetls-2", url = "https://github.com/mlechu/JuliaLowering.jl"}
+JuliaLowering = {rev = "jetls-hacking", url = "https://github.com/mlechu/JuliaLowering.jl"}
 JuliaSyntax = {rev = "jetls-hacking", url = "https://github.com/JuliaLang/JuliaSyntax.jl"}
 
 [compat]

--- a/test/jsjl_utils.jl
+++ b/test/jsjl_utils.jl
@@ -36,7 +36,7 @@ end
 # use `stop` if some lowering pass mutates ctx in a way you don't want
 function jldebug(st0_in::JL.SyntaxTree, stop=5)
     global ctx5, st5, ctx4, st4, ctx3, st3, ctx2, st2, ctx1, st1
-    stop = stop - 1; stop < 0 && return; ctx1, st1 = JL.expand_forms_1(Module(), st0_in, true)
+    stop = stop - 1; stop < 0 && return; ctx1, st1 = JL.expand_forms_1(Module(), st0_in, true, Base.get_world_counter())
     stop = stop - 1; stop < 0 && return; ctx2, st2 = JL.expand_forms_2(ctx1, st1)
     stop = stop - 1; stop < 0 && return; ctx3, st3 = JL.resolve_scopes(ctx2, st2)
     stop = stop - 1; stop < 0 && return; ctx4, st4 = JL.convert_closures(ctx3, st3)


### PR DESCRIPTION
Bump JuliaLowering to the latest `main` as of writing (https://github.com/c42f/JuliaLowering.jl/commit/edf03df9b4befdd938503e90a75c3d78695fb92e) plus the bug fixes and graph utilities from PRs [35](https://github.com/c42f/JuliaLowering.jl/pull/35), [75](https://github.com/c42f/JuliaLowering.jl/pull/75), [78](https://github.com/c42f/JuliaLowering.jl/pull/78), [80](https://github.com/c42f/JuliaLowering.jl/pull/80), and [81](https://github.com/c42f/JuliaLowering.jl/pull/81).

Only requires a PR and a branch change (jetls-2 back to jetls-hacking) because the signature of `expand_forms_1` changed.
