### PR TITLE
config: Remove all code related to "static setting"

### DIFF
--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -1,3 +1,8 @@
+# NOTE: Static server settings that require a server restart to take effect should be
+# accessed during server initialization via `state.init_params.initializationOptions`.
+# These settings differ from dynamic configuration options managed by `ConfigManager`
+# that can be changed at throughout server lifecycle.
+
 """
 Receives `msg::InitializeRequest` and sets up the `server.state` based on `msg.params`.
 As a response to this `msg`, it returns an `InitializeResponse` and performs registration of
@@ -268,9 +273,7 @@ function handle_InitializedNotification(server::Server)
         end
     end
     # - Load LSP configuration
-    #   In a case when client doesn't support the pull model configuration,
-    #   use `init_params.initializationOptions` as the fallback
-    load_lsp_config!(server, state.init_params.initializationOptions, "[LSP] initialize"; on_init=true)
+    load_lsp_config!(server, nothing, "[LSP] initialize"; on_init=true)
 
     registrations = Registration[]
 

--- a/src/workspace-configuration.jl
+++ b/src/workspace-configuration.jl
@@ -13,7 +13,6 @@ function (handler::LoadLSPConfigHandler)(server::Server, @nospecialize(config_va
     end
     if handler.on_init
         # Don't notify even if values different from defaults are loaded initially
-        fix_static_settings!(server.state.config_manager)
     else
         notify_config_changes(handler.server, tracker, handler.source)
         if tracker.diagnostic_setting_changed
@@ -105,7 +104,6 @@ function load_lsp_config!(
         store_lsp_config!(tracker, server, settings, source)
         if on_init
             # Don't notify even if values different from defaults are loaded initially
-            fix_static_settings!(server.state.config_manager)
         else
             notify_config_changes(server, tracker, source)
             if tracker.diagnostic_setting_changed

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -215,7 +215,7 @@ end
 
 function make_test_manager(config_dict::Dict{String,Any})
     lsp_config = JETLS.Configurations.from_dict(JETLS.JETLSConfig, config_dict)
-    data = JETLS.ConfigManagerData(JETLS.DEFAULT_CONFIG, JETLS.EMPTY_CONFIG, lsp_config, nothing)
+    data = JETLS.ConfigManagerData(JETLS.EMPTY_CONFIG, lsp_config, nothing)
     return JETLS.ConfigManager(data)
 end
 

--- a/test/test_did-change-watched-files.jl
+++ b/test/test_did-change-watched-files.jl
@@ -15,14 +15,8 @@ const CLIENT_CAPABILITIES = ClientCapabilities(
     )
 )
 
-const DEBOUNCE_DEFAULT = JETLS.getobjpath(JETLS.DEFAULT_CONFIG,
-    :full_analysis, :debounce)
-
-const STATIC_SETTING_DEFAULT = JETLS.getobjpath(JETLS.DEFAULT_CONFIG,
-    :internal, :static_setting)
-
-const TESTRUNNER_DEFAULT = JETLS.getobjpath(JETLS.DEFAULT_CONFIG,
-    :testrunner, :executable)
+const DEBOUNCE_DEFAULT = JETLS.get_config(JETLS.ConfigManager(JETLS.ConfigManagerData()), :full_analysis, :debounce)
+const TESTRUNNER_DEFAULT = JETLS.get_config(JETLS.ConfigManager(JETLS.ConfigManagerData()), :testrunner, :executable)
 
 # Test the full cycle of `DidChangeWatchedFilesNotification`:
 # 1. Initialize with `.JETLSConfig.toml` file.
@@ -35,11 +29,8 @@ const TESTRUNNER_DEFAULT = JETLS.getobjpath(JETLS.DEFAULT_CONFIG,
 @testset "DidChangeWatchedFilesNotification full-cycle" begin
     mktempdir() do tmpdir
         config_path = joinpath(tmpdir, ".JETLSConfig.toml")
-        STATIC_SETTING_STARTUP = 100
         TESTRUNNER_STARTUP = "testrunner_startup"
         write(config_path, """
-            [internal]
-            static_setting = $STATIC_SETTING_STARTUP
             [testrunner]
             executable = \"$TESTRUNNER_STARTUP\"
             """)
@@ -47,40 +38,16 @@ const TESTRUNNER_DEFAULT = JETLS.getobjpath(JETLS.DEFAULT_CONFIG,
         withserver(; rootUri, capabilities=CLIENT_CAPABILITIES) do (; writereadmsg, server)
             manager = server.state.config_manager
 
-            @test JETLS.get_config(manager, :internal, :static_setting) == STATIC_SETTING_STARTUP
             @test JETLS.get_config(manager, :testrunner, :executable) == TESTRUNNER_STARTUP
 
-            # change `internal.static_setting` to `STATIC_SETTING_V2`
-            STATIC_SETTING_V2 = 200
             write(config_path, """
-                [internal]
-                static_setting = $STATIC_SETTING_V2
                 [testrunner]
                 executable = \"$TESTRUNNER_STARTUP\"
                 """)
 
-            let msg = DidChangeWatchedFilesNotification(;
-                    params=DidChangeWatchedFilesParams(;
-                        changes=[FileEvent(; uri=filepath2uri(config_path), type=FileChangeType.Changed)]
-                    )
-                )
-                (; raw_res) = writereadmsg(msg)
-                @test raw_res isa ShowMessageNotification
-                @test raw_res.params.type == MessageType.Warning
-                expected_static_msg = JETLS.changed_static_settings_message([
-                    JETLS.ConfigChange("internal.static_setting", STATIC_SETTING_STARTUP, STATIC_SETTING_V2)
-                ])
-                @test occursin(expected_static_msg, raw_res.params.message)
-            end
-
-            # Static setting should not be changed
-            @test JETLS.get_config(manager, :internal, :static_setting) == STATIC_SETTING_STARTUP
-
             DEBOUNCE_V2 = 300.0
-            # Add a new key `full_analysis.debounce` (now dynamic)
+            # Add a new key `full_analysis.debounce`
             write(config_path, """
-                [internal]
-                static_setting = $STATIC_SETTING_V2
                 [full_analysis]
                 debounce = $DEBOUNCE_V2
                 [testrunner]
@@ -88,10 +55,8 @@ const TESTRUNNER_DEFAULT = JETLS.getobjpath(JETLS.DEFAULT_CONFIG,
                 """)
 
             let msg = DidChangeWatchedFilesNotification(;
-                    params=DidChangeWatchedFilesParams(;
-                        changes=[FileEvent(; uri=filepath2uri(config_path), type=FileChangeType.Changed)]
-                    )
-                )
+                    params = DidChangeWatchedFilesParams(;
+                        changes = [FileEvent(; uri=filepath2uri(config_path), type=FileChangeType.Changed)]))
                 (; raw_res) = writereadmsg(msg)
                 @test raw_res isa ShowMessageNotification
                 @test raw_res.params.type == MessageType.Info
@@ -99,17 +64,14 @@ const TESTRUNNER_DEFAULT = JETLS.getobjpath(JETLS.DEFAULT_CONFIG,
                     JETLS.ConfigChange("full_analysis.debounce", DEBOUNCE_DEFAULT, DEBOUNCE_V2)
                 ])
                 @test occursin(expected_changes_msg, raw_res.params.message)
-                @test !occursin("internal.static_setting", raw_res.params.message)
             end
 
-            # `full_analysis.debounce` should be changed (dynamic)
+            # `full_analysis.debounce` should be changed
             @test JETLS.get_config(manager, :full_analysis, :debounce) == DEBOUNCE_V2
 
             # Change `testrunner.executable` to "newtestrunner"
             TESTRUNNER_V2 = "testrunner_v2"
             write(config_path, """
-                [internal]
-                static_setting = $STATIC_SETTING_V2
                 [full_analysis]
                 debounce = $DEBOUNCE_V2
                 [testrunner]
@@ -117,10 +79,8 @@ const TESTRUNNER_DEFAULT = JETLS.getobjpath(JETLS.DEFAULT_CONFIG,
                 """)
 
             let msg = DidChangeWatchedFilesNotification(;
-                    params=DidChangeWatchedFilesParams(;
-                        changes=[FileEvent(; uri=filepath2uri(config_path), type=FileChangeType.Changed)]
-                    )
-                )
+                    params = DidChangeWatchedFilesParams(;
+                        changes = [FileEvent(; uri=filepath2uri(config_path), type=FileChangeType.Changed)]))
                 (; raw_res) = writereadmsg(msg)
                 @test raw_res isa ShowMessageNotification
                 @test raw_res.params.type == MessageType.Info
@@ -129,10 +89,9 @@ const TESTRUNNER_DEFAULT = JETLS.getobjpath(JETLS.DEFAULT_CONFIG,
                 ])
                 @test occursin(expected_changes_msg, raw_res.params.message)
                 @test !occursin("full_analysis.debounce", raw_res.params.message)
-                @test !occursin("internal.static_setting", raw_res.params.message)
             end
 
-            # testrunner.executable should be updated in both configs (dynamic)
+            # testrunner.executable should be updated
             @test JETLS.get_config(manager, :testrunner, :executable) == TESTRUNNER_V2
 
             # unknown keys should be reported
@@ -141,10 +100,8 @@ const TESTRUNNER_DEFAULT = JETLS.getobjpath(JETLS.DEFAULT_CONFIG,
                 ___unknown_key___ = \"value\"
                 """)
             let msg = DidChangeWatchedFilesNotification(;
-                    params=DidChangeWatchedFilesParams(;
-                        changes=[FileEvent(; uri=filepath2uri(config_path), type=FileChangeType.Changed)]
-                    )
-                )
+                    params = DidChangeWatchedFilesParams(;
+                        changes = [FileEvent(; uri=filepath2uri(config_path), type=FileChangeType.Changed)]))
                 (; raw_res) = writereadmsg(msg)
                 @test raw_res isa ShowMessageNotification
                 @test raw_res.params.type == MessageType.Error
@@ -155,10 +112,8 @@ const TESTRUNNER_DEFAULT = JETLS.getobjpath(JETLS.DEFAULT_CONFIG,
             # Delete the config file
             rm(config_path)
             let msg = DidChangeWatchedFilesNotification(;
-                    params=DidChangeWatchedFilesParams(;
-                        changes=[FileEvent(; uri=filepath2uri(config_path), type=FileChangeType.Deleted)]
-                    )
-                )
+                    params = DidChangeWatchedFilesParams(;
+                        changes = [FileEvent(; uri=filepath2uri(config_path), type=FileChangeType.Deleted)]))
                 (; raw_res) = writereadmsg(msg; read=2)
                 @test any(raw_res) do r
                     r isa ShowMessageNotification &&
@@ -166,42 +121,30 @@ const TESTRUNNER_DEFAULT = JETLS.getobjpath(JETLS.DEFAULT_CONFIG,
                     occursin(JETLS.config_file_deleted_msg(config_path), r.params.message)
                 end
                 @test any(raw_res) do r
-                    if r isa ShowMessageNotification && r.params.type == MessageType.Warning
+                    if r isa ShowMessageNotification && r.params.type == MessageType.Info
                         expected_changes = JETLS.changed_settings_message([
                             JETLS.ConfigChange("full_analysis.debounce", DEBOUNCE_V2, DEBOUNCE_DEFAULT),
                             JETLS.ConfigChange("testrunner.executable", TESTRUNNER_V2, TESTRUNNER_DEFAULT)
                         ])
-                        expected_static = JETLS.changed_static_settings_message([
-                            JETLS.ConfigChange("internal.static_setting", STATIC_SETTING_V2, STATIC_SETTING_DEFAULT)
-                        ])
-                        return occursin(expected_changes, r.params.message) &&
-                               occursin(expected_static, r.params.message)
+                        return occursin(expected_changes, r.params.message)
                     end
                     return false
                 end
             end
 
-            # After deletion,
-            # - For static keys, `get_config` should remain unchanged
-            @test JETLS.get_config(manager, :internal, :static_setting) == STATIC_SETTING_STARTUP
-            # - For non-static keys, replace with value from the next highest-priority config file. (`__DEFAULT_CONFIG__`)
+            # After deletion, the debounce should be reverted to the default
             @test JETLS.get_config(manager, :full_analysis, :debounce) == DEBOUNCE_DEFAULT
 
             # re-create the config file
-            STATIC_SETTING_RECREATE = 400
             TESTRUNNER_RECREATE = "testrunner_recreate"
             write(config_path, """
-                [internal]
-                static_setting = $STATIC_SETTING_RECREATE
                 [testrunner]
                 executable = \"$TESTRUNNER_RECREATE\"
                 """)
 
             let msg = DidChangeWatchedFilesNotification(;
-                    params=DidChangeWatchedFilesParams(;
-                        changes=[FileEvent(; uri=filepath2uri(config_path), type=FileChangeType.Created)]
-                    )
-                )
+                    params = DidChangeWatchedFilesParams(;
+                        changes = [FileEvent(; uri=filepath2uri(config_path), type=FileChangeType.Created)]))
                 (; raw_res) = writereadmsg(msg; read=2)
                 @test any(raw_res) do r
                     r isa ShowMessageNotification &&
@@ -209,33 +152,25 @@ const TESTRUNNER_DEFAULT = JETLS.getobjpath(JETLS.DEFAULT_CONFIG,
                     occursin(JETLS.config_file_created_msg(config_path), r.params.message)
                 end
                 @test any(raw_res) do r
-                    if r isa ShowMessageNotification && r.params.type == MessageType.Warning
+                    if r isa ShowMessageNotification && r.params.type == MessageType.Info
                         expected_changes = JETLS.changed_settings_message([
                             JETLS.ConfigChange("testrunner.executable", TESTRUNNER_DEFAULT, TESTRUNNER_RECREATE)
                         ])
-                        expected_static = JETLS.changed_static_settings_message([
-                            JETLS.ConfigChange("internal.static_setting", STATIC_SETTING_DEFAULT, STATIC_SETTING_RECREATE)
-                        ])
-                        return occursin(expected_changes, r.params.message) &&
-                               occursin(expected_static, r.params.message)
+                        return occursin(expected_changes, r.params.message)
                     end
                     return false
                 end
             end
 
-            # static keys should not be changed even if higher priority config file is re-created
-            @test JETLS.get_config(manager, :internal, :static_setting) == STATIC_SETTING_STARTUP
-
             # non-config file change (should be ignored)
             other_file = joinpath(tmpdir, "other.txt")
             touch(other_file)
             let msg = DidChangeWatchedFilesNotification(;
-                    params=DidChangeWatchedFilesParams(;
-                        changes=[FileEvent(; uri=filepath2uri(other_file), type=FileChangeType.Changed)]))
+                    params = DidChangeWatchedFilesParams(;
+                        changes = [FileEvent(; uri=filepath2uri(other_file), type=FileChangeType.Changed)]))
                 writereadmsg(msg; read=0)
             end
             # no effect on config
-            @test JETLS.get_config(manager, :internal, :static_setting) == STATIC_SETTING_STARTUP
             @test JETLS.get_config(manager, :testrunner, :executable) == TESTRUNNER_RECREATE
         end
     end
@@ -249,19 +184,14 @@ end
             manager = server.state.config_manager
 
             config_path = joinpath(tmpdir, ".JETLSConfig.toml")
-            STATIC_SETTING_RECREATE = 500
             TESTRUNNER_RECREATE = "testrunner_recreate"
             write(config_path, """
-                [internal]
-                static_setting = $STATIC_SETTING_RECREATE
                 [testrunner]
                 executable = \"$TESTRUNNER_RECREATE\"
                 """)
             creation_notification = DidChangeWatchedFilesNotification(;
-                params=DidChangeWatchedFilesParams(;
-                    changes=[FileEvent(; uri=filepath2uri(config_path), type=FileChangeType.Created)]
-                )
-            )
+                params = DidChangeWatchedFilesParams(;
+                    changes = [FileEvent(; uri=filepath2uri(config_path), type=FileChangeType.Created)]))
             (; raw_res) = writereadmsg(creation_notification; read=2)
             @test any(raw_res) do r
                 r isa ShowMessageNotification &&
@@ -269,49 +199,27 @@ end
                 occursin(JETLS.config_file_created_msg(config_path), r.params.message)
             end
             @test any(raw_res) do r
-                if r isa ShowMessageNotification && r.params.type == MessageType.Warning
+                if r isa ShowMessageNotification && r.params.type == MessageType.Info
                     expected_changes = JETLS.changed_settings_message([
-                        JETLS.ConfigChange("testrunner.executable", TESTRUNNER_DEFAULT, TESTRUNNER_RECREATE)
-                    ])
-                    expected_static = JETLS.changed_static_settings_message([
-                        JETLS.ConfigChange("internal.static_setting", STATIC_SETTING_DEFAULT, STATIC_SETTING_RECREATE)
-                    ])
-                    return occursin(expected_changes, r.params.message) &&
-                           occursin(expected_static, r.params.message)
+                        JETLS.ConfigChange("testrunner.executable", TESTRUNNER_DEFAULT, TESTRUNNER_RECREATE)])
+                    return occursin(expected_changes, r.params.message)
                 end
                 return false
             end
-
-            # If higher priority config file is created,
-            # - static keys should not be changed
-            @test JETLS.get_config(manager, :internal, :static_setting) == STATIC_SETTING_DEFAULT
-            # - non-static keys should be updated
             @test JETLS.get_config(manager, :testrunner, :executable) == TESTRUNNER_RECREATE
 
             # New config file change also should be watched
-            STATIC_SETTING_V2 = 600
             TESTRUNNER_V2 = "testrunner_v2"
             write(config_path, """
-                [internal]
-                static_setting = $STATIC_SETTING_V2
                 [testrunner]
                 executable = \"$TESTRUNNER_V2\"
                 """)
             change_notification = DidChangeWatchedFilesNotification(;
-                params=DidChangeWatchedFilesParams(;
-                    changes=[FileEvent(; uri=filepath2uri(config_path), type=FileChangeType.Changed)]
-                )
-            )
+                params = DidChangeWatchedFilesParams(;
+                    changes = [FileEvent(; uri=filepath2uri(config_path), type=FileChangeType.Changed)]))
             (; raw_res) = writereadmsg(change_notification)
-
             @test raw_res isa ShowMessageNotification
-            @test raw_res.params.type == MessageType.Warning
-            expected_static_msg = JETLS.changed_static_settings_message([
-                JETLS.ConfigChange("internal.static_setting", STATIC_SETTING_RECREATE, STATIC_SETTING_V2)
-            ])
-            @test occursin(expected_static_msg, raw_res.params.message)
-
-            @test JETLS.get_config(manager, :internal, :static_setting) == STATIC_SETTING_DEFAULT
+            @test raw_res.params.type == MessageType.Info
             @test JETLS.get_config(manager, :testrunner, :executable) == TESTRUNNER_V2
         end
     end


### PR DESCRIPTION
Our configuration system has had two concepts: "dynamic setting" and "static setting". However, in practice, static settings were never actually used.

Static settings require server restart, but such configurations should actually be specified as `init_params.initializationOptions` and should be handled in the initialization lifecycle.

For these reasons, the "static setting" concept in `ConfigManager` is unnecessary, so this commit removes all related code.