### PR TITLE
diagnostics: Fix glob pattern matching for path filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed glob pattern matching for `diagnostic.patterns[].path`: `**` now
+  correctly matches zero or more directory levels (e.g., `test/**/*.jl` matches
+  `test/testfile.jl`), and wildcards no longer match hidden files/directories.
+  (aviatesk/JETLS.jl#359)
 - `.JETLSConfig.toml` is now only recognized at the workspace root.
   Previously, config files in subdirectories were also loaded, which was
   inconsistent with [the documentation](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/file-based-config).

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -114,7 +114,7 @@ function parse_diagnostic_pattern(x::AbstractDict{String})
                 lazy"Invalid `path` value for pattern \"$pattern_value\". Must be a string, got $(typeof(path_value))"))
         end
         try
-            Glob.FilenameMatch(path_value)
+            Glob.FilenameMatch(path_value, "dp")
         catch e
             throw(DiagnosticConfigError(
                 lazy"Invalid glob pattern \"$path_value\" for path: $(sprint(showerror, e))"))

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -347,6 +347,11 @@ end
                 pattern = only(config.patterns)
                 @test pattern.path !== nothing
                 @test pattern.path isa Glob.FilenameMatch
+                @test occursin(pattern.path, "test/dir/testfile.jl")
+                # `**` should also match empty path segments (requires the `d = PATHNAME` flag)
+                @test occursin(pattern.path, "test/testfile.jl")
+                # `*` and `**` should not match leading dots in path segments (requires the `p = PERIOD` flag)
+                @test !occursin(pattern.path, "test/.hidden/testfile.jl")
             end
         end
 


### PR DESCRIPTION
Previously, glob patterns like `test/**/*.jl` would not match files directly under the matched directory (e.g., `test/testfile.jl`). This was caused by missing flags in `Glob.FilenameMatch`.

Added the `p` (PERIOD) and `d` (PATHNAME) flags to ensure:
- `**` correctly matches empty path segments
- Hidden files/directories (e.g., `.git/`) are excluded from matching