### PR TITLE
deps: update JuliaSyntax.jl and JuliaLowering.jl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Updated JuliaSyntax.jl and JuliaLowering.jl dependencies to the latest
+  development versions.
 - Updated documentation deployment to use `release` as the default version.
   The documentation now has two versions in the selector: `release` (stable) and
   `dev` (development). The root URL redirects to `/release/` by default.

--- a/Project.toml
+++ b/Project.toml
@@ -24,8 +24,8 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 [sources]
 Glob = {rev = "avi/globstar", url = "https://github.com/aviatesk/Glob.jl"}
 JET = {rev = "1e84376", url = "https://github.com/aviatesk/JET.jl"}
-JuliaLowering = {rev = "avi/JETLS-JSJL-head", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
-JuliaSyntax = {rev = "avi/JETLS-JSJL-head", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
+JuliaLowering = {rev = "avi/JETLS-JSJL-head-2025-11-26", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
+JuliaSyntax = {rev = "avi/JETLS-JSJL-head-2025-11-26", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
 LSP = {rev = "master", subdir = "LSP", url = "https://github.com/aviatesk/JETLS.jl"}
 
 [compat]

--- a/test/test_lowering_diagnostics.jl
+++ b/test/test_lowering_diagnostics.jl
@@ -444,7 +444,7 @@ end
         @test diagnostic.source == JETLS.DIAGNOSTIC_SOURCE
         @test diagnostic.message == "Macro name `@notexisting` not found"
         @test diagnostic.range.start.line == 0
-        @test diagnostic.range.start.character == sizeof("x = ")
+        @test diagnostic.range.start.character == sizeof("x = @")
         @test diagnostic.range.var"end".line == 0
         @test diagnostic.range.var"end".character == sizeof("x = @notexisting")
     end


### PR DESCRIPTION
Update the dependency branches for JuliaSyntax and JuliaLowering to `avi/JETLS-JSJL-head-2025-11-26`. This includes fixes to diagnostic range reporting for macro errors, where the range now starts after the `@` symbol.