### PR TITLE
binding: Fix binding occurrence computation for local variables

### DIFF
--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -357,6 +357,9 @@ function compute_binding_occurrences(
     # The same goes for static parameter bindings
     for (_, idxs) in same_sparam_bindings
         length(idxs) == 1 && continue
+        if !any(i::Int->ctx3.bindings.info[i].kind===:static_parameter, idxs)
+            continue # if this doesn't contain static parameters, ignore it.
+        end
         newoccurrences = union!((occurrences[ctx3.bindings.info[idx]] for idx in idxs)...)
         for idx in idxs
             occurrences[ctx3.bindings.info[idx]] = newoccurrences


### PR DESCRIPTION
Skip merging occurrences for same-named bindings that don't contain static parameters to preserve correct scoping behavior.

E.g.
```julia
let xxx = rand()
    if xxx > 0
        let xxx = xxx
            xxx += 1.0
            println(xxx)
        end
    end
    println(xxx)
end
```