### PR TITLE
diagnostic: fix false lowering diagnostics before full-analysis completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `releases/2025-11-27`) will be kept until the end of December 2025 for
   backward compatibility.
 
+### Fixed
+
+- Fixed false `lowering/macro-expansion-error` diagnostics appearing before
+  initial full-analysis completes. These diagnostics are now skipped until
+  module context is available, then refreshed via `workspace/diagnostic/refresh`.
+  Fixes aviatesk/JETLS.jl#279 and aviatesk/JETLS.jl#290. (aviatesk/JETLS.jl#333)
+
 ### Removed
 
 - Removed the deprecated `runserver.jl` script. Users should use the `jetls`

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -336,6 +336,8 @@ function (dispatcher::ResponseMessageDispatcher)(server::Server, msg::Dict{Symbo
         handle_testrunner_testcase_progress_response(server, msg, request_caller, cancel_flag)
     elseif request_caller isa CodeLensRefreshRequestCaller
         handle_code_lens_refresh_response(server, msg, request_caller)
+    elseif request_caller isa DiagnosticRefreshRequestCaller
+        handle_diagnostic_refresh_response(server, msg, request_caller)
     elseif request_caller isa FormattingProgressCaller
         handle_formatting_progress_response(server, msg, request_caller)
     elseif request_caller isa RangeFormattingProgressCaller

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -178,6 +178,15 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
     mark_analyzed_generation!(manager, request)
     request.notify && notify_diagnostics!(server)
 
+    # Request diagnostic refresh for initial full-analysis completion.
+    # This ensures that clients using pull diagnostics (textDocument/diagnostic) will
+    # re-request diagnostics now that module context is available, allowing
+    # lowering/macro-expansion-error diagnostics to be properly reported.
+    if isnothing(request.prev_analysis_result) &&
+       supports(server, :workspace, :diagnostics, :refreshSupport)
+        request_diagnostic_refresh!(server)
+    end
+
     @label next_request
 
     notify(request.completion)


### PR DESCRIPTION
Skip `lowering/macro-expansion-error` diagnostics when `textDocument/diagnostic` is issued before full-analysis completes. Without the correct module context from full-analysis, macro expansion would fail with false positives.

After initial full-analysis completes, send `workspace/diagnostic/refresh` to prompt clients using pull diagnostics to re-request diagnostics with the correct module context now available.

- fixes aviatesk/JETLS.jl#279
- fixes aviatesk/JETLS.jl#290