### PR TITLE
formatting: add support for JuliaFormatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,39 @@
                 }
               }
             },
+            "formatter": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "Runic",
+                    "JuliaFormatter"
+                  ],
+                  "default": "Runic",
+                  "description": "Preset formatter to use. 'Runic' (default) or 'JuliaFormatter'."
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "custom": {
+                      "type": "object",
+                      "properties": {
+                        "executable": {
+                          "type": "string",
+                          "description": "Path to custom formatter executable for document formatting. The formatter should read Julia code from stdin and output formatted code to stdout. Optional."
+                        },
+                        "executable_range": {
+                          "type": "string",
+                          "description": "Path to custom formatter executable for range formatting. Should accept --lines=START:END argument. Optional."
+                        }
+                      }
+                    }
+                  }
+                }
+              ],
+              "default": "Runic",
+              "markdownDescription": "Formatter configuration. Can be a preset name ('Runic' or 'JuliaFormatter') or a custom formatter object. See [Formatting](https://github.com/aviatesk/JETLS.jl#formatting) for details."
+            },
             "testrunner": {
               "type": "object",
               "properties": {
@@ -104,21 +137,6 @@
                   "type": "string",
                   "default": "",
                   "description": "Path to the TestRunner.jl executable. If empty, uses 'testrunner' from PATH."
-                }
-              }
-            },
-            "formatter": {
-              "type": "object",
-              "properties": {
-                "runic": {
-                  "type": "object",
-                  "properties": {
-                    "executable": {
-                      "type": "string",
-                      "default": "",
-                      "description": "Path to the Runic formatter executable. If empty, uses 'runic' from PATH."
-                    }
-                  }
                 }
               }
             }

--- a/src/formatting.jl
+++ b/src/formatting.jl
@@ -3,9 +3,11 @@ const FORMATTING_REGISTRATION_METHOD = "textDocument/formatting"
 const RANGE_FORMATTING_REGISTRATION_ID = "jetls-rangeFormatting"
 const RANGE_FORMATTING_REGISTRATION_METHOD = "textDocument/rangeFormatting"
 const RUNIC_INSTALLATION_URL = "https://github.com/fredrikekre/Runic.jl#installation"
+const JULIAFORMATTER_INSTALLATION_URL = "https://github.com/domluna/JuliaFormatter.jl#installation"
 
 struct FormattingProgressCaller <: RequestCaller
     uri::URI
+    options::FormattingOptions
     msg_id::Union{String,Int}
     token::ProgressToken
 end
@@ -13,6 +15,7 @@ end
 struct RangeFormattingProgressCaller <: RequestCaller
     uri::URI
     range::Range
+    options::FormattingOptions
     msg_id::Union{String,Int}
     token::ProgressToken
 end
@@ -60,18 +63,19 @@ document_range(fi::FileInfo) = jsobj_to_range(fi.parsed_stream, fi)
 
 function handle_DocumentFormattingRequest(server::Server, msg::DocumentFormattingRequest)
     uri = msg.params.textDocument.uri
+    options = msg.params.options
 
     workDoneToken = msg.params.workDoneToken
     if workDoneToken !== nothing
-        do_format_with_progress(server, uri, msg.id, workDoneToken)
+        do_format_with_progress(server, uri, options, msg.id, workDoneToken)
     elseif supports(server, :window, :workDoneProgress)
         id = String(gensym(:WorkDoneProgressCreateRequest_formatting))
         token = String(gensym(:FormattingProgress))
-        addrequest!(server, id=>FormattingProgressCaller(uri, msg.id, token))
+        addrequest!(server, id=>FormattingProgressCaller(uri, options, msg.id, token))
         params = WorkDoneProgressCreateParams(; token)
         send(server, WorkDoneProgressCreateRequest(; id, params))
     else
-        do_format(server, uri, msg.id)
+        do_format(server, uri, options, msg.id)
     end
 
     return nothing
@@ -83,18 +87,19 @@ function handle_formatting_progress_response(
     if handle_response_error(server, msg, "create work done progress")
         return
     end
-    (; uri, msg_id, token) = request_caller
-    do_format_with_progress(server, uri, msg_id, token)
+    (; uri, options, msg_id, token) = request_caller
+    do_format_with_progress(server, uri, options, msg_id, token)
 end
 
 function do_format_with_progress(
-        server::Server, uri::URI, msg_id::Union{String,Int}, token::ProgressToken
+        server::Server, uri::URI, options::FormattingOptions,
+        msg_id::Union{String,Int}, token::ProgressToken
     )
     send_progress(server, token,
         WorkDoneProgressBegin(; title = "Formatting document"))
     completed = false
     try
-        do_format(server, uri, msg_id)
+        do_format(server, uri, options, msg_id)
         completed = true
     finally
         send_progress(server, token,
@@ -103,8 +108,11 @@ function do_format_with_progress(
     end
 end
 
-function do_format(server::Server, uri::URI, msg_id::Union{String,Int})
-    result = format_result(server.state, uri)
+function do_format(
+        server::Server, uri::URI, options::FormattingOptions,
+        msg_id::Union{String,Int}
+    )
+    result = format_result(server.state, uri, options)
     if result isa ResponseError
         return send(server, DocumentFormattingResponse(; id = msg_id, result = nothing, error = result))
     else
@@ -112,20 +120,66 @@ function do_format(server::Server, uri::URI, msg_id::Union{String,Int})
     end
 end
 
-function format_result(state::ServerState, uri::URI)
-    fi = @something get_file_info(state, uri) return file_cache_error(uri)
-    setting_path = (:formatter, :runic, :executable)
-    executable = get_config(state.config_manager, setting_path...)
-    default_executable = get_default_config(setting_path...)
-    additional_msg = if executable == default_executable
-        install_instruction_message(executable, RUNIC_INSTALLATION_URL)
-    else
-        check_settings_message(setting_path...)
+function get_formatter_executable(formatter::FormatterConfig, for_range::Bool)
+    if formatter isa String
+        # Preset formatter: "Runic" or "JuliaFormatter"
+        executable = default_executable(formatter)
+        executable === nothing &&
+            return request_failed_error(
+                "Unknown formatter preset \"$formatter\". " *
+                "Valid presets are: \"Runic\", \"JuliaFormatter\". " *
+                "For custom formatters, use [formatter.custom] configuration.")
+
+        if for_range && formatter == "JuliaFormatter"
+            return request_failed_error(
+                "JuliaFormatter does not support range formatting. " *
+                "Please use document formatting instead or configure a custom " *
+                "formatter with `executable_range`.")
+        else
+            additional_msg = if formatter == "JuliaFormatter"
+                install_instruction_message(executable, JULIAFORMATTER_INSTALLATION_URL)
+            elseif formatter == "Runic"
+                install_instruction_message(executable, RUNIC_INSTALLATION_URL)
+            else
+                check_settings_message(:formatter)
+            end
+
+            exe_path = @something Sys.which(executable) return request_failed_error(
+                app_notfound_message(executable) * additional_msg)
+            return exe_path
+        end
+    else # Custom formatter
+        formatter = formatter::CustomFormatterConfig
+        if for_range
+            executable = formatter.executable_range
+            if executable === nothing
+                return request_failed_error(
+                    "Custom formatter does not specify `executable_range`. " *
+                    check_settings_message(:formatter))
+            end
+        else
+            executable = formatter.executable
+            if executable === nothing
+                return request_failed_error(
+                    "Custom formatter does not specify `executable`. " *
+                    check_settings_message(:formatter))
+            end
+        end
+        return executable
     end
-    runic = @something Sys.which(executable) return request_failed_error(
-        app_notfound_message(executable) * additional_msg)
-    newText = @something format_runic(runic, document_text(fi)) begin
-        return request_failed_error("Runic formatter returned an error. See server logs for details.")
+end
+
+function format_result(state::ServerState, uri::URI, options::FormattingOptions)
+    fi = @something get_file_info(state, uri) return file_cache_error(uri)
+
+    formatter = get_config(state.config_manager, :formatter)
+    exe = get_formatter_executable(formatter, false)
+    if exe isa ResponseError
+        return exe
+    end
+
+    newText = @something format_code(exe, document_text(fi), nothing, options, formatter) begin
+        return request_failed_error("Formatter returned an error. See server logs for details.")
     end
     return TextEdit[TextEdit(; range = document_range(fi), newText)]
 end
@@ -133,18 +187,19 @@ end
 function handle_DocumentRangeFormattingRequest(server::Server, msg::DocumentRangeFormattingRequest)
     uri = msg.params.textDocument.uri
     range = msg.params.range
+    options = msg.params.options
 
     workDoneToken = msg.params.workDoneToken
     if workDoneToken !== nothing
-        do_range_format_with_progress(server, uri, range, msg.id, workDoneToken)
+        do_range_format_with_progress(server, uri, range, options, msg.id, workDoneToken)
     elseif supports(server, :window, :workDoneProgress)
         id = String(gensym(:WorkDoneProgressCreateRequest_rangeFormatting))
         token = String(gensym(:RangeFormattingProgress))
-        addrequest!(server, id => RangeFormattingProgressCaller(uri, range, msg.id, token))
+        addrequest!(server, id => RangeFormattingProgressCaller(uri, range, options, msg.id, token))
         params = WorkDoneProgressCreateParams(; token)
         send(server, WorkDoneProgressCreateRequest(; id, params))
     else
-        do_range_format(server, uri, range, msg.id)
+        do_range_format(server, uri, range, options, msg.id)
     end
 
     return nothing
@@ -156,18 +211,19 @@ function handle_range_formatting_progress_response(
     if handle_response_error(server, msg, "create work done progress")
         return
     end
-    (; uri, range, msg_id, token) = request_caller
-    do_range_format_with_progress(server, uri, range, msg_id, token)
+    (; uri, range, options, msg_id, token) = request_caller
+    do_range_format_with_progress(server, uri, range, options, msg_id, token)
 end
 
 function do_range_format_with_progress(
-        server::Server, uri::URI, range::Range, msg_id::Union{String,Int}, token::ProgressToken
+        server::Server, uri::URI, range::Range, options::FormattingOptions,
+        msg_id::Union{String,Int}, token::ProgressToken
     )
     send_progress(server, token,
         WorkDoneProgressBegin(; title = "Formatting document range"))
     completed = false
     try
-        do_range_format(server, uri, range, msg_id)
+        do_range_format(server, uri, range, options, msg_id)
         completed = true
     finally
         send_progress(server, token,
@@ -176,8 +232,11 @@ function do_range_format_with_progress(
     end
 end
 
-function do_range_format(server::Server, uri::URI, range::Range, msg_id::Union{String,Int})
-    result = range_format_result(server.state, uri, range)
+function do_range_format(
+        server::Server, uri::URI, range::Range, options::FormattingOptions,
+        msg_id::Union{String,Int}
+    )
+    result = range_format_result(server.state, uri, range, options)
     if result isa ResponseError
         return send(server, DocumentRangeFormattingResponse(; id = msg_id, result = nothing, error = result))
     else
@@ -185,34 +244,66 @@ function do_range_format(server::Server, uri::URI, range::Range, msg_id::Union{S
     end
 end
 
-function range_format_result(state::ServerState, uri::URI, range::Range)
+function range_format_result(
+        state::ServerState, uri::URI, range::Range, options::FormattingOptions
+    )
     fi = @something get_file_info(state, uri) return file_cache_error(uri)
-    setting_path = (:formatter, :runic, :executable)
-    executable = get_config(state.config_manager, setting_path...)
-    default_executable = get_default_config(setting_path...)
-    additional_msg = if executable == default_executable
-        install_instruction_message(executable, RUNIC_INSTALLATION_URL)
-    else
-        check_settings_message(setting_path...)
+
+    formatter = get_config(state.config_manager, :formatter)
+    exe = get_formatter_executable(formatter, true)
+    if exe isa ResponseError
+        return exe
     end
-    runic = @something Sys.which(executable) return request_failed_error(
-        app_notfound_message(executable) * additional_msg)
+
     startline = Int(range.start.line + 1)
     endline = Int(range.var"end".line + 1)
     lines = "$startline:$endline"
-    newText = @something format_runic(runic, document_text(fi), lines) begin
-        return request_failed_error("Runic formatter returned an error. See server logs for details.")
+    newText = @something format_code(exe, document_text(fi), lines, options, formatter) begin
+        return request_failed_error("Formatter returned an error. See server logs for details.")
     end
     edit = TextEdit(; range = document_range(fi), newText)
     return TextEdit[edit]
 end
 
-function format_runic(exe::String, text::AbstractString, lines::Union{Nothing,AbstractString}=nothing)
-    if isnothing(lines)
-        proc = open(`$exe`; read = true, write = true)
-    else
-        proc = open(`$exe --lines=$lines`; read = true, write = true)
+function format_code(
+        exe::String, text::AbstractString, lines::Union{Nothing,AbstractString},
+        options::FormattingOptions, formatter::FormatterConfig
+    )
+    cmd = if formatter isa String
+        # Preset formatter: "Runic" or "JuliaFormatter"
+        if formatter == "Runic"
+            if isnothing(lines)
+                `$exe`
+            else
+                `$exe --lines=$lines`
+            end
+        elseif formatter == "JuliaFormatter"
+            # JuliaFormatter doesn't support range formatting
+            # (should not reach here due to earlier validation)
+            if isnothing(lines)
+                tabSize = options.tabSize
+                if tabSize !== nothing
+                    `$exe --indent=$(Int(tabSize)) --prioritize-config-file`
+                else
+                    `$exe`
+                end
+            else
+                return nothing
+            end
+        else # Unknown preset (should not reach here)
+            return nothing
+        end
+    else # Custom formatter
+        formatter = formatter::CustomFormatterConfig
+        # Assume custom formatters use the same interface as Runic
+        if isnothing(lines)
+            `$exe`
+        else
+            `$exe --lines=$lines`
+        end
     end
+
+    proc = open(cmd; read = true, write = true)
     write(proc, text)
     close(proc.in)
     wait(proc)

--- a/src/types.jl
+++ b/src/types.jl
@@ -334,18 +334,28 @@ end
 is_static_setting(::Type{TestRunnerConfig}, ::Symbol) = false
 default_config(::Type{TestRunnerConfig}) = TestRunnerConfig(@static Sys.iswindows() ? "testrunner.bat" : "testrunner")
 
-@option struct RunicConfig <: ConfigSection
+@option "custom" struct CustomFormatterConfig
     executable::Maybe{String}
+    executable_range::Maybe{String}
 end
 
-is_static_setting(::Type{RunicConfig}, ::Symbol) = false
-default_config(::Type{RunicConfig}) = RunicConfig(@static Sys.iswindows() ? "runic.bat" : "runic")
+const FormatterConfig = Union{String,CustomFormatterConfig}
 
-@option struct FormatterConfig <: ConfigSection
-    runic::Maybe{RunicConfig}
+is_static_setting(::Type{FormatterConfig}) = false
+is_static_setting(::Type{FormatterConfig}, ::Symbol) = false
+function default_config(::Type{FormatterConfig})
+    return "Runic"
 end
 
-default_config(::Type{FormatterConfig}) = FormatterConfig(default_config(RunicConfig))
+function default_executable(formatter::String)
+    if formatter == "Runic"
+        return @static Sys.iswindows() ? "runic.bat" : "runic"
+    elseif formatter == "JuliaFormatter"
+        return @static Sys.iswindows() ? "jlfmt.bat" : "jlfmt"
+    else
+        return nothing
+    end
+end
 
 # configuration item for test purpose
 @option struct InternalConfig <: ConfigSection


### PR DESCRIPTION
This commit extends the formatting system to support multiple formatter backends beyond Runic.jl. Users can now choose between preset formatters (`"runic"` or `"jlfmt"`) or configure custom formatters with their own executables.

The formatter configuration has been redesigned from a nested structure (`formatter.runic.executable`) to a simpler top-level `formatter` setting that accepts either:
- A preset name string: `"runic"` or `"jlfmt"`
- A custom formatter defined under `formatter.custom` with `executable` and optional `executable_range` fields

Due to limitations in Configurations.jl, custom formatters must be specified in the `[formatter.custom]` section rather than directly as the `formatter` value. Custom formatters can specify separate executables for document and range formatting operations.

Additionally, `FormattingOptions` from LSP requests are now propagated through the formatting pipeline, enabling formatters to respect client-provided settings like tab size. For JuliaFormatter, the tab size option is passed via the `--indent` flag. This client-wise setting will be overwritten by .JuliaFormatter.toml configuration if it's found since we are using the `--prioritize-config-file` option.

Requires https://github.com/domluna/JuliaFormatter.jl/pull/947 to be merged.