### PR TITLE
full-analysis: Refactor analysis entry lookup with server-initiated progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   Revise assumes it's loaded from a REPL session. Revise is now a direct
   dependency that's conditionally loaded at compile time based on the
   `JETLS_DEV_MODE` flag.
+- Significantly refactored the full-analysis pipeline implementation. Modified
+  the full-analysis pipeline behavior to output more detailed logs when
+  `JETLS_DEV_MODE` is enabled.
 
 ## 2025-11-28
 

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -331,8 +331,10 @@ struct ResponseMessageDispatcher
 end
 function (dispatcher::ResponseMessageDispatcher)(server::Server, msg::Dict{Symbol,Any})
     (; cancel_flag, request_caller) = dispatcher
-    if request_caller isa RequestAnalysisCaller
-        handle_request_analysis_response(server, request_caller, cancel_flag)
+    if request_caller isa InstantiationProgressCaller
+        handle_instantiation_progress_response(server, request_caller)
+    elseif request_caller isa AnalysisProgressCaller
+        handle_analysis_progress_response(server, request_caller, cancel_flag)
     elseif request_caller isa ShowDocumentRequestCaller
         handle_show_document_response(server, msg, request_caller)
     elseif request_caller isa SetDocumentContentCaller

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -1,3 +1,76 @@
+# Progress support
+# ================
+
+struct InstantiationRequest
+    env_path::String
+    pkgname::Union{Nothing,String}
+    filekind::Symbol                 # :script, :src, :test
+    filedir::String                  # used for :test to construct runtestsuri
+    root_path::Union{String,Nothing} # used for progress
+end
+
+struct InstantiationProgressCaller <: RequestCaller
+    uri::URI
+    ins_request::InstantiationRequest
+    onsave::Bool
+    notify_diagnostics::Bool
+    token::ProgressToken
+end
+
+struct AnalysisProgressCaller <: RequestCaller
+    uri::URI
+    onsave::Bool
+    entry::AnalysisEntry
+    prev_analysis_result::Union{Nothing,AnalysisResult}
+    notify_diagnostics::Bool
+    token::ProgressToken
+end
+cancellable_token(rc::AnalysisProgressCaller) = rc.token
+
+function request_instantiation_progress!(
+        server::Server, uri::URI, ins_request::InstantiationRequest,
+        onsave::Bool, notify_diagnostics::Bool
+    )
+    id = String(gensym(:WorkDoneProgressCreateRequest_instantiation))
+    token = String(gensym(:InstantiationProgress))
+    addrequest!(server, id => InstantiationProgressCaller(uri, ins_request, onsave, notify_diagnostics, token))
+    params = WorkDoneProgressCreateParams(; token)
+    send(server, WorkDoneProgressCreateRequest(; id, params))
+end
+
+function handle_instantiation_progress_response(server::Server, caller::InstantiationProgressCaller)
+    (; uri, ins_request, onsave, notify_diagnostics, token) = caller
+    entry = do_instantiation_with_progress(server, uri, ins_request, token)
+    # Now request a new progress token for the analysis phase
+    request_analysis_progress!(server, uri, onsave, entry, #=prev_analysis_result=#nothing, notify_diagnostics)
+end
+
+function request_analysis_progress!(
+        server::Server, uri::URI, onsave::Bool, @nospecialize(entry::AnalysisEntry),
+        prev_analysis_result::Union{Nothing,AnalysisResult},
+        notify_diagnostics::Bool
+    )
+    id = String(gensym(:WorkDoneProgressCreateRequest_analysis))
+    token = String(gensym(:AnalysisProgress))
+    addrequest!(server, id => AnalysisProgressCaller(
+        uri, onsave, entry, prev_analysis_result, notify_diagnostics, token))
+    params = WorkDoneProgressCreateParams(; token)
+    send(server, WorkDoneProgressCreateRequest(; id, params))
+end
+
+function handle_analysis_progress_response(
+        server::Server, caller::AnalysisProgressCaller, cancel_flag::CancelFlag
+    )
+    (; uri, onsave, entry, prev_analysis_result, notify_diagnostics, token) = caller
+    cancellable_token = CancellableToken(token, cancel_flag)
+    schedule_analysis!(
+        server, uri, entry, prev_analysis_result, onsave;
+        cancellable_token, notify_diagnostics)
+end
+
+# Analysis worker
+# ===============
+
 function start_analysis_workers!(server::Server)
     for i = 1:length(server.state.analysis_manager.worker_tasks)
         server.state.analysis_manager.worker_tasks[i] = Threads.@spawn :default try
@@ -9,58 +82,102 @@ function start_analysis_workers!(server::Server)
     end
 end
 
+ # Analysis queue processing implementation (analysis serialized per AnalysisEntry)
+function analysis_worker(server::Server)
+    # Note: Currently single worker, but designed for future multi-worker scaling.
+    # When multiple workers exist, the per-entry serialization ensures correctness.
+    while true
+        request = take!(server.state.analysis_manager.queue)
+        @tryinvokelatest resolve_analysis_request(server, request)
+        GC.safepoint()
+    end
+end
+
+# Analysis worker pipeline
+# ========================
+
+"""
+    request_analysis!(server, uri, onsave; wait=false, notify_diagnostics=true)
+
+Driver function that requests full-analysis for a file.
+
+When the client supports `window/workDoneProgress` and `wait=false`, this function issues
+server-initiated progress tokens for both environment instantiation (if needed) and the
+subsequent analysis phase, then returns immediately. The actual work is performed
+asynchronously when the client confirms each progress token.
+
+When `wait=true` or progress is not supported, the function performs the work synchronously
+and blocks until analysis completes.
+
+The `onsave` parameter affects generation management: when `true`, the generation counter
+is incremented to ensure analysis runs even if the file content hasn't changed since the
+last analysis (useful for save-triggered re-analysis).
+
+The `notify_diagnostics` parameter controls whether to send diagnostic notifications after
+analysis completes (used by tests to suppress notifications).
+"""
+function request_analysis!(
+        server::Server, uri::URI, onsave::Bool;
+        wait::Bool = false,
+        notify_diagnostics::Bool = true
+    )
+    manager = server.state.analysis_manager
+    prev_analysis_result = get_analysis_info(manager, uri)
+
+    if prev_analysis_result isa OutOfScope
+        cache_out_of_scope!(manager, uri, prev_analysis_result)
+        return nothing
+    end
+
+    local entry::AnalysisEntry
+    if prev_analysis_result isa AnalysisResult
+        entry = prev_analysis_result.entry
+    else
+        # prev_analysis_result === nothing: fresh analysis
+        phase1_result = lookup_analysis_entry(server, uri)
+        if phase1_result isa OutOfScope
+            cache_out_of_scope!(manager, uri, phase1_result)
+            return nothing
+        elseif phase1_result isa InstantiationRequest
+            if !wait && supports(server, :window, :workDoneProgress)
+                request_instantiation_progress!(server, uri, phase1_result, onsave, notify_diagnostics)
+                return nothing
+            else
+                entry = do_instantiation(server, uri, phase1_result)
+            end
+        else
+            entry = phase1_result::AnalysisEntry
+        end
+    end
+
+    if !wait && supports(server, :window, :workDoneProgress)
+        request_analysis_progress!(server, uri, onsave, entry, prev_analysis_result, notify_diagnostics)
+    else
+        completion = Base.Event()
+        schedule_analysis!(server, uri, entry, prev_analysis_result, onsave; completion, notify_diagnostics)
+        wait && Base.wait(completion)
+    end
+end
+
 get_analysis_info(manager::AnalysisManager, uri::URI) = get(load(manager.cache), uri, nothing)
 
-struct RequestAnalysisCaller <: RequestCaller
-    uri::URI
-    onsave::Bool
-    token::ProgressToken
-end
-cancellable_token(rc::RequestAnalysisCaller) = rc.token
-
-function request_analysis_on_open!(server::Server, uri::URI)
-    if supports(server, :window, :workDoneProgress)
-        id = String(gensym(:WorkDoneProgressCreateRequest_request_analysis_on_open!))
-        token = String(gensym(:WorkDoneProgressCreateRequest_request_analysis_on_open!))
-        addrequest!(server, id=>RequestAnalysisCaller(uri, #=onsave=#false, token))
-        params = WorkDoneProgressCreateParams(; token)
-        send(server, WorkDoneProgressCreateRequest(; id, params))
-    else
-        Threads.@spawn :default request_analysis!(server, uri)
+function cache_out_of_scope!(manager::AnalysisManager, uri::URI, outofscope::OutOfScope)
+    store!(manager.cache) do cache
+        if get(cache, uri, nothing) === outofscope
+            cache, nothing
+        else
+            local new_cache = copy(cache)
+            new_cache[uri] = outofscope
+            new_cache, nothing
+        end
     end
-end
-
-function request_analysis_on_save!(server::Server, uri::URI)
-    if supports(server, :window, :workDoneProgress)
-        id = String(gensym(:WorkDoneProgressCreateRequest_request_analysis_on_save!))
-        token = String(gensym(:WorkDoneProgressCreateRequest_request_analysis_on_save!))
-        addrequest!(server, id=>RequestAnalysisCaller(uri, #=onsave=#true, token))
-        params = WorkDoneProgressCreateParams(; token)
-        send(server, WorkDoneProgressCreateRequest(; id, params))
-    else
-        Threads.@spawn :default request_analysis!(server, uri; onsave=true)
-    end
-end
-
-function handle_request_analysis_response(
-        server::Server, request_caller::RequestAnalysisCaller, cancel_flag::CancelFlag
-    )
-    (; uri, onsave, token) = request_caller
-    cancellable_token = CancellableToken(token, cancel_flag)
-    # Each response message should be synchronous, so don't use `Threads.@spawn` here
-    request_analysis!(server, uri; cancellable_token, onsave)
-end
-
-mutable struct ProgressState
-    const cancellable_token::CancellableToken
-    begun::Bool
-    ProgressState(cancellable_token::CancellableToken) = new(cancellable_token, false)
 end
 
 """
-    request_analysis!(server, uri; ...)
+    schedule_analysis!(server, uri, entry, prev_analysis_result, onsave; ...)
 
-Requests full analysis for a file, ensuring per-entry serialization.
+Schedule analysis for a confirmed entry. This is called after entry lookup is complete.
+Handles generation management, debouncing, and queueing.
 
 The `pending_analyses` mechanism ensures that analyses for the same `AnalysisEntry` are
 serialized (never run concurrently), which is essential for correctness when multiple
@@ -75,62 +192,14 @@ that skips analysis when the file content hasn't changed since the last analysis
 See https://publish.obsidian.md/jetls/work/JETLS/Make+JETLS+multithreaded#4.%20Multithreading%20Full-Analysis
 for the details of this concurrent analysis management.
 """
-function request_analysis!(
-        server::Server, uri::URI;
+function schedule_analysis!(
+        server::Server, uri::URI, @nospecialize(entry::AnalysisEntry),
+        prev_analysis_result::Union{Nothing,AnalysisResult}, onsave::Bool;
+        completion::Base.Event = Base.Event(),
         cancellable_token::Union{Nothing,CancellableToken} = nothing,
-        kwargs...
-    )
-    completion = Base.Event()
-    try
-        _request_analysis!(server, uri, completion; cancellable_token, kwargs...)
-        wait(completion)
-    finally
-        if cancellable_token !== nothing
-            end_full_analysis_progress(server, cancellable_token)
-        end
-    end
-end
-
-function _request_analysis!(
-        server::Server, uri::URI, completion::Base.Event;
-        cancellable_token::Union{Nothing,CancellableToken} = nothing,
-        onsave::Bool = false,
-        notify_diagnostics::Bool = true, # used by tests
+        notify_diagnostics::Bool = true,
     )
     manager = server.state.analysis_manager
-    prev_analysis_result = get_analysis_info(server.state.analysis_manager, uri)
-    local outofscope::OutOfScope
-    if isnothing(prev_analysis_result)
-        progress_state = cancellable_token !== nothing ? ProgressState(cancellable_token) : nothing
-        entry = lookup_analysis_entry(server, uri, progress_state)
-        if entry isa OutOfScope
-            outofscope = entry
-            @goto out_of_scope
-        end
-        if cancellable_token !== nothing && progress_state !== nothing && !progress_state.begun
-            begin_full_analysis_progress(server, entry, false, cancellable_token)
-        end
-    elseif prev_analysis_result isa OutOfScope
-        outofscope = prev_analysis_result
-        @label out_of_scope
-        store!(manager.cache) do cache
-            if get(cache, uri, nothing) === outofscope
-                cache, nothing
-            else
-                local new_cache = copy(cache)
-                new_cache[uri] = outofscope
-                new_cache, nothing
-            end
-        end
-        return nothing
-    else
-        prev_analysis_result::AnalysisResult
-        entry = prev_analysis_result.entry
-        if cancellable_token !== nothing
-            begin_full_analysis_progress(server, entry, true, cancellable_token)
-        end
-    end
-    entry = entry::AnalysisEntry
 
     if onsave
         generation = increment_generation!(manager, entry)
@@ -146,22 +215,23 @@ function _request_analysis!(
     if onsave && debounce > 0
         local delay::Float64 = debounce
         store!(manager.debounced) do debounced
-            # Cancel existing timer if any
             if haskey(debounced, request.entry)
+                # Cancel existing timer if any
                 debounce_timer, debounce_completion = debounced[request.entry]
                 close(debounce_timer)
+                JETLS_DEV_MODE && @info "Cancelled analysis debounce timer:" entry=progress_title(request.entry) uri
                 notify(debounce_completion)
             end
             local new_debounced = copy(debounced)
-            # Set debounce timer
-            new_debounced[request.entry] = Timer(delay) do _
+            timer = Timer(delay) do _
                 store!(manager.debounced) do debounced′
                     local new_debounced′ = copy(debounced′)
                     delete!(new_debounced′, request.entry)
                     return new_debounced′, nothing
                 end
                 queue_request!(server, request)
-            end, request.completion
+            end
+            new_debounced[request.entry] = timer, request.completion
             return new_debounced, nothing
         end
     else
@@ -182,6 +252,7 @@ function queue_request!(server::Server, request::AnalysisRequest)
             local new_analyses = copy(analyses)
             new_analyses[request.entry] = request
             if old_request !== nothing # replaced by the new request i.e. cancelled
+                JETLS_DEV_MODE && @info "Cancelled staled pending analysis request:" entry=progress_title(request.entry) request.uri
                 notify(old_request.completion)
             end
             return new_analyses, false
@@ -197,26 +268,25 @@ function queue_request!(server::Server, request::AnalysisRequest)
     end
 end
 
- # Analysis queue processing implementation (analysis serialized per AnalysisEntry)
-function analysis_worker(server::Server)
-    # Note: Currently single worker, but designed for future multi-worker scaling.
-    # When multiple workers exist, the per-entry serialization ensures correctness.
-    while true
-        request = take!(server.state.analysis_manager.queue)
-        @tryinvokelatest resolve_analysis_request(server, request)
-        GC.safepoint()
-    end
-end
-
 function resolve_analysis_request(server::Server, request::AnalysisRequest)
     manager = server.state.analysis_manager
 
     if is_generation_analyzed(manager, request)
         # Skip if this generation was already analyzed (no new changes since last analysis)
+        JETLS_DEV_MODE && @info "Skipped analysis for unchanged analysis unit" entry=progress_title(request.entry) request.uri
         @goto next_request
     end
 
-    has_any_parse_errors(server, request) && @goto next_request
+    if has_any_parse_errors(server, request)
+        JETLS_DEV_MODE && @info "Requested analysis unit has parse errors" entry=progress_title(request.entry) request.uri
+        @goto next_request
+    end
+
+    initial_analysis = request.prev_analysis_result === nothing
+    cancellable_token = request.cancellable_token
+    if cancellable_token !== nothing
+        begin_full_analysis_progress(server, cancellable_token, request.entry, initial_analysis)
+    end
 
     analysis_result = try
         execute_analysis_request(server, request)
@@ -224,6 +294,10 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
         @error "Error in `execute_analysis_request` for " request
         Base.display_error(stderr, err, catch_backtrace())
         @goto next_request
+    finally
+        if cancellable_token !== nothing
+            end_full_analysis_progress(server, cancellable_token)
+        end
     end
 
     update_analysis_cache!(manager, analysis_result)
@@ -234,7 +308,7 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
     # This ensures that clients using pull diagnostics (textDocument/diagnostic) will
     # re-request diagnostics now that module context is available, allowing
     # lowering/macro-expansion-error diagnostics to be properly reported.
-    if isnothing(request.prev_analysis_result) && supports(server, :workspace, :diagnostics, :refreshSupport)
+    if initial_analysis && supports(server, :workspace, :diagnostics, :refreshSupport)
         request_diagnostic_refresh!(server)
     end
 
@@ -242,7 +316,7 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
 
     notify(request.completion)
 
-    # Check for pending request and re-queue if needed
+    # Check for pending request and re-queue if exist
     pending_request = store!(manager.pending_analyses) do analyses
         if haskey(analyses, request.entry)
             new_analyses = copy(analyses)
@@ -305,36 +379,53 @@ function mark_analyzed_generation!(manager::AnalysisManager, request::AnalysisRe
     end
 end
 
+function execute_analysis_request(server::Server, request::AnalysisRequest)
+    entry = request.entry
+
+    if entry isa ScriptAnalysisEntry
+        result = analyze_parsed_if_exist(server, request)
+
+    elseif entry isa ScriptInEnvAnalysisEntry
+        result = activate_do(entry.env_path) do
+            analyze_parsed_if_exist(server, request)
+        end
+
+    elseif entry isa PackageSourceAnalysisEntry
+        result = activate_do(entry.env_path) do
+            analyze_parsed_if_exist(server, request, entry.pkgid)
+        end
+
+    elseif entry isa PackageTestAnalysisEntry
+        result = activate_do(entry.env_path) do
+            analyze_parsed_if_exist(server, request)
+        end
+
+    else error("Unsupported analysis entry $entry") end
+
+    ret = new_analysis_result(request, result)
+
+    # TODO Request fallback analysis in cases this script was not analyzed by the analysis entry
+    # request.uri ∉ analyzed_file_uris(ret)
+    return ret
+end
+
 function begin_full_analysis_progress(
-        server::Server, @nospecialize(entry::AnalysisEntry), reanalyzing::Bool,
-        cancellable_token::CancellableToken
+        server::Server, cancellable_token::CancellableToken,
+        @nospecialize(entry::AnalysisEntry), initial_analysis::Bool,
     )
-    title = (reanalyzing ? "Reanalyzing" : "Analyzing") * " " * progress_title(entry)
+    title = (initial_analysis ? "Analyzing" : "Reanalyzing") * " " * progress_title(entry)
     send_progress(server, cancellable_token.token,
         WorkDoneProgressBegin(;
             title,
             cancellable = true,
-            message = "Analysis requested",
+            message = "Analysis started",
             percentage = 0))
-    yield_to_endpoint()
-end
-
-function begin_full_analysis_progress_by_instantiate(
-        server::Server, title::String, progress_state::ProgressState
-    )
-    send_progress(server, progress_state.cancellable_token.token,
-        WorkDoneProgressBegin(;
-            title = "Analyzing " * title,
-            cancellable = true,
-            message = "Instantiating environment",
-            percentage = 0))
-    progress_state.begun = true
     yield_to_endpoint()
 end
 
 function end_full_analysis_progress(server::Server, cancellable_token::CancellableToken)
     send_progress(server, cancellable_token.token,
-        WorkDoneProgressEnd(; message = "Full analysis finished"))
+        WorkDoneProgressEnd(; message = "Analysis completed"))
 end
 
 function analyze_parsed_if_exist(server::Server, request::AnalysisRequest, args...)
@@ -376,14 +467,214 @@ function new_analysis_result(request::AnalysisRequest, result)
     return AnalysisResult(entry, uri2diagnostics, analyzer, analyzed_file_infos, actual2virtual)
 end
 
-function ensure_instantiated!(
-        server::Server, env_path::String, title::String,
-        progress_state::Union{Nothing,ProgressState}
-    )
-    if get_config(server.state.config_manager, :full_analysis, :auto_instantiate)
-        if progress_state !== nothing
-            begin_full_analysis_progress_by_instantiate(server, title, progress_state)
+# Analysis entry lookup
+# =====================
+
+entryuri(entry::AnalysisEntry) = entryuri_impl(entry)::URI
+progress_title(entry::AnalysisEntry) = progress_title_impl(entry)::String
+getjetconfigs(entry::AnalysisEntry) = getjetconfigs_impl(entry)::Dict{Symbol,Any}
+
+let default_jetconfigs = Dict{Symbol,Any}(
+        :toplevel_logger => nothing,
+        # force concretization of documentation
+        :concretization_patterns => [:($(Base.Docs.doc!)(xs__))])
+    global getjetconfigs_impl(::AnalysisEntry) = default_jetconfigs
+end
+
+struct ScriptAnalysisEntry <: AnalysisEntry
+    uri::URI
+end
+entryuri_impl(entry::ScriptAnalysisEntry) = entry.uri
+progress_title_impl(entry::ScriptAnalysisEntry) = basename(uri2filename(entry.uri)) * " [no env]"
+
+struct ScriptInEnvAnalysisEntry <: AnalysisEntry
+    env_path::String
+    uri::URI
+end
+entryuri_impl(entry::ScriptInEnvAnalysisEntry) = entry.uri
+progress_title_impl(entry::ScriptInEnvAnalysisEntry) = basename(uri2filename(entry.uri)) * " [in env]"
+
+struct PackageSourceAnalysisEntry <: AnalysisEntry
+    env_path::String
+    pkgfileuri::URI
+    pkgid::Base.PkgId
+end
+entryuri_impl(entry::PackageSourceAnalysisEntry) = entry.pkgfileuri
+progress_title_impl(entry::PackageSourceAnalysisEntry) = entry.pkgid.name * ".jl" * " [package]"
+let jetconfigs = Dict{Symbol,Any}(
+        :toplevel_logger => nothing,
+        :analyze_from_definitions => true,
+        :concretization_patterns => [:(x_)])
+    global getjetconfigs_impl(::PackageSourceAnalysisEntry) = jetconfigs
+end
+
+struct PackageTestAnalysisEntry <: AnalysisEntry
+    env_path::String
+    runtestsuri::URI
+    pkgid::Base.PkgId
+end
+entryuri_impl(entry::PackageTestAnalysisEntry) = entry.runtestsuri
+progress_title_impl(entry::PackageTestAnalysisEntry) = entry.pkgid.name * ".jl" * " [package test]"
+
+"""
+    lookup_analysis_entry(server, uri) -> AnalysisEntry | InstantiationRequest | OutOfScope
+
+Phase 1 of analysis entry lookup. Returns immediately without blocking.
+- If no instantiation is needed (cached or no env), returns an `AnalysisEntry` directly.
+- If instantiation is needed, returns `InstantiationRequest` with the information required
+  to perform instantiation in phase 2 (`do_instantiation` or `do_instantiation_with_progress`).
+- If the file is out of scope, returns `OutOfScope`.
+"""
+function lookup_analysis_entry(server::Server, uri::URI)
+    state = server.state
+    maybe_env_path = find_analysis_env_path(state, uri)
+    if maybe_env_path isa OutOfScope
+        return maybe_env_path
+    end
+
+    root_path = isdefined(state, :root_path) ? state.root_path : nothing
+
+    env_path = maybe_env_path
+    if isnothing(env_path)
+        return ScriptAnalysisEntry(uri)
+    elseif uri.scheme == "untitled"
+        if is_env_cached(server, env_path)
+            return ScriptInEnvAnalysisEntry(env_path, uri)
+        else
+            return InstantiationRequest(env_path, nothing, :script, "", root_path)
         end
+    end
+
+    pkgname = find_pkg_name(env_path)
+    filepath = uri2filepath(uri)::String # uri.scheme == "file"
+    if isnothing(pkgname) # TODO Test environment with workspace setup fails here
+        if is_env_cached(server, env_path)
+            return ScriptInEnvAnalysisEntry(env_path, uri)
+        else
+            return InstantiationRequest(env_path, nothing, :script, "", root_path)
+        end
+    end
+
+    filekind, filedir = find_package_directory(filepath, env_path)
+    if filekind === :src || filekind === :test
+        cached = get_cached_pkg_env(server, env_path)
+        if cached !== missing
+            if cached === nothing
+                return ScriptInEnvAnalysisEntry(env_path, uri)
+            else
+                pkgid, pkgfile = cached
+                if filekind === :src
+                    return PackageSourceAnalysisEntry(env_path, filepath2uri(pkgfile), pkgid)
+                else
+                    runtestsuri = filepath2uri(joinpath(filedir, "runtests.jl"))
+                    return PackageTestAnalysisEntry(env_path, runtestsuri, pkgid)
+                end
+            end
+        else
+            return InstantiationRequest(env_path, pkgname, filekind, filedir, root_path)
+        end
+    elseif filekind === :docs # TODO
+    elseif filekind === :ext # TODO
+    else
+        @assert filekind === :script
+    end
+
+    if is_env_cached(server, env_path)
+        return ScriptInEnvAnalysisEntry(env_path, uri)
+    else
+        return InstantiationRequest(env_path, nothing, :script, "", root_path)
+    end
+end
+
+function is_env_cached(server::Server, env_path::String)
+    instantiated_envs = server.state.analysis_manager.instantiated_envs
+    return haskey(load(instantiated_envs), env_path)
+end
+
+function get_cached_pkg_env(server::Server, env_path::String)
+    instantiated_envs = server.state.analysis_manager.instantiated_envs
+    return get(load(instantiated_envs), env_path, missing)
+end
+
+# Environment instantiation
+# =========================
+
+function do_instantiation(server::Server, uri::URI, ins_request::InstantiationRequest)
+    (; env_path, pkgname, filekind, filedir) = ins_request
+    if pkgname === nothing
+        ensure_instantiated_if_requested!(server, env_path)
+        return ScriptInEnvAnalysisEntry(env_path, uri)
+    else
+        pkgid, pkgfile = @something(
+            instantiate_package_environment!(server, env_path, pkgname),
+            return ScriptInEnvAnalysisEntry(env_path, uri))
+        if filekind === :src
+            return PackageSourceAnalysisEntry(env_path, filepath2uri(pkgfile), pkgid)
+        else # :test
+            runtestsuri = filepath2uri(joinpath(filedir, "runtests.jl"))
+            return PackageTestAnalysisEntry(env_path, runtestsuri, pkgid)
+        end
+    end
+end
+
+function instantiate_package_environment!(server::Server, env_path::String, pkgname::String)
+    instantiated_envs = server.state.analysis_manager.instantiated_envs
+    activate_do(env_path) do
+        # Check cache inside lock to avoid race conditions
+        cached = get(load(instantiated_envs), env_path, missing)
+        if cached !== missing
+            return cached
+        end
+        # Cache miss - perform environment detection
+        ensure_instantiated!(server, env_path)
+        pkgenv = @lock Base.require_lock @something Base.identify_package_env(pkgname) begin
+            @warn "Failed to identify package environment" env_path pkgname filepath
+            return store!(instantiated_envs) do cache
+                new_cache = copy(cache)
+                new_cache[env_path] = nothing
+                new_cache, nothing
+            end
+        end
+        pkgid, env = pkgenv
+        pkgfile = @something Base.locate_package(pkgid, env) begin
+            @warn "Expected a package to have a source file" pkgname
+            return store!(instantiated_envs) do cache
+                new_cache = copy(cache)
+                new_cache[env_path] = nothing
+                new_cache, nothing
+            end
+        end
+        return store!(instantiated_envs) do cache
+            new_cache = copy(cache)
+            new_cache[env_path] = (pkgid, pkgfile)
+            new_cache, (pkgid, pkgfile)
+        end
+    end
+end
+
+function ensure_instantiated_if_requested!(server::Server, env_path::String)
+    instantiated_envs = server.state.analysis_manager.instantiated_envs
+    activate_do(env_path) do
+        # Check if already processed (success or failure)
+        if haskey(load(instantiated_envs), env_path)
+            return
+        end
+        ensure_instantiated!(server, env_path)
+        # Mark as processed
+        store!(instantiated_envs) do cache
+            if haskey(cache, env_path)
+                cache, nothing
+            else
+                new_cache = copy(cache)
+                new_cache[env_path] = nothing
+                new_cache, nothing
+            end
+        end
+    end
+end
+
+function ensure_instantiated!(server::Server, env_path::String)
+    if get_config(server.state.config_manager, :full_analysis, :auto_instantiate)
         try
             JETLS_DEV_MODE && @info "Instantiating package environment" env_path
             Pkg.instantiate()
@@ -418,192 +709,20 @@ function ensure_instantiated!(
     end
 end
 
-function ensure_instantiated_if_needed!(
-        server::Server, env_path::String, title::String,
-        progress_state::Union{Nothing,ProgressState}
+# Resolves the delayed environment instantiation with progress reporting.
+# Called after receiving confirmation for server-initiated progress token.
+function do_instantiation_with_progress(
+        server::Server, uri::URI, ins_request::InstantiationRequest, token::ProgressToken
     )
-    instantiated_envs = server.state.analysis_manager.instantiated_envs
-    activate_do(env_path) do
-        # Check if already processed (success or failure)
-        if haskey(load(instantiated_envs), env_path)
-            return
-        end
-        ensure_instantiated!(server, env_path, title, progress_state)
-        # Mark as processed
-        store!(instantiated_envs) do cache
-            if haskey(cache, env_path)
-                cache, nothing
-            else
-                new_cache = copy(cache)
-                new_cache[env_path] = nothing
-                new_cache, nothing
-            end
-        end
-    end
-end
-
-function instantiate_package_environment!(
-        server::Server, env_path::String, pkgname::String,
-        progress_state::Union{Nothing,ProgressState}
-    )
-    instantiated_envs = server.state.analysis_manager.instantiated_envs
-    activate_do(env_path) do
-        # Check cache inside lock to avoid race conditions
-        cached = get(load(instantiated_envs), env_path, missing)
-        if cached !== missing
-            return cached
-        end
-        # Cache miss - perform environment detection
-        ensure_instantiated!(server, env_path, progress_title_for_pkg(pkgname), progress_state)
-        pkgenv = @lock Base.require_lock @something Base.identify_package_env(pkgname) begin
-            @warn "Failed to identify package environment" env_path pkgname filepath
-            return store!(instantiated_envs) do cache
-                new_cache = copy(cache)
-                new_cache[env_path] = nothing
-                new_cache, nothing
-            end
-        end
-        pkgid, env = pkgenv
-        pkgfile = @something Base.locate_package(pkgid, env) begin
-            @warn "Expected a package to have a source file" pkgname
-            return store!(instantiated_envs) do cache
-                new_cache = copy(cache)
-                new_cache[env_path] = nothing
-                new_cache, nothing
-            end
-        end
-        return store!(instantiated_envs) do cache
-            new_cache = copy(cache)
-            new_cache[env_path] = (pkgid, pkgfile)
-            new_cache, (pkgid, pkgfile)
-        end
-    end
-end
-
-entryuri(entry::AnalysisEntry) = entryuri_impl(entry)::URI
-progress_title(entry::AnalysisEntry) = progress_title_impl(entry)::String
-getjetconfigs(entry::AnalysisEntry) = getjetconfigs_impl(entry)::Dict{Symbol,Any}
-
-let default_jetconfigs = Dict{Symbol,Any}(
-        :toplevel_logger => nothing,
-        # force concretization of documentation
-        :concretization_patterns => [:($(Base.Docs.doc!)(xs__))])
-    global getjetconfigs_impl(::AnalysisEntry) = default_jetconfigs
-end
-
-struct ScriptAnalysisEntry <: AnalysisEntry
-    uri::URI
-end
-entryuri_impl(entry::ScriptAnalysisEntry) = entry.uri
-progress_title_impl(entry::ScriptAnalysisEntry) = progress_title_for_uri(entry.uri)
-progress_title_for_uri(uri::URI) = basename(uri2filename(uri)) * " [no env]"
-
-struct ScriptInEnvAnalysisEntry <: AnalysisEntry
-    env_path::String
-    uri::URI
-end
-entryuri_impl(entry::ScriptInEnvAnalysisEntry) = entry.uri
-progress_title_impl(entry::ScriptInEnvAnalysisEntry) = progress_title_for_uri_in_env(entry.uri)
-progress_title_for_uri_in_env(uri::URI) = basename(uri2filename(uri)) * " [in env]"
-
-struct PackageSourceAnalysisEntry <: AnalysisEntry
-    env_path::String
-    pkgfileuri::URI
-    pkgid::Base.PkgId
-end
-entryuri_impl(entry::PackageSourceAnalysisEntry) = entry.pkgfileuri
-progress_title_impl(entry::PackageSourceAnalysisEntry) = progress_title_for_pkg(entry.pkgid)
-progress_title_for_pkg(pkgid::Base.PkgId) = progress_title_for_pkg(pkgid.name)
-progress_title_for_pkg(pkgname::AbstractString) = pkgname * ".jl" * " [package]"
-let jetconfigs = Dict{Symbol,Any}(
-        :toplevel_logger => nothing,
-        :analyze_from_definitions => true,
-        :concretization_patterns => [:(x_)])
-    global getjetconfigs_impl(::PackageSourceAnalysisEntry) = jetconfigs
-end
-
-struct PackageTestAnalysisEntry <: AnalysisEntry
-    env_path::String
-    runtestsuri::URI
-    pkgid::Base.PkgId
-end
-entryuri_impl(entry::PackageTestAnalysisEntry) = entry.runtestsuri
-progress_title_impl(entry::PackageTestAnalysisEntry) = progress_title_for_pkgtest(entry.pkgid)
-progress_title_for_pkgtest(pkgid::Base.PkgId) = pkgid.name * ".jl" * " [package test]"
-
-function lookup_analysis_entry(
-        server::Server, uri::URI,
-        progress_state::Union{Nothing,ProgressState} = nothing,
-    )
-    state = server.state
-    maybe_env_path = find_analysis_env_path(state, uri)
-    if maybe_env_path isa OutOfScope
-        outofscope = maybe_env_path
-        return outofscope
-    end
-
-    env_path = maybe_env_path
-    if isnothing(env_path)
-        return ScriptAnalysisEntry(uri)
-    elseif uri.scheme == "untitled"
-        ensure_instantiated_if_needed!(server, env_path, progress_title_for_uri_in_env(uri), progress_state)
-        return ScriptInEnvAnalysisEntry(env_path, uri)
-    end
-
-    pkgname = find_pkg_name(env_path)
-    filepath = uri2filepath(uri)::String # uri.scheme == "file"
-    if isnothing(pkgname) # TODO Test environment with workspace setup fails here
-        ensure_instantiated_if_needed!(server, env_path, progress_title_for_uri_in_env(uri), progress_state)
-        return ScriptInEnvAnalysisEntry(env_path, uri)
-    end
-    filekind, filedir = find_package_directory(filepath, env_path)
-    if filekind === :src
-        pkgid, pkgfile = @something(
-            instantiate_package_environment!(server, env_path, pkgname, progress_state),
-            return ScriptInEnvAnalysisEntry(env_path, uri))
-        pkgfileuri = filepath2uri(pkgfile)
-        return PackageSourceAnalysisEntry(env_path, pkgfileuri, pkgid)
-    elseif filekind === :test
-        pkgid, _ = @something(
-            instantiate_package_environment!(server, env_path, pkgname, progress_state),
-            return ScriptInEnvAnalysisEntry(env_path, uri))
-        runtestsuri = filepath2uri(joinpath(filedir, "runtests.jl"))
-        return PackageTestAnalysisEntry(env_path, runtestsuri, pkgid)
-    elseif filekind === :docs # TODO
-    elseif filekind === :ext # TODO
-    else
-        @assert filekind === :script
-    end
-    ensure_instantiated_if_needed!(server, env_path, progress_title_for_uri_in_env(uri), progress_state)
-    return ScriptInEnvAnalysisEntry(env_path, uri)
-end
-
-function execute_analysis_request(server::Server, request::AnalysisRequest)
-    entry = request.entry
-
-    if entry isa ScriptAnalysisEntry
-        result = analyze_parsed_if_exist(server, request)
-
-    elseif entry isa ScriptInEnvAnalysisEntry
-        result = activate_do(entry.env_path) do
-            analyze_parsed_if_exist(server, request)
-        end
-
-    elseif entry isa PackageSourceAnalysisEntry
-        result = activate_do(entry.env_path) do
-            analyze_parsed_if_exist(server, request, entry.pkgid)
-        end
-
-    elseif entry isa PackageTestAnalysisEntry
-        result = activate_do(entry.env_path) do
-            analyze_parsed_if_exist(server, request)
-        end
-
-    else error("Unsupported analysis entry $entry") end
-
-    ret = new_analysis_result(request, result)
-
-    # TODO Request fallback analysis in cases this script was not analyzed by the analysis entry
-    # request.uri ∉ analyzed_file_uris(ret)
-    return ret
+    root_path = ins_request.root_path
+    message_path = isnothing(root_path) ? ins_request.env_path :
+        relpath(ins_request.env_path, dirname(root_path))
+    send_progress(server, token,
+        WorkDoneProgressBegin(;
+            title = "Instantiating environment",
+            message = message_path,
+            cancellable = false))
+    entry = do_instantiation(server, uri, ins_request)
+    send_progress(server, token, WorkDoneProgressEnd())
+    return entry
 end

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -50,7 +50,7 @@ function handle_DidOpenTextDocumentNotification(server::Server, msg::DidOpenText
     update_testsetinfos!(server, uri, fi)
     cache_saved_file_info!(server.state, uri, parsed_stream)
 
-    request_analysis_on_open!(server, uri)
+    request_analysis!(server, uri, #=onsave=#false)
 end
 
 function handle_DidChangeTextDocumentNotification(server::Server, msg::DidChangeTextDocumentNotification)
@@ -85,7 +85,7 @@ function handle_DidSaveTextDocumentNotification(server::Server, msg::DidSaveText
     end
     cache_saved_file_info!(server.state, uri, text)
 
-    request_analysis_on_save!(server, uri)
+    request_analysis!(server, uri, #=onsave=#true)
 end
 
 function handle_DidCloseTextDocumentNotification(server::Server, msg::DidCloseTextDocumentNotification)

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -260,7 +260,7 @@ function with_completion_request(
             else
                 JETLS.cache_file_info!(server.state, uri, 1, clean_code)
                 JETLS.cache_saved_file_info!(server.state, uri, clean_code)
-                JETLS.request_analysis!(server, uri; notify_diagnostics=false)
+                JETLS.request_analysis!(server, uri, #=onsave=#false; wait=true, notify_diagnostics=false)
             end
 
             for (i, pos) in enumerate(positions)

--- a/test/test_lookup_analysis_entry.jl
+++ b/test/test_lookup_analysis_entry.jl
@@ -1,0 +1,60 @@
+module test_lookup_analysis_entry
+
+using Test
+using Pkg
+using JETLS
+using JETLS: lookup_analysis_entry, ScriptInEnvAnalysisEntry, entryenvpath
+using JETLS.URIs2: filepath2uri
+
+@testset "lookup_analysis_entry for docs" begin
+    mktempdir() do temp_root
+        proj_dir = joinpath(temp_root, "TestPkg")
+        mkpath(proj_dir)
+        env_path = joinpath(proj_dir, "Project.toml")
+        write(env_path, """
+            name = "TestPkg"
+            uuid = "12345678-1234-1234-1234-123456789012"
+            version = "0.1.0"
+            """)
+
+        src_dir = joinpath(proj_dir, "src")
+        docs_dir = joinpath(proj_dir, "docs")
+        mkpath(src_dir)
+        mkpath(docs_dir)
+        mkpath(joinpath(docs_dir, "src"))
+
+        write(joinpath(src_dir, "TestPkg.jl"), "module TestPkg end")
+        write(joinpath(docs_dir, "make.jl"), "# docs make script")
+
+        # Test docs with docs/Project.toml
+        let docs_env_path = joinpath(docs_dir, "Project.toml")
+            write(docs_env_path, """
+                [deps]
+                Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+                """)
+
+            filepath = joinpath(docs_dir, "make.jl")
+            uri = filepath2uri(filepath)
+            server = Server()
+            server.state.root_path = proj_dir
+            entry = lookup_analysis_entry(server, uri)
+            @test entry isa ScriptInEnvAnalysisEntry
+            @test entryenvpath(entry) == docs_env_path
+        end
+
+        # Test docs without docs/Project.toml (falls back to root Project.toml)
+        let docs_env_path = joinpath(docs_dir, "Project.toml")
+            rm(docs_env_path; force=true)
+
+            filepath = joinpath(docs_dir, "make.jl")
+            uri = filepath2uri(filepath)
+            server = Server()
+            server.state.root_path = proj_dir
+            entry = lookup_analysis_entry(server, uri)
+            @test entry isa ScriptInEnvAnalysisEntry
+            @test entryenvpath(entry) == env_path
+        end
+    end
+end
+
+end # module test_lookup_analysis_entry

--- a/test/test_lowering_diagnostics.jl
+++ b/test/test_lowering_diagnostics.jl
@@ -310,7 +310,7 @@ end
             withserver() do (; writereadmsg, id_counter, server)
                 JETLS.cache_file_info!(server.state, uri, 1, script)
                 JETLS.cache_saved_file_info!(server.state, uri, script)
-                JETLS.request_analysis!(server, uri; notify_diagnostics=false)
+                JETLS.request_analysis!(server, uri, #=onsave=#false; wait=true, notify_diagnostics=false)
 
                 id = id_counter[] += 1
                 (; raw_res) = writereadmsg(DocumentDiagnosticRequest(;

--- a/test/test_resolver.jl
+++ b/test/test_resolver.jl
@@ -14,7 +14,7 @@ function analyze_and_resolve(s::AbstractString; kwargs...)
         fileinfo = JETLS.cache_file_info!(state, uri, 1, text)
         JETLS.cache_saved_file_info!(state, uri, text)
         JETLS.start_analysis_workers!(server)
-        JETLS.request_analysis!(server, uri; notify_diagnostics=false)
+        JETLS.request_analysis!(server, uri, #=onsave=#false; wait=true, notify_diagnostics=false)
 
         (; mod, analyzer) = JETLS.get_context_info(state, uri, position)
 


### PR DESCRIPTION
Split analysis entry lookup into two phases to enable dedicated progress reporting for environment instantiation and analysis.

Phase 1 (`lookup_analysis_entry`) performs a non-blocking check that returns:
- `AnalysisEntry` directly if no instantiation is needed (cached or no env)
- `InstantiationRequest` if instantiation is required
- `OutOfScope` if the file is out of analysis scope

Phase 2 (`do_instantiation` or `do_instantiation_with_progress`) performs the actual instantiation when needed.

This design allows the server to issue separate progress tokens for instantiation and analysis phases, providing users with earlier and more accurate progress feedback. The `InstantiationProgressCaller` is non-cancellable since instantiation cannot be cancelled, while `AnalysisProgressCaller` remains cancellable.

Also consolidate the entry point: replace separate `request_analysis_on_open!` and `request_analysis_on_save!` functions with a unified `request_analysis!` that handles both cases via the `onsave` parameter.