### PR TITLE
cancellation: fix memory leak in request cancellation handling

### DIFF
--- a/src/FixedSizeFIFOQueue/FixedSizeFIFOQueue.jl
+++ b/src/FixedSizeFIFOQueue/FixedSizeFIFOQueue.jl
@@ -1,0 +1,59 @@
+mutable struct FixedSizeFIFOQueue{T}
+    const data::Vector{T}
+    head::Int
+    tail::Int
+    size::Int
+    const capacity::Int
+    const items::Set{T}
+
+    function FixedSizeFIFOQueue{T}(capacity::Int) where T
+        capacity > 0 || throw(ArgumentError("Capacity must be positive"))
+        data = Vector{T}(undef, capacity)
+        new{T}(data, 1, 1, 0, capacity, Set{T}())
+    end
+    FixedSizeFIFOQueue(capacity::Int) = FixedSizeFIFOQueue{Any}(capacity)
+end
+
+function Base.push!(queue::FixedSizeFIFOQueue{T}, item::T) where T
+    if queue.size == queue.capacity
+        # Queue is full, overwrite oldest element
+        old_item = queue.data[queue.head]
+        delete!(queue.items, old_item)
+        queue.data[queue.tail] = item
+        push!(queue.items, item)
+        queue.head = mod1(queue.head + 1, queue.capacity)
+        queue.tail = mod1(queue.tail + 1, queue.capacity)
+    else
+        # Queue has space
+        queue.data[queue.tail] = item
+        push!(queue.items, item)
+        queue.tail = mod1(queue.tail + 1, queue.capacity)
+        queue.size += 1
+    end
+    return queue
+end
+
+Base.in(item::T, queue::FixedSizeFIFOQueue{T}) where T = item in queue.items
+
+Base.isempty(queue::FixedSizeFIFOQueue) = queue.size == 0
+
+isfull(queue::FixedSizeFIFOQueue) = queue.size == queue.capacity
+
+Base.length(queue::FixedSizeFIFOQueue) = queue.size
+
+capacity(queue::FixedSizeFIFOQueue) = queue.capacity
+
+function Base.collect(queue::FixedSizeFIFOQueue{T}) where T
+    result = Vector{T}(undef, queue.size)
+    idx = queue.head
+    for i in 1:queue.size
+        result[i] = queue.data[idx]
+        idx = mod1(idx + 1, queue.capacity)
+    end
+    return result
+end
+
+function Base.show(io::IO, queue::FixedSizeFIFOQueue{T}) where T
+    items = collect(queue)
+    print(io, "FixedSizeFIFOQueue{$T}(capacity=$(queue.capacity), items=$items)")
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -371,6 +371,8 @@ const CompletionResolverInfo = CASContainer{Union{Nothing,Tuple{Module,LSPostPro
 # Type aliases for concurrent updates using LWContainer (non-retriable operations)
 const ConfigManager = LWContainer{ConfigManagerData, LWStats}
 
+const HandledHistory = FixedSizeFIFOQueue{Union{Int,String}}
+
 mutable struct ServerState
     const file_cache::FileCache # syntactic analysis cache (synced with `textDocument/didChange`)
     const saved_file_cache::SavedFileCache # syntactic analysis cache (synced with `textDocument/didSave`)
@@ -378,6 +380,7 @@ mutable struct ServerState
     const analysis_manager::AnalysisManager
     const extra_diagnostics::ExtraDiagnostics
     const currently_handled::CurrentlyHandled
+    const handled_history::HandledHistory
     const currently_requested::CurrentlyRequested
     const currently_registered::CurrentlyRegistered
     const config_manager::ConfigManager
@@ -397,6 +400,7 @@ mutable struct ServerState
             #=analysis_manager=# AnalysisManager(#=n_workers=# 1), # TODO multiple workers
             #=extra_diagnostics=# ExtraDiagnostics(ExtraDiagnosticsData()),
             #=currently_handled=# CurrentlyHandled(),
+            #=handled_history=# HandledHistory(128),
             #=currently_requested=# CurrentlyRequested(Base.PersistentDict{String,RequestCaller}()),
             #=currently_registered=# CurrentlyRegistered(Set{Registered}()),
             #=config_manager=# ConfigManager(ConfigManagerData()),

--- a/test/FixedSizeFIFOQueue/test_FixedSizeFIFOQueue.jl
+++ b/test/FixedSizeFIFOQueue/test_FixedSizeFIFOQueue.jl
@@ -1,0 +1,161 @@
+module test_FixedSizeFIFOQueue
+
+using Test
+using JETLS: FixedSizeFIFOQueue, capacity, isfull
+
+struct TestType
+    x::Int
+end
+
+mutable struct MutableTestType
+    x::Int
+    data::Vector{Int}
+end
+
+@testset "FixedSizeFIFOQueue basic operations" begin
+    let q = FixedSizeFIFOQueue{Int}(3)
+        @test isempty(q)
+        @test !isfull(q)
+        @test length(q) == 0
+        @test capacity(q) == 3
+
+        push!(q, 1)
+        @test !isempty(q)
+        @test length(q) == 1
+        @test 1 in q
+        @test !(2 in q)
+
+        push!(q, 2)
+        push!(q, 3)
+        @test isfull(q)
+        @test length(q) == 3
+        @test 1 in q && 2 in q && 3 in q
+    end
+
+    let q = FixedSizeFIFOQueue{Int}(3)
+        push!(q, 1)
+        push!(q, 2)
+        push!(q, 3)
+        push!(q, 4)  # Should overwrite 1
+        @test isfull(q)
+        @test length(q) == 3
+        @test !(1 in q)
+        @test 2 in q && 3 in q && 4 in q
+
+        push!(q, 5)  # Should overwrite 2
+        @test !(2 in q)
+        @test 3 in q && 4 in q && 5 in q
+    end
+end
+
+@testset "FixedSizeFIFOQueue type flexibility" begin
+    let q = FixedSizeFIFOQueue(2)
+        push!(q, "hello")
+        push!(q, 42)
+        @test "hello" in q
+        @test 42 in q
+
+        push!(q, :symbol)
+        @test !("hello" in q)
+        @test 42 in q
+        @test :symbol in q
+    end
+
+    let q = FixedSizeFIFOQueue{TestType}(2)
+        t1 = TestType(1)
+        t2 = TestType(2)
+        t3 = TestType(3)
+
+        push!(q, t1)
+        push!(q, t2)
+        @test t1 in q
+        @test t2 in q
+
+        push!(q, t3)
+        @test !(t1 in q)
+        @test t2 in q
+        @test t3 in q
+    end
+end
+
+@testset "FixedSizeFIFOQueue edge cases" begin
+    let q = FixedSizeFIFOQueue{String}(1)
+        push!(q, "a")
+        @test "a" in q
+        push!(q, "b")
+        @test !("a" in q)
+        @test "b" in q
+    end
+
+    @test_throws ArgumentError FixedSizeFIFOQueue{Int}(0)
+    @test_throws ArgumentError FixedSizeFIFOQueue{Int}(-1)
+end
+
+@testset "FixedSizeFIFOQueue collect and display" begin
+    let q = FixedSizeFIFOQueue{Int}(3)
+        push!(q, 1)
+        push!(q, 2)
+        push!(q, 3)
+
+        items = collect(q)
+        @test items == [1, 2, 3]
+
+        push!(q, 4)  # Overwrites 1
+        items = collect(q)
+        @test items == [2, 3, 4]
+
+        str = string(q)
+        @test occursin("FixedSizeFIFOQueue{Int", str)
+        @test occursin("capacity=3", str)
+        @test occursin("[2, 3, 4]", str)
+    end
+end
+
+@testset "FixedSizeFIFOQueue large capacity" begin
+    let q = FixedSizeFIFOQueue{Union{Int,String}}(1000)
+        for i in 1:500
+            push!(q, i)
+        end
+        for i in 501:1000
+            push!(q, "id-$i")
+        end
+
+        @test isfull(q)
+        @test 1 in q
+        @test 500 in q
+        @test "id-501" in q
+        @test "id-1000" in q
+
+        push!(q, "extra-1")
+        @test !(1 in q)  # First element should be evicted
+        @test 2 in q      # Second element should still be there
+        @test "extra-1" in q
+
+        for i in 1:100
+            push!(q, "new-$i")
+        end
+
+        @test !(2 in q)
+        @test !(100 in q)
+        @test "new-100" in q
+    end
+end
+
+@testset "FixedSizeFIFOQueue garbage collection" begin
+    let q = FixedSizeFIFOQueue{MutableTestType}(2)
+        obj1 = MutableTestType(1, [1,2,3])
+        obj2 = MutableTestType(2, [4,5,6])
+        obj3 = MutableTestType(3, [7,8,9])
+
+        push!(q, obj1)
+        push!(q, obj2)
+        push!(q, obj3)
+
+        @test obj2 in q
+        @test obj3 in q
+        @test !(obj1 in q.data)
+        @test !(obj1 in q.items)
+    end
+end
+
+end # module test_FixedSizeFIFOQueue

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ include("setup.jl")
 end
 
 @testset "AtomicContainers" include("AtomicContainers/test_AtomicContainers.jl")
+@testset "FixedSizeFIFOQueue" include("FixedSizeFIFOQueue/test_FixedSizeFIFOQueue.jl")
 
 @testset "JETLS" begin
     @testset "utils" begin


### PR DESCRIPTION
Implement `FixedSizeFIFOQueue` to keep track of recently handled request IDs and prevent dead IDs from accumulating in `currently_handled` when clients send `CancelRequestNotification` for already processed requests.

The `handled_history` queue maintains the last `128` processed IDs with O(1) membership testing, allowing the server to efficiently ignore duplicate cancellation requests while preventing unbounded memory growth.