### PR TITLE
use byte offset for UTF-8 position encoding instead of character count 

### DIFF
--- a/src/utils/string.jl
+++ b/src/utils/string.jl
@@ -34,7 +34,7 @@ function pos_to_utf8_offset(s::String, ch::UInt, encoding::PositionEncodingKind.
             offset = nextind(s, offset)
         end
     elseif encoding == PositionEncodingKind.UTF8 # UTF-8 counts bytes
-        offset = Int(ch) + 1
+        offset = min(Int(ch), sizeof(s)) + 1
     else # UTF-32 counts characters
         while offset <= sizeof(s) && char_count < ch
             char_count += 1

--- a/test/utils/test_string.jl
+++ b/test/utils/test_string.jl
@@ -59,15 +59,21 @@ using JETLS.LSP.PositionEncodingKind: UTF8, UTF16, UTF32
         @test pos_to_utf8_offset("", UInt(0), UTF16) == 1
         @test pos_to_utf8_offset("", UInt(10), UTF16) == 1
         @test pos_to_utf8_offset("", UInt(0), UTF8) == 1
+        @test pos_to_utf8_offset("", UInt(10), UTF8) == 1  # Clamped to end
 
-        # Position beyond string
+        # Position beyond string - UTF-8 should clamp to string bounds
         @test pos_to_utf8_offset("ab", UInt(10), UTF16) == 3
-        @test pos_to_utf8_offset("ab", UInt(10), UTF8) == 11  # Byte 10
+        @test pos_to_utf8_offset("ab", UInt(10), UTF8) == 3  # Clamped to sizeof("ab")+1
+        @test pos_to_utf8_offset("abc", UInt(100), UTF8) == 4  # Clamped to end
+
+        # Position exactly at end of string
+        @test pos_to_utf8_offset("abc", UInt(3), UTF8) == 4  # Exactly at end
 
         # Single emoji - UTF-16 stops mid-emoji at position 1
         @test pos_to_utf8_offset("😀", UInt(1), UTF8) == 2  # Byte offset 1
         @test pos_to_utf8_offset("😀", UInt(1), UTF16) == 1  # Mid-emoji!
         @test pos_to_utf8_offset("😀", UInt(2), UTF16) == 5
+        @test pos_to_utf8_offset("😀", UInt(10), UTF8) == 5  # Clamped to end (4 bytes + 1)
     end
 
     @testset "UTF-16 vs UTF-8 differences" begin


### PR DESCRIPTION
This PR fixes issue when communicating with editors that expect UTF-8–based offsets. The previous implementation counted characters, but according to the LSP specification, offsets in UTF-8 mode should be counted in bytes:
[https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#:~:text=Character%20offsets%20count%20UTF%2D8%20code%20units%20(e.g%20bytes)](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#:~:text=Character%20offsets%20count%20UTF%2D8%20code%20units%20%28e.g%20bytes%29)

This PR updates the offset calculation accordingly and fixes the misalignment observed in editors such as Helix. (see below)
Editors that use UTF-16 by default (e.g., VS Code) are not affected.

| before  | after |
| ---- | ---- |
| <img width="597"  alt="image" src="https://github.com/user-attachments/assets/4a8e5ad5-4ea7-488c-9554-ec4d11086376" /> | <img width="597"  alt="image" src="https://github.com/user-attachments/assets/4b330ec5-dddf-4a30-907e-4d0a4494d451" /> | 