### PR TITLE
full-analysis: Parallelize signature analysis phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   See [Initialization options](https://aviatesk.github.io/JETLS.jl/dev/launching/#init-options)
   for details.
 
+### Changed
+
+- Parallelized signature analysis phase using `Threads.@spawn`, leveraging the
+  thread-safe inference pipeline introduced in Julia v1.12. On a 4-core machine,
+  first-time analysis of CSV.jl improved from 30s to 18s (~1.7x faster), and
+  JETLS.jl itself from 154s to 36s (~4.3x faster).
+
 ### Fixed
 
 - Fixed handling of messages received before the initialize request per

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -45,6 +45,12 @@ using Glob: Glob
 
 abstract type AnalysisEntry end # used by `Analyzer.LSAnalyzer`
 
+include("AtomicContainers/AtomicContainers.jl")
+using .AtomicContainers
+const SWStats  = JETLS_DEV_MODE ? AtomicContainers.SWStats : Nothing
+const LWStats  = JETLS_DEV_MODE ? AtomicContainers.LWStats : Nothing
+const CASStats = JETLS_DEV_MODE ? AtomicContainers.CASStats : Nothing
+
 include("analysis/Analyzer.jl")
 using .Analyzer
 
@@ -54,12 +60,7 @@ Analyzer.LSAnalyzer(args...; kwargs...) = LSAnalyzer(ScriptAnalysisEntry(filepat
 
 include("analysis/resolver.jl")
 
-include("AtomicContainers/AtomicContainers.jl")
 include("FixedSizeFIFOQueue/FixedSizeFIFOQueue.jl")
-using .AtomicContainers
-const SWStats  = JETLS_DEV_MODE ? AtomicContainers.SWStats : Nothing
-const LWStats  = JETLS_DEV_MODE ? AtomicContainers.LWStats : Nothing
-const CASStats = JETLS_DEV_MODE ? AtomicContainers.CASStats : Nothing
 
 include("utils/general.jl")
 


### PR DESCRIPTION
Parallelize signature analysis using `Threads.@spawn`, leveraging the thread-safe inference pipeline introduced in Julia v1.12. Each analysis task creates its own analyzer with fresh local caches to avoid data races.

Key changes:
- Add `SignatureAnalysisProgress` struct with atomic fields for thread-safe progress tracking
- Make `LS_ANALYZER_CACHE` thread-safe using `CASContainer`
- Move `AtomicContainers` include earlier to make it available in `Analyzer.jl`

On a 4-core machine (`--threads=4,2`):
- CSV.jl first-time analysis: 30s -> 18s (~1.7x faster)
- JETLS.jl first-time analysis: 154s -> 36s (~4.3x faster)

# Performance experiments
The measurement results below are for `--threads=auto` (`--threads=4,2`).

## JETLS.jl 

> `master` [`1dac93f`](https://github.com/aviatesk/JETLS.jl/commit/1dac93f5a5b4e522243090d3ab9e806249a7d47d) vs. `avi/parallelize-sig-analysis`

| JETLS Branch                   | First time analysis (generation=0) | Re-analysis (generation=1) | Re-analysis (generation=2) |
| ------------------------------ | ---------------------------------- | -------------------------- | -------------------------- |
| `master`                       | 153.58                             | 18.64                      | 20.43                      |
| `avi/parallelize-sig-analysis` | 35.89                              | 14.2                       | 14.66                      |

## CSV.jl

> [`04ec1cf`](https://github.com/JuliaData/CSV.jl/commit/04ec1cf3a7b0f069c573ba7c9da351026427532b)

| JETLS Branch                   | First time analysis (generation=0) | Re-analysis (generation=1) | Re-analysis (generation=2) |
| ------------------------------ | ---------------------------------- | -------------------------- | -------------------------- |
| `master`                       | 29.71                              | 12.31                      | 7.0                        |
| `avi/parallelize-sig-analysis` | 18.45                              | 5.68                       | 4.1                        |
