### PR TITLE
Emacs/eglot: use TCP socket for communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,9 @@ Minimal [Emacs](https://www.gnu.org/software/emacs/)
                 "--history-file=no"
                 "--project=/path/to/JETLS.jl"
                 "--threads=auto"
-                "/path/to/JETLS.jl/runserver.jl"))
+                "/path/to/JETLS.jl/runserver.jl"
+                "--socket"
+                :autoport))
 ```
 ### Neovim
 


### PR DESCRIPTION
As far as I can tell, eglot can't use Unix domain sockets, but it can use TCP.

Ref: https://www.gnu.org/software/emacs/manual/html_mono/eglot.html#index-eglot_002dserver_002dprograms

Feel free to close if this isn't a better default