### PR TITLE
binding: Fix false positive unused variable in filtered comprehensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
 - Diff: [`9b39829...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/9b39829...HEAD)
 
+### Fixed
+
+- Fixed false positive unused variable diagnostics in comprehensions with filter
+  conditions. For example, `[x for (i, x) in enumerate(xs) if isodd(i)]` no
+  longer incorrectly reports `i` as unused. Fixes aviatesk/JETLS.jl#360.
+
 ## 2025-12-08
 
 - Commit: [`9b39829`](https://github.com/aviatesk/JETLS.jl/commit/9b39829)


### PR DESCRIPTION
Previously, bindings were grouped separately for arguments and static parameters by name only. This caused false positives for comprehensions with filter conditions like `[x for (i, x) in enumerate(xs) if isodd(i)]` where `i` would be incorrectly reported as unused.

The fix groups local bindings (including `:local` and `:static_parameter`) by both name and source location, ensuring that multiple binding entries created by JuliaSyntax for the same source-level variable are properly aggregated.

Argument bindings are still processed separately to correctly handle default parameter cases where unused arguments should still be reported.

- fixes #360