### PR TITLE
CI: Add path-based triggers

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,17 @@ on:
   push:
     branches:
       - master
+    paths:
+      - "src/**"
+      - "test/**"
+      - "LSP/**"
+      - ".github/workflows/CI.yml"
   pull_request:
+    paths:
+      - "src/**"
+      - "test/**"
+      - "LSP/**"
+      - ".github/workflows/CI.yml"
 
 jobs:
   test:
@@ -128,22 +138,6 @@ jobs:
       - uses: julia-actions/julia-runtest@latest
         env:
           JULIA_NUM_THREADS: "4,2"
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
-
-  LSP:
-    name: Test LSP.jl
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: "1.12" # most stable version
-          arch: x64
-      - uses: julia-actions/cache@v2
-      - name: test LSP
-        shell: julia --color=yes --project=. {0}    # this is necessary for the next command to work on Windows
-        run: 'using Pkg; Pkg.activate(normpath(pwd(), "LSP")); Pkg.instantiate(); Pkg.test(; coverage=true)'
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
 

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -4,8 +4,13 @@ on:
   push:
     branches:
       - master # update to match your development branch (master, main, dev, trunk, ...)
-    tags: '*'
+    paths:
+      - "docs/**"
+      - ".github/workflows/Documentation.yml"
   pull_request:
+    paths:
+      - "docs/**"
+      - ".github/workflows/Documentation.yml"
 
 jobs:
   build:

--- a/.github/workflows/LSP.yml
+++ b/.github/workflows/LSP.yml
@@ -1,0 +1,30 @@
+name: LSP
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "LSP/**"
+      - ".github/workflows/LSP.yml"
+  pull_request:
+    paths:
+      - "LSP/**"
+      - ".github/workflows/LSP.yml"
+
+jobs:
+  LSP:
+    name: Test LSP.jl
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: "1.12" # most stable version
+          arch: x64
+      - uses: julia-actions/cache@v2
+      - name: test LSP
+        shell: julia --color=yes --project=. {0}    # this is necessary for the next command to work on Windows
+        run: 'using Pkg; Pkg.activate(normpath(pwd(), "LSP")); Pkg.instantiate(); Pkg.test(; coverage=true)'
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v5


### PR DESCRIPTION
Separates LSP testing into its own workflow file and adds path-based triggers to all workflows to avoid unnecessary runs.