### PR TITLE
remove `Threads.@spawn` from testrunner and formatting

### DIFF
--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -235,9 +235,6 @@ function (::SequentialMessageHandler)(server::Server, @nospecialize msg)
 end
 
 # TODO This cancellation handling still has the following cleanup issues not yet implemented:
-# - Each `ResponseMessage` handler is currently written asynchronously as a remnant of the
-#   previous implementation, so it immediately returns a `HandledId` in any case.
-#   If a `CancelRequestNotification` is issued afterwards, a dead ID will remain in `currently_handled`
 # - When a client mistakenly sends a `CancelRequestNotification` for an already processed request,
 #   it will register a dead ID in `currently_handled`. A fixed size FIFO queue to record
 #   already handled message IDs may solve this problem in many cases.

--- a/src/formatting.jl
+++ b/src/formatting.jl
@@ -69,7 +69,7 @@ function handle_DocumentFormattingRequest(server::Server, msg::DocumentFormattin
 
     workDoneToken = msg.params.workDoneToken
     if workDoneToken !== nothing
-        Threads.@spawn do_format_with_progress(server, uri, msg.id, workDoneToken)
+        do_format_with_progress(server, uri, msg.id, workDoneToken)
     elseif supports(server, :window, :workDoneProgress)
         id = String(gensym(:WorkDoneProgressCreateRequest_formatting))
         token = String(gensym(:FormattingProgress))
@@ -77,7 +77,7 @@ function handle_DocumentFormattingRequest(server::Server, msg::DocumentFormattin
         params = WorkDoneProgressCreateParams(; token)
         send(server, WorkDoneProgressCreateRequest(; id, params))
     else
-        Threads.@spawn do_format(server, uri, msg.id)
+        do_format(server, uri, msg.id)
     end
 
     return nothing
@@ -134,7 +134,7 @@ function handle_DocumentRangeFormattingRequest(server::Server, msg::DocumentRang
 
     workDoneToken = msg.params.workDoneToken
     if workDoneToken !== nothing
-        Threads.@spawn do_range_format_with_progress(server, uri, range, msg.id, workDoneToken)
+        do_range_format_with_progress(server, uri, range, msg.id, workDoneToken)
     elseif supports(server, :window, :workDoneProgress)
         id = String(gensym(:WorkDoneProgressCreateRequest_rangeFormatting))
         token = String(gensym(:RangeFormattingProgress))
@@ -142,7 +142,7 @@ function handle_DocumentRangeFormattingRequest(server::Server, msg::DocumentRang
         params = WorkDoneProgressCreateParams(; token)
         send(server, WorkDoneProgressCreateRequest(; id, params))
     else
-        Threads.@spawn do_range_format(server, uri, range, msg.id)
+        do_range_format(server, uri, range, msg.id)
     end
 
     return nothing

--- a/src/response.jl
+++ b/src/response.jl
@@ -139,7 +139,7 @@ function handle_testrunner_testset_progress_response(server::Server, msg::Dict{S
         return
     end
     (; uri, fi, idx, testset_name, filepath, token) = request_caller
-    Threads.@spawn testrunner_run_testset(server, uri, fi, idx, testset_name, filepath; token)
+    testrunner_run_testset(server, uri, fi, idx, testset_name, filepath; token)
 end
 
 function handle_testrunner_testcase_progress_response(server::Server, msg::Dict{Symbol,Any}, request_caller::TestRunnerTestcaseProgressCaller)
@@ -147,7 +147,7 @@ function handle_testrunner_testcase_progress_response(server::Server, msg::Dict{
         return
     end
     (; uri, testcase_line, testcase_text, filepath, token) = request_caller
-    Threads.@spawn testrunner_run_testcase(server, uri, testcase_line, testcase_text, filepath; token)
+    testrunner_run_testcase(server, uri, testcase_line, testcase_text, filepath; token)
 end
 
 function handle_code_lens_refresh_response(server::Server, msg::Dict{Symbol,Any}, ::CodeLensRefreshRequestCaller)
@@ -162,7 +162,7 @@ function handle_formatting_progress_response(server::Server, msg::Dict{Symbol,An
         return
     end
     (; uri, msg_id, token) = request_caller
-    Threads.@spawn do_format_with_progress(server, uri, msg_id, token)
+    do_format_with_progress(server, uri, msg_id, token)
 end
 
 function handle_range_formatting_progress_response(server::Server, msg::Dict{Symbol,Any}, request_caller::RangeFormattingProgressCaller)
@@ -170,5 +170,5 @@ function handle_range_formatting_progress_response(server::Server, msg::Dict{Sym
         return
     end
     (; uri, range, msg_id, token) = request_caller
-    Threads.@spawn do_range_format_with_progress(server, uri, range, msg_id, token)
+    do_range_format_with_progress(server, uri, range, msg_id, token)
 end

--- a/src/testrunner/testrunner.jl
+++ b/src/testrunner/testrunner.jl
@@ -657,7 +657,7 @@ function testrunner_run_testset_from_uri(server::Server, uri::URI, idx::Int, tsn
         params = WorkDoneProgressCreateParams(; token)
         send(server, WorkDoneProgressCreateRequest(; id, params))
     else
-        Threads.@spawn testrunner_run_testset(server, uri, fi, idx, tsn, filepath)
+        testrunner_run_testset(server, uri, fi, idx, tsn, filepath)
     end
     return nothing
 end
@@ -689,7 +689,7 @@ function testrunner_run_testcase_from_uri(server::Server, uri::URI, tcl::Int, tc
         params = WorkDoneProgressCreateParams(; token)
         send(server, WorkDoneProgressCreateRequest(; id, params))
     else
-        Threads.@spawn testrunner_run_testcase(server, uri, tcl, tct, filepath)
+        testrunner_run_testcase(server, uri, tcl, tct, filepath)
     end
     return nothing
 end


### PR DESCRIPTION
The testrunner and formatting features that call external processes previously used `Threads.@spawn` to perform async local execution within the previous synchronous message handling loop. Now that all message handling is performed concurrently, this is no longer necessary.

This commit removes `Threads.@spawn` from these message handlers, allowing the message handlers themselves to execute synchronously.