### PR TITLE
notebook: Implement Jupyter notebook document support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
 - Diff: [`fd5f113...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/fd5f113...HEAD)
 
+### Added
+
+- Jupyter notebook support: JETLS now provides language features for Julia code
+  cells in Jupyter notebooks, including completions, hover, go-to-definition,
+  rename, and diagnostics. All cells are analyzed together, so definitions from
+  earlier cells are available in later cells.
+
+  > JETLS × notebook LSP demo
+
+  https://github.com/user-attachments/assets/a3bc3937-37dd-4fe5-9a29-f608329d87a5
+
 ## 2025-12-06
 
 - Commit: [`fd5f113`](https://github.com/aviatesk/JETLS.jl/commit/fd5f113)

--- a/LSP/src/URIs2/uri_helpers.jl
+++ b/LSP/src/URIs2/uri_helpers.jl
@@ -1,10 +1,8 @@
 function uri2filename(uri::URI)
     if uri.scheme == "file"
         return uri2filepath(uri)::String
-    elseif uri.scheme == "untitled"
-        return uri.path
     else
-        error(lazy"Unsupported uri: $uri")
+        return uri.path
     end
 end
 

--- a/LSP/src/basic-json-structures.jl
+++ b/LSP/src/basic-json-structures.jl
@@ -229,9 +229,55 @@ To keep the type definition simple all properties are marked as optional.
 end
 
 """
-A document selector is the combination of one or more document filters.
+A notebook document filter denotes a notebook document by
+different properties.
+
+# Tags
+- since - 3.17.0
 """
-const DocumentSelector = Vector{DocumentFilter}
+@interface NotebookDocumentFilter begin
+    "The type of the enclosing notebook."
+    notebookType::Union{Nothing, String} = nothing
+
+    "A Uri scheme, like `file` or `untitled`."
+    scheme::Union{Nothing, String} = nothing
+
+    "A glob pattern."
+    pattern::Union{Nothing, String} = nothing
+end
+
+"""
+A notebook cell text document filter denotes a cell text
+document by different properties.
+
+# Tags
+- since - 3.17.0
+"""
+@interface NotebookCellTextDocumentFilter begin
+    """
+    A filter that matches against the notebook
+    containing the notebook cell. If a string
+    value is provided it matches against the
+    notebook type. '*' matches every notebook.
+    """
+    notebook::Union{String, NotebookDocumentFilter}
+
+    """
+    A language id like `python`.
+
+    Will be matched against the language id of the
+    notebook cell document. '*' matches every language.
+    """
+    language::Union{Nothing, String} = nothing
+end
+
+"""
+A document selector is the combination of one or more document filters.
+
+!!! note "3.17.0"
+    Since 3.17.0, a document selector can also include notebook cell text document filters.
+"""
+const DocumentSelector = Vector{Union{DocumentFilter, NotebookCellTextDocumentFilter}}
 
 # TextEdit & AnnotatedTextEdit
 # ============================
@@ -513,30 +559,6 @@ Diagnostic objects are only valid in the scope of a resource.
     - since – 3.16.0
     """
     data::Union{Any, Nothing} = nothing
-end
-
-# Utility constructor
-function Diagnostic(diag::Diagnostic;
-        range::Range = diag.range,
-        severity::Union{DiagnosticSeverity.Ty,Nothing} = diag.severity,
-        code::Union{String,Int,Nothing} = diag.code,
-        codeDescription::Union{CodeDescription,Nothing} = diag.codeDescription,
-        source::Union{String,Nothing} = diag.source,
-        message::String = diag.message,
-        tags::Union{Vector{DiagnosticTag.Ty},Nothing} = diag.tags,
-        relatedInformation::Union{Vector{DiagnosticRelatedInformation},Nothing} = diag.relatedInformation,
-        data::Any = diag.data
-    )
-    return Diagnostic(;
-        range,
-        severity,
-        code,
-        codeDescription,
-        source,
-        message,
-        tags,
-        relatedInformation,
-        data)
 end
 
 # Command

--- a/LSP/src/document-synchronization.jl
+++ b/LSP/src/document-synchronization.jl
@@ -281,49 +281,6 @@ A notebook document.
 end
 
 """
-A notebook document filter denotes a notebook document by
-different properties.
-
-# Tags
-- since - 3.17.0
-"""
-@interface NotebookDocumentFilter begin
-    "The type of the enclosing notebook."
-    notebookType::Union{Nothing, String} = nothing
-
-    "A Uri scheme, like `file` or `untitled`."
-    scheme::Union{Nothing, String} = nothing
-
-    "A glob pattern."
-    pattern::Union{Nothing, String} = nothing
-end
-
-"""
-A notebook cell text document filter denotes a cell text
-document by different properties.
-
-# Tags
-- since - 3.17.0
-"""
-@interface NotebookCellTextDocumentFilter begin
-    """
-    A filter that matches against the notebook
-    containing the notebook cell. If a string
-    value is provided it matches against the
-    notebook type. '*' matches every notebook.
-    """
-    notebook::Union{String, NotebookDocumentFilter}
-
-    """
-    A language id like `python`.
-
-    Will be matched against the language id of the
-    notebook cell document. '*' matches every language.
-    """
-    language::Union{Nothing, String} = nothing
-end
-
-"""
 A literal to identify a notebook document in the client.
 
 # Tags

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ the list itself is subject to change.
 - [x] Parallel/concurrent message handling
 - [x] Work done progress support
 - [x] Message cancellation support
-- [ ] Notebook support
+- [x] Notebook support
 - Release
   - [x] Publish a standalone VSCode language client extension
   - [x] Make installable as Pkg executable app

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -36,6 +36,7 @@ makedocs(;
         "Diagnostic" => "diagnostic.md",
         "Formatter integration" => "formatting.md",
         "TestRunner integration" => "testrunner.md",
+        "Jupyter notebook support" => "notebook.md",
         "Configuration" => "configuration.md",
         "Launching" => "launching.md",
     ],

--- a/docs/src/notebook.md
+++ b/docs/src/notebook.md
@@ -1,0 +1,41 @@
+# Jupyter notebook support
+
+!!! warning "Experimental"
+    Notebook support is experimental. The LSP specification for notebooks is
+    still evolving, and `jetls-client` VS Code extension uses an unreleased
+    version of [`vscode-languageclient`](https://www.npmjs.com/package/vscode-languageclient)
+    to fully enable this feature.
+
+JETLS provides language features for Julia code cells in Jupyter notebooks.
+
+## Demo
+
+```@raw html
+<center>
+<iframe class="display-light-only" style="width:100%;height:min(500px,70vh);aspect-ratio:16/9" src="https://github.com/user-attachments/assets/b5bb5201-d735-4a37-b430-932b519254ee" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</center>
+<iframe class="display-dark-only" style="width:100%;height:min(500px,70vh);aspect-ratio:16/9" src="https://github.com/user-attachments/assets/f7476257-7a53-44a1-8c8c-1ad57e136a63" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</center>
+```
+
+As shown in this demo, all code cells are analyzed together as a single source,
+as if the notebook were a single Julia script. The language server is aware of
+all cells, so features like go-to-definition, completions, and diagnostics work
+across cells just as they would in a regular Julia script.
+
+## Client support
+
+As of December 2025, notebook LSP is only supported by VS Code and VS Code-based
+editors (such as [Cursor](https://cursor.com/), [Eclipse Theia](https://theia-ide.org/),
+or [VS Codium](https://vscodium.com/)).
+Other editors like Neovim, Emacs, or Zed do not currently support the notebook
+LSP protocol, so this feature is not available in those environments.
+
+## Usage
+
+1. Open a `.ipynb` file in VS Code
+2. Select "Julia" as the notebook kernel/language
+
+The notebook environment is detected automatically, just like for regular Julia
+scripts. If a `Project.toml` exists in the current or a parent directory, it
+will be used as the project environment.

--- a/jetls-client/CHANGELOG.md
+++ b/jetls-client/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Jupyter notebook support: JETLS now provides language features for Julia code
+  cells in Jupyter notebooks, including completions, hover, go-to-definition,
+  rename, and diagnostics. All cells are analyzed together, so definitions from
+  earlier cells are available in later cells.
+
+  > JETLS × notebook LSP demo
+
+  https://github.com/user-attachments/assets/a3bc3937-37dd-4fe5-9a29-f608329d87a5
+
 - Published extension to [Open VSX Registry](https://open-vsx.org/extension/aviatesk/jetls-client)
   for users of VSCode-compatible editors like [Eclipse Theia](https://theia-ide.org/)
   or [Cursor](https://cursor.com/).
@@ -19,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that require a restart to take effect. Currently supports `n_analysis_workers`
   for configuring concurrent analysis worker tasks.
   See <https://aviatesk.github.io/JETLS.jl/dev/launching/#init-options> for details.
+
+### Changed
+
+- Updated `vscode-languageclient` to 10.0.0-next.18 to enable pull diagnostics
+  support for Jupyter notebook cells.
 
 ## v0.2.4
 

--- a/jetls-client/jetls-client.ts
+++ b/jetls-client/jetls-client.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 import * as vscode from "vscode";
-import { ExtensionContext, OutputChannel } from "vscode";
+import { ExtensionContext, LogOutputChannel } from "vscode";
 
 import {
   LanguageClient,
@@ -15,7 +15,7 @@ import * as fs from "fs";
 import * as cp from "child_process";
 
 let languageClient: LanguageClient;
-let outputChannel: OutputChannel;
+let outputChannel: LogOutputChannel;
 let statusBarItem: vscode.StatusBarItem;
 
 type ExecutableConfig = { path?: string; threads?: string } | string[];
@@ -456,6 +456,10 @@ async function startLanguageServer() {
         scheme: "untitled",
         language: "julia",
       },
+      {
+        notebook: { notebookType: "jupyter-notebook" },
+        language: "julia",
+      },
     ],
     initializationOptions,
     outputChannel,
@@ -642,7 +646,7 @@ export function activate(context: ExtensionContext) {
     ),
   );
 
-  outputChannel = vscode.window.createOutputChannel("JETLS Language Server");
+  outputChannel = vscode.window.createOutputChannel("JETLS Language Server", { log: true });
 
   checkForUpdates(context);
 

--- a/jetls-client/package-lock.json
+++ b/jetls-client/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "jetls-client",
-  "version": "0.1.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jetls-client",
-      "version": "0.1.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "glob": "^11.0.0",
-        "vscode-languageclient": "^9.0.1"
+        "vscode-languageclient": "^10.0.0-next.18"
       },
       "devDependencies": {
         "@eslint/js": "^9.13.0",
@@ -1235,6 +1235,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/binary-extensions": {
@@ -1254,6 +1255,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -3373,54 +3375,57 @@
       "license": "MIT"
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "version": "9.0.0-next.10",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.0-next.10.tgz",
+      "integrity": "sha512-P+UOjuG/B1zkLM+bGIdmBwSkDejxtgo6EjG0pIkwnFBI0a2Mb7od36uUu8CPbECeQuh+n3zGcNwDl16DhuJ5IA==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
-      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "version": "10.0.0-next.18",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.0.0-next.18.tgz",
+      "integrity": "sha512-Dpcr0VEEf4SuMW17TFCuKovhvbCx6/tHTnmFyLW1KTJCdVmNG08hXVAmw8Z/izec7TQlzEvzw5PvRfYGzdtr5Q==",
       "license": "MIT",
       "dependencies": {
-        "minimatch": "^5.1.0",
-        "semver": "^7.3.7",
-        "vscode-languageserver-protocol": "3.17.5"
+        "minimatch": "^10.0.3",
+        "semver": "^7.7.1",
+        "vscode-languageserver-protocol": "3.17.6-next.15"
       },
       "engines": {
-        "vscode": "^1.82.0"
+        "vscode": "^1.91.0"
       }
     },
     "node_modules/vscode-languageclient/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "license": "ISC",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "@isaacs/brace-expansion": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "version": "3.17.6-next.15",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.6-next.15.tgz",
+      "integrity": "sha512-aoWX1wwGCndzfrTRhGKVpKAPVy9+WYhUtZW/PJQfHODmVwhVwb4we68CgsQZRTl36t8ZqlSOO2c2TdBPW7hrCw==",
       "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
+        "vscode-jsonrpc": "9.0.0-next.10",
+        "vscode-languageserver-types": "3.17.6-next.6"
       }
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "version": "3.17.6-next.6",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.6-next.6.tgz",
+      "integrity": "sha512-aiJY5/yW+xzw7KPNlwi3gQtddq/3EIn5z8X8nCgJfaiAij2R1APKePngv+MUdLdYJBVTLu+Qa0ODsT+pHgYguQ==",
       "license": "MIT"
     },
     "node_modules/which": {

--- a/jetls-client/package.json
+++ b/jetls-client/package.json
@@ -281,7 +281,7 @@
   },
   "dependencies": {
     "glob": "^11.0.0",
-    "vscode-languageclient": "^9.0.1"
+    "vscode-languageclient": "^10.0.0-next.18"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",

--- a/jetls-client/tsconfig.json
+++ b/jetls-client/tsconfig.json
@@ -1,8 +1,9 @@
 {
 	"compilerOptions": {
-		"module": "commonjs",
-		"target": "es2020",
-		"lib": ["es2020"],
+		"module": "node16",
+		"moduleResolution": "node16",
+		"target": "es2022",
+		"lib": ["es2022"],
 		"outDir": "out",
 		"rootDir": ".",
 		"sourceMap": true,

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -84,6 +84,7 @@ include("analysis/Interpreter.jl")
 using .Interpreter
 
 include("document-synchronization.jl")
+include("notebook.jl")
 include("analysis/full-analysis.jl")
 include("registration.jl")
 include("apply-edit.jl")
@@ -243,7 +244,11 @@ function is_sequential_msg(@nospecialize msg)
     return msg isa DidOpenTextDocumentNotification ||
            msg isa DidChangeTextDocumentNotification ||
            msg isa DidCloseTextDocumentNotification ||
-           msg isa DidSaveTextDocumentNotification
+           msg isa DidSaveTextDocumentNotification ||
+           msg isa DidOpenNotebookDocumentNotification ||
+           msg isa DidChangeNotebookDocumentNotification ||
+           msg isa DidCloseNotebookDocumentNotification ||
+           msg isa DidSaveNotebookDocumentNotification
 end
 
 function start_sequential_message_worker(server::Server)
@@ -278,6 +283,14 @@ function handle_sequential_message(server::Server, @nospecialize msg)
         handle_DidCloseTextDocumentNotification(server, msg)
     elseif msg isa DidSaveTextDocumentNotification
         handle_DidSaveTextDocumentNotification(server, msg)
+    elseif msg isa DidOpenNotebookDocumentNotification
+        handle_DidOpenNotebookDocumentNotification(server, msg)
+    elseif msg isa DidChangeNotebookDocumentNotification
+        handle_DidChangeNotebookDocumentNotification(server, msg)
+    elseif msg isa DidCloseNotebookDocumentNotification
+        handle_DidCloseNotebookDocumentNotification(server, msg)
+    elseif msg isa DidSaveNotebookDocumentNotification
+        handle_DidSaveNotebookDocumentNotification(server, msg)
     elseif JETLS_DEV_MODE
         if isdefined(msg, :method)
             _id = getfield(msg, :method)

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -21,7 +21,7 @@ function cache_file_info!(
     prev_fi = get_file_info(state, uri)
     prev_testsetinfos = prev_fi === nothing ? EMPTY_TESTSETINFOS : prev_fi.testsetinfos
 
-    filename = @something uri2filename(uri) error(lazy"Unsupported URI: $uri")
+    filename = uri2filename(uri)
     st0 = JS.build_tree(JL.SyntaxTree, parsed_stream; filename)
     testsetinfos, any_deleted = compute_testsetinfos!(server, st0, prev_testsetinfos)
 

--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -197,6 +197,14 @@ function handle_InitializeRequest(
                 change = TextDocumentSyncKind.Full,
                 save = SaveOptions(;
                     includeText = true)),
+            notebookDocumentSync = NotebookDocumentSyncOptions(;
+                notebookSelector = NotebookDocumentSyncOptionsNotebookSelectorItem[
+                    NotebookDocumentSyncOptionsNotebookSelectorItem(;
+                        notebook = "jupyter-notebook",
+                        cells = NotebookDocumentSyncOptionsNotebookSelectorCellsItem[
+                            NotebookDocumentSyncOptionsNotebookSelectorCellsItem(;
+                                language = "julia")])],
+                save = true),
             completionProvider,
             signatureHelpProvider,
             definitionProvider,

--- a/src/notebook.jl
+++ b/src/notebook.jl
@@ -1,0 +1,367 @@
+# Document synchronization
+# ========================
+
+get_notebook_info(state::ServerState, uri::URI) =
+    get(load(state.notebook_cache), uri, nothing)
+
+get_notebook_uri_for_cell(state::ServerState, cell_uri::URI) =
+    get(load(state.cell_to_notebook), cell_uri, nothing)
+
+function concatenate_cells(cells::Vector{NotebookCellInfo})
+    source = ""
+    cell_ranges = CellRange[]
+    current_line = 0
+    for cell in cells
+        cell.kind == NotebookCellKind.Code || continue
+        isempty(cell.text) && continue
+        source *= cell.text * "\n"
+        push!(cell_ranges, CellRange(cell.uri, current_line))
+        current_line += count(==('\n'), cell.text) + 1
+    end
+    return ConcatenatedNotebook(source, cell_ranges)
+end
+
+function cache_notebook_file_info!(server::Server, notebook_uri::URI, notebook_info::NotebookInfo)
+    state = server.state
+    parsed_stream = ParseStream!(notebook_info.concat.source)
+    fi = FileInfo(notebook_info.version, parsed_stream, notebook_uri, notebook_info.encoding)
+    return store!(state.file_cache) do cache
+        Base.PersistentDict(cache, notebook_uri => fi), fi
+    end
+end
+
+function cache_notebook_saved_file_info!(server::Server, notebook_uri::URI, notebook_info::NotebookInfo)
+    state = server.state
+    parsed_stream = ParseStream!(notebook_info.concat.source)
+    sfi = SavedFileInfo(parsed_stream, notebook_uri)
+    return store!(state.saved_file_cache) do cache
+        Base.PersistentDict(cache, notebook_uri => sfi), sfi
+    end
+end
+
+cells_from_lsp(cells::Vector{NotebookCell}) =
+    NotebookCellInfo[NotebookCellInfo(cell.document, cell.kind, "") for cell in cells]
+
+function apply_cell_structure_change!(
+        cells::Vector{NotebookCellInfo},
+        cell_texts::Dict{URI,String},
+        structure::NotebookDocumentChangeEventCellsStructure
+    )
+    array_change = structure.array
+    start_idx = array_change.start + 1
+    delete_count = array_change.deleteCount
+    if delete_count > 0
+        deleteat!(cells, start_idx:start_idx+delete_count-1)
+    end
+    new_cells = array_change.cells
+    if new_cells !== nothing
+        splice!(cells, start_idx:start_idx-1, cells_from_lsp(new_cells))
+    end
+    did_open = structure.didOpen
+    if did_open !== nothing
+        for doc in did_open
+            cell_texts[doc.uri] = doc.text
+        end
+    end
+    did_close = structure.didClose
+    if did_close !== nothing
+        for doc in did_close
+            delete!(cell_texts, doc.uri)
+        end
+    end
+end
+
+function apply_cell_data_change!(cells::Vector{NotebookCellInfo}, data::Vector{NotebookCell})
+    for updated_cell in data
+        for (i, cell) in enumerate(cells)
+            if cell.uri == updated_cell.document
+                cells[i] = NotebookCellInfo(updated_cell.document, updated_cell.kind, cell.text)
+                break
+            end
+        end
+    end
+end
+
+# NOTE: This function implements incremental text change application because VS Code's
+# notebook client sends incremental changes by default. Unlike regular text documents where
+# servers can specify `TextDocumentSyncKind.Full` to receive full content on each change,
+# `NotebookDocumentSyncOptions` does not provide an equivalent option for cell text content.
+function apply_cell_text_change!(
+        cell_texts::Dict{URI,String},
+        text_content::Vector{NotebookDocumentChangeEventCellsTextContentItem},
+        encoding::PositionEncodingKind.Ty
+    )
+    for content_change in text_content
+        doc_uri = content_change.document.uri
+        current_text = get(cell_texts, doc_uri, "")
+        for change_event in content_change.changes
+            if change_event.range === nothing
+                current_text = change_event.text
+            else
+                current_text = apply_text_change(
+                    current_text, change_event.range, change_event.text, encoding)
+            end
+        end
+        cell_texts[doc_uri] = current_text
+    end
+end
+
+function handle_DidOpenNotebookDocumentNotification(
+        server::Server, msg::DidOpenNotebookDocumentNotification
+    )
+    state = server.state
+    notebook_doc = msg.params.notebookDocument
+    notebook_uri = notebook_doc.uri
+    cell_texts = Dict{URI,String}(doc.uri => doc.text for doc in msg.params.cellTextDocuments)
+    cells = NotebookCellInfo[
+        NotebookCellInfo(cell.document, cell.kind, get(cell_texts, cell.document, ""))
+        for cell in notebook_doc.cells]
+    concat = concatenate_cells(cells)
+    notebook_info = NotebookInfo(
+        notebook_doc.version, notebook_doc.notebookType, state.encoding, cells, concat)
+    store!(state.notebook_cache) do cache::Base.PersistentDict{URI,NotebookInfo}
+        Base.PersistentDict(cache, notebook_uri => notebook_info), nothing
+    end
+    store!(state.cell_to_notebook) do mapping::Base.PersistentDict{URI,URI}
+        for cell in cells
+            mapping = Base.PersistentDict(mapping, cell.uri => notebook_uri)
+        end
+        mapping, nothing
+    end
+    cache_notebook_file_info!(server, notebook_uri, notebook_info)
+    cache_notebook_saved_file_info!(server, notebook_uri, notebook_info)
+    request_analysis!(server, notebook_uri, #=onsave=#false)
+    nothing
+end
+
+function handle_DidChangeNotebookDocumentNotification(
+        server::Server, msg::DidChangeNotebookDocumentNotification
+    )
+    state = server.state
+    notebook_uri = msg.params.notebookDocument.uri
+    cells_change = msg.params.change.cells
+    next_notebook_info = store!(state.notebook_cache) do cache::Base.PersistentDict{URI,NotebookInfo}
+        notebook_info = get(cache, notebook_uri, nothing)
+        if notebook_info === nothing
+            JETLS_DEV_MODE && @warn "Received notebookDocument/didChange for unknown notebook" notebook_uri
+            return cache, nothing
+        end
+        cells = copy(notebook_info.cells)
+        cell_texts = Dict{URI,String}(cell.uri => cell.text for cell in cells)
+        if cells_change !== nothing
+            structure = cells_change.structure
+            structure !== nothing && apply_cell_structure_change!(cells, cell_texts, structure)
+            data = cells_change.data
+            data !== nothing && apply_cell_data_change!(cells, data)
+            text_content = cells_change.textContent
+            text_content !== nothing && apply_cell_text_change!(cell_texts, text_content, notebook_info.encoding)
+        end
+        updated_cells = NotebookCellInfo[
+            NotebookCellInfo(cell.uri, cell.kind, get(cell_texts, cell.uri, cell.text))
+            for cell in cells]
+        concat = concatenate_cells(updated_cells)
+        new_notebook_info = NotebookInfo(notebook_info;
+            version = msg.params.notebookDocument.version,
+            cells = updated_cells,
+            concat)
+        Base.PersistentDict(cache, notebook_uri => new_notebook_info), new_notebook_info
+    end
+    next_notebook_info === nothing && return nothing
+    store!(state.cell_to_notebook) do mapping::Base.PersistentDict{URI,URI}
+        structure = cells_change === nothing ? nothing : cells_change.structure
+        if structure !== nothing
+            did_close = structure.didClose
+            if did_close !== nothing
+                for doc in did_close
+                    mapping = Base.delete(mapping, doc.uri)
+                end
+            end
+        end
+        for cell in next_notebook_info.cells
+            mapping = Base.PersistentDict(mapping, cell.uri => notebook_uri)
+        end
+        mapping, nothing
+    end
+    cache_notebook_file_info!(server, notebook_uri, next_notebook_info)
+    nothing
+end
+
+function handle_DidSaveNotebookDocumentNotification(
+        server::Server, msg::DidSaveNotebookDocumentNotification
+    )
+    notebook_uri = msg.params.notebookDocument.uri
+    notebook_info = @something get_notebook_info(server.state, notebook_uri) begin
+        JETLS_DEV_MODE && @warn "Received notebookDocument/didSave for unknown notebook" notebook_uri
+        return nothing
+    end
+    cache_notebook_saved_file_info!(server, notebook_uri, notebook_info)
+    request_analysis!(server, notebook_uri, #=onsave=#true)
+    nothing
+end
+
+function handle_DidCloseNotebookDocumentNotification(
+        server::Server, msg::DidCloseNotebookDocumentNotification
+    )
+    state = server.state
+    notebook_uri = msg.params.notebookDocument.uri
+    store!(state.notebook_cache) do cache::Base.PersistentDict{URI,NotebookInfo}
+        Base.delete(cache, notebook_uri), nothing
+    end
+    store!(state.cell_to_notebook) do mapping::Base.PersistentDict{URI,URI}
+        for (; uri) in msg.params.cellTextDocuments
+            mapping = Base.delete(mapping, uri)
+        end
+        mapping, nothing
+    end
+    store!(state.file_cache) do cache
+        Base.delete(cache, notebook_uri), nothing
+    end
+    store!(state.saved_file_cache) do cache
+        Base.delete(cache, notebook_uri), nothing
+    end
+    nothing
+end
+
+# Diagnostic
+# ==========
+
+is_notebook_uri(state::ServerState, uri::URI) = haskey(load(state.notebook_cache), uri)
+
+function map_notebook_diagnostics!(uri2diagnostics::URI2Diagnostics, state::ServerState)
+    notebook_uris_to_delete = URI[]
+    for uri in keys(uri2diagnostics)
+        is_notebook_uri(state, uri) || continue
+        notebook_uri = uri
+        notebook_info = @something get_notebook_info(state, notebook_uri) continue
+        cell_diagnostics = map_notebook_diagnostics_for_uri(state, uri2diagnostics, notebook_uri)
+        for cell in notebook_info.cells
+            cell.kind == NotebookCellKind.Code || continue
+            diagnostics = get!(Vector{Diagnostic}, uri2diagnostics, cell.uri)
+            cell_diags = get(Vector{Diagnostic}, cell_diagnostics, cell.uri)
+            append!(diagnostics, cell_diags)
+        end
+        push!(notebook_uris_to_delete, notebook_uri)
+    end
+    for notebook_uri in notebook_uris_to_delete
+        delete!(uri2diagnostics, notebook_uri)
+    end
+end
+
+function localize_diagnostic(diag::Diagnostic, cell_range::CellRange)
+    local_start_line = diag.range.start.line - cell_range.line_offset
+    local_end_line = diag.range.var"end".line - cell_range.line_offset
+    return Diagnostic(diag; range = Range(;
+        start = Position(; line = local_start_line, character = diag.range.start.character),
+        var"end" = Position(; line = local_end_line, character = diag.range.var"end".character)))
+end
+
+function map_notebook_diagnostics_for_uri(
+        state::ServerState, uri2diagnostics::URI2Diagnostics, notebook_uri::URI
+    )
+    cell_diagnostics = Dict{URI,Vector{Diagnostic}}()
+    notebook_info = @something get_notebook_info(state, notebook_uri) return cell_diagnostics
+    isempty(notebook_info.concat.cell_ranges) && return cell_diagnostics
+    for diag in uri2diagnostics[notebook_uri]
+        cell_range = @something find_cell_for_line(notebook_info.concat, diag.range.start.line) continue
+        cell_diag = localize_diagnostic(diag, cell_range)
+        push!(get!(Vector{Diagnostic}, cell_diagnostics, cell_range.cell_uri), cell_diag)
+    end
+    return cell_diagnostics
+end
+
+function map_cell_diagnostics(
+        state::ServerState, notebook_uri::URI, cell_uri::URI, diagnostics::Vector{Diagnostic}
+    )
+    notebook_info = @something get_notebook_info(state, notebook_uri) return Diagnostic[]
+    cell_range = @something find_cell_range_by_uri(notebook_info.concat, cell_uri) return Diagnostic[]
+    result = Diagnostic[]
+    for diag in diagnostics
+        found_range = @something find_cell_for_line(notebook_info.concat, diag.range.start.line) continue
+        found_range.cell_uri == cell_uri || continue
+        cell_diag = localize_diagnostic(diag, cell_range)
+        push!(result, cell_diag)
+    end
+    return result
+end
+
+# Position
+# ========
+
+function find_cell_range_by_uri(concat::ConcatenatedNotebook, cell_uri::URI)
+    for range in concat.cell_ranges
+        if range.cell_uri == cell_uri
+            return range
+        end
+    end
+    return nothing
+end
+
+function cell_to_global_position(concat::ConcatenatedNotebook, cell_uri::URI, cell_pos::Position)
+    cell_range = @something find_cell_range_by_uri(concat, cell_uri) return nothing
+    line = cell_pos.line + cell_range.line_offset
+    character = cell_pos.character
+    return Position(; line, character)
+end
+
+function find_cell_for_line(concat::ConcatenatedNotebook, notebook_line::UInt)
+    for (i, range) in enumerate(concat.cell_ranges)
+        next_line_offset = i < length(concat.cell_ranges) ?
+            concat.cell_ranges[i+1].line_offset : typemax(Int)
+        if range.line_offset <= notebook_line < next_line_offset
+            return range
+        end
+    end
+    return nothing
+end
+
+function global_to_cell_position(concat::ConcatenatedNotebook, notebook_pos::Position)
+    cell_range = @something find_cell_for_line(concat, notebook_pos.line) return nothing
+    line = notebook_pos.line - cell_range.line_offset
+    character = notebook_pos.character
+    return Position(; line, character), cell_range.cell_uri
+end
+
+"""
+    adjust_position(state::ServerState, uri::URI, pos::Position)
+
+Adjust a cell-local position to a global position in the concatenated notebook source.
+If the URI is not a notebook cell, returns the position unchanged.
+"""
+function adjust_position(state::ServerState, uri::URI, pos::Position)
+    notebook_uri = @something get_notebook_uri_for_cell(state, uri) return pos
+    notebook_info = @something get_notebook_info(state, notebook_uri) return pos
+    return @something cell_to_global_position(notebook_info.concat, uri, pos) return pos
+end
+
+"""
+    unadjust_position(state::ServerState, uri::URI, pos::Position) -> (Position, URI)
+
+Convert a global position in the concatenated notebook source back to a cell-local position.
+Returns a tuple of (position, cell_uri) where cell_uri is the URI of the cell containing the position.
+If the URI is not a notebook cell, returns the position and URI unchanged.
+"""
+function unadjust_position(state::ServerState, uri::URI, pos::Position)
+    notebook_uri = @something get_notebook_uri_for_cell(state, uri) return (pos, uri)
+    notebook_info = @something get_notebook_info(state, notebook_uri) return (pos, uri)
+    return @something global_to_cell_position(notebook_info.concat, pos) return (pos, uri)
+end
+
+"""
+    unadjust_range(state::ServerState, uri::URI, range::Range) -> (Range, URI)
+
+Convert a global range in the concatenated notebook source back to a cell-local range.
+Returns a tuple of (range, cell_uri). Note: start and end positions are assumed to be in the same cell.
+If the URI is not a notebook cell, returns the range and URI unchanged.
+"""
+function unadjust_range(state::ServerState, uri::URI, range::Range)
+    start_pos, start_uri = unadjust_position(state, uri, range.start)
+    end_pos, _ = unadjust_position(state, uri, range.var"end")
+    return Range(; start = start_pos, var"end" = end_pos), start_uri
+end
+
+function unadjust_location(state::ServerState, cell_uri::URI, loc::Location)
+    notebook_uri = @something get_notebook_uri_for_cell(state, cell_uri) return loc
+    loc.uri == notebook_uri || return loc
+    range, uri = unadjust_range(state, cell_uri, loc.range)
+    return Location(; uri, range)
+end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -19,10 +19,7 @@ module __demo__ end
         uri = filepath2uri(filename)
         @compile_workload let
             fi = cache_file_info!(server, uri, #=version=#1, text)
-            let comp_params = CompletionParams(;
-                    textDocument = TextDocumentIdentifier(; uri),
-                    position)
-                items = get_completion_items(server.state, uri, fi, comp_params)
+            let items = get_completion_items(server.state, uri, fi, position, nothing)
                 any(item->item.label=="out", items) || @warn "completion seems to be broken"
                 any(item->item.label=="bar", items) || @warn "completion seems to be broken"
             end

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -485,8 +485,9 @@ function handle_SignatureHelpRequest(
                 error = result))
     end
     fi = result
-    (; mod, analyzer, postprocessor) = get_context_info(state, uri, msg.params.position)
-    b = xy_to_offset(fi, msg.params.position)
+    pos = adjust_position(state, uri, msg.params.position)
+    (; mod, analyzer, postprocessor) = get_context_info(state, uri, pos)
+    b = xy_to_offset(fi, pos)
     signatures = cursor_siginfos(mod, fi, b, analyzer; postprocessor)
     activeSignature = nothing
     activeParameter = nothing

--- a/src/types.jl
+++ b/src/types.jl
@@ -47,7 +47,7 @@ function FileInfo( # Constructor for production code (with URI)
         encoding::LSP.PositionEncodingKind.Ty = LSP.PositionEncodingKind.UTF16,
         testsetinfos::Vector{TestsetInfo} = EMPTY_TESTSETINFOS
     )
-    filename = @something uri2filename(uri) error(lazy"Unsupported URI: $uri")
+    filename = uri2filename(uri)
     return FileInfo(version, parsed_stream, filename, encoding, testsetinfos)
 end
 
@@ -62,11 +62,39 @@ struct SavedFileInfo
     syntax_node::JS.SyntaxNode
 
     function SavedFileInfo(parsed_stream::JS.ParseStream, uri::URI)
-        filename = @something uri2filename(uri) error(lazy"Unsupported URI: $uri")
+        filename = uri2filename(uri)
         syntax_node = JS.build_tree(JS.SyntaxNode, parsed_stream; filename)
         new(parsed_stream, syntax_node)
     end
 end
+
+# Notebook document synchronization
+# =================================
+
+struct NotebookCellInfo
+    uri::URI
+    kind::LSP.NotebookCellKind.Ty
+    text::String
+end
+
+struct CellRange
+    cell_uri::URI
+    line_offset::Int  # 0-based line offset in concatenated source
+end
+
+struct ConcatenatedNotebook
+    source::String
+    cell_ranges::Vector{CellRange}
+end
+
+struct NotebookInfo
+    version::Int
+    notebookType::String
+    encoding::LSP.PositionEncodingKind.Ty
+    cells::Vector{NotebookCellInfo}
+    concat::ConcatenatedNotebook
+end
+@define_override_constructor NotebookInfo
 
 mutable struct CancelFlag
     @atomic cancelled::Bool
@@ -450,6 +478,8 @@ end
 # Type aliases for document-synchronization caches using `SWContainer` (sequential-only updates)
 const FileCache = SWContainer{Base.PersistentDict{URI,FileInfo}, SWStats}
 const SavedFileCache = SWContainer{Base.PersistentDict{URI,SavedFileInfo}, SWStats}
+const NotebookCache = SWContainer{Base.PersistentDict{URI,NotebookInfo}, SWStats}
+const CellToNotebookMap = SWContainer{Base.PersistentDict{URI,URI}, SWStats} # cell URI -> notebook URI
 
 # Type aliases for concurrent updates using CASContainer (lightweight operations)
 const ExtraDiagnostics = CASContainer{ExtraDiagnosticsData, CASStats}
@@ -465,6 +495,8 @@ const HandledHistory = FixedSizeFIFOQueue{Union{Int,String}}
 mutable struct ServerState
     const file_cache::FileCache # syntactic analysis cache (synced with `textDocument/didChange`)
     const saved_file_cache::SavedFileCache # syntactic analysis cache (synced with `textDocument/didSave`)
+    const notebook_cache::NotebookCache # notebook document cache (synced with `notebookDocument/did*`), mapping notebook URIs to their notebook info
+    const cell_to_notebook::CellToNotebookMap # maps cell URIs to their notebook URI
     const analysis_manager::AnalysisManager
     const extra_diagnostics::ExtraDiagnostics
     const currently_handled::CurrentlyHandled
@@ -486,6 +518,8 @@ mutable struct ServerState
         return new(
             #=file_cache=# FileCache(Base.PersistentDict{URI,FileInfo}()),
             #=saved_file_cache=# SavedFileCache(Base.PersistentDict{URI,SavedFileInfo}()),
+            #=notebook_cache=# NotebookCache(Base.PersistentDict{URI,NotebookInfo}()),
+            #=cell_to_notebook=# CellToNotebookMap(Base.PersistentDict{URI,URI}()),
             #=analysis_manager=# AnalysisManager(),
             #=extra_diagnostics=# ExtraDiagnostics(ExtraDiagnosticsData()),
             #=currently_handled=# CurrentlyHandled(),

--- a/src/utils/lsp.jl
+++ b/src/utils/lsp.jl
@@ -12,6 +12,7 @@ overlap(rng1::Range, rng2::Range) = max(rng1.start, rng2.start) <= min(rng1.var"
 # LSP utilities
 
 @define_override_constructor LSP.CompletionItem
+@define_override_constructor LSP.Diagnostic
 @define_override_constructor LSP.Position
 @define_override_constructor LSP.Range
 

--- a/src/utils/string.jl
+++ b/src/utils/string.jl
@@ -2,6 +2,32 @@
 # These functions do the conversion.
 
 """
+    apply_text_change(
+        text::String, range::Range, new_text::String, encoding::PositionEncodingKind.Ty
+    ) -> String
+
+Apply a text change (replacement) to a string at the specified range.
+
+This function handles incremental text document changes as specified in the LSP protocol.
+It converts the LSP range (0-based line/character positions) to byte offsets and replaces
+the specified range with the new text.
+
+# Arguments
+- `text::String`: The original text content
+- `range::Range`: The LSP range to replace (0-based line and character positions)
+- `new_text::String`: The text to insert at the specified range
+- `encoding::PositionEncodingKind.Ty`: The encoding for character positions
+"""
+function apply_text_change(
+        text::String, range::Range, new_text::String, encoding::PositionEncodingKind.Ty
+    )
+    textbuf = Vector{UInt8}(text)
+    start_byte = _xy_to_offset(textbuf, range.start, encoding)
+    end_byte = _xy_to_offset(textbuf, range.var"end", encoding)
+    return String(textbuf[1:start_byte-1]) * new_text * String(textbuf[end_byte:end])
+end
+
+"""
     pos_to_utf8_offset(s::String, ch::UInt, encoding::PositionEncodingKind.Ty = PositionEncodingKind.UTF16) -> offset::Int
 
 Convert a character position to a UTF-8 byte offset in a Julia string.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,4 +36,5 @@ end
     @testset "rename" include("test_rename.jl")
     @testset "testrunner" include("test_testrunner.jl")
     @testset "full lifecycle" include("test_full_lifecycle.jl")
+    @testset "notebook" include("test_notebook.jl")
 end

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -314,7 +314,7 @@ end
     """
 
     cnt = 0
-    with_completion_request(program) do i, result, uri
+    with_completion_request(program) do i, result, _
         items = result.items
         if i == 1
             @test any(items) do item
@@ -383,7 +383,7 @@ end
 
     context = CompletionContext(; triggerKind=CompletionTriggerKind.Invoked)
     cnt = 0
-    with_completion_request(text; context) do i, result, uri
+    with_completion_request(text; context) do _, result, _
         items = result.items
         @test any(items) do item
             item.label == "yyy"
@@ -397,7 +397,7 @@ end
 @testset "empty completion" begin
     let text = "│"
         cnt = 0
-        with_completion_request(text) do i, result, uri
+        with_completion_request(text) do _, result, _
             items = result.items
             # should not crash and return something
             @test length(items) > 0
@@ -408,7 +408,7 @@ end
 
     let text = "\n\n\n│"
         cnt = 0
-        with_completion_request(text) do i, result, uri
+        with_completion_request(text) do _, result, _
             items = result.items
             # should not crash and return something
             @test length(items) > 0
@@ -429,7 +429,7 @@ end
             triggerKind=CompletionTriggerKind.TriggerCharacter,
             triggerCharacter="@")
         cnt = 0
-        with_completion_request(text; context) do i, result, uri
+        with_completion_request(text; context) do _, result, _
             items = result.items
             @test any(items) do item
                 item.label == "@nospecialize" &&
@@ -451,7 +451,7 @@ end
         """
         context = CompletionContext(; triggerKind=CompletionTriggerKind.Invoked)
         cnt = 0
-        with_completion_request(text; context) do i, result, uri
+        with_completion_request(text; context) do _, result, _
             items = result.items
             @test any(items) do item
                 item.label == "@nospecialize" &&
@@ -473,7 +473,7 @@ end
         """
         context = CompletionContext(; triggerKind=CompletionTriggerKind.Invoked)
         cnt = 0
-        with_completion_request(text; context) do i, result, uri
+        with_completion_request(text; context) do _, result, _
             items = result.items
             @test any(items) do item
                 item.label == "yyy"
@@ -491,7 +491,7 @@ end
         """
         context = CompletionContext(; triggerKind=CompletionTriggerKind.Invoked)
         cnt = 0
-        with_completion_request(text; context) do i, result, uri
+        with_completion_request(text; context) do _, result, _
             items = result.items
             @test any(items) do item
                 item.label == "@nospecialize" &&
@@ -708,7 +708,7 @@ end
             triggerKind=CompletionTriggerKind.TriggerCharacter,
             triggerCharacter="\\")
         cnt = 0
-        with_completion_request(text; context) do i, result, uri
+        with_completion_request(text; context) do _, result, _
             items = result.items
             @test any(items) do item
                 item.label == "\\alpha"
@@ -731,7 +731,7 @@ end
             triggerKind=CompletionTriggerKind.TriggerCharacter,
             triggerCharacter=":")
         cnt = 0
-        with_completion_request(text; context) do i, result, uri
+        with_completion_request(text; context) do _, result, _
             items = result.items
             @test any(items) do item
                 item.label == "\\:pizza:"

--- a/test/test_hover.jl
+++ b/test/test_hover.jl
@@ -248,7 +248,7 @@ function get_local_hover(mod::Module, text::AbstractString, pos::Position; filen
     st0_top = JETLS.build_syntax_tree(fi)
     @assert JS.kind(st0_top) === JS.K"toplevel"
     offset = JETLS.xy_to_offset(fi, pos)
-    return JETLS.local_binding_hover(fi, uri, st0_top, offset, mod)
+    return JETLS.local_binding_hover(JETLS.ServerState(), fi, uri, st0_top, offset, mod)
 end
 
 function func(xxx, yyy)

--- a/test/test_notebook.jl
+++ b/test/test_notebook.jl
@@ -1,0 +1,235 @@
+module test_notebook
+
+include("setup.jl")
+
+using Test
+using JETLS
+using JETLS.LSP
+using JETLS.URIs2
+
+function make_cell_uri(tempdir::AbstractString, cell_id::Union{Int,AbstractString})
+    return filepath2uri(normpath(tempdir, "cell_$cell_id"))
+end
+
+function make_DidOpenNotebookDocumentNotification(
+        notebook_uri::URI,
+        cells::Vector{NotebookCell},
+        cell_texts::Dict{URI,String};
+        version::Int = 1,
+        notebookType::String = "jupyter-notebook"
+    )
+    cellTextDocuments = TextDocumentItem[
+        TextDocumentItem(;
+            uri = cell.document,
+            languageId = "julia",
+            version = 1,
+            text = get(cell_texts, cell.document, ""))
+        for cell in cells if cell.kind == NotebookCellKind.Code]
+    return DidOpenNotebookDocumentNotification(;
+        params = DidOpenNotebookDocumentParams(;
+            notebookDocument = NotebookDocument(;
+                uri = notebook_uri,
+                notebookType,
+                version,
+                cells),
+            cellTextDocuments))
+end
+
+function make_DidChangeNotebookDocumentNotification(
+        notebook_uri::URI,
+        change::NotebookDocumentChangeEvent;
+        version::Int
+    )
+    return DidChangeNotebookDocumentNotification(;
+        params = DidChangeNotebookDocumentParams(;
+            notebookDocument = VersionedNotebookDocumentIdentifier(; uri = notebook_uri, version),
+            change))
+end
+
+function make_DidSaveNotebookDocumentNotification(notebook_uri::URI)
+    return DidSaveNotebookDocumentNotification(;
+        params = DidSaveNotebookDocumentParams(;
+            notebookDocument = NotebookDocumentIdentifier(; uri = notebook_uri)))
+end
+
+function make_DocumentDiagnosticRequest(id::Int, uri::URI)
+    return DocumentDiagnosticRequest(;
+        id,
+        params = DocumentDiagnosticParams(;
+            textDocument = TextDocumentIdentifier(; uri)))
+end
+
+@testset "notebook end to end" begin
+    old_env = Pkg.project().path
+    mktempdir() do tempdir; try
+        Pkg.activate(tempdir; io=devnull)
+        Pkg.add("Example"; io=devnull)
+
+        notebook_uri = filepath2uri(normpath(tempdir, "test.ipynb"))
+
+        withserver() do (; server, writemsg, writereadmsg, id_counter)
+            cell1_uri = make_cell_uri(tempdir, 1)
+            cell2_uri = make_cell_uri(tempdir, 2)
+
+            # 1. Open notebook with one empty cell and wait for PublishDiagnosticsNotification
+            let cells = NotebookCell[
+                    NotebookCell(; kind = NotebookCellKind.Code, document = cell1_uri),
+                ]
+                cell_texts = Dict{URI,String}(cell1_uri => "")
+                (; raw_res) = writereadmsg(
+                    make_DidOpenNotebookDocumentNotification(notebook_uri, cells, cell_texts))
+                @test raw_res isa PublishDiagnosticsNotification
+            end
+
+            # Verify state after step 1: empty cell should result in empty concat
+            let notebook_info = JETLS.get_notebook_info(server.state, notebook_uri)
+                @test notebook_info !== nothing
+                @test length(notebook_info.cells) == 1
+                @test notebook_info.cells[1].uri == cell1_uri
+                @test notebook_info.cells[1].text == ""
+                @test notebook_info.concat.source == ""
+                @test isempty(notebook_info.concat.cell_ranges)
+            end
+
+            # 2. Add cell 2 with code that has unused argument
+            let cell1_text = "using Example"
+                cell2_text = "func(x, y) = identity(x)"
+                change = NotebookDocumentChangeEvent(;
+                    cells = NotebookDocumentChangeEventCells(;
+                        structure = NotebookDocumentChangeEventCellsStructure(;
+                            array = NotebookCellArrayChange(;
+                                start = UInt(1), deleteCount = UInt(0),
+                                cells = [NotebookCell(; kind = NotebookCellKind.Code, document = cell2_uri)]),
+                            didOpen = [TextDocumentItem(; uri = cell2_uri, languageId = "julia", version = 1, text = cell2_text)]),
+                        textContent = [NotebookDocumentChangeEventCellsTextContentItem(;
+                            document = VersionedTextDocumentIdentifier(; uri = cell1_uri, version = 2),
+                            changes = [TextDocumentContentChangeEvent(; text = cell1_text)])]))
+                writemsg(make_DidChangeNotebookDocumentNotification(notebook_uri, change; version = 2))
+            end
+
+            # 3. Send textDocument/diagnostic for cell 2 -> verify unused `y` diagnostic
+            let id = id_counter[] += 1
+                (; raw_res) = writereadmsg(make_DocumentDiagnosticRequest(id, cell2_uri))
+                @test raw_res isa DocumentDiagnosticResponse
+                @test raw_res.result isa RelatedFullDocumentDiagnosticReport
+                diagnostics = raw_res.result.items
+                found_unused_y = any(diagnostics) do diag
+                    diag.code == JETLS.LOWERING_UNUSED_ARGUMENT_CODE &&
+                    occursin("y", diag.message)
+                end
+                @test found_unused_y
+            end
+
+            # Verify state after step 2: two cells with correct line offsets
+            let notebook_info = JETLS.get_notebook_info(server.state, notebook_uri)
+                @test notebook_info !== nothing
+                @test length(notebook_info.cells) == 2
+                @test notebook_info.cells[1].text == "using Example"
+                @test notebook_info.cells[2].text == "func(x, y) = identity(x)"
+                @test notebook_info.concat.source == "using Example\nfunc(x, y) = identity(x)\n"
+                @test length(notebook_info.concat.cell_ranges) == 2
+                @test notebook_info.concat.cell_ranges[1].line_offset == 0
+                @test notebook_info.concat.cell_ranges[2].line_offset == 1
+            end
+
+            # 4. Update cell 2 to remove unused argument
+            let new_text = "func(x) = identity(x)"
+                change = NotebookDocumentChangeEvent(;
+                    cells = NotebookDocumentChangeEventCells(;
+                        textContent = [NotebookDocumentChangeEventCellsTextContentItem(;
+                            document = VersionedTextDocumentIdentifier(; uri = cell2_uri, version = 2),
+                            changes = [TextDocumentContentChangeEvent(; text = new_text)])]))
+                writemsg(make_DidChangeNotebookDocumentNotification(notebook_uri, change; version = 3))
+            end
+
+            # 5. Verify diagnostics no longer have unused `y`
+            let id = id_counter[] += 1
+                (; raw_res) = writereadmsg(make_DocumentDiagnosticRequest(id, cell2_uri))
+                @test raw_res isa DocumentDiagnosticResponse
+                @test raw_res.result isa RelatedFullDocumentDiagnosticReport
+                diagnostics = raw_res.result.items
+                has_unused_y = any(diagnostics) do diag
+                    diag.code == JETLS.LOWERING_UNUSED_ARGUMENT_CODE &&
+                    occursin("y", diag.message)
+                end
+                @test !has_unused_y
+            end
+
+            # Verify state after step 4: cell 2 text updated
+            let notebook_info = JETLS.get_notebook_info(server.state, notebook_uri)
+                @test notebook_info !== nothing
+                @test notebook_info.cells[2].text == "func(x) = identity(x)"
+                @test notebook_info.concat.source == "using Example\nfunc(x) = identity(x)\n"
+            end
+
+            # 6. Add markdown cell (should be ignored for diagnostics)
+            markdown_uri = make_cell_uri(tempdir, "markdown")
+            let new_cells = NotebookCell[
+                    NotebookCell(; kind = NotebookCellKind.Markup, document = markdown_uri),
+                ]
+                change = NotebookDocumentChangeEvent(;
+                    cells = NotebookDocumentChangeEventCells(;
+                        structure = NotebookDocumentChangeEventCellsStructure(;
+                            array = NotebookCellArrayChange(; start = UInt(2), deleteCount = UInt(0), cells = new_cells))))
+                writemsg(make_DidChangeNotebookDocumentNotification(notebook_uri, change; version = 4))
+            end
+
+            # 7. Add code cell 3 with undefined function call
+            cell3_uri = make_cell_uri(tempdir, 3)
+            let cell3_text = "undefhello(func(\"world\"))"
+                new_cells = NotebookCell[
+                    NotebookCell(; kind = NotebookCellKind.Code, document = cell3_uri),
+                ]
+                cell_texts = [
+                    TextDocumentItem(; uri = cell3_uri, languageId = "julia", version = 1, text = cell3_text),
+                ]
+                change = NotebookDocumentChangeEvent(;
+                    cells = NotebookDocumentChangeEventCells(;
+                        structure = NotebookDocumentChangeEventCellsStructure(;
+                            array = NotebookCellArrayChange(; start = UInt(3), deleteCount = UInt(0), cells = new_cells),
+                            didOpen = cell_texts)))
+                writemsg(make_DidChangeNotebookDocumentNotification(notebook_uri, change; version = 5))
+            end
+
+            # 8. Send DidSave and wait for PublishDiagnosticsNotification with `undefhello` error
+            # read=3: PublishDiagnosticsNotification is sent for all 3 code cells (markdown ignored)
+            let (; raw_res) = writereadmsg(make_DidSaveNotebookDocumentNotification(notebook_uri); read = 3)
+                @test all(msg -> msg isa PublishDiagnosticsNotification, raw_res)
+                cell3_notification = nothing
+                for msg in raw_res
+                    if msg.params.uri == cell3_uri
+                        cell3_notification = msg
+                        break
+                    end
+                end
+                @test cell3_notification !== nothing
+                @test any(cell3_notification.params.diagnostics) do diag
+                    diag.source == JETLS.DIAGNOSTIC_SOURCE &&
+                    occursin("undefhello", diag.message)
+                end
+            end
+
+            # Verify state after steps 6 and 7: 4 cells total, but only 3 code cells in concat
+            let notebook_info = JETLS.get_notebook_info(server.state, notebook_uri)
+                @test notebook_info !== nothing
+                @test length(notebook_info.cells) == 4
+                @test notebook_info.cells[1].kind == NotebookCellKind.Code
+                @test notebook_info.cells[2].kind == NotebookCellKind.Code
+                @test notebook_info.cells[3].kind == NotebookCellKind.Markup
+                @test notebook_info.cells[4].kind == NotebookCellKind.Code
+                # Markdown cell should be skipped in concatenation
+                @test length(notebook_info.concat.cell_ranges) == 3
+                @test notebook_info.concat.cell_ranges[1].cell_uri == cell1_uri
+                @test notebook_info.concat.cell_ranges[1].line_offset == 0
+                @test notebook_info.concat.cell_ranges[2].cell_uri == cell2_uri
+                @test notebook_info.concat.cell_ranges[2].line_offset == 1
+                @test notebook_info.concat.cell_ranges[3].cell_uri == cell3_uri
+                @test notebook_info.concat.cell_ranges[3].line_offset == 2
+            end
+        end
+    finally
+        Pkg.activate(old_env; io=devnull)
+    end; end
+end
+
+end # module test_notebook


### PR DESCRIPTION
https://github.com/user-attachments/assets/f7476257-7a53-44a1-8c8c-1ad57e136a63

Add support for Jupyter notebook documents in the language server, enabling features like completions, hover, definitions, rename, and diagnostics to work within notebook cells.

The implementation concatenates all code cells into a single virtual source document, allowing the existing analysis infrastructure to work unchanged. Each cell's content is joined with newlines, and `CellRange` records track the line offset where each cell begins in the concatenated source.

To bridge between cell-local positions (used by clients) and global positions (used internally), the following mapping functions are introduced:

- `adjust_position`: Converts cell-local position to global position by adding the cell's line offset
- `unadjust_position`/`unadjust_range`: Converts global position back to cell-local coordinates, also returning the cell URI

These mappings are applied at LSP request entry points (completions, hover, definition, rename, etc.) to adjust incoming positions, and when constructing responses to convert ranges back to cell coordinates.

For diagnostics, map_notebook_diagnostics! transforms diagnostics computed on the concatenated source into per-cell diagnostics by distributing them to the appropriate cell URIs based on line offsets.

Notebook document synchronization handles incremental text changes since `NotebookDocumentSyncOptions` does not provide an equivalent to `TextDocumentSyncKind.Full` for cell content.

jetls-client: Update vscode-languageclient to 10.0.0-next.18 to enable pull diagnostics support for notebook cells. This requires updating tsconfig.json to use node16 module resolution and es2022 target, and switching to `LogOutputChannel` as required by the new version.

LSP: Move `NotebookDocumentFilter` and `NotebookCellTextDocumentFilter` to basic-json-structures.jl to allow `DocumentSelector` to include notebook cell text document filters as per LSP 3.17.0 specification.