### PR TITLE
config: Track initialization state and fix config change notification

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -180,9 +180,15 @@ so `config` is guaranteed to not be `nothing`.
 """
 Base.@constprop :aggressive function get_config(manager::ConfigManager, key_path::Symbol...)
     data = load(manager)
-    config = getobjpath(data.__filled_settings__, key_path...)
+    config = getobjpath(data.filled_settings, key_path...)
     @assert !isnothing(config) "Invalid default configuration values"
     return config
+end
+
+function initialize_config!(manager::ConfigManager)
+    store!(manager) do old_data::ConfigManagerData
+        return ConfigManagerData(old_data; initialized=true), nothing
+    end
 end
 
 struct ConfigChange

--- a/src/did-change-watched-files.jl
+++ b/src/did-change-watched-files.jl
@@ -74,7 +74,7 @@ function load_file_config!(callback, server::Server, filepath::AbstractString;
             file_config=new_file_config,
             file_config_path=filepath
         )
-        on_difference(callback, get_settings(old_data), get_settings(new_data))
+        on_difference(callback, old_data.settings, new_data.settings)
         return new_data, nothing
     end
 end
@@ -89,7 +89,7 @@ function delete_file_config!(callback, manager::ConfigManager, filepath::Abstrac
             file_config=EMPTY_CONFIG,
             file_config_path=nothing
         )
-        on_difference(callback, get_settings(old_data), get_settings(new_data))
+        on_difference(callback, old_data.settings, new_data.settings)
         return new_data, nothing
     end
 end

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -215,7 +215,7 @@ end
 
 function make_test_manager(config_dict::Dict{String,Any})
     lsp_config = JETLS.Configurations.from_dict(JETLS.JETLSConfig, config_dict)
-    data = JETLS.ConfigManagerData(JETLS.EMPTY_CONFIG, lsp_config, nothing)
+    data = JETLS.ConfigManagerData(JETLS.EMPTY_CONFIG, lsp_config, nothing, true)
     return JETLS.ConfigManager(data)
 end
 


### PR DESCRIPTION
This commit improves configuration initialization by explicitly tracking when the initial config loading is complete.

This prevents premature config change notifications from `workspace/didChangeConfiguration` notification that may send during server initialization, given our concurrent message handling architecture. This particular fix the noisy config change notification on Zed during server initialization.