### PR TITLE
docs: Add Vim9 LSP configuration

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -120,6 +120,21 @@ Minimal [Sublime](https://www.sublimetext.com/) setup using the
 }
 ```
 
+### Vim
+Minimal [Vim](https://www.vim.org) setup using the
+[Vim9 LSP plugin](https://github.com/yegappan/lsp)
+
+```vim
+call LspAddServer([#{name: 'JETLS.jl',
+                 \   filetype: 'julia',
+                 \   path: 'jetls',
+                 \   args: [
+                 \       '--threads=auto',
+                 \       '--'
+                 \   ]
+                 \ }])
+```
+
 ### Zed
 
 [Zed](https://zed.dev/) extension for Julia/JETLS is available:


### PR DESCRIPTION
This adds the configuration for yegappan/lsp, which is on the way of becoming the official Vim LSP client.