### PR TITLE
testrunner: Integrate testsetinfos into FileCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
 - Diff: [`c23409d...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/c23409d...HEAD)
 
+### Fixed
+
+- TestRunner code lenses and code actions now properly wait for file cache
+  population before being computed.
+
 ### Changed
 
 - Updated JuliaSyntax.jl and JuliaLowering to the latest development versions.

--- a/src/code-action.jl
+++ b/src/code-action.jl
@@ -36,8 +36,8 @@ function handle_CodeActionRequest(
     end
     fi = result
     code_actions = Union{CodeAction,Command}[]
-    testsetinfos = get_testsetinfos(server.state, uri)
-    isnothing(testsetinfos) ||
+    testsetinfos = fi.testsetinfos
+    isempty(testsetinfos) ||
         testrunner_code_actions!(code_actions, uri, fi, testsetinfos, msg.params.range)
     return send(server,
         CodeActionResponse(;

--- a/src/code-lens.jl
+++ b/src/code-lens.jl
@@ -33,8 +33,8 @@ function handle_CodeLensRequest(server::Server, msg::CodeLensRequest, cancel_fla
     end
     fi = result
     code_lenses = CodeLens[]
-    testsetinfos = get_testsetinfos(server.state, uri)
-    isnothing(testsetinfos) ||
+    testsetinfos = fi.testsetinfos
+    isempty(testsetinfos) ||
         testrunner_code_lenses!(code_lenses, uri, fi, testsetinfos)
     return send(server,
         CodeLensResponse(;

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -18,12 +18,11 @@ module __demo__ end
     mktemp() do filename, _
         uri = filepath2uri(filename)
         @compile_workload let
-            state = server.state
-            fi = cache_file_info!(state, uri, #=version=#1, text)
+            fi = cache_file_info!(server, uri, #=version=#1, text)
             let comp_params = CompletionParams(;
                     textDocument = TextDocumentIdentifier(; uri),
                     position)
-                items = get_completion_items(state, uri, fi, comp_params)
+                items = get_completion_items(server.state, uri, fi, comp_params)
                 any(item->item.label=="out", items) || @warn "completion seems to be broken"
                 any(item->item.label=="bar", items) || @warn "completion seems to be broken"
             end

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -212,8 +212,6 @@ Fetch cached saved FileInfo given an LSclient-provided structure with a URI
 get_saved_file_info(s::ServerState, uri::URI) = get(load(s.saved_file_cache), uri, nothing)
 get_saved_file_info(s::ServerState, t::TextDocumentIdentifier) = get_saved_file_info(s, t.uri)
 
-get_testsetinfos(s::ServerState, uri::URI) = get(load(s.testsetinfos_cache), uri, nothing)
-
 """
     get_context_info(state::ServerState, uri::URI, pos::Position) -> (; mod, analyzer, postprocessor)
 

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -258,7 +258,7 @@ function with_completion_request(
                 @test raw_res isa PublishDiagnosticsNotification
                 @test raw_res.params.uri == uri
             else
-                JETLS.cache_file_info!(server.state, uri, 1, clean_code)
+                JETLS.cache_file_info!(server, uri, 1, clean_code)
                 JETLS.cache_saved_file_info!(server.state, uri, clean_code)
                 JETLS.request_analysis!(server, uri, #=onsave=#false; wait=true, notify_diagnostics=false)
             end
@@ -510,10 +510,10 @@ function test_backslash_offset(code::String, expected_result)
     text, positions = JETLS.get_text_and_positions(code)
     @assert length(positions) == 1 "test_backslash_offset requires exactly one cursor marker"
 
-    state = JETLS.ServerState()
+    server = JETLS.Server()
     filename = abspath("test_backslash.jl")
     uri = filename2uri(filename)
-    fi = JETLS.cache_file_info!(state, uri, 1, text)
+    fi = JETLS.cache_file_info!(server, uri, 1, text)
 
     result = JETLS.get_backslash_offset(fi, positions[1])
     @test result == expected_result

--- a/test/test_lowering_diagnostics.jl
+++ b/test/test_lowering_diagnostics.jl
@@ -308,7 +308,7 @@ end
         withscript(script) do script_path
             uri = filepath2uri(script_path)
             withserver() do (; writereadmsg, id_counter, server)
-                JETLS.cache_file_info!(server.state, uri, 1, script)
+                JETLS.cache_file_info!(server, uri, 1, script)
                 JETLS.cache_saved_file_info!(server.state, uri, script)
                 JETLS.request_analysis!(server, uri, #=onsave=#false; wait=true, notify_diagnostics=false)
 
@@ -420,7 +420,7 @@ end
         macro foo(x, y) \$(x) end
         macro bar(x, y) \$(x) end
         """
-        fi = JETLS.cache_file_info!(server.state, uri, #=version=#0, text)
+        fi = JETLS.cache_file_info!(server, uri, #=version=#0, text)
         diagnostics = JETLS.toplevel_lowering_diagnostics(server, uri, fi)
         @test length(diagnostics) == 2
         @test count(diagnostics) do diagnostic

--- a/test/test_resolver.jl
+++ b/test/test_resolver.jl
@@ -11,7 +11,7 @@ function analyze_and_resolve(s::AbstractString; kwargs...)
     state = server.state
     mktemp() do filename, _
         uri = filename2uri(filename)
-        fileinfo = JETLS.cache_file_info!(state, uri, 1, text)
+        fileinfo = JETLS.cache_file_info!(server, uri, 1, text)
         JETLS.cache_saved_file_info!(state, uri, text)
         JETLS.start_analysis_workers!(server)
         JETLS.request_analysis!(server, uri, #=onsave=#false; wait=true, notify_diagnostics=false)

--- a/test/test_signature_help.jl
+++ b/test/test_signature_help.jl
@@ -312,7 +312,7 @@ end
         foo(nothing,│)
         """
         cnt = 0
-        with_signature_help_request(text) do i, result, uri, script_path
+        with_signature_help_request(text) do _, result, _, script_path
             @test length(result.signatures) == 2
             @test any(result.signatures) do siginfo
                 siginfo.label == "foo(xxx)" &&
@@ -346,9 +346,6 @@ end
                 @test raw_res isa PublishDiagnosticsNotification
                 @test raw_res.params.uri == uri
 
-                # TODO Comment in the following
-                #      The following line doesn't work because `get_context_module` isn't synced
-                #      with `DidChangeTextDocumentNotification`
                 edited_code = """
                 foo(xxx) = :xxx
                 foo(xxx, yyy) = :xxx_yyy


### PR DESCRIPTION
Move testsetinfos management from a separate `TestsetInfosCache` into the `FileInfo` struct itself. This allows testsetinfos to be computed atomically when caching file info, ensuring that when a `FileInfo` is retrieved via `get_file_info`, it always contains valid testsetinfos. As a result, testrunner code lenses and code actions now properly wait for cache population before being computed.