### PR TITLE
docs: show release date in version selector and set release as default

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -40,3 +40,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+      - name: Set release as default version
+        if: github.event_name == 'push'
+        run: |
+          git fetch origin gh-pages
+          git checkout gh-pages
+          echo '<meta http-equiv="refresh" content="0; url=./release/"/>' > index.html
+          git add index.html
+          git commit -m "Set release as default documentation version" || true
+          git push origin gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,9 +58,27 @@ jobs:
           using Pkg
           Pkg.develop(PackageSpec(path=pwd()))
           Pkg.instantiate()
+      - name: Get release date
+        id: release_date
+        run: |
+          # Extract date from the latest "release: YYYY-MM-DD" commit message
+          DATE=$(git log --oneline --grep="^release:" -1 --format="%s" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' || echo "")
+          if [ -z "$DATE" ]; then
+            DATE=$(date +%Y-%m-%d)
+          fi
+          echo "date=$DATE" >> $GITHUB_OUTPUT
       - name: Build and deploy
         run: julia --color=yes --project=docs docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
           DOCUMENTER_DEVBRANCH: release
+          DOCUMENTER_RELEASE_DATE: ${{ steps.release_date.outputs.date }}
+      - name: Set release as default version
+        run: |
+          git fetch origin gh-pages
+          git checkout gh-pages
+          echo '<meta http-equiv="refresh" content="0; url=./release/"/>' > index.html
+          git add index.html
+          git commit -m "Set release as default documentation version" || true
+          git push origin gh-pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
 > - Diff: [`2be0cff...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/2be0cff...HEAD)
 
+### Changed
+
+- Updated documentation deployment to show release date in version selector.
+  The documentation version selector now displays `release (YYYY-MM-DD)` instead
+  of just `stable`, making it clearer which release version is being viewed.
+  The release date is automatically extracted from the `release: YYYY-MM-DD`
+  commit message.
+
 ## [2025-11-25]
 
 [2025-11-25]: https://github.com/aviatesk/JETLS.jl/pull/323

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -260,6 +260,9 @@ analyzing.
    git commit -m 'release: YYYY-MM-DD'
    git push -u origin releases/YYYY-MM-DD
    ```
+   **Important**: The commit message must follow the `release: YYYY-MM-DD` format
+   exactly. The documentation CI extracts this date to display in the version
+   selector of Documentation (e.g., `release (2025-11-25)`).
 
 4. Create a pull request from `releases/YYYY-MM-DD` to `release` and merge it
    using "Create a merge commit" (not squash or rebase). This preserves the

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,9 +19,32 @@ makedocs(;
     ],
 )
 
+const devbranch = get(ENV, "DOCUMENTER_DEVBRANCH", "master")
+const release_date = get(ENV, "DOCUMENTER_RELEASE_DATE", "")
+
+# Custom deploy configuration for `release` branch deployment
+# Documenter.jl normally only deploys to versioned folders (like `v1.0.0/`) when
+# triggered by a git tag. Since JETLS uses a `release` branch instead of tags,
+# we need a custom DeployConfig that treats `release` branch pushes as releases.
+struct ReleaseBranchConfig <: Documenter.DeployConfig end
+
+function Documenter.deploy_folder(
+        ::ReleaseBranchConfig;
+        repo::String, branch::String, kwargs...
+    )
+    return Documenter.DeployDecision(; all_ok=true, branch, is_preview=false,
+        repo, subfolder="release")
+end
+Documenter.authentication_method(::ReleaseBranchConfig) = Documenter.SSH
+Documenter.authenticated_repo_url(::ReleaseBranchConfig) =
+    "git@github.com:aviatesk/JETLS.jl.git"
+
 deploydocs(;
     repo = "github.com/aviatesk/JETLS.jl",
     push_preview = true,
-    devbranch = get(ENV, "DOCUMENTER_DEVBRANCH", "master"),
-    devurl = get(ENV, "DOCUMENTER_DEVBRANCH", "dev"),
+    devbranch,
+    deploy_config = devbranch == "release" ? ReleaseBranchConfig() : Documenter.auto_detect_deploy_system(),
+    # Only set versions from release branch to preserve the release date label
+    versions = devbranch == "release" ?
+        ["release ($release_date)" => "release", "dev" => "dev"] : nothing,
 )


### PR DESCRIPTION
Configure documentation deployment to display the release date in the version selector (e.g., `release (2025-11-25)`) instead of just `stable`. The date is extracted from commit messages matching `release: YYYY-MM-DD`.

Also set the `release` documentation as the default landing page. Both `Documentation.yml` (master) and `release.yml` workflows now update the root `index.html` to redirect to `/release/` instead of `/dev/`.

Add custom `ReleaseBranchConfig` to deploy `release` branch docs to the `/release/` subfolder instead of `/dev/`.