### PR TITLE
config: Restrict .JETLSConfig.toml to workspace root only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
 - Diff: [`aae52f5...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/aae52f5...HEAD)
 
+### Fixed
+
+- `.JETLSConfig.toml` is now only recognized at the workspace root.
+  Previously, config files in subdirectories were also loaded, which was
+  inconsistent with [the documentation](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/file-based-config).
+
 ### Internal
 
 - Added heap snapshot profiling support. Create a `.JETLSProfile` file in the

--- a/src/did-change-watched-files.jl
+++ b/src/did-change-watched-files.jl
@@ -12,7 +12,9 @@ function did_change_watched_files_registration(server::Server)
         registerOptions = DidChangeWatchedFilesRegistrationOptions(;
             watchers = FileSystemWatcher[
                 FileSystemWatcher(;
-                    globPattern = "**/$CONFIG_FILE",
+                    globPattern = RelativePattern(;
+                        baseUri = root_uri,
+                        pattern = CONFIG_FILE),
                     kind = WatchKind.Create | WatchKind.Change | WatchKind.Delete),
                 FileSystemWatcher(;
                     globPattern = RelativePattern(;


### PR DESCRIPTION
Use RelativePattern for file watching to ensure .JETLSConfig.toml is only recognized in the workspace root directory. Previously, config files in subdirectories were also loaded due to the "**/" glob pattern, which was inconsistent with the documentation.