### PR TITLE
jetls-client: Prepare v0.2.0 release with migration support

### DIFF
--- a/jetls-client/CHANGELOG.md
+++ b/jetls-client/CHANGELOG.md
@@ -10,7 +10,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > [!note]
 >
 > - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
+
+## [v0.2.0]
+
+[v0.2.0]: https://github.com/aviatesk/JETLS.jl/compare/b0a4a4c...HEAD
+
+> [!note]
+>
 > - Diff: [`b0a4a4c...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/b0a4a4c...HEAD)
+
+> [!warning]
+> **Breaking changes**: JETLS installation method has changed significantly.
+> You must reinstall JETLS using the new `jetls` executable app.
+> See the [installation steps](#installation-steps) below.
+
+### Installation steps
+
+1. Install the `jetls` executable app:
+   ```bash
+   julia -e 'using Pkg; Pkg.Apps.add("https://github.com/aviatesk/JETLS.jl#release")'
+   ```
+2. Make sure `~/.julia/bin` is in your `PATH`
+3. Restart VSCode
 
 ### Changed
 


### PR DESCRIPTION
Update jetls-client to v0.2.0 with enhanced update notification system that guides users through the breaking changes in JETLS installation method.

Changes:
- Update CHANGELOG.md with v0.2.0 release notes including breaking changes and installation steps
- Implement three-tier notification system in checkForUpdates():
  1. First-time installation: Welcome message with 'Install JETLS' button that runs the new installation command
  2. v0.1.x -> v0.2.0 upgrade: Warning message about breaking changes with 'Reinstall JETLS' button and link to migration guide (CHANGELOG.md#v020)
  3. Normal updates: Standard update notification with 'Update JETLS' button
- All notifications provide direct terminal commands or documentation links for easy user action

The v0.2.0 release requires users to reinstall JETLS using the new `jetls` executable app method instead of the previous runserver.jl approach. The notification system ensures smooth migration for existing users while providing clear onboarding for new users.