### PR TITLE
pkg: add global lock for concurrent environment switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed error when receiving notifications after shutdown request. The server
   now silently ignores notifications instead of causing errors from invalid
   property access (which is not possible for notifications).
+- Fixed race condition in package environment detection when multiple files are
+  opened simultaneously. Added global lock to `activate_do` to serialize
+  environment switching operations. This fixes spurious "Failed to identify
+  package environment" warnings.
 
 ## 2025-11-28
 


### PR DESCRIPTION
Previously, when multiple files were opened simultaneously, each could trigger `lookup_analysis_entry` which calls `activate_do` to switch environments. Without synchronization, this could cause race conditions where concurrent environment switches would interfere with each other, potentially causing package environment detection to fail.

This fix adds a global `ACTIVATE_LOCK` to serialize all `activate_do` calls, ensuring that environment activation, the callback execution, and environment restoration happen atomically.