### PR TITLE
full-analysis: Add module_overrides initialization option

### DIFF
--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -1,3 +1,25 @@
+# Configuration
+# =============
+
+function parse_module_override(x::AbstractDict{String})
+    if !haskey(x, "module_name")
+        error(lazy"Missing required field `module_name` in module_override")
+    end
+    module_name = x["module_name"]
+    if !(module_name isa String)
+        error(lazy"Invalid `module_name` value. Must be a string, got $(typeof(module_name))")
+    end
+    if !haskey(x, "path")
+        error(lazy"Missing required field `path` in module_override for module \"$module_name\"")
+    end
+    path_value = x["path"]
+    if !(path_value isa String)
+        error(lazy"Invalid `path` value for module \"$module_name\". Must be a string, got $(typeof(path_value))")
+    end
+    path_glob = Glob.FilenameMatch(path_value, "dp")
+    return ModuleOverride(module_name, path_glob)
+end
+
 # Progress support
 # ================
 

--- a/src/init_options.jl
+++ b/src/init_options.jl
@@ -1,8 +1,9 @@
-const DEFAULT_INIT_OPTIONS = InitOptions(; n_analysis_workers=1)
+const DEFAULT_INIT_OPTIONS = InitOptions(; n_analysis_workers=1, module_overrides=ModuleOverride[])
 
 function merge_init_options(base::InitOptions, overlay::InitOptions)
     InitOptions(;
-        n_analysis_workers = something(overlay.n_analysis_workers, base.n_analysis_workers))
+        n_analysis_workers = something(overlay.n_analysis_workers, base.n_analysis_workers),
+        module_overrides = something(overlay.module_overrides, base.module_overrides))
 end
 
 function validate_init_options(opts::InitOptions)

--- a/src/types.jl
+++ b/src/types.jl
@@ -422,15 +422,26 @@ function ConfigManagerData(
     return ConfigManagerData(file_config, lsp_config, file_config_path, initialized)
 end
 
+# Internal, undocumented configuration for full-analysis module overrides.
+struct ModuleOverride <: ConfigSection
+    module_name::String
+    path::Glob.FilenameMatch{String}
+end
+@define_eq_overloads ModuleOverride
+Base.convert(::Type{ModuleOverride}, x::AbstractDict{String}) = parse_module_override(x)
+
 # Static initialization options from `InitializeParams.initializationOptions`.
 # These are set once during the initialize request and remain constant.
 @option struct InitOptions
     n_analysis_workers::Maybe{Int}
+    module_overrides::Maybe{Vector{ModuleOverride}}
 end
 function Base.show(io::IO, init_options::InitOptions)
     print(io, "InitOptions(;")
     n_analysis_workers = init_options.n_analysis_workers
     n_analysis_workers === nothing || print(io, " n_analysis_workers=", n_analysis_workers)
+    module_overrides = init_options.module_overrides
+    module_overrides === nothing || print(io, " module_overrides=", module_overrides)
     print(io, ")")
 end
 

--- a/src/utils/pkg.jl
+++ b/src/utils/pkg.jl
@@ -1,3 +1,12 @@
+function find_loaded_module(module_name::String)
+    for (pkgid, mod) in Base.loaded_modules
+        if pkgid.name == module_name
+            return mod
+        end
+    end
+    return nothing
+end
+
 function find_analysis_env_path(state::ServerState, uri::URI)
     if uri.scheme == "file"
         filepath = uri2filepath(uri)::String
@@ -12,6 +21,25 @@ function find_analysis_env_path(state::ServerState, uri::URI)
         if isdefined(state, :root_path)
             if !issubdir(dirname(filepath), state.root_path)
                 return OutOfScope()
+            end
+        end
+        module_overrides = state.init_options.module_overrides
+        if module_overrides !== nothing
+            if isdefined(state, :root_path) && startswith(filepath, state.root_path)
+                path_for_glob = relpath(filepath, state.root_path)
+            else
+                path_for_glob = filepath
+            end
+            for override in module_overrides
+                if occursin(override.path, path_for_glob)
+                    mod = find_loaded_module(override.module_name)
+                    if mod !== nothing
+                        JETLS_DEV_MODE && @info "Analysis module overridden" module_name=override.module_name path=filepath
+                        return OutOfScope(mod)
+                    else
+                        @warn "Analysis module override specified but module not loaded" module_name=override.module_name path=filepath
+                    end
+                end
             end
         end
         return find_env_path(filepath)


### PR DESCRIPTION
This adds an internal, experimental option to override the analysis module for files matching specific glob patterns. When a file path matches a configured pattern, the analysis uses the specified pre-loaded module instead of searching for an environment.

This is useful for development scenarios where certain files should be analyzed using a specific module that is already loaded in the language server process, especially for developing JETLS while working around #357 .