### PR TITLE
runserver: Handle pre-initialization messages per LSP spec

### DIFF
--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -159,7 +159,7 @@ runserver(args...; kwargs...) = runserver(Returns(nothing), args...; kwargs...) 
 runserver(callback, in::IO, out::IO; kwargs...) = runserver(callback, Endpoint(in, out); kwargs...)
 runserver(callback, endpoint::Endpoint; kwargs...) = runserver(Server(callback, endpoint); kwargs...)
 function runserver(server::Server; client_process_id::Union{Nothing,Int}=nothing)
-    shutdown_requested = false
+    initialize_requested = shutdown_requested = false
     local exit_code::Int = 1
     JETLS_DEV_MODE && @info "Running JETLS server loop"
     seq_queue = start_sequential_message_worker(server)
@@ -182,8 +182,9 @@ function runserver(server::Server; client_process_id::Union{Nothing,Int}=nothing
     try
         for msg in server.endpoint
             server.callback !== nothing && server.callback(:received, msg)
-            # handle lifecycle-related messages
+            # Handle lifecycle-related messages
             if msg isa InitializeRequest
+                initialize_requested = true
                 handle_InitializeRequest(server, msg; client_process_id)
             elseif msg isa InitializedNotification
                 handle_InitializedNotification(server)
@@ -196,6 +197,17 @@ function runserver(server::Server; client_process_id::Union{Nothing,Int}=nothing
             elseif msg === self_shutdown_token
                 exit_code = 1
                 break
+            # Handle messages received before initialization (LSP 3.17 spec):
+            # - For requests: respond with error code -32002 (ServerNotInitialized)
+            # - For notifications: drop silently (exit already handled above)
+            elseif !initialize_requested
+                if isdefined(msg, :id)
+                    send(server, ResponseMessage(;
+                        id = msg.id,
+                        error = ResponseError(;
+                            code = ErrorCodes.ServerNotInitialized,
+                            message = "Server has not been initialized")))
+                end
             elseif shutdown_requested
                 if isdefined(msg, :id)
                     send(server, ResponseMessage(;


### PR DESCRIPTION
According to LSP 3.17 specification, if the server receives a request or notification before the initialize request, it should:
- For requests: respond with error code -32002 (ServerNotInitialized)
- For notifications: drop silently, except for the exit notification

This adds the initialize_requested flag to track whether the initialize request has been received, and rejects/drops messages accordingly.

Written by Claude