### PR TITLE
release: Implement environment isolation via dependency vendoring

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+vendor/** linguist-generated

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
 node_modules
 out
+Project.toml.bak
 Manifest.toml
 Manifest-*.toml
 .envrc
 **/.JETLSConfig.toml
 *.vsix
 docs/build/
+
+# The following line is negated on release branches
+/vendor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,24 @@ This section tracks the major changes to JETLS.jl, the language server implement
 
 #### Changed / Breaking
 
+- Implemented environment isolation via dependency vendoring to prevent conflicts
+  between JETLS dependencies and packages being analyzed.
+  All JETLS dependencies are now vendored with rewritten UUIDs in the `release`
+  branch, allowing JETLS to maintain its own isolated copies of dependencies.
+  This resolves issues where version conflicts between JETLS and analyzed
+  packages would prevent analysis.
+  Users should install JETLS from the `release` branch using
+  `Pkg.Apps.add("https://github.com/aviatesk/JETLS.jl#release")`. (aviatesk/JETLS.jl#314)
+  - For developers:
+    See <https://aviatesk.github.io/JETLS.jl/dev/development/#Release-process>
+    for details on the release process.
 - Migrated the JETLS entry point from the `runserver.jl` script to the `jetls`
   [executable app](https://pkgdocs.julialang.org/dev/apps/) defined by JETLS.jl itself.
   This significantly changes how JETLS is installed and launched,
   while the new methods are generally simpler: (aviatesk/JETLS.jl#314)
   - Installation: Install the `jetls` executable app using:
     ```bash
-    julia -e 'using Pkg; Pkg.Apps.add("https://github.com/aviatesk/JETLS.jl")'
+    julia -e 'using Pkg; Pkg.Apps.add("https://github.com/aviatesk/JETLS.jl#release")'
     ```
     This installs the executable to `~/.julia/bin/` (as `jetls` on Unix-like systems, `jetls.exe` on Windows).
     Make sure `~/.julia/bin` is in your `PATH`.
@@ -84,7 +95,7 @@ a VSCode language client extension for JETLS.
   See <https://aviatesk.github.io/JETLS.jl/dev/#Getting-started> for the new installation and configuration guide.
   Most users can complete the migration by installing the `jetls` executable app:
   ```bash
-  julia -e 'using Pkg; Pkg.Apps.add("https://github.com/aviatesk/JETLS.jl")'
+  julia -e 'using Pkg; Pkg.Apps.add("https://github.com/aviatesk/JETLS.jl#release")'
   ```
 - [JETLS configuration](https://aviatesk.github.io/JETLS.jl/dev/configuration/)
   should now be set with `jetls-client.settings` section,

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -35,7 +35,7 @@ For those who want to use JETLS with other editors, please refer to the [Other e
 1. Install the `jetls` [executable app](https://pkgdocs.julialang.org/dev/apps/),
    which is the main entry point for running JETLS:
    ```bash
-   julia -e 'using Pkg; Pkg.Apps.add("https://github.com/aviatesk/JETLS.jl")'
+   julia -e 'using Pkg; Pkg.Apps.add("https://github.com/aviatesk/JETLS.jl#release")'
    ```
    This will install the `jetls` executable (`jetls.exe` on Windows) to `~/.julia/bin/`.
    Make sure `~/.julia/bin` is available on the `PATH` environment so the `jetls` executable is accessible.
@@ -100,7 +100,7 @@ For editors other than VSCode, first install the `jetls`
 the main entry point for running JETLS:
 
 ```bash
-julia -e 'using Pkg; Pkg.Apps.add("https://github.com/aviatesk/JETLS.jl")'
+julia -e 'using Pkg; Pkg.Apps.add("https://github.com/aviatesk/JETLS.jl#release")'
 ```
 
 Make sure `~/.julia/bin` is available on the `PATH` environment so the `jetls`

--- a/docs/src/launching.md
+++ b/docs/src/launching.md
@@ -9,7 +9,7 @@ The JETLS server is launched using the `jetls` executable, which is the main
 entry point of launching JETLS that can be installed as an
 [executable app](https://pkgdocs.julialang.org/dev/apps/) via Pkg.jl:
 ```bash
-julia -e 'using Pkg; Pkg.Apps.add("https://github.com/aviatesk/JETLS.jl")'
+julia -e 'using Pkg; Pkg.Apps.add("https://github.com/aviatesk/JETLS.jl#release")'
 ```
 
 You can run `jetls` with various options to configure how the server communicates

--- a/runserver.jl
+++ b/runserver.jl
@@ -9,7 +9,7 @@ WARNING: runserver.jl is deprecated and will be removed in a future release.
 Please use the `jetls` executable app instead.
 
 Installation:
-  julia -e 'using Pkg; Pkg.Apps.add("https://github.com/aviatesk/JETLS.jl")'
+  julia -e 'using Pkg; Pkg.Apps.add("https://github.com/aviatesk/JETLS.jl#release")'
 
 Migration:
   Old: julia --project=/path/to/JETLS runserver.jl --socket=8080

--- a/scripts/vendor-deps.jl
+++ b/scripts/vendor-deps.jl
@@ -1,0 +1,479 @@
+#!/usr/bin/env julia
+
+"""
+isolate-env.jl
+
+This script automates the JETLS release process by vendoring all dependencies.
+
+Usage:
+    julia isolate-env.jl --source-branch=<branch>
+
+Process:
+1. Fetch Project.toml files from source branch
+2. Backup existing Project.toml files
+3. Clean Manifest files
+4. Update dependencies
+5. Vendor packages (copy sources, rewrite UUIDs, update references)
+6. Replace Project.toml with vendored versions
+"""
+
+using Pkg
+using TOML
+using UUIDs
+
+const CURRENT_DIR = pwd()
+
+const VENDOR_DIR = joinpath(CURRENT_DIR, "vendor")
+const VENDOR_NAMESPACE = "JETLS-vendor"
+
+struct Config
+    source_branch::String
+end
+
+function is_jll_package(name::AbstractString)
+    return endswith(name, "_jll")
+end
+
+# COMBAK: In the future, it might be better to vendor Compiler as well?
+function should_vendor(uuid::UUID, name::AbstractString)
+    Pkg.Types.is_stdlib(uuid) && return false
+    is_jll_package(name) && return false
+    name == "JETLS" && return false
+    return true
+end
+
+function is_extension_module(pkgid::Base.PkgId, mod::Module)
+    pkg_dir = pkgdir(mod)
+    pkg_dir === nothing && return true
+
+    project_path = joinpath(pkg_dir, "Project.toml")
+    isfile(project_path) || return true
+
+    project = TOML.parsefile(project_path)
+    pkg_name = get(project, "name", nothing)
+    pkg_name === nothing && return true
+
+    return pkg_name != pkgid.name
+end
+
+function collect_packages_to_vendor()
+    packages = Pair{String, UUID}[]
+    for (pkgid, mod) in Base.loaded_modules
+        pkgid.uuid === nothing && continue
+        should_vendor(pkgid.uuid, pkgid.name) || continue
+        is_extension_module(pkgid, mod) && continue
+        push!(packages, pkgid.name => pkgid.uuid)
+    end
+    sort!(packages, by = first)
+    return packages
+end
+
+function generate_new_uuid(original_uuid::UUID)
+    return uuid5(original_uuid, VENDOR_NAMESPACE)
+end
+
+function copy_package_source(mod::Module, pkg_name::AbstractString)
+    src_dir = pkgdir(mod)
+    src_dir === nothing && error("Could not find source directory for $pkg_name")
+
+    dest_dir = joinpath(VENDOR_DIR, pkg_name)
+
+    if isdir(dest_dir)
+        @info "Removing existing vendor directory: $dest_dir"
+        rm(dest_dir; recursive = true)
+    end
+
+    @info "Copying $pkg_name from $src_dir to $dest_dir"
+    cp(src_dir, dest_dir)
+
+    for (root, dirs, files) in walkdir(dest_dir)
+        for file in files
+            filepath = joinpath(root, file)
+            chmod(filepath, 0o644)
+        end
+    end
+
+    return dest_dir
+end
+
+function rewrite_package_uuid(vendor_pkg_dir::AbstractString, new_uuid::UUID)
+    project_path = joinpath(vendor_pkg_dir, "Project.toml")
+    isfile(project_path) || error("Project.toml not found in $vendor_pkg_dir")
+
+    project = TOML.parsefile(project_path)
+    old_uuid = project["uuid"]
+    project["uuid"] = string(new_uuid)
+
+    @info "Rewriting UUID in $project_path: $old_uuid => $(project["uuid"])"
+
+    open(project_path, "w") do io
+        TOML.print(io, project)
+    end
+
+    return project
+end
+
+function update_vendored_dependencies!(
+        vendor_pkg_dir::AbstractString,
+        uuid_mapping::Dict{UUID, UUID},
+        current_branch::AbstractString
+    )
+    project_path = joinpath(vendor_pkg_dir, "Project.toml")
+    project = TOML.parsefile(project_path)
+
+    haskey(project, "deps") || return
+
+    deps_updated = false
+    vendored_deps = String[]
+
+    for (dep_name, dep_uuid_str) in project["deps"]
+        dep_uuid = UUID(dep_uuid_str)
+        if haskey(uuid_mapping, dep_uuid)
+            new_uuid = uuid_mapping[dep_uuid]
+            project["deps"][dep_name] = string(new_uuid)
+            @info "Updated dependency in $(basename(vendor_pkg_dir)): $dep_name $dep_uuid => $new_uuid"
+            deps_updated = true
+            push!(vendored_deps, dep_name)
+        end
+    end
+
+    if !isempty(vendored_deps)
+        if !haskey(project, "sources")
+            project["sources"] = Dict{String, Any}()
+        end
+
+        jetls_url = "https://github.com/aviatesk/JETLS.jl"
+        for dep_name in vendored_deps
+            project["sources"][dep_name] = Dict{String, Any}(
+                "url" => jetls_url,
+                "subdir" => joinpath("vendor", dep_name),
+                "rev" => current_branch
+            )
+            @info "Added source entry in $(basename(vendor_pkg_dir)) for $dep_name with rev=$current_branch"
+        end
+        deps_updated = true
+    end
+
+    return if deps_updated
+        open(project_path, "w") do io
+            TOML.print(io, project)
+        end
+    end
+end
+
+function update_workspace_project!(
+        workspace_path::AbstractString,
+        uuid_mapping::Dict{UUID, UUID},
+        vendor_base_path::AbstractString
+    )
+    project_path = joinpath(workspace_path, "Project.toml")
+    isfile(project_path) || return
+
+    project = TOML.parsefile(project_path)
+    haskey(project, "deps") || return
+
+    vendored_deps = Set{String}()
+    deps_updated = false
+
+    for (dep_name, dep_uuid_str) in project["deps"]
+        dep_uuid = UUID(dep_uuid_str)
+        if haskey(uuid_mapping, dep_uuid)
+            new_uuid = uuid_mapping[dep_uuid]
+            project["deps"][dep_name] = string(new_uuid)
+            @info "  Updated dependency in $(basename(workspace_path))/Project.toml: $dep_name"
+            push!(vendored_deps, dep_name)
+            deps_updated = true
+        end
+    end
+
+    if !isempty(vendored_deps)
+        if !haskey(project, "sources")
+            project["sources"] = Dict{String, Any}()
+        end
+
+        for dep_name in vendored_deps
+            project["sources"][dep_name] = Dict("path" => joinpath(vendor_base_path, dep_name))
+            @info "  Added source entry in $(basename(workspace_path))/Project.toml for $dep_name"
+        end
+    end
+
+    if deps_updated
+        open(project_path, "w") do io
+            TOML.print(io, project)
+        end
+    end
+end
+
+function update_project_with_vendored_deps(
+        uuid_mapping::Dict{UUID, UUID},
+        all_vendored_packages::Vector{Pair{String, UUID}}
+    )
+    project_path = joinpath(CURRENT_DIR, "Project.toml")
+    project = TOML.parsefile(project_path)
+
+    for (dep_name, dep_uuid_str) in project["deps"]
+        dep_uuid = UUID(dep_uuid_str)
+        if haskey(uuid_mapping, dep_uuid)
+            new_uuid = uuid_mapping[dep_uuid]
+            project["deps"][dep_name] = string(new_uuid)
+            @info "Updated dependency in Project.toml: $dep_name $dep_uuid => $new_uuid"
+        end
+    end
+
+    for (pkg_name, original_uuid) in all_vendored_packages
+        if haskey(uuid_mapping, original_uuid)
+            new_uuid = uuid_mapping[original_uuid]
+            if !haskey(project["deps"], pkg_name)
+                project["deps"][pkg_name] = string(new_uuid)
+                @info "Added vendored dependency to Project.toml: $pkg_name => $new_uuid"
+            end
+        end
+    end
+
+    current_branch = get_current_branch()
+    project["sources"] = Dict{String, Any}()
+
+    jetls_url = "https://github.com/aviatesk/JETLS.jl"
+
+    for (pkg_name, original_uuid) in all_vendored_packages
+        if haskey(uuid_mapping, original_uuid)
+            new_source = Dict{String, Any}()
+            new_source["url"] = jetls_url
+            new_source["subdir"] = joinpath("vendor", pkg_name)
+            new_source["rev"] = current_branch
+
+            project["sources"][pkg_name] = new_source
+            @info "Added source entry for $pkg_name with rev=$current_branch"
+        end
+    end
+
+    main_path = joinpath(CURRENT_DIR, "Project.toml")
+    @info "Writing vendored Project.toml to $main_path"
+    open(main_path, "w") do io
+        TOML.print(io, project)
+    end
+
+    if haskey(project, "workspace") && haskey(project["workspace"], "projects")
+        @info "Updating workspace projects..."
+        for workspace_name in project["workspace"]["projects"]
+            workspace_path = joinpath(CURRENT_DIR, workspace_name)
+            if isdir(workspace_path)
+                @info "Processing workspace: $workspace_name"
+                update_workspace_project!(workspace_path, uuid_mapping, joinpath("..", "vendor"))
+            end
+        end
+    end
+end
+
+function fetch_project_from_branch(
+        source_branch::AbstractString,
+        project_path::AbstractString
+    )::String
+    result = read(`git show origin/$(source_branch):$(project_path)`, String)
+    return result
+end
+
+function get_current_branch()::String
+    result = read(`git branch --show-current`, String)
+    return strip(result)
+end
+
+function get_workspace_projects()::Vector{String}
+    project_path = joinpath(CURRENT_DIR, "Project.toml")
+    isfile(project_path) || return String[]
+
+    project = TOML.parsefile(project_path)
+    if haskey(project, "workspace") && haskey(project["workspace"], "projects")
+        return collect(project["workspace"]["projects"])
+    end
+    return String[]
+end
+
+function clean_manifests()
+    @info "Cleaning manifest files..."
+    for file in readdir(CURRENT_DIR)
+        if file == "Manifest.toml" || startswith(file, "Manifest-v") && endswith(file, ".toml")
+            manifest_path = joinpath(CURRENT_DIR, file)
+            @info "Removing $manifest_path"
+            rm(manifest_path)
+        end
+    end
+end
+
+
+function vendor_dependencies_from_branch(config::Config)
+    @info "=== JETLS Vendoring Script ==="
+    @info "Source branch: $(config.source_branch)"
+
+    @info "\n[Step 1/6] Fetching origin/$(config.source_branch)..."
+    run(`git fetch origin $(config.source_branch)`)
+
+    @info "\n[Step 2/6] Fetching Project.toml files from origin/$(config.source_branch)..."
+
+    main_project = fetch_project_from_branch(config.source_branch, "Project.toml")
+    main_path = joinpath(CURRENT_DIR, "Project.toml")
+    write(main_path, main_project)
+    @info "Fetched Project.toml from $(config.source_branch)"
+
+    backup_path = main_path * ".bak"
+    cp(main_path, backup_path; force=true)
+    @info "Backed up Project.toml to $(basename(backup_path))"
+
+    workspace_projects = get_workspace_projects()
+    for workspace_name in workspace_projects
+        workspace_path = joinpath(CURRENT_DIR, workspace_name)
+        workspace_project_path = joinpath(workspace_name, "Project.toml")
+
+        try
+            workspace_project = fetch_project_from_branch(config.source_branch, workspace_project_path)
+            write(joinpath(workspace_path, "Project.toml"), workspace_project)
+            @info "Fetched $workspace_project_path from $(config.source_branch)"
+
+            workspace_backup = joinpath(workspace_path, "Project.toml.bak")
+            cp(joinpath(workspace_path, "Project.toml"), workspace_backup; force=true)
+            @info "Backed up $workspace_project_path to $(basename(workspace_backup))"
+        catch e
+            @warn "Could not fetch $workspace_project_path from $(config.source_branch): $e"
+        end
+    end
+
+    @info "\n[Step 3/6] Cleaning manifest files..."
+    clean_manifests()
+
+    @info "\n[Step 4/6] Updating dependencies..."
+    Pkg.update()
+
+    @info "\n[Step 5/6] Running vendor isolation..."
+    vendor_loaded_packages()
+
+    @info "\n[Step 6/6] Release preparation complete!"
+    @info "Vendored package directory: $(VENDOR_DIR)"
+end
+
+function print_help()
+    println("""
+    isolate-env.jl - JETLS Dependency Vendoring Script
+
+    USAGE:
+        julia isolate-env.jl --source-branch=<branch>
+
+    DESCRIPTION:
+        Automates the JETLS release process by vendoring all non-stdlib, non-JLL
+        dependencies. This creates isolated copies of dependencies with rewritten
+        UUIDs to avoid conflicts with packages being analyzed.
+
+    PROCESS:
+        1. Fetch Project.toml files from source branch
+        2. Backup existing Project.toml files (*.bak)
+        3. Clean manifest files
+        4. Update dependencies with Pkg.update()
+        5. Vendor packages:
+           - Copy package sources to vendor/ directory
+           - Rewrite UUIDs deterministically
+           - Update inter-package references
+        6. Replace Project.toml with vendored versions
+
+    OPTIONS:
+        --help, -h
+            Show this help message and exit
+
+        --source-branch=<branch>
+            Development branch to fetch Project.toml from (required)
+            Example: --source-branch=master
+
+    EXAMPLE:
+        # Prepare release branch with vendored dependencies from master
+        julia isolate-env.jl --source-branch=master
+
+    OUTPUT:
+        vendor/         Vendored package sources with rewritten UUIDs
+        Project.toml    Updated with vendored dependency UUIDs and [sources]
+        *.bak           Backup files of original Project.toml files
+
+    """)
+end
+
+function parse_args(args::Vector{String})
+    source_branch = nothing
+
+    for arg in args
+        if arg == "--help" || arg == "-h"
+            print_help()
+            exit(0)
+        elseif startswith(arg, "--source-branch=")
+            source_branch = split(arg, "=", limit=2)[2]
+        else
+            @warn "Unknown argument: $arg"
+            println("\nRun with --help for usage information")
+            exit(1)
+        end
+    end
+
+    if source_branch === nothing
+        error("--source-branch argument is required\nRun with --help for usage information")
+    end
+
+    return Config(source_branch)
+end
+
+function vendor_loaded_packages()
+    # Core vendoring logic:
+    # 1. Load JETLS to populate Base.loaded_modules
+    # 2. Copy package sources to vendor/ directory
+    # 3. Rewrite UUIDs in Project.toml files
+    # 4. Update dependency references between vendored packages
+    # 5. Update Project.toml with vendored UUIDs and [sources] entries
+
+    @info "Loading JETLS to populate Base.loaded_modules..."
+    @eval using JETLS
+
+    @info "Identifying packages to vendor..."
+    packages = collect_packages_to_vendor()
+    @info "Found $(length(packages)) packages to vendor:"
+    for (name, uuid) in packages
+        println("  $name => $uuid")
+    end
+
+    mkpath(VENDOR_DIR)
+
+    uuid_mapping = Dict{UUID, UUID}()
+
+    @info "Step 1: Copying packages and rewriting UUIDs..."
+    for (pkg_name, original_uuid) in packages
+        pkgid = Base.PkgId(original_uuid, pkg_name)
+        mod = get(Base.loaded_modules, pkgid, nothing)
+
+        if mod === nothing
+            @warn "Module $pkg_name not found in Base.loaded_modules, skipping"
+            continue
+        end
+
+        new_uuid = generate_new_uuid(original_uuid)
+        uuid_mapping[original_uuid] = new_uuid
+
+        vendor_pkg_dir = copy_package_source(mod, pkg_name)
+        rewrite_package_uuid(vendor_pkg_dir, new_uuid)
+    end
+
+    @info "Step 2: Updating inter-package dependencies..."
+    current_branch = get_current_branch()
+    for (pkg_name, _) in packages
+        vendor_pkg_dir = joinpath(VENDOR_DIR, pkg_name)
+        update_vendored_dependencies!(vendor_pkg_dir, uuid_mapping, current_branch)
+    end
+
+    @info "Step 3: Updating Project.toml with vendored dependencies..."
+    update_project_with_vendored_deps(uuid_mapping, packages)
+
+    @info "Step 4: Tidying up Project.toml format..."
+    project_path = joinpath(CURRENT_DIR, "Project.toml")
+    project = Pkg.Types.read_project(project_path)
+    Pkg.Types.write_project(project, project_path)
+
+    @info "Vendor isolation complete!"
+    @info "Vendored packages are in: $VENDOR_DIR"
+end
+
+function @main(args::Vector{String})
+    vendor_dependencies_from_branch(parse_args(args))
+end


### PR DESCRIPTION
This commit introduces a release process that isolates JETLS's dependencies from packages being analyzed by vendoring them with rewritten UUIDs.

The vendor-deps.jl script automates the entire release process:
1. Fetches clean Project.toml from the development branch
2. Updates and vendors all non-stdlib, non-JLL dependencies
3. Rewrites UUIDs deterministically using uuid5
4. Updates Project.toml with vendored dependencies and `[sources]` entries

This approach ensures JETLS's dependencies never conflict with packages users are analyzing, resolving issues where version conflicts between JETLS and analyzed packages would prevent analysis.

---

The following describes the current release process using the above script (at least until JETLS has an official release process).

Fow now, we employ the following branch strategy:
- Development branch (`master`): Regular development with normal UUIDs
- Release branch (`release`): Vendored dependencies with rewritten UUIDs

Then the `release` branch is managed as follows:
1. Check out the `release` branch
2. Merge (not rebase) changes from the development branch: `git merge -X theirs master`[^merge-strategy]
3. Vendor dependency packages: `julia vendor-deps.jl --source-branch=master`
4. Commit changes
5. Push to remote `release`

[^merge-strategy]: The `-X theirs` option automatically resolves merge conflicts by preferring the `master` branch version. This is necessary because `Project.toml` files are always modified on the `release` branch (with vendored UUIDs), causing conflicts when merging. Since `vendor-deps.jl` fetches and overwrites `Project.toml` from `master` anyway in step 3, these conflicts can be safely resolved by taking the `master` version. Using `git merge` (rather than `git rebase`) keeps the commit history linear for users who update via `git pull`.

This means users would manually run `git pull origin release` followed by `Pkg.update()` to install and update JETLS (this is almost the same as the  current process, except that we're pulling from `master`). However, I may change this distribution method to make it easier using Pkg apps.

For detailed consideration of this vendor approach and release process, refer to:
- https://publish.obsidian.md/jetls/work/JETLS/Release+process+for+JETLS+alpha
- https://publish.obsidian.md/jetls/work/JETLS/JETLS+environment+isolation