### PR TITLE
document highlight: support global bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ the list itself is subject to change.
   - [ ] Global binding definition
   - [x] Local binding definition
   - [ ] Type-aware method definition
-- Document Highlight
-  - [x] Highlight local binding
 - Hover
   - [x] Method documentation
   - [x] Global binding documentation
@@ -75,6 +73,10 @@ the list itself is subject to change.
   - [x] [Runic](https://github.com/fredrikekre/Runic.jl) integration
   - [x] [JuliaFormatter](https://github.com/domluna/JuliaFormatter.jl) integration
   - [x] Make formatting backend configurable
+- Document Highlight
+  - [x] Local binding
+  - [/] Global binding (dot-accessed binding not supported yet)
+  - [ ] Field name
 - Rename
   - [x] Local binding
   - [ ] Global binding

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -448,6 +448,16 @@ function compute_binding_occurrences!(
                     if !isnothing(ismacro)
                         ismacro[] |= startswith(binfo.name, "@")
                     end
+                    start_idx = 2
+                end
+            end
+        elseif k === JS.K"method_defs" || k === JS.K"constdecl"
+            if nc ≥ 1
+                local global_binding = st[1]
+                if JS.kind(global_binding) === JS.K"BindingId"
+                    binfo = JL.lookup_binding(ctx3, global_binding)
+                    record_occurrence!(occurrences, :def, global_binding, binfo)
+                    start_idx = 2
                 end
             end
         elseif infunc && k === JS.K"block" && nc ≥ 1


### PR DESCRIPTION
Since we haven't implemented syntax tree caching yet, this commit performs lowering on the entire file for each document highlighting request (although this duplicates work with diagnostics).

Global rename could also be supported with this approach within a single file, but since global bindings can span multiple files, we should at least look at all editable contexts within the current analysis context. It would be better to work on this after integration with Revise progresses.