### PR TITLE
lsp: Use comma-delimited format for source location links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
   https://github.com/user-attachments/assets/b5bb5201-d735-4a37-b430-932b519254ee
 
+### Fixed
+
+- Fixed source location links in hover content to use comma-delimited format
+  (`#L<line>,<character>`) instead of `#L<line>C<character>`. The previous
+  format was not correctly parsed by VS Code - the column position was ignored.
+  The new format follows VS Code's implementation and works with other LSP
+  clients like Sublime Text's LSP plugin. Fixes aviatesk/JETLS.jl#281.
+
 ## 2025-12-06
 
 - Commit: [`fd5f113`](https://github.com/aviatesk/JETLS.jl/commit/fd5f113)

--- a/src/utils/lsp.jl
+++ b/src/utils/lsp.jl
@@ -27,10 +27,12 @@ const DEFAULT_DOCUMENT_SELECTOR = DocumentFilter[
 
 Create a markdown-style link to a source location that can be displayed in LSP clients.
 
-This function generates clickable links in the format `[display text](uri#L<line>C<character>)`
+This function generates clickable links in the format `[display text](uri#L<line>,<character>)`
 that LSP clients can use to navigate to specific file locations. While not explicitly part of
-the LSP specification, this markdown link format is widely supported by LSP clients including
-VS Code, Neovim, and others.
+the LSP specification, this markdown link format is supported by VS Code and LSP clients that
+follow the same convention (e.g. Sublime Text's LSP plugin).
+
+See: https://github.com/microsoft/vscode/blob/25c94ab342a6b167d4b97ade0829955d4f7e094e/src/vs/platform/opener/common/opener.ts#L131-L143
 
 # Arguments
 - `uri::URI`: The file URI to link to
@@ -43,8 +45,6 @@ VS Code, Neovim, and others.
 # Returns
 A markdown-formatted string containing the clickable link that can be rendered in hover
 documentation, completion items, or other LSP responses supporting markdown content.
-
-[remote file](http://example.com/file.jl#L5)
 
 # Examples
 ```julia
@@ -59,7 +59,7 @@ create_source_location_link(uri, "file.jl:42"; line=42)
 
 # Link with line and character position
 create_source_location_link(uri, "file.jl:42:10"; line=42, character=10)
-# Returns: "[file.jl:42:10](file:///path/to/file.jl#L42C10)"
+# Returns: "[file.jl:42:10](file:///path/to/file.jl#L42,10)"
 
 # Using URI with automatic display text
 uri = URI("file:///path/to/file.jl")
@@ -75,7 +75,7 @@ function create_source_location_link(uri::URI,
     if line !== nothing
         linktext *= "#L$line"
         if character !== nothing
-            linktext *= "C$character"
+            linktext *= ",$character"
         end
     end
     if isnothing(showtext)

--- a/test/utils/test_lsp.jl
+++ b/test/utils/test_lsp.jl
@@ -9,10 +9,10 @@ using JETLS.LSP.URIs2
     uri = URI("file:///path/to/file.jl")
     @test JETLS.create_source_location_link(uri) == "[/path/to/file.jl](file:///path/to/file.jl)"
     @test JETLS.create_source_location_link(uri; line=42) == "[/path/to/file.jl:42](file:///path/to/file.jl#L42)"
-    @test JETLS.create_source_location_link(uri; line=42, character=10) == "[/path/to/file.jl:42](file:///path/to/file.jl#L42C10)"
+    @test JETLS.create_source_location_link(uri; line=42, character=10) == "[/path/to/file.jl:42](file:///path/to/file.jl#L42,10)"
     @test JETLS.create_source_location_link(uri, "file.jl") == "[file.jl](file:///path/to/file.jl)"
     @test JETLS.create_source_location_link(uri, "file.jl:42"; line=42) == "[file.jl:42](file:///path/to/file.jl#L42)"
-    @test JETLS.create_source_location_link(uri, "file.jl:42:10"; line=42, character=10) == "[file.jl:42:10](file:///path/to/file.jl#L42C10)"
+    @test JETLS.create_source_location_link(uri, "file.jl:42:10"; line=42, character=10) == "[file.jl:42:10](file:///path/to/file.jl#L42,10)"
     @test JETLS.create_source_location_link(uri; character=10) == "[/path/to/file.jl](file:///path/to/file.jl)"
 
     http_uri = URI("http://example.com/file.jl")


### PR DESCRIPTION
Change the markdown link format from `#L<line>C<character>` to `#L<line>,<character>` for source location links. The previous format with 'C' delimiter was not correctly parsed by VS Code - only the line number was recognized while the column was ignored.

The new comma-delimited format follows VS Code's implementation and is also supported by other LSP clients like Sublime Text's LSP plugin.

Closes aviatesk/JETLS.jl#281