### PR TITLE
Add cancellation support for work done progress operations

### DIFF
--- a/src/analysis/Interpreter.jl
+++ b/src/analysis/Interpreter.jl
@@ -64,6 +64,7 @@ function JET.analyze_from_definitions!(interp::LSInterpreter, config::JET.Toplev
             params = ProgressParams(;
                 token,
                 value = WorkDoneProgressReport(;
+                    cancellable = true,
                     message = "0 / $n [signature analysis]",
                     percentage = 50))))
         yield_to_endpoint()
@@ -75,6 +76,7 @@ function JET.analyze_from_definitions!(interp::LSInterpreter, config::JET.Toplev
                 params = ProgressParams(;
                     token,
                     value = WorkDoneProgressReport(;
+                        cancellable = true,
                         message = "$i / $n [signature analysis]",
                         percentage))))
             yield_to_endpoint(0.01)
@@ -121,6 +123,7 @@ function JET.virtual_process!(interp::LSInterpreter,
             params = ProgressParams(;
                 token,
                 value = WorkDoneProgressReport(;
+                    cancellable = true,
                     message = shortpath * " [file analysis]",
                     percentage))))
         yield_to_endpoint()

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -3,6 +3,7 @@ struct RequestAnalysisCaller <: RequestCaller
     onsave::Bool
     token::ProgressToken
 end
+work_done_progress_token(rc::RequestAnalysisCaller) = rc.token
 
 function ParseStream!(s::Union{AbstractString,Vector{UInt8}})
     stream = JS.ParseStream(s)

--- a/src/testrunner/testrunner.jl
+++ b/src/testrunner/testrunner.jl
@@ -388,8 +388,10 @@ function show_testrunner_result_in_message(server::Server, result::TestRunnerRes
             actions)))
 end
 
-function testrunner_run_testset(server::Server, uri::URI, fi::FileInfo, idx::Int, tsn::String, filepath::String;
-                                token::Union{Nothing,ProgressToken}=nothing)
+function testrunner_run_testset(
+        server::Server, uri::URI, fi::FileInfo, idx::Int, tsn::String, filepath::String;
+        token::Union{Nothing,ProgressToken} = nothing, cancel_flag::CancelFlag = CancelFlag(false)
+    )
     executable = get_config(server.state.config_manager, "testrunner", "executable")
     if isnothing(Sys.which(executable))
         show_error_message(server, app_notfound_message(
@@ -403,13 +405,13 @@ function testrunner_run_testset(server::Server, uri::URI, fi::FileInfo, idx::Int
             params = ProgressParams(;
                 token,
                 value = WorkDoneProgressBegin(;
-                    title = "Running tests for $tsn",
-                    cancellable = false))))
+                    cancellable = true,
+                    title = "Running tests for $tsn"))))
     end
 
     local result::String
     try
-        result = _testrunner_run_testset(server, executable, uri, fi, idx, tsn, filepath)
+        result = _testrunner_run_testset(server, executable, uri, fi, idx, tsn, filepath, cancel_flag)
     catch err
         result = sprint(Base.showerror, err, catch_backtrace())
         @error "Error from testrunner executor" err
@@ -429,7 +431,10 @@ end
 is_testsetinfo_valid(fi::FileInfo, testsetinfos::TestsetInfos, idx::Int) =
     testsetinfos.version == fi.version && checkbounds(Bool, testsetinfos.infos, idx)
 
-function _testrunner_run_testset(server::Server, executable::AbstractString, uri::URI, fi::FileInfo, idx::Int, tsn::String, filepath::String)
+function _testrunner_run_testset(
+        server::Server, executable::AbstractString, uri::URI, fi::FileInfo,
+        idx::Int, tsn::String, filepath::String, cancel_flag::CancelFlag
+    )
     testsetinfos = @something get_testsetinfos(server.state, uri) begin
         show_warning_message(server, """
             Test structure not found, so test execution is being cancelled.
@@ -448,7 +453,20 @@ function _testrunner_run_testset(server::Server, executable::AbstractString, uri
     test_env_path = find_uri_env_path(server.state, uri)
     cmd = testrunner_cmd(executable, filepath, tsn, tsl, test_env_path)
     testrunnerproc = open(cmd; read=true)
-    wait(testrunnerproc)
+
+    # Wait for the process with cancellation support
+    while true
+        process_running(testrunnerproc) || break
+        if is_cancelled(cancel_flag)
+            kill(testrunnerproc)
+            return "Test execution cancelled by user"
+        end
+        sleep(0.1)
+    end
+    if is_cancelled(cancel_flag)
+         return "Test execution cancelled by user"
+    end
+
     result = try
         JSONRPC.JSON3.read(testrunnerproc, TestRunnerResult)
     catch err
@@ -503,8 +521,10 @@ function _testrunner_run_testset(server::Server, executable::AbstractString, uri
     return ret
 end
 
-function testrunner_run_testcase(server::Server, uri::URI, tcl::Int, tct::String, filepath::String;
-                                 token::Union{Nothing,ProgressToken}=nothing)
+function testrunner_run_testcase(
+        server::Server, uri::URI, tcl::Int, tct::String, filepath::String;
+        token::Union{Nothing,ProgressToken} = nothing, cancel_flag::CancelFlag = CancelFlag(false)
+    )
     executable = get_config(server.state.config_manager, "testrunner", "executable")
     if isnothing(Sys.which(executable))
         show_error_message(server, app_notfound_message(
@@ -518,13 +538,13 @@ function testrunner_run_testcase(server::Server, uri::URI, tcl::Int, tct::String
             params = ProgressParams(;
                 token,
                 value = WorkDoneProgressBegin(;
-                    title = "Running test case $tct at L$tcl",
-                    cancellable = false))))
+                    cancellable = true,
+                    title = "Running test case $tct at L$tcl"))))
     end
 
     local result::String
     try
-        result = _testrunner_run_testcase(server, executable, uri, tcl, tct, filepath)
+        result = _testrunner_run_testcase(server, executable, uri, tcl, tct, filepath, cancel_flag)
     catch err
         result = sprint(Base.showerror, err, catch_backtrace())
         @error "Error from testrunner executor" err
@@ -540,11 +560,27 @@ function testrunner_run_testcase(server::Server, uri::URI, tcl::Int, tct::String
     end
 end
 
-function _testrunner_run_testcase(server::Server, executable::AbstractString, uri::URI, tcl::Int, tct::String, filepath::String)
+function _testrunner_run_testcase(
+        server::Server, executable::AbstractString, uri::URI, tcl::Int, tct::String, filepath::String,
+        cancel_flag::CancelFlag
+    )
     test_env_path = find_uri_env_path(server.state, uri)
     cmd = testrunner_cmd(executable, filepath, tcl, test_env_path)
     testrunnerproc = open(cmd; read=true)
-    wait(testrunnerproc)
+
+    # Wait for the process with cancellation support
+    while true
+        process_running(testrunnerproc) || break
+        if is_cancelled(cancel_flag)
+            kill(testrunnerproc)
+            return "Test execution cancelled by user"
+        end
+        sleep(0.1)
+    end
+    if is_cancelled(cancel_flag)
+         return "Test execution cancelled by user"
+    end
+
     result = try
         JSONRPC.JSON3.read(testrunnerproc, TestRunnerResult)
     catch err
@@ -630,6 +666,7 @@ struct TestRunnerTestsetProgressCaller <: RequestCaller
     filepath::String
     token::ProgressToken
 end
+work_done_progress_token(rc::TestRunnerTestsetProgressCaller) = rc.token
 
 """
     testrunner_run_testset_from_uri(server::Server, uri::URI, idx::Int) -> Union{Nothing, String}
@@ -669,6 +706,7 @@ struct TestRunnerTestcaseProgressCaller <: RequestCaller
     filepath::String
     token::ProgressToken
 end
+work_done_progress_token(rc::TestRunnerTestcaseProgressCaller) = rc.token
 
 function testrunner_run_testcase_from_uri(server::Server, uri::URI, tcl::Int, tct::String)
     fi = @something get_file_info(server.state, uri) begin

--- a/src/types.jl
+++ b/src/types.jl
@@ -189,6 +189,7 @@ struct AnalysisManager
 end
 
 abstract type RequestCaller end
+work_done_progress_token(::RequestCaller) = nothing
 
 struct Registered
     id::String


### PR DESCRIPTION
Implements proper cancellation handling for operations initiated with work done progress request, including test execution, analysis, and formatting.

- Added `WorkDoneProgressCancelNotification` handling
- Pass cancel flags through progress operations