### PR TITLE
config: support `workspace/configuration`

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,50 @@
           "type": "number",
           "default": 0,
           "description": "Port number for socket communication (0 = auto-assign). Only used when 'socket' communication channel is used."
+        },
+        "jetls-client.jetlsSettings": {
+          "scope": "resource",
+          "type": "object",
+          "default": {},
+          "markdownDescription": "JETLS server configuration settings. See [JETLS Configuration](https://github.com/aviatesk/JETLS.jl#configuration) for available options.",
+          "properties": {
+            "full_analysis": {
+              "type": "object",
+              "properties": {
+                "debounce": {
+                  "type": "number",
+                  "default": 1.0,
+                  "minimum": 0.0,
+                  "description": "Debounce time in seconds before triggering full analysis after a document change."
+                }
+              }
+            },
+            "testrunner": {
+              "type": "object",
+              "properties": {
+                "executable": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Path to the TestRunner.jl executable. If empty, uses 'testrunner' from PATH."
+                }
+              }
+            },
+            "formatter": {
+              "type": "object",
+              "properties": {
+                "runic": {
+                  "type": "object",
+                  "properties": {
+                    "executable": {
+                      "type": "string",
+                      "default": "",
+                      "description": "Path to the Runic formatter executable. If empty, uses 'runic' from PATH."
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -88,6 +132,7 @@
     "watch": "node esbuild.js --watch",
     "tsc": "tsc --noEmit",
     "lint": "eslint",
+    "check": "npm run tsc && npm run lint",
     "vscode:prepublish": "npm run tsc && npm run lint && npm run build"
   },
   "dependencies": {

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -66,6 +66,7 @@ include("utils/lsp.jl")
 include("utils/server.jl")
 
 include("config.jl")
+include("workspace-configuration.jl")
 
 include("analysis/Interpreter.jl")
 using .Interpreter
@@ -308,6 +309,8 @@ function (dispatcher::ResponseMessageDispatcher)(server::Server, msg::Dict{Symbo
         handle_formatting_progress_response(server, msg, request_caller)
     elseif request_caller isa RangeFormattingProgressCaller
         handle_range_formatting_progress_response(server, msg, request_caller)
+    elseif request_caller isa WorkspaceConfigurationCaller
+        handle_workspace_configuration_response(server, msg, request_caller)
     elseif request_caller isa RegisterCapabilityRequestCaller || request_caller isa UnregisterCapabilityRequestCaller
         # nothing to do
     else
@@ -378,6 +381,8 @@ end
 function handle_notification_message(server::Server, @nospecialize msg)
     if msg isa DidChangeWatchedFilesNotification
         handle_DidChangeWatchedFilesNotification(server, msg)
+    elseif msg isa DidChangeConfigurationNotification
+        handle_DidChangeConfigurationNotification(server, msg)
     elseif JETLS_DEV_MODE
         if isdefined(msg, :method)
             _id = getfield(msg, :method)

--- a/src/did-change-watched-files.jl
+++ b/src/did-change-watched-files.jl
@@ -19,69 +19,29 @@ end
 #     method = DID_CHANGE_WATCHED_FILES_REGISTRATION_METHOD))
 # register(currently_running, did_change_watched_files_registration())
 
+config_file_created_msg(path::AbstractString) = "JETLS configuration file loaded: $path"
+config_file_deleted_msg(path::AbstractString) = "JETLS configuration file removed: $path"
+
 function handle_config_file_change!(
         server::Server, changed_path::AbstractString, change_type::FileChangeType.Ty
     )
-    changed_settings = String[]
-    changed_static_settings = String[]
+    tracker = ConfigChangeTracker()
 
     if change_type == FileChangeType.Created
-        load_config!(server, changed_path) do old_val, new_val, path
-            if is_static_setting(path...)
-                push!(changed_static_settings, join(path, "."))
-            else
-                push!(changed_settings, join(path, "."))
-            end
-            new_val
-        end
-        kind = "Created"
+        load_config!(tracker, server, changed_path)
+        kind = "created"
+        show_info_message(server, config_file_created_msg(changed_path))
     elseif change_type == FileChangeType.Changed
-        load_config!(server, changed_path; reload=true) do old_val, new_val, path
-            if is_static_setting(path...)
-                push!(changed_static_settings, join(path, "."))
-            else
-                push!(changed_settings, join(path, "."))
-            end
-            new_val
-        end
-        kind = "Updated"
+        load_config!(tracker, server, changed_path; reload=true)
+        kind = "updated"
     elseif change_type == FileChangeType.Deleted
-        delete_config!(server.state.config_manager, changed_path) do old_val, new_val, path
-            if is_static_setting(path...)
-                push!(changed_static_settings, join(path, "."))
-            else
-                push!(changed_settings, join(path, "."))
-            end
-            new_val
-        end
-        kind = "Deleted"
+        delete_config!(tracker, server.state.config_manager, changed_path)
+        kind = "deleted"
+        show_info_message(server, config_file_deleted_msg(changed_path))
     else error("Unknown FileChangeType") end
 
-    if !isempty(changed_static_settings) && !isempty(changed_settings)
-        settings_str = join(string.('`', changed_settings, '`'), ", ")
-        static_str = join(string.('`', changed_static_settings, '`'), ", ")
-        show_warning_message(server, """
-            $kind config file: $changed_path
-            Changes applied: $settings_str
-            Static settings affected: $static_str (requires restart to apply)
-            """)
-    elseif !isempty(changed_static_settings)
-        static_str = join(string.('`', changed_static_settings, '`'), ", ")
-        show_warning_message(server, """
-            $kind config file: $changed_path
-            Static settings affected: $static_str (requires restart to apply)
-            """)
-    elseif !isempty(changed_settings)
-        settings_str = join(string.('`', changed_settings, '`'), ", ")
-        show_info_message(server, """
-            $kind config file: $changed_path
-            Changes applied: $settings_str
-            """)
-    elseif kind != "Updated"
-        show_info_message(server, """
-            $kind config file: $changed_path
-            """)
-    end
+    source = "[.JETLSConfig.toml] $(dirname(changed_path)) ($kind)"
+    notify_config_changes(server, tracker, source)
 end
 
 function handle_DidChangeWatchedFilesNotification(server::Server, msg::DidChangeWatchedFilesNotification)

--- a/src/lifecycle.jl
+++ b/src/lifecycle.jl
@@ -57,6 +57,7 @@ function handle_InitializeRequest(server::Server, msg::InitializeRequest)
             load_config!(Returns(nothing), server, config_path)
         end
     end
+
     fix_static_settings!(state.config_manager)
 
     start_analysis_workers!(server)
@@ -392,7 +393,16 @@ function handle_InitializedNotification(server::Server)
         # so it must be registered dynamically
     end
 
+    if supports(server, :workspace, :didChangeConfiguration, :dynamicRegistration)
+        push!(registrations, did_change_configuration_registration())
+        if JETLS_DEV_MODE
+            @info "Dynamically registering 'workspace/didChangeConfiguration' upon `InitializedNotification`"
+        end
+    end
+
     register(server, registrations)
+
+    load_lsp_config!(server, "[LSP] workspace/configuration")
 
     JETLS_DEV_MODE && show_setup_info("Initialized JETLS with the following setup:")
 end

--- a/src/workspace-configuration.jl
+++ b/src/workspace-configuration.jl
@@ -1,0 +1,111 @@
+struct LoadLSPConfigHandler
+    server::Server
+    source::String
+end
+
+function (handler::LoadLSPConfigHandler)(server::Server, @nospecialize(config_value))
+    tracker = ConfigChangeTracker()
+    if config_value === nothing
+        delete_lsp_config!(tracker, server)
+    else
+        store_lsp_config!(tracker, server, config_value, handler.source)
+    end
+    notify_config_changes(handler.server, tracker, handler.source)
+end
+
+struct WorkspaceConfigurationCaller <: RequestCaller
+    handler::LoadLSPConfigHandler
+end
+
+function request_workspace_configuration(
+        handler::LoadLSPConfigHandler,
+        server::Server,
+        section::Union{Nothing,String}=nothing
+    )
+    id = String(gensym(:WorkspaceConfigurationRequest))
+    addrequest!(server, id=>WorkspaceConfigurationCaller(handler))
+    return send(server, ConfigurationRequest(;
+        id,
+        params = ConfigurationParams(;
+            items = ConfigurationItem[ConfigurationItem(; section)])))
+end
+
+function handle_workspace_configuration_response(
+        server::Server, msg::Dict{Symbol,Any}, caller::WorkspaceConfigurationCaller
+    )
+    if handle_response_error(server, msg, "workspace/configuration")
+    elseif haskey(msg, :result)
+        result = msg[:result]
+        if result isa Vector && !isempty(result)
+            config_value = first(result)
+            caller.handler(server, config_value)
+        elseif JETLS_DEV_MODE
+            @info "workspace/configuration returned empty result"
+        end
+    else
+        show_error_message(server, "Unexpected response from workspace/configuration request")
+    end
+end
+
+function load_lsp_config!(server::Server, source::AbstractString)
+    supports(server, :workspace, :configuration) || return false
+    handler = LoadLSPConfigHandler(server, source)
+    request_workspace_configuration(handler, server, nothing)
+    return true
+end
+
+unmatched_keys_in_lsp_config_msg(unmatched_keys) =
+    unmatched_keys_msg("LSP configuration contains unknown keys:", unmatched_keys)
+
+function store_lsp_config!(tracker::ConfigChangeTracker, server::Server, @nospecialize(config_value), source::AbstractString)
+    if config_value isa Dict{String,Any}
+        config_dict = config_value
+    else
+        show_error_message(server, "Unexpected config data was passed from $source, deleting LSP configuration")
+        return delete_lsp_config!(tracker, server)
+    end
+    store!(server.state.config_manager) do old_data::ConfigManagerData
+        new_config = try
+            Configurations.from_dict(JETLSConfig, config_dict)
+        catch e
+            if e isa Configurations.InvalidKeyError
+                unknown_keys = collect_unmatched_keys(to_config_dict(config_dict))
+                if !isempty(unknown_keys)
+                    show_error_message(server, unmatched_keys_in_lsp_config_msg(unknown_keys))
+                    return old_data, nothing
+                end
+            end
+            show_error_message(server, "Failed to parse LSP configuration: $(e)")
+            return old_data, nothing
+        end
+
+        new_watched_files = copy(old_data.watched_files)
+        new_watched_files["__LSP_CONFIG__"] = new_config
+        new_current_settings = get_current_settings(new_watched_files)
+        on_difference(tracker, old_data.current_settings, new_current_settings)
+        new_data = ConfigManagerData(new_current_settings, old_data.static_settings, new_watched_files)
+        return new_data, nothing
+    end
+end
+
+function delete_lsp_config!(tracker::ConfigChangeTracker, server::Server)
+    delete_config!(tracker, server.state.config_manager, "__LSP_CONFIG__")
+end
+
+function handle_DidChangeConfigurationNotification(server::Server, msg::DidChangeConfigurationNotification)
+    source = "[LSP] workspace/didChangeConfiguration"
+    if !load_lsp_config!(server, source)
+        # If the client doesn't support the pull model configuration,
+        # use `msg.params.settings` as the fallback
+        tracker = ConfigChangeTracker()
+        store_lsp_config!(tracker, server, msg.params.settings, source)
+        notify_config_changes(server, tracker, source)
+    end
+end
+
+function did_change_configuration_registration()
+    return Registration(;
+        id = String(gensym(:DidChangeConfigurationRegistration)),
+        method = "workspace/didChangeConfiguration",
+        registerOptions = nothing)
+end


### PR DESCRIPTION
Implement LSP `workspace/configuration` protocol to allow clients to provide configuration to JETLS via LSP, in addition to .JETLSConfig.toml files.

Configuration priority (highest to lowest):
1. Project root .JETLSConfig.toml
2. LSP `workspace/configuration`
3. Built-in defaults

Server side implementation details:
- Server requests configuration during initialization
- Clients respond with JETLS-specific settings
- `workspace/didChangeConfiguration` notifications allow to retrive changed configuraions
- Common infrastructure for tracking and notifying config changes used by both did-change-watched-files.jl and workspace-configuration.jl

Alos this commit includes some client changes:
- extension.ts: Register `workspace/configuration` request handler that maps null section to `jetls-client.jetlsSettings`
- package.json: Define `jetls-client.jetlsSettings` schema with nested configuration for full_analysis, testrunner, and formatter settings

Also updated README to include comprehensive Configuration section documenting both .JETLSConfig.toml and LSP configuration methods, priority rules, and client implementation guidance.