### PR TITLE
diagnostics: Add file path-based configuration support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ projects = ["docs", "test"]
 
 [deps]
 Configurations = "5218b696-f38b-4ac9-8b61-a12ec717816d"
+Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 JuliaLowering = "f3c80556-a63f-4383-b822-37d64f81a311"
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
@@ -20,13 +21,15 @@ REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [sources]
+Glob = {rev = "avi/globstar", url = "https://github.com/aviatesk/Glob.jl"}
 JET = {rev = "1e84376", url = "https://github.com/aviatesk/JET.jl"}
-JuliaLowering = {rev = "avi/JETLS-JSJL-head", url = "https://github.com/JuliaLang/julia", subdir="JuliaLowering"}
-JuliaSyntax = {rev = "avi/JETLS-JSJL-head", url = "https://github.com/JuliaLang/julia", subdir="JuliaSyntax"}
+JuliaLowering = {rev = "avi/JETLS-JSJL-head", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
+JuliaSyntax = {rev = "avi/JETLS-JSJL-head", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
 LSP = {path = "LSP"}
 
 [compat]
 Configurations = "0.17.6"
+Glob = "1.3.1"
 JET = "0.10.6"
 JuliaLowering = "1"
 JuliaSyntax = "2"

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -23,6 +23,7 @@ pattern = ""               # string, required
 match_by = ""              # string, required, "code" or "message"
 match_type = ""            # string, required, "literal" or "regex"
 severity = ""              # string or number, required, "error"/"warning"/"warn"/"information"/"info"/"hint"/"off" or 0/1/2/3/4
+path = ""                  # string (optional), glob pattern for file paths
 
 [testrunner]
 executable = "testrunner"  # string, default: "testrunner" (or "testrunner.bat" on Windows)
@@ -133,10 +134,11 @@ Each pattern is defined as a table array entry with the following fields:
 
 ```toml
 [[diagnostic.patterns]]
-pattern = "pattern-value"  # the pattern to match
-match_by = "code"          # "code" or "message"
-match_type = "literal"     # "literal" or "regex"
-severity = "hint"          # severity level
+pattern = "pattern-value"  # string: the pattern to match
+match_by = "code"          # string: "code" or "message"
+match_type = "literal"     # string: "literal" or "regex"
+severity = "hint"          # string or number: severity level
+path = "src/**/*.jl"       # string (optional): restrict to specific files
 ```
 
 - `pattern` (**Type**: string): The pattern to match. For code matching, use diagnostic
@@ -149,6 +151,11 @@ severity = "hint"          # severity level
   - `"literal"`: Exact string match
   - `"regex"`: Regular expression match
 - `severity` (**Type**: string or number): Severity level to apply
+- `path` (**Type**: string, optional): Glob pattern to restrict this
+  configuration to specific files.
+  Patterns are matched against _file paths relative to the workspace root_.
+  Supports globstar (`**`) for matching directories recursively.
+  If omitted, the pattern applies to all files.
 
 ##### Severity values
 
@@ -254,6 +261,22 @@ pattern = "Macro name `.*` not found"
 match_by = "message"
 match_type = "regex"
 severity = "off"
+
+# File path-based filtering: downgrade unused arguments in test files
+[[diagnostic.patterns]]
+pattern = "lowering/unused-argument"
+match_by = "code"
+match_type = "literal"
+severity = "hint"
+path = "test/**/*.jl"
+
+# Disable all diagnostics for generated files
+[[diagnostic.patterns]]
+pattern = ".*"
+match_by = "code"
+match_type = "regex"
+severity = "off"
+path = "gen/**/*.jl"
 ```
 
 See the [configuring diagnostics](@ref configuring-diagnostic) section for

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -261,46 +261,45 @@ nothing # This is an internal comment for this documenation: # hide
 nothing # Use H5 for subsections in this section so that the `@contents` block above works as intended. # hide
 ```
 
-##### Quick example
+##### Common use cases
+
+Suppress specific macro expansion errors:
 
 ```toml
-# Pattern matching against diagnostic code
 [[diagnostic.patterns]]
-pattern = "lowering/.*"
-match_by = "code"
-match_type = "regex"
-severity = "warning"
-
-# Pattern matching against diagnostic message
-[[diagnostic.patterns]]
-pattern = "Macro name `@namespace` not found"
+pattern = "Macro name `MyPkg.@mymacro` not found"
 match_by = "message"
-match_type = "literal"
-severity = "info"
-
-# Disable specific diagnostic by code
-[[diagnostic.patterns]]
-pattern = "lowering/unused-argument"
-match_by = "code"
 match_type = "literal"
 severity = "off"
 ```
 
-##### Common use cases
+Apply different settings for test files:
+
+```toml
+# Downgrade unused arguments to hints in test files
+[[diagnostic.patterns]]
+pattern = "lowering/unused-argument"
+match_by = "code"
+match_type = "literal"
+severity = "hint"
+path = "test/**/*.jl"
+
+# Disable all diagnostics for generated code
+[[diagnostic.patterns]]
+pattern = ".*"
+match_by = "code"
+match_type = "regex"
+severity = "off"
+path = "gen/**/*.jl"
+```
 
 Disable unused variable warnings during prototyping:
 
 ```toml
 [[diagnostic.patterns]]
-pattern = "lowering/unused-argument"
+pattern = "lowering/(unused-argument|unused-local)"
 match_by = "code"
-match_type = "literal"
-severity = "off"
-
-[[diagnostic.patterns]]
-pattern = "lowering/unused-local"
-match_by = "code"
-match_type = "literal"
+match_type = "regex"
 severity = "off"
 ```
 
@@ -312,16 +311,6 @@ pattern = "inference/.*"
 match_by = "code"
 match_type = "regex"
 severity = "hint"
-```
-
-Suppress specific macro expansion errors:
-
-```toml
-[[diagnostic.patterns]]
-pattern = "Macro name `MyPkg.@mymacro` not found"
-match_by = "message"
-match_type = "literal"
-severity = "off"
 ```
 
 For complete configuration options, severity values, pattern matching syntax,

--- a/package.json
+++ b/package.json
@@ -197,6 +197,10 @@
                           }
                         ],
                         "description": "Severity level to apply: 'error'/1 for critical issues, 'warning'/'warn'/2 for potential problems, 'information'/'info'/3 for informational messages, 'hint'/4 for suggestions, 'off'/0 to disable."
+                      },
+                      "path": {
+                        "type": "string",
+                        "description": "Optional glob pattern to restrict this configuration to specific files (e.g., 'test/**/*.jl'). Patterns are matched against file paths relative to the workspace root. Supports globstar (**) for matching directories recursively."
                       }
                     }
                   }

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -33,6 +33,7 @@ using Markdown: Markdown
 using TOML: TOML
 
 using Configurations: @option, Configurations, Maybe
+using Glob: Glob
 
 abstract type AnalysisEntry end # used by `Analyzer.LSAnalyzer`
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -381,6 +381,7 @@ struct DiagnosticPattern <: ConfigSection
     match_by::String
     match_type::String
     severity::Int
+    path::Maybe{Glob.FilenameMatch{String}}
 end
 @define_eq_overloads DiagnosticPattern
 


### PR DESCRIPTION
This commit implements file path-based filtering for diagnostic patterns as discussed at
https://publish.obsidian.md/jetls/work/JETLS/diagnostic+Support+file+path+based+configuration, allowing users to apply different diagnostic configurations to specific files or directories using glob patterns.

Users can now add an optional `path` field to diagnostic pattern configurations that accepts glob patterns (e.g., `"test/**/*.jl"`). When specified, the diagnostic pattern only applies to files matching that glob pattern. Patterns are matched against file paths relative to the workspace root, with support for globstar (`**`) for recursive directory matching.

Written with a help from Claude.