### PR TITLE
Fix and simplify jetls spawning logic for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,7 +274,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     ```bash
     julia -e 'using Pkg; Pkg.Apps.add(; url="https://github.com/aviatesk/JETLS.jl", rev="release")'
     ```
-    This installs the executable to `~/.julia/bin/` (as `jetls` on Unix-like systems, `jetls.bat` on Windows).
+    This installs the executable to `~/.julia/bin/jetls`.
     Make sure `~/.julia/bin` is in your `PATH`.
   - Updating: Update JETLS to the latest version by re-running the installation command:
     ```bash

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -31,7 +31,7 @@ Install it with:
 julia -e 'using Pkg; Pkg.Apps.add(; url="https://github.com/aviatesk/JETLS.jl", rev="release")'
 ```
 
-This will install the `jetls` executable (`jetls.bat` on Windows) to `~/.julia/bin/`.
+This will install the `jetls` executable to `~/.julia/bin/`.
 Make sure `~/.julia/bin` is available on the `PATH` environment so the executable is accessible.
 
 You can verify the installation by running:

--- a/jetls-client/README.md
+++ b/jetls-client/README.md
@@ -33,7 +33,7 @@ diagnostic, macro-aware go-to definition and such.
    ```bash
    julia -e 'using Pkg; Pkg.Apps.add(; url="https://github.com/aviatesk/JETLS.jl", rev="release")'
    ```
-   This will install the `jetls` executable (`jetls.bat` on Windows) to `~/.julia/bin/`.
+   This will install the `jetls` executable to `~/.julia/bin/`.
 2. Make sure `~/.julia/bin` is available on the `PATH` environment so the `jetls` executable is accessible.
    You can verify the installation by running:
    ```bash
@@ -48,8 +48,7 @@ diagnostic, macro-aware go-to definition and such.
    - Click `Install`
 4. Open any Julia file
 
-The extension will automatically use the `jetls` (or `jetls.bat` on Windows)
-executable from your `PATH`.
+The extension will automatically use the `jetls` executable from your `PATH`.
 
 > [!note]
 > To update JETLS to the latest version, re-run the installation command:

--- a/jetls-client/jetls-client.ts
+++ b/jetls-client/jetls-client.ts
@@ -158,8 +158,7 @@ function createTimeoutHandler(
 
 function getServerConfig(): ServerConfig {
   const config = vscode.workspace.getConfiguration("jetls-client");
-  const defaultExecutable =
-    process.platform === "win32" ? "jetls.bat" : "jetls";
+  const defaultExecutable = "jetls";
   const executable = config.get<ExecutableConfig>("executable", {
     path: defaultExecutable,
     threads: "auto",
@@ -198,8 +197,7 @@ async function startLanguageServer() {
     baseCommand = cmd;
     baseArgs = args;
   } else {
-    const defaultExecutable =
-      process.platform === "win32" ? "jetls.bat" : "jetls";
+    const defaultExecutable = "jetls";
     baseCommand = serverConfig.executable.path || defaultExecutable;
     const threads = serverConfig.executable.threads || "auto";
     baseArgs = [`--threads=${threads}`, "--"];
@@ -237,9 +235,7 @@ async function startLanguageServer() {
   );
 
   // On Windows, batch files must be spawned with shell: true
-  const needsShell =
-    process.platform === "win32" && baseCommand.endsWith(".bat");
-  const spawnOptions = needsShell ? { shell: true } : {};
+  const spawnOptions = process.platform === "win32" ? { shell: true } : {};
 
   let serverOptions: ServerOptions;
 

--- a/jetls-client/package.json
+++ b/jetls-client/package.json
@@ -59,7 +59,7 @@
                 "path": {
                   "type": "string",
                   "default": "jetls",
-                  "markdownDescription": "Path to the `jetls` executable. Default is `'jetls'` (`'jetls.bat'` on Windows) which expects the executable to be in your `PATH`."
+                  "markdownDescription": "Path to the `jetls` executable. Default is `'jetls'` which expects the executable to be in your `PATH`."
                 },
                 "threads": {
                   "type": "string",


### PR DESCRIPTION
Fixes https://github.com/aviatesk/JETLS.jl/issues/339, since https://github.com/aviatesk/JETLS.jl/pull/372 was not sufficient.

#372 was an improvement and the `shell=true` was needed. There was still a flaw in the name of the executable.

Normally `jetls` will be `jetls.bat`, but it can still be spawned with `jetls`, as long as it gets `shell=true`. That allows us to simplify the logic, fixing #372 in the process. The problem was that the default value of `jetls` was used, and since that didn't end with `.bat`, it did not get `shell=true`. I think we can just always use the shell on Windows, since folks will have a `.bat` in practice, and the code is simpler.