### PR TITLE
jetls: Migrate from runserver.jl to jetls executable app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,8 +147,8 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
 
-  test_runserver:
-    name: Test runserver.jl
+  test_jetls:
+    name: Test jetls executable
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -159,4 +159,4 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - name: run test
         run: |
-          julia --startup-file=no --project=./test ./test/test_runserver.jl
+          julia --startup-file=no --project=./test ./test/test_jetls.jl

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,4 +2,3 @@
 !out/
 !README.md
 !LICENSE.md
-!runserver.jl

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -143,7 +143,7 @@ For example, you can dynamically add `,` as a `triggerCharacter` for
 then add the following diff to unregister the already enabled completion feature.
 Make a small edit to the file the language server is currently analyzing to send
 some request from the client to the server. This will allow Revise to apply this
-diff to the server process via the dev mode callback (see [runserver.jl](./runserver.jl)),
+diff to the server process via the dev mode callback (see the `JETLS.main` entrypoint),
 which should disable the completion feature:
 ```diff
 diff --git a/src/completions.jl b/src/completions.jl

--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [sources]
@@ -25,7 +26,7 @@ Glob = {rev = "avi/globstar", url = "https://github.com/aviatesk/Glob.jl"}
 JET = {rev = "1e84376", url = "https://github.com/aviatesk/JET.jl"}
 JuliaLowering = {rev = "avi/JETLS-JSJL-head", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
 JuliaSyntax = {rev = "avi/JETLS-JSJL-head", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
-LSP = {path = "LSP"}
+LSP = {subdir = "LSP", url = "https://github.com/aviatesk/JETLS.jl"}
 
 [compat]
 Configurations = "0.17.6"
@@ -39,5 +40,9 @@ Pkg = "1.11.0"
 PrecompileTools = "1.3.2"
 Preferences = "1.4.3"
 REPL = "1.11.0"
+Sockets = "1.11.0"
 TOML = "1.0.3"
 julia = "1.12"
+
+[apps.jetls]
+julia_flags = ["--startup-file=no", "--history-file=no", "--threads=auto"]

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -301,7 +301,7 @@ See [TestRunner integration](@ref) for setup instructions.
 
 ## How to configure JETLS
 
-### Method 1: File-based configuration
+### [Method 1: File-based configuration](@id config/file-based-config)
 
 Create a `.JETLSConfig.toml` file in your project root.
 This configuration method works client-agnostically, thus allows projects to
@@ -328,7 +328,7 @@ severity = "off"
 executable = "/path/to/custom/testrunner"
 ```
 
-### Method 2: Editor configuration via LSP
+### [Method 2: Editor configuration via LSP](@id config/lsp-config)
 
 If your client supports [`workspace/configuration`](#workspace-configuration-support),
 you can configure JETLS in a client-specific manner.
@@ -336,16 +336,16 @@ As examples, we show the configuration methods for the VSCode extension
 [`jetls-client`](https://marketplace.visualstudio.com/items?itemName=aviatesk.jetls-client), and the Zed extension
 [`aviatesk/zed-julia#avi/JETLS`](https://github.com/aviatesk/zed-julia/tree/avi/JETLS).
 
-#### VSCode (`jetls-client` extension)
+#### [VSCode (`jetls-client` extension)](@id config/lsp-config/vscode)
 
-Configure JETLS in VSCode's settings.json file with `jetls-client.jetlsSettings`
+Configure JETLS in VSCode's settings.json file with `jetls-client.settings`
 section:
 
 > Example `.vscode/settings.json`:
 
 ```json
 {
-  "jetls-client.jetlsSettings": {
+  "jetls-client.settings": {
     "full_analysis": {
       "debounce": 2.0
     },
@@ -372,7 +372,7 @@ section:
 See [`package.json`](https://github.com/aviatesk/JETLS.jl/blob/master/package.json)
 for the complete list of available VSCode settings and their descriptions.
 
-#### Zed (`aviatesk/zed-julia#avi/JETLS` extension)
+#### [Zed (`aviatesk/zed-julia#avi/JETLS` extension)](@id config/lsp-config/zed)
 
 Configure JETLS in Zed's settings.json file with the `lsp.JETLS.settings`
 section:
@@ -383,14 +383,6 @@ section:
 {
   "lsp": {
     "JETLS": {
-      // Required configuration items for starting the server
-      "binary": {
-        "path": "/path/to/julia/executable",
-        "env": {
-          "JETLS_DIRECTORY": "/path/to/JETLS/directory/"
-        }
-      },
-      // JETLS configurations
       "settings": {
         "full_analysis": {
           "debounce": 2.0

--- a/docs/src/launching.md
+++ b/docs/src/launching.md
@@ -1,23 +1,29 @@
 # Launching JETLS
 
-This guide explains how to launch the JETLS language server using
-`runserver.jl` and describes the available communication channels.
+This guide explains how to launch the JETLS language server using the `jetls`
+executable and describes the available communication channels.
 
-## Using runserver.jl
+## Using the `jetls` executable
 
-The JETLS server is launched using the `runserver.jl` script at the root of
-the repository. You can run it with various options to configure how the
-server communicates with clients.
-
-> `julia runserver.jl --help`
+The JETLS server is launched using the `jetls` executable, which is the main
+entry point of launching JETLS that can be installed as an
+[executable app](https://pkgdocs.julialang.org/dev/apps/) via Pkg.jl:
+```bash
+julia -e 'using Pkg; Pkg.Apps.add("https://github.com/aviatesk/JETLS.jl")'
 ```
-JETLS - A Julia language server providing advanced static analysis and seamless
-runtime integration. Powered by JET.jl, JuliaSyntax.jl, and JuliaLowering.jl.
 
-Usage: julia runserver.jl [OPTIONS]
+You can run `jetls` with various options to configure how the server communicates
+with clients.
+
+> `jetls --help`
+```
+JETLS - A Julia language server with runtime-aware static analysis,
+powered by JET.jl, JuliaSyntax.jl, and JuliaLowering.jl
+
+Usage: jetls [OPTIONS]
 
 Communication channel options (choose one, default: --stdio):
-  --stdio                     Use standard input/output
+  --stdio                     Use standard input/output (not recommended)
   --pipe-connect=<path>       Connect to client's Unix domain socket/named pipe
   --pipe-listen=<path>        Listen on Unix domain socket/named pipe
   --socket=<port>             Listen on TCP socket
@@ -27,16 +33,16 @@ Options:
   --help, -h                  Show this help message
 
 Examples:
-  julia runserver.jl
-  julia runserver.jl --socket=8080
-  julia runserver.jl --pipe-connect=/tmp/jetls.sock --clientProcessId=12345
-  julia runserver.jl --pipe-listen=/tmp/jetls.sock
+  jetls --pipe-listen=/tmp/jetls.sock
+  jetls --pipe-connect=/tmp/jetls.sock --clientProcessId=12345
+  jetls --socket=8080
+  jetls --threads=auto -- --clientProcessId=12345
 ```
 
 ## Communication channels
 
-`runserver.jl` supports multiple communication channels between the client and server.
-Choose based on your environment and requirements:
+The `jetls` executable supports multiple communication channels between the
+client and server. Choose based on your environment and requirements:
 
 ### `pipe-connect` / `pipe-listen` (Unix domain socket / named pipe)
 
@@ -46,7 +52,7 @@ Choose based on your environment and requirements:
 - **Limitations**: Not suitable for cross-container communication
 - **Note**: Client is responsible for socket file cleanup in both modes
 
-`runserver.jl` provides two pipe modes:
+The `jetls` executable provides two pipe modes:
 
 #### `pipe-connect`
 
@@ -60,7 +66,7 @@ Server connects to a client-created socket. This is the mode used by the
 
 Example:
 ```bash
-julia runserver.jl --pipe-connect=/tmp/jetls.sock
+jetls --pipe-connect=/tmp/jetls.sock
 ```
 
 #### `pipe-listen`
@@ -75,7 +81,7 @@ This is the traditional LSP server mode:
 
 Example:
 ```bash
-julia runserver.jl --pipe-listen=/tmp/jetls.sock
+jetls --pipe-listen=/tmp/jetls.sock
 ```
 
 ### `socket` (TCP)
@@ -89,7 +95,7 @@ julia runserver.jl --pipe-listen=/tmp/jetls.sock
 
 Example:
 ```bash
-julia runserver.jl --socket=7777
+jetls --socket=7777
 ```
 
 The server will print `<JETLS-PORT>7777</JETLS-PORT>` to stdout once it starts
@@ -97,7 +103,7 @@ listening. This is especially useful when using `--socket=0` for automatic port
 assignment, as the actual port number will be announced:
 
 ```bash
-julia runserver.jl --socket=0
+jetls --socket=0
 # Output: <JETLS-PORT>54321</JETLS-PORT>  (actual port assigned by OS)
 ```
 
@@ -116,9 +122,9 @@ ssh -L 8080:localhost:8080 user@remote
 
 Example:
 ```bash
-julia runserver.jl --stdio
+jetls --stdio
 # or simply
-julia runserver.jl
+jetls
 ```
 
 !!! warning
@@ -126,7 +132,7 @@ julia runserver.jl
     dependency packages may corrupt the LSP protocol and break the connection.
     Prefer `pipe` or `socket` modes when possible.
 
-## Communication channel configuration for VSCode (`jetls-client`)
+## [Communication channel configuration for VSCode (`jetls-client`)](@id communication/vscode)
 
 The [`jetls-client`](https://marketplace.visualstudio.com/items?itemName=aviatesk.jetls-client)
 VSCode extension by default automatically selects the most appropriate

--- a/package.json
+++ b/package.json
@@ -44,23 +44,40 @@
       "type": "object",
       "title": "JETLS configurations",
       "properties": {
-        "jetls-client.juliaExecutablePath": {
+        "jetls-client.executable": {
           "scope": "resource",
-          "type": "string",
-          "default": "julia",
-          "description": "Path to the Julia executable."
-        },
-        "jetls-client.juliaThreads": {
-          "scope": "resource",
-          "type": "string",
-          "default": "auto",
-          "description": "Number of Julia threads to use (used as --threads= option). Default is 'auto'."
-        },
-        "jetls-client.jetlsDirectory": {
-          "scope": "resource",
-          "type": "string",
-          "default": "",
-          "description": "Directory path for JETLS project environment (used as --project= option). If not set, uses global Julia environment."
+          "oneOf": [
+            {
+              "type": "object",
+              "markdownDescription": "Standard configuration (recommended for most users).",
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "default": "jetls",
+                  "markdownDescription": "Path to the `jetls` executable. Default is `'jetls'` (`'jetls.exe'` on Windows) which expects the executable to be in your `PATH`."
+                },
+                "threads": {
+                  "type": "string",
+                  "default": "auto",
+                  "markdownDescription": "Number of Julia threads to use (used as `--threads=` option). Default is `'auto'`."
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "array",
+              "markdownDescription": "Advanced: Full command to launch JETLS from a local checkout.",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "default": {
+            "path": "jetls",
+            "threads": "auto"
+          },
+          "markdownDescription": "JETLS executable configuration. Most users do not need to change this.\n\nUse object form `{path, threads}` to customize the installed JETLS executable path or thread setting.\n\nUse array form `[\"julia\", \"--startup-file=no\", \"--history-file=no\", \"--project=/path/to/JETLS\", \"-m\", \"JETLS\"]` to use a local JETLS checkout instead of globally installed executable.",
+          "order": 1
         },
         "jetls-client.communicationChannel": {
           "scope": "resource",
@@ -72,28 +89,31 @@
             "socket"
           ],
           "default": "auto",
-          "description": "Communication channel for the language server. 'auto' (default) selects the best option based on environment, 'pipe' for local development with stdout isolation, 'socket' for network communication, or 'stdio' for maximum compatibility (but risk of stdout pollution)."
+          "markdownDescription": "Communication channel for the language server:\n- `'auto'` (default) selects the best option based on environment\n- `'pipe'` for local development with stdout isolation\n- `'socket'` for network communication\n- `'stdio'` for maximum compatibility (but risk of stdout pollution).\n\nSee [Communication channels](https://aviatesk.github.io/JETLS.jl/dev/launching/#Communication-channels) documentation for more details.",
+          "order": 2
         },
         "jetls-client.socketPort": {
           "scope": "resource",
           "type": "number",
           "default": 0,
-          "description": "Port number for socket communication (0 = auto-assign). Only used when 'socket' communication channel is used."
+          "markdownDescription": "Port number for socket communication (`0` = auto-assign). Only used when `'socket'` communication channel is used.",
+          "order": 3
         },
-        "jetls-client.jetlsSettings": {
+        "jetls-client.settings": {
           "scope": "resource",
           "type": "object",
           "default": {},
-          "markdownDescription": "JETLS server configuration settings. See [JETLS Configuration](https://github.com/aviatesk/JETLS.jl#configuration) for available options.",
+          "markdownDescription": "JETLS server configuration settings. See [Configuration documentation](https://aviatesk.github.io/JETLS.jl/dev/configuration/) for detailed information.",
           "properties": {
             "full_analysis": {
               "type": "object",
+              "markdownDescription": "Configuration for full JET analysis. See [Full analysis configuration](https://aviatesk.github.io/JETLS.jl/dev/configuration/#config/full_analysis).",
               "properties": {
                 "debounce": {
                   "type": "number",
                   "default": 1,
                   "minimum": 0,
-                  "description": "Debounce time in seconds before triggering full analysis after a document change."
+                  "markdownDescription": "Debounce time in seconds before triggering full analysis after a document change."
                 }
               }
             },
@@ -106,7 +126,7 @@
                     "JuliaFormatter"
                   ],
                   "default": "Runic",
-                  "description": "Preset formatter to use. 'Runic' (default) or 'JuliaFormatter'."
+                  "markdownDescription": "Preset formatter to use: `'Runic'` (default) or `'JuliaFormatter'`."
                 },
                 {
                   "type": "object",
@@ -116,11 +136,11 @@
                       "properties": {
                         "executable": {
                           "type": "string",
-                          "description": "Path to custom formatter executable for document formatting. Optional."
+                          "markdownDescription": "Path to custom formatter executable for document formatting."
                         },
                         "executable_range": {
                           "type": "string",
-                          "description": "Path to custom formatter executable for range formatting. Optional."
+                          "markdownDescription": "Path to custom formatter executable for range formatting."
                         }
                       }
                     }
@@ -128,20 +148,21 @@
                 }
               ],
               "default": "Runic",
-              "markdownDescription": "Formatter configuration. Can be a preset name ('Runic' or 'JuliaFormatter') or a custom formatter object. See [Formatting](https://github.com/aviatesk/JETLS.jl#formatting) for details."
+              "markdownDescription": "Formatter configuration. Can be a preset name (`'Runic'` or `'JuliaFormatter'`) or a custom formatter object. See [Formatting configuration](https://aviatesk.github.io/JETLS.jl/dev/configuration/#config/formatter)."
             },
             "diagnostic": {
               "type": "object",
+              "markdownDescription": "Diagnostic configuration. See [Diagnostic configuration](https://aviatesk.github.io/JETLS.jl/dev/configuration/#config/diagnostic).",
               "properties": {
                 "enabled": {
                   "type": "boolean",
                   "default": true,
-                  "description": "Enable or disable all JETLS diagnostics. When set to false, no diagnostic messages will be shown."
+                  "markdownDescription": "Enable or disable all JETLS diagnostics. When set to `false`, no diagnostic messages will be shown."
                 },
                 "patterns": {
                   "type": "array",
                   "default": [],
-                  "description": "Fine-grained control over diagnostics through pattern matching against diagnostic codes or messages.",
+                  "markdownDescription": "Fine-grained control over diagnostics through pattern matching. See [Pattern-based diagnostic configuration](https://aviatesk.github.io/JETLS.jl/dev/configuration/#config/diagnostic/patterns).",
                   "items": {
                     "type": "object",
                     "required": [
@@ -153,7 +174,7 @@
                     "properties": {
                       "pattern": {
                         "type": "string",
-                        "description": "The pattern to match (e.g., 'lowering/unused-argument' for code matching, or 'Macro name `.*` not found' for message matching)."
+                        "markdownDescription": "The pattern to match (e.g., `'lowering/unused-argument'` for code matching, or `'Macro name .*'` for message matching)."
                       },
                       "match_by": {
                         "type": "string",
@@ -161,7 +182,7 @@
                           "code",
                           "message"
                         ],
-                        "description": "What to match against: 'code' matches against diagnostic codes (e.g., 'lowering/unused-argument'), 'message' matches against diagnostic message text."
+                        "markdownDescription": "What to match against:\n- `'code'`: Match against diagnostic codes (e.g., `'lowering/unused-argument'`)\n- `'message'`: Match against diagnostic message text"
                       },
                       "match_type": {
                         "type": "string",
@@ -169,7 +190,7 @@
                           "literal",
                           "regex"
                         ],
-                        "description": "How to interpret the pattern: 'literal' for exact string match, 'regex' for regular expression match."
+                        "markdownDescription": "How to interpret the pattern:\n- `'literal'`: Exact string match\n- `'regex'`: Regular expression match"
                       },
                       "severity": {
                         "oneOf": [
@@ -196,11 +217,11 @@
                             ]
                           }
                         ],
-                        "description": "Severity level to apply: 'error'/1 for critical issues, 'warning'/'warn'/2 for potential problems, 'information'/'info'/3 for informational messages, 'hint'/4 for suggestions, 'off'/0 to disable."
+                        "markdownDescription": "Severity level:\n- `'error'`/`1`: Critical issues\n- `'warning'`/`'warn'`/`2`: Potential problems\n- `'information'`/`'info'`/`3`: Informational messages\n- `'hint'`/`4`: Suggestions\n- `'off'`/`0`: Disable"
                       },
                       "path": {
                         "type": "string",
-                        "description": "Optional glob pattern to restrict this configuration to specific files (e.g., 'test/**/*.jl'). Patterns are matched against file paths relative to the workspace root. Supports globstar (**) for matching directories recursively."
+                        "markdownDescription": "Optional glob pattern to restrict this configuration to specific files (e.g., `'test/**/*.jl'`). Patterns are matched against file paths relative to the workspace root. Supports globstar (`**`) for matching directories recursively."
                       }
                     }
                   }
@@ -209,15 +230,17 @@
             },
             "testrunner": {
               "type": "object",
+              "markdownDescription": "TestRunner integration configuration. See [TestRunner integration](https://aviatesk.github.io/JETLS.jl/dev/configuration/#config/testrunner).",
               "properties": {
                 "executable": {
                   "type": "string",
                   "default": "testrunner",
-                  "description": "Path to the TestRunner.jl executable. If not set, uses 'testrunner' from PATH."
+                  "markdownDescription": "Path to the TestRunner.jl executable. If not set, uses `'testrunner'` from `PATH`."
                 }
               }
             }
-          }
+          },
+          "order": 0
         }
       }
     }

--- a/runserver.jl
+++ b/runserver.jl
@@ -1,189 +1,26 @@
-module var"##__JETLSEntryPoint__##"
+#!/usr/bin/env julia
 
-@info "Running JETLS with Julia version" VERSION
+# Migration message for users still using runserver.jl
+println(stderr, """
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+WARNING: runserver.jl is deprecated and will be removed in a future release.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-using Pkg
-using Sockets
+Please use the `jetls` executable app instead.
 
-# TODO load Revise only when `JETLS_DEV_MODE` is true
-try
-    # load Revise with JuliaInterpreter used by JETLS
-    using Revise
-catch
-    @warn "Revise not found"
-end
+Installation:
+  julia -e 'using Pkg; Pkg.Apps.add("https://github.com/aviatesk/JETLS.jl")'
 
-@info "Loading JETLS..."
+Migration:
+  Old: julia --project=/path/to/JETLS runserver.jl --socket=8080
+  New: jetls --socket=8080
 
-try
-    using JETLS
-catch
-    @error "JETLS not found in this environment" Pkg.project().path
-    exit(1)
-end
+For local JETLS development:
+  julia --project=/path/to/JETLS -m JETLS [OPTIONS]
 
-function show_help()
-    println(stdout, """
-    JETLS - A Julia language server providing advanced static analysis and seamless
-    runtime integration. Powered by JET.jl, JuliaSyntax.jl, and JuliaLowering.jl.
+Read https://aviatesk.github.io/JETLS.jl/dev/#JETLS.jl-documentation for more details.
 
-    Usage: julia runserver.jl [OPTIONS]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+""")
 
-    Communication channel options (choose one, default: --stdio):
-      --stdio                     Use standard input/output
-      --pipe-connect=<path>       Connect to client's Unix domain socket/named pipe
-      --pipe-listen=<path>        Listen on Unix domain socket/named pipe
-      --socket=<port>             Listen on TCP socket
-
-    Options:
-      --clientProcessId=<pid>     Monitor client process (enables crash detection)
-      --help, -h                  Show this help message
-
-    Examples:
-      julia runserver.jl
-      julia runserver.jl --socket=8080
-      julia runserver.jl --pipe-connect=/tmp/jetls.sock --clientProcessId=12345
-      julia runserver.jl --pipe-listen=/tmp/jetls.sock
-    """)
-end
-
-function (@main)(args::Vector{String})::Cint
-    pipe_connect_path = pipe_listen_path = socket_port = client_process_id = nothing
-
-    i = 1
-    while i <= length(args)
-        arg = args[i]
-        if occursin(r"^(?:-h|--help|help)$", arg)
-            show_help()
-            return Cint(0)
-        elseif occursin(r"^(?:--)?stdio$", arg)
-        elseif occursin(r"^(?:--)?pipe-connect$", arg)
-            if i < length(args)
-                pipe_connect_path = args[i+1]
-                i += 1
-            else
-                @error "--pipe-connect requires a path argument: use --pipe-connect=<path> or --pipe-connect <path>"
-                return Cint(1)
-            end
-        elseif (m = match(r"^--pipe-connect=(.+)$", arg); !isnothing(m))
-            pipe_connect_path = m.captures[1]
-        elseif occursin(r"^(?:--)?pipe-listen$", arg)
-            if i < length(args)
-                pipe_listen_path = args[i+1]
-                i += 1
-            else
-                @error "--pipe-listen requires a path argument: use --pipe-listen=<path> or --pipe-listen <path>"
-                return Cint(1)
-            end
-        elseif (m = match(r"^--pipe-listen=(.+)$", arg); !isnothing(m))
-            pipe_listen_path = m.captures[1]
-        elseif occursin(r"^(?:--)?socket$", arg)
-            if i < length(args)
-                socket_port = tryparse(Int, args[i+1])
-                i += 1
-                @goto check_socket_port
-            else
-                @error "--socket requires a port argument: use --socket=<port> or --socket <port>"
-                return Cint(1)
-            end
-        elseif (m = match(r"^--socket=(\d+)$", arg); !isnothing(m))
-            socket_port = tryparse(Int, m.captures[1])
-            @label check_socket_port
-            if isnothing(socket_port)
-                @error "Invalid port number for --socket (must be a valid integer)"
-                return Cint(1)
-            end
-        elseif occursin(r"^--clientProcessId$", arg)
-            if i < length(args)
-                client_process_id = tryparse(Int, args[i+1])
-                i += 1
-                @goto check_client_process_id
-            else
-                @error "--clientProcessId requires a process ID argument: use --clientProcessId=<pid> or --clientProcessId <pid>"
-                return Cint(1)
-            end
-        elseif (m = match(r"^--clientProcessId=(\d+)$", arg); !isnothing(m))
-            client_process_id = tryparse(Int, m.captures[1])
-            @label check_client_process_id
-            if isnothing(client_process_id)
-                @error "Invalid process ID for --clientProcessId (must be a valid integer)"
-                return Cint(1)
-            end
-        else
-            @error "Unknown CLI argument" arg
-            return Cint(1)
-        end
-        i += 1
-    end
-
-    isnothing(client_process_id) ||
-        @info "Client process ID provided via command line" client_process_id
-
-    # Create endpoint based on communication channel
-    if !isnothing(pipe_connect_path)
-        try
-            pipe_type = Sys.iswindows() ? "Windows named pipe" : "Unix domain socket"
-            conn = connect(pipe_connect_path)
-            endpoint = Endpoint(conn, conn)
-            @info "Connected to $pipe_type" pipe_connect_path
-        catch e
-            @error "Failed to connect to pipe" pipe_connect_path
-            Base.display_error(stderr, e, catch_backtrace())
-            return Cint(1)
-        end
-    elseif !isnothing(pipe_listen_path)
-        try
-            pipe_type = Sys.iswindows() ? "Windows named pipe" : "Unix domain socket"
-            server_socket = listen(pipe_listen_path)
-            println(stdout, "<JETLS-PIPE-READY>$pipe_listen_path</JETLS-PIPE-READY>")
-            @info "Waiting for connection on $pipe_type" pipe_listen_path
-            conn = accept(server_socket)
-            endpoint = Endpoint(conn, conn)
-            @info "Accepted connection on $pipe_type"
-        catch e
-            @error "Failed to listen on pipe" pipe_listen_path
-            Base.display_error(stderr, e, catch_backtrace())
-            return Cint(1)
-        end
-    elseif !isnothing(socket_port)
-        try
-            server_socket = listen(socket_port)
-            actual_port = getsockname(server_socket)[2]
-            println(stdout, "<JETLS-PORT>$actual_port</JETLS-PORT>")
-            @info "Waiting for connection on port" actual_port
-            conn = accept(server_socket)
-            endpoint = Endpoint(conn, conn)
-            @info "Connected via TCP socket" actual_port
-        catch e
-            @error "Failed to create socket connection" socket_port
-            Base.display_error(stderr, e, catch_backtrace())
-            return Cint(1)
-        end
-    else # use stdio as the communication channel
-        endpoint = Endpoint(stdin, stdout)
-        @info "Using stdio for communication"
-    end
-
-    if JETLS.JETLS_DEV_MODE
-        server = Server(endpoint) do s::Symbol, x
-            @nospecialize x
-            # allow Revise to apply changes with the dev mode enabled
-            if s === :received
-                if !(x isa JETLS.ShutdownRequest || x isa JETLS.ExitNotification)
-                    Revise.revise()
-                end
-            end
-        end
-        JETLS.currently_running = server
-        t = Threads.@spawn :interactive runserver(server; client_process_id)
-    else
-        t = Threads.@spawn :interactive runserver(endpoint; client_process_id)
-    end
-    res = fetch(t)
-    @info "JETLS server stopped" res.exit_code
-    return res.exit_code
-end
-
-end # module var"##__JETLSEntryPoint__##"
-
-using .var"##__JETLSEntryPoint__##": main
+exit(1)

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -15,9 +15,6 @@ const JETLS_DEBUG_LOWERING = Preferences.@load_preference("JETLS_DEBUG_LOWERING"
 function show_setup_info(msg)
     @info msg Sys.BINDIR pkgdir(JETLS) Threads.nthreads() JETLS_DEV_MODE JETLS_TEST_MODE JETLS_DEBUG_LOWERING
 end
-push_init_hooks!() do
-    show_setup_info("Running JETLS with the following setup:")
-end
 
 using LSP
 using LSP: LSP
@@ -422,6 +419,8 @@ function handle_notification_message(server::Server, @nospecialize msg)
     end
     nothing
 end
+
+include("app.jl")
 
 include("precompile.jl")
 

--- a/src/app.jl
+++ b/src/app.jl
@@ -1,0 +1,183 @@
+using Sockets: Sockets
+
+const help_message = """
+    JETLS - A Julia language server with runtime-aware static analysis,
+    powered by JET.jl, JuliaSyntax.jl, and JuliaLowering.jl
+
+    Usage: jetls [OPTIONS]
+
+    Communication channel options (choose one, default: --stdio):
+      --stdio                     Use standard input/output (not recommended)
+      --pipe-connect=<path>       Connect to client's Unix domain socket/named pipe
+      --pipe-listen=<path>        Listen on Unix domain socket/named pipe
+      --socket=<port>             Listen on TCP socket
+
+    Options:
+      --clientProcessId=<pid>     Monitor client process (enables crash detection)
+      --help, -h                  Show this help message
+
+    Examples:
+      jetls --pipe-listen=/tmp/jetls.sock
+      jetls --pipe-connect=/tmp/jetls.sock --clientProcessId=12345
+      jetls --socket=8080
+      jetls --threads=auto -- --clientProcessId=12345
+    """
+
+@doc help_message
+function (@main)(args::Vector{String})::Cint
+    pipe_connect_path = pipe_listen_path = socket_port = client_process_id = nothing
+
+    i = 1
+    while i <= length(args)
+        arg = args[i]
+        if occursin(r"^(?:-h|--help|help)$", arg)
+            println(stdout, help_message)
+            return Cint(0)
+        elseif occursin(r"^(?:--)?stdio$", arg)
+        elseif occursin(r"^(?:--)?pipe-connect$", arg)
+            if i < length(args)
+                pipe_connect_path = args[i+1]
+                i += 1
+            else
+                @error "--pipe-connect requires a path argument: use --pipe-connect=<path> or --pipe-connect <path>"
+                return Cint(1)
+            end
+        elseif (m = match(r"^--pipe-connect=(.+)$", arg); !isnothing(m))
+            pipe_connect_path = m.captures[1]
+        elseif occursin(r"^(?:--)?pipe-listen$", arg)
+            if i < length(args)
+                pipe_listen_path = args[i+1]
+                i += 1
+            else
+                @error "--pipe-listen requires a path argument: use --pipe-listen=<path> or --pipe-listen <path>"
+                return Cint(1)
+            end
+        elseif (m = match(r"^--pipe-listen=(.+)$", arg); !isnothing(m))
+            pipe_listen_path = m.captures[1]
+        elseif occursin(r"^(?:--)?socket$", arg)
+            if i < length(args)
+                socket_port = tryparse(Int, args[i+1])
+                i += 1
+                @goto check_socket_port
+            else
+                @error "--socket requires a port argument: use --socket=<port> or --socket <port>"
+                return Cint(1)
+            end
+        elseif (m = match(r"^--socket=(\d+)$", arg); !isnothing(m))
+            socket_port = tryparse(Int, m.captures[1])
+            @label check_socket_port
+            if isnothing(socket_port)
+                @error "Invalid port number for --socket (must be a valid integer)"
+                return Cint(1)
+            end
+        elseif occursin(r"^--clientProcessId$", arg)
+            if i < length(args)
+                client_process_id = tryparse(Int, args[i+1])
+                i += 1
+                @goto check_client_process_id
+            else
+                @error "--clientProcessId requires a process ID argument: use --clientProcessId=<pid> or --clientProcessId <pid>"
+                return Cint(1)
+            end
+        elseif (m = match(r"^--clientProcessId=(\d+)$", arg); !isnothing(m))
+            client_process_id = tryparse(Int, m.captures[1])
+            @label check_client_process_id
+            if isnothing(client_process_id)
+                @error "Invalid process ID for --clientProcessId (must be a valid integer)"
+                return Cint(1)
+            end
+        else
+            @error "Unknown CLI argument" arg
+            return Cint(1)
+        end
+        i += 1
+    end
+
+    isnothing(client_process_id) ||
+        @info "Client process ID provided via command line" client_process_id
+
+    local endpoint::Endpoint
+    if !isnothing(pipe_connect_path)
+        try
+            pipe_type = Sys.iswindows() ? "Windows named pipe" : "Unix domain socket"
+            conn = Sockets.connect(pipe_connect_path)
+            endpoint = Endpoint(conn, conn)
+            @info "Connected to $pipe_type" pipe_connect_path
+        catch e
+            @error "Failed to connect to pipe" pipe_connect_path
+            Base.display_error(stderr, e, catch_backtrace())
+            return Cint(1)
+        end
+    elseif !isnothing(pipe_listen_path)
+        try
+            pipe_type = Sys.iswindows() ? "Windows named pipe" : "Unix domain socket"
+            server_socket = Sockets.listen(pipe_listen_path)
+            println(stdout, "<JETLS-PIPE-READY>$pipe_listen_path</JETLS-PIPE-READY>")
+            @info "Waiting for connection on $pipe_type" pipe_listen_path
+            conn = Sockets.accept(server_socket)
+            endpoint = Endpoint(conn, conn)
+            @info "Accepted connection on $pipe_type"
+        catch e
+            @error "Failed to listen on pipe" pipe_listen_path
+            Base.display_error(stderr, e, catch_backtrace())
+            return Cint(1)
+        end
+    elseif !isnothing(socket_port)
+        try
+            server_socket = Sockets.listen(socket_port)
+            actual_port = Sockets.getsockname(server_socket)[2]
+            println(stdout, "<JETLS-PORT>$actual_port</JETLS-PORT>")
+            @info "Waiting for connection on port" actual_port
+            conn = Sockets.accept(server_socket)
+            endpoint = Endpoint(conn, conn)
+            @info "Connected via TCP socket" actual_port
+        catch e
+            @error "Failed to create socket connection" socket_port
+            Base.display_error(stderr, e, catch_backtrace())
+            return Cint(1)
+        end
+    else # use stdio as the communication channel
+        endpoint = Endpoint(stdin, stdout)
+        @info "Using stdio for communication"
+    end
+
+    show_setup_info("Running JETLS with the following setup:")
+
+    old_LOAD_PATH = copy(LOAD_PATH)
+    try
+        # HACK: Set `LOAD_PATH` to the same state as during normal Julia script execution.
+        # JETLS internally uses `Pkg.activate` on user package environments and may actually load them,
+        # so this replacement is necessary.
+        empty!(LOAD_PATH)
+        push!(LOAD_PATH, "@", "@v$(VERSION.major).$(VERSION.minor)", "@stdlib")
+
+        if JETLS_DEV_MODE
+            # Load Revise only in `JETLS_DEV_MODE`
+            Revise = try
+                @info "Loading Revise in JETLS_DEV_MODE"
+                Base.require(Base.PkgId(Base.UUID("295af30f-e4ad-537b-8983-00126c2a3abe"), "Revise"))
+            catch e
+                @warn "Failed to load Revise in JETLS_DEV_MODE" e
+                nothing
+            end
+            global currently_running
+            currently_running = server = Server(endpoint) do s::Symbol, x
+                @nospecialize x
+                # allow Revise to apply changes with the dev mode enabled
+                if s === :received
+                    if !(x isa ShutdownRequest || x isa ExitNotification)
+                        Revise !== nothing && @invokelatest Revise.revise()
+                    end
+                end
+            end
+            t = Threads.@spawn :interactive runserver(server; client_process_id)
+        else
+            t = Threads.@spawn :interactive runserver(endpoint; client_process_id)
+        end
+        res = fetch(t)
+        @info "JETLS server stopped" res.exit_code
+        return res.exit_code
+    finally
+        append!(LOAD_PATH, old_LOAD_PATH)
+    end
+end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -38,6 +38,8 @@ module __demo__ end
                 virtualize=false,
                 context=__demo__,
                 toplevel_logger=nothing)
+
+            precompile(main, (Vector{String},))
         end
     end
 end

--- a/test/test_jetls.jl
+++ b/test/test_jetls.jl
@@ -1,16 +1,16 @@
-module test_runserver
+module test_jetls
 
 """
-Test file for exercising runserver.jl with raw JSON communication.
+Test file for exercising the `jetls` executable app with raw JSON communication.
 
-This test spawns actual server processes using runserver.jl and communicates
+This test spawns actual server processes using `julia -m JETLS` and communicates
 with them via stdin/stdout using raw JSON-RPC messages, testing:
 
 1. Server startup and basic lifecycle (initialize, shutdown, exit)
 2. Process management and graceful termination
 
 To run this test independently:
-    julia --startup-file=no -e 'using Test; @testset "runserver" include("test/test_runserver.jl")'
+    julia --startup-file=no -e 'using Test; @testset "jetls" include("test/test_jetls.jl")'
 """
 
 using Test
@@ -19,10 +19,9 @@ using JETLS
 # Test configuration
 const JULIA_CMD = normpath(Sys.BINDIR, "julia")
 const JETLS_DIR = pkgdir(JETLS)
-const SERVER_SCRIPT = normpath(JETLS_DIR, "runserver.jl")
 
 function withserverprocess(f)
-    cmd = `$JULIA_CMD --project=$JETLS_DIR $SERVER_SCRIPT`
+    cmd = `$JULIA_CMD --project=$JETLS_DIR -m JETLS`
     proc = open(cmd; write=true, read=true)
     try
         return f(proc)
@@ -123,7 +122,7 @@ withserverprocess() do proc
     }"""
     write_lsp_message(proc, exit_msg)
 
-    @test with_timeout(#=timeout=#DEFAULT_TIMEOUT, "server process to shutdown") do elapsed
+    @test with_timeout(#=timeout=#DEFAULT_TIMEOUT, "server process to shutdown") do _
         process_running(proc) && return nothing
         return true
     end
@@ -160,11 +159,11 @@ withserverprocess() do proc
     }"""
     write_lsp_message(proc, exit_msg)
 
-    @test with_timeout(#=timeout=#DEFAULT_TIMEOUT, "server process to shutdown") do elapsed
+    @test with_timeout(#=timeout=#DEFAULT_TIMEOUT, "server process to shutdown") do _
         process_running(proc) && return nothing
         return true
     end
     @test process_exited(proc) && proc.exitcode == 1
 end
 
-end # module test_runserver
+end # module test_jetls


### PR DESCRIPTION
Replace the runserver.jl entry point with a proper Julia executable app (`jetls`), which can be installed via `Pkg.Apps.add`. This provides a cleaner installation and update workflow for users.

Major changes:
- Implement app.jl with `@main` entry point handling CLI arguments
- Update `jetls-client` to use configurable executable with union type:
  - Standard mode: `{path: "jetls", threads: "auto"}`
  - Custom mode: `["julia", "--project=/path", "-m", "JETLS"]` for local development
- Replace runserver.jl with deprecation notice directing users to jetls app
- Update all documentation (index.md, launching.md, configuration.md) to reference jetls instead of runserver.jl
- Simplify editor setup examples (Emacs, Neovim, Helix) to use `jetls` command
- Change `jetls-client.jetlsSettings` to `jetls-client.settings` for consistency

The jetls app provides:
- Simplified installation: `julia -e 'using Pkg; Pkg.Apps.add("JETLS")'`
- Easy updates: `julia -e 'using Pkg; Pkg.Apps.update("JETLS")'`
- Clean CLI with `--threads`, communication channel options
- Support for local development via `julia -m JETLS`

Backward compatibility:
- runserver.jl now shows migration instructions and exits with error code 1
- Will be completely removed in a future release