### PR TITLE
concurrency: implement request cancellation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ likely be implemented in the near future, for those who want to test this server
 Please note that not only the progress of the list, but also the structure of
 the list itself is subject to change.
 
-- [x] Parallel/concurrent message handling
 - Full-Analysis
   - [x] Document synchronization
   - [ ] JuliaLowering integration
@@ -154,6 +153,9 @@ the list itself is subject to change.
   - [x] Prototype implementation
   - [ ] Documentation
   - [ ] Schema support
+- [x] Parallel/concurrent message handling
+- [x] Work done progress support
+- [x] Message cancellation support
 
 Detailed development notes and progress for this project are collected at
 <https://publish.obsidian.md/jetls>, so those interested might want to take a look.

--- a/src/code-action.jl
+++ b/src/code-action.jl
@@ -23,7 +23,14 @@ end
 #     method = CODE_ACTION_REGISTRATION_METHOD))
 # register(currently_running, code_action_registration())
 
-function handle_CodeActionRequest(server::Server, msg::CodeActionRequest)
+function handle_CodeActionRequest(server::Server, msg::CodeActionRequest, cancel_flag::CancelFlag)
+    if is_cancelled(cancel_flag)
+        return send(server,
+            CodeActionResponse(;
+                id = msg.id,
+                result = nothing,
+                error = request_cancelled_error()))
+    end
     uri = msg.params.textDocument.uri
     fi = @something get_file_info(server.state, uri) begin
         return send(server,

--- a/src/code-lens.jl
+++ b/src/code-lens.jl
@@ -21,7 +21,14 @@ end
 #     method = CODE_LENS_REGISTRATION_METHOD))
 # register(currently_running, code_lens_registration())
 
-function handle_CodeLensRequest(server::Server, msg::CodeLensRequest)
+function handle_CodeLensRequest(server::Server, msg::CodeLensRequest, cancel_flag::CancelFlag)
+    if is_cancelled(cancel_flag)
+        return send(server,
+            CodeLensResponse(;
+                id = msg.id,
+                result = nothing,
+                error = request_cancelled_error()))
+    end
     uri = msg.params.textDocument.uri
     fi = @something get_file_info(server.state, uri) begin
         return send(server,

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -418,20 +418,34 @@ function get_completion_items(state::ServerState, uri::URI, params::CompletionPa
         items)))
 end
 
-function handle_CompletionRequest(server::Server, msg::CompletionRequest)
+function handle_CompletionRequest(server::Server, msg::CompletionRequest, cancel_flag::CancelFlag)
+    if is_cancelled(cancel_flag)
+        return send(server,
+            CompletionResponse(;
+                id = msg.id,
+                result = nothing,
+                error = request_cancelled_error()))
+    end
     uri = msg.params.textDocument.uri
     items = get_completion_items(server.state, uri, msg.params)
     return send(server,
-        ResponseMessage(;
+        CompletionResponse(;
             id = msg.id,
             result = CompletionList(;
                 isIncomplete = false,
                 items)))
 end
 
-function handle_CompletionResolveRequest(server::Server, msg::CompletionResolveRequest)
+function handle_CompletionResolveRequest(server::Server, msg::CompletionResolveRequest, cancel_flag::CancelFlag)
+    if is_cancelled(cancel_flag)
+        return send(server,
+            CompletionResolveResponse(;
+                id = msg.id,
+                result = nothing,
+                error = request_cancelled_error()))
+    end
     return send(server,
-        ResponseMessage(;
+        CompletionResolveResponse(;
             id = msg.id,
             result = resolve_completion_item(server.state, msg.params)))
 end

--- a/src/definition.jl
+++ b/src/definition.jl
@@ -61,7 +61,14 @@ LSP.LocationLink(loc::Location, originSelectionRange::Range) =
         targetSelectionRange = loc.range,
         originSelectionRange)
 
-function handle_DefinitionRequest(server::Server, msg::DefinitionRequest)
+function handle_DefinitionRequest(server::Server, msg::DefinitionRequest, cancel_flag::CancelFlag)
+    if is_cancelled(cancel_flag)
+        return send(server,
+            DefinitionResponse(;
+                id = msg.id,
+                result = nothing,
+                error = request_cancelled_error()))
+    end
     origin_position = msg.params.position
     uri = msg.params.textDocument.uri
 

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -415,9 +415,16 @@ end
 # unregister(currently_running, Unregistration(;
 #     id = DIAGNOSTIC_REGISTRATION_ID,
 #     method = DIAGNOSTIC_REGISTRATION_METHOD))
-# register(currently_running, diagnostic_resistration())
+# register(currently_running, diagnostic_registration())
 
-function handle_DocumentDiagnosticRequest(server::Server, msg::DocumentDiagnosticRequest)
+function handle_DocumentDiagnosticRequest(server::Server, msg::DocumentDiagnosticRequest, cancel_flag::CancelFlag)
+    if is_cancelled(cancel_flag)
+        return send(server,
+            DocumentDiagnosticResponse(;
+                id = msg.id,
+                result = nothing,
+                error = request_cancelled_error()))
+    end
     uri = msg.params.textDocument.uri
 
     # This `previousResultId` calculation is mostly meaningless, but it might help the

--- a/src/document-highlight.jl
+++ b/src/document-highlight.jl
@@ -23,7 +23,14 @@ end
 
 # TODO Add some syntactic highlight feature?
 
-function handle_DocumentHighlightRequest(server::Server, msg::DocumentHighlightRequest)
+function handle_DocumentHighlightRequest(server::Server, msg::DocumentHighlightRequest, cancel_flag::CancelFlag)
+    if is_cancelled(cancel_flag)
+        return send(server,
+            DocumentHighlightResponse(;
+                id = msg.id,
+                result = nothing,
+                error = request_cancelled_error()))
+    end
     uri = msg.params.textDocument.uri
     pos = msg.params.position
 

--- a/src/execute-command.jl
+++ b/src/execute-command.jl
@@ -32,7 +32,14 @@ end
 #     method = EXECUTE_COMMAND_REGISTRATION_METHOD))
 # register(currently_running, execute_command_registration())
 
-function handle_ExecuteCommandRequest(server::Server, msg::ExecuteCommandRequest)
+function handle_ExecuteCommandRequest(server::Server, msg::ExecuteCommandRequest, cancel_flag::CancelFlag)
+    if is_cancelled(cancel_flag)
+        return send(server,
+            ExecuteCommandResponse(;
+                id = msg.id,
+                result = nothing,
+                error = request_cancelled_error()))
+    end
     command = msg.params.command
     if command == COMMAND_TESTRUNNER_RUN_TESTSET
         return execute_testrunner_run_testset_command(server, msg)

--- a/src/formatting.jl
+++ b/src/formatting.jl
@@ -57,7 +57,14 @@ end
 document_text(fi::FileInfo) = JS.sourcetext(fi.parsed_stream)
 document_range(fi::FileInfo) = jsobj_to_range(fi.parsed_stream, fi)
 
-function handle_DocumentFormattingRequest(server::Server, msg::DocumentFormattingRequest)
+function handle_DocumentFormattingRequest(server::Server, msg::DocumentFormattingRequest, cancel_flag::CancelFlag)
+    if is_cancelled(cancel_flag)
+        return send(server,
+            DocumentFormattingResponse(;
+                id = msg.id,
+                result = nothing,
+                error = request_cancelled_error()))
+    end
     uri = msg.params.textDocument.uri
 
     workDoneToken = msg.params.workDoneToken
@@ -114,7 +121,14 @@ function format_result(state::ServerState, uri::URI)
     return TextEdit[TextEdit(; range = document_range(fi), newText)]
 end
 
-function handle_DocumentRangeFormattingRequest(server::Server, msg::DocumentRangeFormattingRequest)
+function handle_DocumentRangeFormattingRequest(server::Server, msg::DocumentRangeFormattingRequest, cancel_flag::CancelFlag)
+    if is_cancelled(cancel_flag)
+        return send(server,
+            ResponseMessage(;
+                id = msg.id,
+                result = nothing,
+                error = request_cancelled_error()))
+    end
     uri = msg.params.textDocument.uri
     range = msg.params.range
 

--- a/src/hover.jl
+++ b/src/hover.jl
@@ -54,7 +54,14 @@ function local_binding_hover_info(fi::FileInfo, uri::URI, definitions::JL.Syntax
     return String(take!(io))
 end
 
-function handle_HoverRequest(server::Server, msg::HoverRequest)
+function handle_HoverRequest(server::Server, msg::HoverRequest, cancel_flag::CancelFlag)
+    if is_cancelled(cancel_flag)
+        return send(server,
+            HoverResponse(;
+                id = msg.id,
+                result = nothing,
+                error = request_cancelled_error()))
+    end
     pos = msg.params.position
     uri = msg.params.textDocument.uri
 

--- a/src/inlay-hint.jl
+++ b/src/inlay-hint.jl
@@ -22,7 +22,14 @@ end
 #     method = INLAY_HINT_REGISTRATION_METHOD))
 # register(currently_running, inlay_hint_registration(#=static=#true))
 
-function handle_InlayHintRequest(server::Server, msg::InlayHintRequest)
+function handle_InlayHintRequest(server::Server, msg::InlayHintRequest, cancel_flag::CancelFlag)
+    if is_cancelled(cancel_flag)
+        return send(server,
+            InlayHintResponse(;
+                id = msg.id,
+                result = nothing,
+                error = request_cancelled_error()))
+    end
     uri = msg.params.textDocument.uri
     range = msg.params.range
 

--- a/src/registration.jl
+++ b/src/registration.jl
@@ -1,3 +1,6 @@
+struct RegisterCapabilityRequestCaller <: RequestCaller end
+struct UnregisterCapabilityRequestCaller <: RequestCaller end
+
 register(server::Server, registration::Registration) =
     register(server, Registration[registration])
 function register(server::Server, registrations::Vector{Registration})
@@ -13,10 +16,12 @@ function register(server::Server, registrations::Vector{Registration})
             return data, false
         end
     end
+    id = String(gensym(:RegisterCapabilityRequest))
     send(server, RegisterCapabilityRequest(;
-        id = String(gensym(:RegisterCapabilityRequest)),
+        id,
         params = RegistrationParams(;
             registrations = filtered)))
+    addrequest!(server, id=>RegisterCapabilityRequestCaller())
 end
 
 unregister(server::Server, unregistration::Unregistration) =
@@ -33,8 +38,10 @@ function unregister(server::Server, unregisterations::Vector{Unregistration})
             return data, false
         end
     end
+    id = String(gensym(:UnregisterCapabilityRequest))
     send(server, UnregisterCapabilityRequest(;
-        id = String(gensym(:UnregisterCapabilityRequest)),
+        id,
         params = UnregistrationParams(;
             unregisterations = filtered)))
+    addrequest!(server, id=>UnregisterCapabilityRequestCaller())
 end

--- a/src/rename.jl
+++ b/src/rename.jl
@@ -24,7 +24,14 @@ end
 #     method = RENAME_REGISTRATION_METHOD))
 # register(currently_running, rename_registration())
 
-function handle_PrepareRenameRequest(server::Server, msg::PrepareRenameRequest)
+function handle_PrepareRenameRequest(server::Server, msg::PrepareRenameRequest, cancel_flag::CancelFlag)
+    if is_cancelled(cancel_flag)
+        return send(server,
+            PrepareRenameResponse(;
+                id = msg.id,
+                result = nothing,
+                error = request_cancelled_error()))
+    end
     uri = msg.params.textDocument.uri
     pos = msg.params.position
 
@@ -61,7 +68,14 @@ function local_binding_rename_preparation(fi::FileInfo, pos::Position, mod::Modu
     end
 end
 
-function handle_RenameRequest(server::Server, msg::RenameRequest)
+function handle_RenameRequest(server::Server, msg::RenameRequest, cancel_flag::CancelFlag)
+    if is_cancelled(cancel_flag)
+        return send(server,
+            RenameResponse(;
+                id = msg.id,
+                result = nothing,
+                error = request_cancelled_error()))
+    end
     uri = msg.params.textDocument.uri
     pos = msg.params.position
     newName = msg.params.newName

--- a/src/response.jl
+++ b/src/response.jl
@@ -53,6 +53,8 @@ function handle_requested_response(server::Server, msg::Dict{Symbol,Any},
         handle_formatting_progress_response(server, msg, request_caller)
     elseif request_caller isa RangeFormattingProgressCaller
         handle_range_formatting_progress_response(server, msg, request_caller)
+    elseif request_caller isa RegisterCapabilityRequestCaller || request_caller isa UnregisterCapabilityRequestCaller
+        # nothing to do
     else
         error("Unknown request caller type")
     end

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -467,7 +467,14 @@ end
 `textDocument/signatureHelp` is requested when one of the negotiated trigger characters is typed.
 Some clients, e.g. Eglot (emacs), requests it more frequently.
 """
-function handle_SignatureHelpRequest(server::Server, msg::SignatureHelpRequest)
+function handle_SignatureHelpRequest(server::Server, msg::SignatureHelpRequest, cancel_flag::CancelFlag)
+    if is_cancelled(cancel_flag)
+        return send(server,
+            SignatureHelpResponse(;
+                id = msg.id,
+                result = nothing,
+                error = request_cancelled_error()))
+    end
     state = server.state
     uri = msg.params.textDocument.uri
     fi = @something get_file_info(state, uri) begin

--- a/src/utils/lsp.jl
+++ b/src/utils/lsp.jl
@@ -112,6 +112,13 @@ function request_failed_error(message::AbstractString; data=nothing)
         data)
 end
 
+function request_cancelled_error(message::AbstractString="Request was cancelled"; data=nothing)
+    return ResponseError(;
+        code = ErrorCodes.RequestCancelled,
+        message,
+        data)
+end
+
 """
     show_error_message(server::Server, message::String)
 


### PR DESCRIPTION
This commit adds comprehensive support for LSP request cancellation through the `$/cancelRequest` notification protocol. The implementation introduces a thread-safe cancellation mechanism that allows clients to cancel long-running requests gracefully.

Key changes:
- Refactored message handling into separate worker threads:
  * Sequential worker: Handles document lifecycle notifications that must be processed in order (open/change/close/save)
  * Concurrent worker: Manages all other messages with cancellation support
- Added `CancelFlag` type with atomic operations for thread-safe cancellation tracking
- Introduced `CurrentlyHandled` dictionary to map request IDs to their cancel flags
- Updated all request handlers to accept a `cancel_flag` parameter and check for cancellation before processing

The architecture cleanly separates sequential and concurrent processing while providing a robust cancellation infrastructure. Request handlers can now bail out early when cancelled, returning appropriate error responses to the client per LSP specification.