### PR TITLE
use `jetls-hacking`-2 branch for newer JL implementation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,15 +22,15 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 [sources]
 JET = {rev = "master", url = "https://github.com/aviatesk/JET.jl"}
 JSONRPC = {path = "JSONRPC"}
-JuliaLowering = {rev = "jetls-hacking", url = "https://github.com/mlechu/JuliaLowering.jl"}
-JuliaSyntax = {rev = "jetls-hacking", url = "https://github.com/JuliaLang/JuliaSyntax.jl"}
+JuliaLowering = {rev = "jetls-hacking-2", url = "https://github.com/mlechu/JuliaLowering.jl"}
+JuliaSyntax = {rev = "jetls-hacking-2", url = "https://github.com/JuliaLang/JuliaSyntax.jl"}
 LSP = {path = "LSP"}
 
 [compat]
 JET = "0.10.6"
 JSONRPC = "0.1"
 JuliaLowering = "1.0.0"
-JuliaSyntax = "1.0"
+# JuliaSyntax = "2"
 LSP = "0.1"
 Markdown = "1.11.0"
 Pkg = "1.11.0"

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -187,7 +187,7 @@ function global_completions!(items::Dict{String, CompletionItem}, state::ServerS
         edit_start_pos = offset_to_xy(fi, JS.first_byte(prev_token))
         is_macro_invoke = true
     # Case: `@macr│`
-    elseif prev_kind === JS.K"MacroName"
+    elseif prev_kind === JS.K"macro_name"
         edit_start_pos = offset_to_xy(fi, JS.first_byte(prev_tok(prev_token)))
         is_macro_invoke = true
     # Case `│` (empty program)

--- a/src/hover.jl
+++ b/src/hover.jl
@@ -94,7 +94,7 @@ function handle_HoverRequest(server::Server, msg::HoverRequest)
             end
         end
     end
-    if !JS.is_identifier(identifier_node)
+    if !(JS.is_identifier(identifier_node) || JS.kind(identifier_node) === JS.K"macro_name")
         return send(server, HoverResponse(; id = msg.id, result = null))
     end
     identifier = Expr(identifier_node)

--- a/src/testrunner/testrunner.jl
+++ b/src/testrunner/testrunner.jl
@@ -7,15 +7,15 @@ const TESTRUNNER_CLEAR_RESULT_TITLE = "✓ Clear result"
 const TESTRUNNER_INSTALLATION_URL = "https://github.com/aviatesk/JETLS.jl#prerequisites"
 
 const TEST_MACROS = [
-    "@inferred",
-    "@test",
-    "@test_broken",
-    "@test_deprecated",
-    "@test_logs",
-    "@test_nowarn",
-    "@test_skip",
-    "@test_throws",
-    "@test_warn"
+    "inferred",
+    "test",
+    "test_broken",
+    "test_deprecated",
+    "test_logs",
+    "test_nowarn",
+    "test_skip",
+    "test_throws",
+    "test_warn"
 ]
 
 function summary_testrunner_result(result::TestRunnerResult)
@@ -115,10 +115,13 @@ function find_executable_testsets(st0_top::SyntaxTree0)
             return TraversalNoRecurse()
         elseif JS.kind(st0) === JS.K"macrocall" && JS.numchildren(st0) ≥ 2
             macroname = st0[1]
-            if JS.kind(macroname) === JS.K"MacroName" && macroname.name_val == "@testset"
-                testsetname = st0[2]
-                if JS.kind(testsetname) === JS.K"string"
-                    push!(testsets, st0)
+            if JS.kind(macroname) === JS.K"macro_name" && JS.numchildren(macroname) ≥ 1
+                macroname_s = macroname[1]
+                if hasproperty(macroname_s, :name_val) && macroname_s.name_val == "testset"
+                    testsetname = st0[2]
+                    if JS.kind(testsetname) === JS.K"string"
+                        push!(testsets, st0)
+                    end
                 end
             end
         end
@@ -263,19 +266,22 @@ function testrunner_testcase_code_actions!(
             return TraversalNoRecurse()
         elseif JS.kind(st0) === JS.K"macrocall" && JS.numchildren(st0) ≥ 1
             macroname = st0[1]
-            if JS.kind(macroname) === JS.K"MacroName" && macroname.name_val in TEST_MACROS
-                tcr = jsobj_to_range(st0, fi; adjust_last=1) # +1 to support cases like `@test ...│`
-                overlap(action_range, tcr) || return nothing
-                tcl = JS.source_line(st0)
-                tct = "`" * JS.sourcetext(st0) * "`"
-                run_arguments = Any[uri, tcl, tct]
-                title = "$TESTRUNNER_RUN_TITLE $tct"
-                push!(code_actions, CodeAction(;
-                    title,
-                    command = Command(;
+            if JS.kind(macroname) === JS.K"macro_name" && JS.numchildren(macroname) ≥ 1
+                macroname_s = macroname[1]
+                if hasproperty(macroname_s, :name_val) && macroname_s.name_val in TEST_MACROS
+                    tcr = jsobj_to_range(st0, fi; adjust_last=1) # +1 to support cases like `@test ...│`
+                    overlap(action_range, tcr) || return nothing
+                    tcl = JS.source_line(st0)
+                    tct = "`" * JS.sourcetext(st0) * "`"
+                    run_arguments = Any[uri, tcl, tct]
+                    title = "$TESTRUNNER_RUN_TITLE $tct"
+                    push!(code_actions, CodeAction(;
                         title,
-                        command = COMMAND_TESTRUNNER_RUN_TESTCASE,
-                        arguments = run_arguments)))
+                        command = Command(;
+                            title,
+                            command = COMMAND_TESTRUNNER_RUN_TESTCASE,
+                            arguments = run_arguments)))
+                end
             end
         end
     end

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -442,7 +442,7 @@ end
 
 noparen_macrocall(st0::JL.SyntaxTree) =
     JS.kind(st0) === JS.K"macrocall" &&
-    !(JS.numchildren(st0) ≥ 2 && JS.kind(st0[1]) === JS.K"StringMacroName") &&
+    !(JS.numchildren(st0) ≥ 2 && JS.kind(st0[1]) === JS.K"StrMacroName") &&
     !JS.has_flags(st0, JS.PARENS_FLAG)
 
 """
@@ -481,6 +481,8 @@ function select_target_node(node0::Union{JS.SyntaxNode,JL.SyntaxTree}, offset::I
         if (JS.kind(basᵢ) === JS.K"." &&
             basᵢ[1] !== target) # e.g. don't allow jumps to `tmeet` from `Base.Compi│ler.tmeet`
             target = basᵢ
+        elseif JS.kind(basᵢ) === JS.K"macro_name"
+            target = basᵢ # treat the entire macro name as an identifier
         else
             return target
         end

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -179,7 +179,7 @@ function _select_target_binding(st0_top::JL.SyntaxTree, offset::Int, mod::Module
                                 caller::AbstractString = "_select_target_binding")
     st0 = @something greatest_local(st0_top, offset) return nothing # nothing we can lower
 
-    bas = byte_ancestors(st0′::JL.SyntaxTree->JS.kind(st0′)===JS.K"MacroName", st0, offset)
+    bas = byte_ancestors(st0′::JL.SyntaxTree->JS.kind(st0′)===JS.K"macro_name", st0, offset)
     if !isempty(bas)
         # Our definition generally won't be local, and lowering would destroy it
         # anyway.  Defer to global logic.

--- a/test/test_lowering_diagnostics.jl
+++ b/test/test_lowering_diagnostics.jl
@@ -444,7 +444,7 @@ end
         @test diagnostic.source == JETLS.LOWERING_DIAGNOSTIC_SOURCE
         @test diagnostic.message == "Macro name `@notexisting` not found"
         @test diagnostic.range.start.line == 0
-        @test diagnostic.range.start.character == sizeof("x = @")
+        @test diagnostic.range.start.character == sizeof("x = ")
         @test diagnostic.range.var"end".line == 0
         @test diagnostic.range.var"end".character == sizeof("x = @notexisting")
     end

--- a/test/utils/test_ast.jl
+++ b/test/utils/test_ast.jl
@@ -481,9 +481,9 @@ end
             """
             fi, node = get_target_node(T, code)
             @test node !== nothing
-            @test JS.kind(node) === JS.K"MacroName"
+            @test JS.kind(node) === JS.K"macro_name"
             let range = JETLS.jsobj_to_range(node, fi)
-                @test range.start.line == 0 && range.start.character == 1 # not include the @-mark
+                @test range.start.line == 0 && range.start.character == 0 # include @-mark
                 @test range.var"end".line == 0 && range.var"end".character == sizeof("@inline")
             end
         end
@@ -494,7 +494,7 @@ end
             fi, node = get_target_node(T, code)
             @test node !== nothing
             let range = JETLS.jsobj_to_range(node, fi)
-                @test range.start.line == 0 && range.start.character == 0
+                @test range.start.line == 0 && range.start.character == 0 # include `Base.`
                 @test range.var"end".line == 0 && range.var"end".character == sizeof("Base.@inline")
             end
         end


### PR DESCRIPTION
This commit utilizes a new branch `jetls-hacking-2` for JETLS. ~~This branch is basically the latest c42f/JuliaLowering.jl#main - https://github.com/c42f/JuliaLowering.jl/pull/87~~. Since the current JETLS implementation does not run inference on JL-generated code, we could simply include that commit straightforwardly.

`jetls-hacking-2` is now the very latest c42f/JuliaLowering.jl#main + https://github.com/c42f/JuliaLowering.jl/pull/89.

- closes #275
