### PR TITLE
full-analysis: auto-instantiate environments and cache detection results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
 - Diff: [`eda08b5...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/eda08b5...HEAD)
 
+### Added
+
+- JETLS now automatically runs `Pkg.instantiate()` for packages that have not
+  been instantiated yet (e.g., freshly cloned repositories). This allows
+  full analysis to work immediately upon opening such packages. Note that this
+  will automatically create a `Manifest.toml` file when the package has not been
+  instantiated yet. This behavior is controlled by the `full_analysis.auto_instantiate`
+  configuration option (default: `true`). Set it to `false` to disable.
+
 ### Fixed
 
 - Fixed error when receiving notifications after shutdown request. The server

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -8,6 +8,7 @@ This documentation uses TOML format to describe the configuration schema.
 ```toml
 [full_analysis]
 debounce = 1.0             # number (seconds), default: 1.0
+auto_instantiate = true    # boolean, default: true
 
 formatter = "Runic"        # String preset: "Runic" (default) or "JuliaFormatter"
 
@@ -33,6 +34,7 @@ executable = "testrunner"  # string, default: "testrunner" (or "testrunner.bat" 
 
 - [`[full_analysis]`](@ref config/full_analysis)
     - [`[full_analysis] debounce`](@ref config/full_analysis-debounce)
+    - [`[full_analysis] auto_instantiate`](@ref config/full_analysis-auto_instantiate)
 - [`formatter`](@ref config/formatter)
 - [`[diagnostic]`](@ref config/diagnostic)
     - [`[diagnostic] enabled`](@ref config/diagnostic-enabled)
@@ -56,6 +58,22 @@ may delay diagnostic updates.
 ```toml
 [full_analysis]
 debounce = 2.0  # Wait 2 seconds after save before analyzing
+```
+
+#### [`[full_analysis] auto_instantiate`](@id config/full_analysis-auto_instantiate)
+
+- **Type**: boolean
+- **Default**: `true`
+
+When enabled, JETLS automatically runs `Pkg.instantiate()` for packages that have
+not been instantiated yet (e.g., freshly cloned repositories). This allows full
+analysis to work immediately upon opening such packages. Note that this will
+automatically create a `Manifest.toml` file when the package has not been
+instantiated yet.
+
+```toml
+[full_analysis]
+auto_instantiate = false  # Disable automatic instantiation
 ```
 
 ### [`formatter`](@id config/formatter)

--- a/jetls-client/package.json
+++ b/jetls-client/package.json
@@ -119,6 +119,11 @@
                   "default": 1,
                   "minimum": 0,
                   "markdownDescription": "Debounce time in seconds before triggering full analysis after a document change."
+                },
+                "auto_instantiate": {
+                  "type": "boolean",
+                  "default": true,
+                  "markdownDescription": "When enabled, JETLS automatically runs `Pkg.instantiate()` for packages that have not been instantiated yet (e.g., freshly cloned repositories). This allows full analysis to work immediately upon opening such packages. Note that this will automatically create a `Manifest.toml` file when the package has not been instantiated yet."
                 }
               }
             },

--- a/src/types.jl
+++ b/src/types.jl
@@ -186,6 +186,7 @@ const PendingAnalyses = CASContainer{Dict{AnalysisEntry,Union{Nothing,AnalysisRe
 const CurrentGenerations = CASContainer{Dict{AnalysisEntry,Int}}
 const AnalyzedGenerations = CASContainer{Dict{AnalysisEntry,Int}}
 const DebouncedRequests = LWContainer{Dict{AnalysisEntry,Timer}, LWStats}
+const InstantiatedEnvs = LWContainer{Dict{String,Union{Nothing,Tuple{Base.PkgId,URI}}}}
 
 struct AnalysisManager
     cache::AnalysisCache
@@ -195,6 +196,7 @@ struct AnalysisManager
     current_generations::CurrentGenerations
     analyzed_generations::AnalyzedGenerations
     debounced::DebouncedRequests
+    instantiated_envs::InstantiatedEnvs
     function AnalysisManager(n_workers::Int)
         return new(
             AnalysisCache(Dict{URI,AnalysisInfo}()),
@@ -203,7 +205,8 @@ struct AnalysisManager
             Vector{Task}(undef, n_workers),
             CurrentGenerations(Dict{AnalysisEntry,Int}()),
             AnalyzedGenerations(Dict{AnalysisEntry,Int}()),
-            DebouncedRequests(Dict{AnalysisEntry,Timer}())
+            DebouncedRequests(Dict{AnalysisEntry,Timer}()),
+            InstantiatedEnvs(Dict{String,Union{Nothing,Tuple{Base.PkgId,URI}}}())
         )
     end
 end
@@ -316,8 +319,9 @@ _unwrap_maybe(::Type{T}) where {T} = T
 
 @option struct FullAnalysisConfig <: ConfigSection
     debounce::Maybe{Float64}
+    auto_instantiate::Maybe{Bool}
 end
-default_config(::Type{FullAnalysisConfig}) = FullAnalysisConfig(1.0)
+default_config(::Type{FullAnalysisConfig}) = FullAnalysisConfig(1.0, true)
 
 @option struct TestRunnerConfig <: ConfigSection
     executable::Maybe{String}

--- a/test/test_config.jl
+++ b/test/test_config.jl
@@ -14,11 +14,11 @@ using JETLS
 
     @testset "`merge_setting`" begin
         base_config = JETLS.JETLSConfig(;
-            full_analysis=JETLS.FullAnalysisConfig(1.0),
+            full_analysis=JETLS.FullAnalysisConfig(; debounce=1.0),
             testrunner=JETLS.TestRunnerConfig("base_runner"),
         )
         overlay_config = JETLS.JETLSConfig(;
-            full_analysis=JETLS.FullAnalysisConfig(2.0),
+            full_analysis=JETLS.FullAnalysisConfig(; debounce=2.0),
         )
         merged = JETLS.merge_setting(base_config, overlay_config)
 
@@ -28,11 +28,11 @@ using JETLS
 
     @testset "`on_difference`" begin
         let config1 = JETLS.JETLSConfig(;
-                full_analysis=JETLS.FullAnalysisConfig(1.0),
+                full_analysis=JETLS.FullAnalysisConfig(; debounce=1.0),
                 testrunner=JETLS.TestRunnerConfig("runner1"),
             )
             config2 = JETLS.JETLSConfig(;
-                full_analysis=JETLS.FullAnalysisConfig(2.0),
+                full_analysis=JETLS.FullAnalysisConfig(; debounce=2.0),
                 testrunner=JETLS.TestRunnerConfig("runner2")
             )
             paths_called = []
@@ -116,7 +116,7 @@ end
     manager = JETLS.ConfigManager(JETLS.ConfigManagerData())
 
     test_config = JETLS.JETLSConfig(;
-        full_analysis=JETLS.FullAnalysisConfig(2.0),
+        full_analysis=JETLS.FullAnalysisConfig(; debounce=2.0),
         testrunner=JETLS.TestRunnerConfig("test_runner"),
     )
 
@@ -136,7 +136,7 @@ end
 
     # Test priority: file config has higher priority than LSP config
     lsp_config = JETLS.JETLSConfig(;
-        full_analysis=JETLS.FullAnalysisConfig(999.0),
+        full_analysis=JETLS.FullAnalysisConfig(; debounce=999.0),
         testrunner=JETLS.TestRunnerConfig("lsp_runner")
     )
     store_lsp_config!(manager, lsp_config)
@@ -147,7 +147,7 @@ end
     # Test updating config
     store_lsp_config!(manager, JETLS.EMPTY_CONFIG)
     updated_config = JETLS.JETLSConfig(;
-        full_analysis=JETLS.FullAnalysisConfig(3.0),
+        full_analysis=JETLS.FullAnalysisConfig(; debounce=3.0),
         testrunner=JETLS.TestRunnerConfig("new_runner"),
     )
     store_file_config!(manager, "/foo/bar/.JETLSConfig.toml", updated_config)
@@ -159,7 +159,7 @@ end
     manager = JETLS.ConfigManager(JETLS.ConfigManagerData())
 
     lsp_config = JETLS.JETLSConfig(;
-        full_analysis=JETLS.FullAnalysisConfig(2.0),
+        full_analysis=JETLS.FullAnalysisConfig(; debounce=2.0),
         testrunner=nothing
     )
     file_config = JETLS.JETLSConfig(;
@@ -179,7 +179,7 @@ end
 @testset "LSP configuration merging without file config" begin
     manager = JETLS.ConfigManager(JETLS.ConfigManagerData())
     lsp_config = JETLS.JETLSConfig(;
-        full_analysis=JETLS.FullAnalysisConfig(3.0),
+        full_analysis=JETLS.FullAnalysisConfig(; debounce=3.0),
         testrunner=JETLS.TestRunnerConfig("lsp_runner")
     )
     store_lsp_config!(manager, lsp_config)


### PR DESCRIPTION
Add automatic `Pkg.instantiate()` for environments that have not been instantiated yet (e.g., freshly cloned repositories or new project directories). This allows full analysis to work immediately upon opening files in such environments, whether they are package source files, test files, or scripts with their own Project.toml.

Also add caching for environment detection results to avoid redundant `Pkg.instantiate()` calls and `Base.identify_package_env` lookups for the same environment.

The behavior is controlled by `full_analysis.auto_instantiate` config option (default: `true`).