### PR TITLE
ast: Preserve `@nospecialize`/`@specialize` in `remove_macrocalls`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   opened simultaneously. Added global lock to `activate_do` to serialize
   environment switching operations. This fixes spurious "Failed to identify
   package environment" warnings.
+- Fixed document highlight and rename not working for function parameters
+  annotated with `@nospecialize` or `@specialize`.
 
 ### Internal
 


### PR DESCRIPTION
The `remove_macrocalls` function converts macrocall nodes to block nodes to enable LSP features to work with local variables inside macrocalls. However, this transformation caused `@nospecialize` and `@specialize` macros in function argument lists to become invalid block expressions, which prevented JuliaLowering from generating correct lowered trees.

This commit adds special handling for these macros: instead of transforming them, we keep them intact. JuliaLowering.jl provides new macro style definitions for `@nospecialize` and `@specialize`, so they don't need to be removed in the first place.

This fix enables document highlight and rename to work correctly for function parameters annotated with these macros.