### PR TITLE
full-analysis: reintroduce `staled` field to avoid redundant reanalysis

### DIFF
--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -1,4 +1,4 @@
-function run_full_analysis!(server::Server, uri::URI; throttle::Bool=false, token::Union{Nothing,ProgressToken}=nothing)
+function run_full_analysis!(server::Server, uri::URI; onsave::Bool=false, token::Union{Nothing,ProgressToken}=nothing)
     if !haskey(server.state.analysis_cache, uri)
         res = initiate_analysis_unit!(server, uri; token)
         if res isa AnalysisUnit
@@ -11,7 +11,9 @@ function run_full_analysis!(server::Server, uri::URI; throttle::Bool=false, toke
         else
             # TODO support multiple analysis units, which can happen if this file is included from multiple different analysis_units
             analysis_unit = first(analysis_info)
-
+            if onsave
+                analysis_unit.result.staled = true
+            end
             function task()
                 res = reanalyze!(server, analysis_unit; token)
                 if res isa AnalysisUnit
@@ -19,9 +21,9 @@ function run_full_analysis!(server::Server, uri::URI; throttle::Bool=false, toke
                 end
             end
             id = hash(run_full_analysis!, hash(analysis_unit))
-            if throttle
-                debounce(id, get_config(server.state.config_manager, "full_analysis", "debounce")) do
-                    JETLS.throttle(id, get_config(server.state.config_manager, "full_analysis", "throttle")) do
+            if onsave
+                debounce(id, get_config(server.state.config_manager, "performance", "full_analysis", "debounce")) do
+                    throttle(id, get_config(server.state.config_manager, "performance", "full_analysis", "throttle")) do
                         task()
                     end
                 end
@@ -104,7 +106,7 @@ function new_analysis_unit(entry::AnalysisEntry, result)
     successfully_analyzed_file_infos = copy(analyzed_file_infos)
     is_full_analysis_successful(result) || empty!(successfully_analyzed_file_infos)
     analysis_result = FullAnalysisResult(
-        result.res.actual2virtual::JET.Actual2Virtual, update_analyzer_world(result.analyzer),
+        #=staled=#false, result.res.actual2virtual::JET.Actual2Virtual, update_analyzer_world(result.analyzer),
         uri2diagnostics, analyzed_file_infos, successfully_analyzed_file_infos)
     return AnalysisUnit(entry, analysis_result)
 end
@@ -131,6 +133,7 @@ function update_analysis_unit!(analysis_unit::AnalysisUnit, result)
         empty!(get!(()->Diagnostic[], uri2diagnostics, new_file_uri))
     end
     jet_result_to_diagnostics!(uri2diagnostics, result)
+    analysis_unit.result.staled = false
     if is_full_analysis_successful(result)
         analysis_unit.result.actual2virtual = result.res.actual2virtual
         analysis_unit.result.analyzer = update_analyzer_world(result.analyzer)
@@ -263,6 +266,10 @@ end
 
 function reanalyze!(server::Server, analysis_unit::AnalysisUnit; token::Union{Nothing,ProgressToken}=nothing)
     state = server.state
+    analysis_result = analysis_unit.result
+    if !(analysis_result.staled)
+        return nothing
+    end
 
     any_parse_failed = any(analyzed_file_uris(analysis_unit)) do uri::URI
         fi = get_saved_file_info(state, uri)

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -1,6 +1,6 @@
 struct RunFullAnalysisCaller <: RequestCaller
     uri::URI
-    throttle::Bool
+    onsave::Bool
     token::ProgressToken
 end
 
@@ -53,7 +53,7 @@ function handle_DidOpenTextDocumentNotification(server::Server, msg::DidOpenText
     if supports(server, :window, :workDoneProgress)
         id = String(gensym(:WorkDoneProgressCreateRequest_run_full_analysis!))
         token = String(gensym(:WorkDoneProgressCreateRequest_run_full_analysis!))
-        addrequest!(server, id=>RunFullAnalysisCaller(uri, #=throttle=#false, token))
+        addrequest!(server, id=>RunFullAnalysisCaller(uri, #=onsave=#false, token))
         send(server,
             WorkDoneProgressCreateRequest(;
                 id,
@@ -98,14 +98,14 @@ function handle_DidSaveTextDocumentNotification(server::Server, msg::DidSaveText
     if supports(server, :window, :workDoneProgress)
         id = String(gensym(:WorkDoneProgressCreateRequest_run_full_analysis!))
         token = String(gensym(:WorkDoneProgressCreateRequest_run_full_analysis!))
-        addrequest!(server, id=>RunFullAnalysisCaller(uri, #=throttle=#true, token))
+        addrequest!(server, id=>RunFullAnalysisCaller(uri, #=onsave=#true, token))
         send(server,
             WorkDoneProgressCreateRequest(;
                 id,
                 params = WorkDoneProgressCreateParams(;
                     token = token)))
     else
-        run_full_analysis!(server, uri; throttle=true)
+        run_full_analysis!(server, uri; onsave=true)
     end
 end
 

--- a/src/response.jl
+++ b/src/response.jl
@@ -59,8 +59,8 @@ function handle_requested_response(server::Server, msg::Dict{Symbol,Any},
 end
 
 function handle_run_full_analysis_response(server::Server, msg::Dict{Symbol,Any}, request_caller::RunFullAnalysisCaller)
-    (; uri, throttle, token) = request_caller
-    run_full_analysis!(server, uri; throttle, token)
+    (; uri, onsave, token) = request_caller
+    run_full_analysis!(server, uri; onsave, token)
 end
 
 function handle_show_document_response(server::Server, msg::Dict{Symbol,Any}, request_caller::ShowDocumentRequestCaller)

--- a/src/types.jl
+++ b/src/types.jl
@@ -132,6 +132,7 @@ end
 const URI2Diagnostics = Dict{URI,Vector{Diagnostic}}
 
 mutable struct FullAnalysisResult
+    staled::Bool
     actual2virtual::JET.Actual2Virtual
     analyzer::LSAnalyzer
     const uri2diagnostics::URI2Diagnostics


### PR DESCRIPTION
Reverts aviatesk/JETLS.jl#240.
The `staled` field is actually useful to prevent redundant analysis when opening files that have already been analyzed by their analysis unit.