### PR TITLE
references: Implement find binding references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
 - Diff: [`9b39829...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/9b39829...HEAD)
 
+### Added
+
+- Added `textDocument/references` support for bindings. Both local and global
+  bindings are supported, although currently the support for global references
+  is experimental and has some notable limitations:
+  - References can only be found within the same analysis unit. For example,
+    when finding references to `somebinding` defined in `PkgA/src/somefile.jl`,
+    usages in `PkgA/src/` can be found, but usages in `PkgA/test/` cannot be
+    detected because test files are in a separate analysis unit.
+  - Aliasing is not considered. Usages via `using ..PkgA: somebinding as otherbinding`
+    or module-qualified access like `PkgA.somebinding` are not detected.
+
 ### Fixed
 
 - Fixed false positive unused variable diagnostics in comprehensions with filter

--- a/README.md
+++ b/README.md
@@ -81,8 +81,11 @@ the list itself is subject to change.
   - [x] Global binding
   - [ ] Field name / Dot-accessed bindings
 - Find references
-  - [ ] Local binding
-  - [ ] Global binding
+  - [x] Local binding
+  - Global reference
+    - [x] Minimum support
+    - [ ] Cross-analysis-unit reference detection
+    - [ ] Aliased reference support
   - [ ] Field name
 - Rename
   - [x] Local binding

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -94,6 +94,7 @@ include("execute-command.jl")
 include("completions.jl")
 include("signature-help.jl")
 include("definition.jl")
+include("references.jl")
 include("hover.jl")
 include("document-highlight.jl")
 include("diagnostics.jl")
@@ -387,6 +388,8 @@ function (dispatcher::ResponseMessageDispatcher)(server::Server, msg::Dict{Symbo
         handle_formatting_progress_response(server, msg, request_caller)
     elseif request_caller isa RangeFormattingProgressCaller
         handle_range_formatting_progress_response(server, msg, request_caller)
+    elseif request_caller isa ReferencesProgressCaller
+        handle_references_progress_response(server, msg, request_caller)
     elseif request_caller isa ProfileProgressCaller
         handle_profile_progress_response(server, msg, request_caller)
     elseif request_caller isa WorkspaceConfigurationCaller
@@ -422,6 +425,8 @@ function (dispatcher::RequestMessageDispatcher)(server::Server, @nospecialize ms
         handle_SignatureHelpRequest(server, msg, cancel_flag)
     elseif msg isa DefinitionRequest
         handle_DefinitionRequest(server, msg, cancel_flag)
+    elseif msg isa ReferencesRequest
+        handle_ReferencesRequest(server, msg, cancel_flag)
     elseif msg isa HoverRequest
         handle_HoverRequest(server, msg, cancel_flag)
     elseif msg isa DocumentHighlightRequest

--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -94,6 +94,15 @@ function handle_InitializeRequest(
         end
     end
 
+    if supports(server, :textDocument, :references, :dynamicRegistration)
+        referencesProvider = nothing # will be registered dynamically
+    else
+        referencesProvider = references_options(server)
+        if JETLS_DEV_MODE
+            @info "Registering 'textDocument/references' with `InitializeResponse`"
+        end
+    end
+
     if supports(server, :textDocument, :hover, :dynamicRegistration)
         hoverProvider = nothing # will be registered dynamically
     else
@@ -208,6 +217,7 @@ function handle_InitializeRequest(
             completionProvider,
             signatureHelpProvider,
             definitionProvider,
+            referencesProvider,
             documentHighlightProvider,
             hoverProvider,
             diagnosticProvider,
@@ -326,6 +336,16 @@ function handle_InitializedNotification(server::Server)
         end
     else
         # NOTE If documentHighlight's `dynamicRegistration` is not supported,
+        # it needs to be registered along with initialization in the `InitializeResponse`.
+    end
+
+    if supports(server, :textDocument, :references, :dynamicRegistration)
+        push!(registrations, references_registration(server))
+        if JETLS_DEV_MODE
+            @info "Dynamically registering 'textDocument/references' upon `InitializedNotification`"
+        end
+    else
+        # NOTE If references's `dynamicRegistration` is not supported,
         # it needs to be registered along with initialization in the `InitializeResponse`.
     end
 

--- a/src/references.jl
+++ b/src/references.jl
@@ -1,0 +1,195 @@
+const REFERENCES_REGISTRATION_ID = "jetls-references"
+const REFERENCES_REGISTRATION_METHOD = "textDocument/references"
+
+struct ReferencesProgressCaller <: RequestCaller
+    uri::URI
+    fi::FileInfo
+    pos::Position
+    include_declaration::Bool
+    msg_id::MessageId
+    token::ProgressToken
+end
+
+function references_options(server::Server)
+    return ReferenceOptions(;
+        workDoneProgress = supports(server, :window, :workDoneProgress))
+end
+
+function references_registration(server::Server)
+    return Registration(;
+        id = REFERENCES_REGISTRATION_ID,
+        method = REFERENCES_REGISTRATION_METHOD,
+        registerOptions = ReferenceRegistrationOptions(;
+            documentSelector = DEFAULT_DOCUMENT_SELECTOR,
+            workDoneProgress = supports(server, :window, :workDoneProgress)))
+end
+
+function handle_ReferencesRequest(
+        server::Server, msg::ReferencesRequest, cancel_flag::CancelFlag)
+    uri = msg.params.textDocument.uri
+    pos = adjust_position(server.state, uri, msg.params.position)
+    include_declaration = msg.params.context.includeDeclaration
+
+    result = get_file_info(server.state, uri, cancel_flag)
+    if result isa ResponseError
+        return send(server,
+            ReferencesResponse(;
+                id = msg.id,
+                result = nothing,
+                error = result))
+    end
+    fi = result
+
+    workDoneToken = msg.params.workDoneToken
+    if workDoneToken !== nothing
+        do_find_references_with_progress(server, uri, fi, pos, include_declaration, msg.id, workDoneToken)
+    elseif supports(server, :window, :workDoneProgress)
+        id = String(gensym(:WorkDoneProgressCreateRequest_references))
+        token = String(gensym(:ReferencesProgress))
+        addrequest!(server, id => ReferencesProgressCaller(uri, fi, pos, include_declaration, msg.id, token))
+        params = WorkDoneProgressCreateParams(; token)
+        send(server, WorkDoneProgressCreateRequest(; id, params))
+    else
+        do_find_references(server, uri, fi, pos, include_declaration, msg.id)
+    end
+
+    return nothing
+end
+
+function handle_references_progress_response(
+        server::Server, msg::Dict{Symbol,Any}, request_caller::ReferencesProgressCaller)
+    if handle_response_error(server, msg, "create work done progress")
+        return
+    end
+    (; uri, fi, pos, include_declaration, msg_id, token) = request_caller
+    do_find_references_with_progress(server, uri, fi, pos, include_declaration, msg_id, token)
+end
+
+function do_find_references_with_progress(
+        server::Server, uri::URI, fi::FileInfo, pos::Position,
+        include_declaration::Bool, msg_id::MessageId, token::ProgressToken)
+    locations = find_references(server, uri, fi, pos; token, include_declaration)
+    return send(server, ReferencesResponse(;
+        id = msg_id,
+        result = isempty(locations) ? null : locations))
+end
+
+function do_find_references(
+        server::Server, uri::URI, fi::FileInfo, pos::Position,
+        include_declaration::Bool, msg_id::MessageId)
+    locations = find_references(server, uri, fi, pos; include_declaration)
+    return send(server, ReferencesResponse(;
+        id = msg_id,
+        result = isempty(locations) ? null : locations))
+end
+
+function find_references(
+        server::Server, uri::URI, fi::FileInfo, pos::Position;
+        token::Union{Nothing,ProgressToken} = nothing,
+        include_declaration::Bool = true,
+    )
+    st0_top = build_syntax_tree(fi)
+    offset = xy_to_offset(fi, pos)
+    (; mod) = get_context_info(server.state, uri, pos)
+    locations = Location[]
+
+    (; ctx3, st3, binding) = @something begin
+        _select_target_binding(st0_top, offset, mod; caller="find_references!")
+    end return locations
+
+    binfo = JL.lookup_binding(ctx3, binding)
+    if binfo.kind === :global
+        find_global_references!(locations, server, uri, fi, st0_top, binfo, token;
+            include_declaration)
+    else
+        find_local_references!(locations, server, uri, fi, ctx3, st3, binfo; include_declaration)
+    end
+
+    return locations
+end
+
+function find_global_references!(
+        locations::Vector{Location}, server::Server,
+        uri::URI, fi::FileInfo, st0_top::JL.SyntaxTree, binfo::JL.BindingInfo,
+        token::Union{Nothing,ProgressToken};
+        include_declaration::Bool=true,
+    )
+    uris_to_search = collect_search_uris(server, uri)
+
+    n_files = length(uris_to_search)
+    if token !== nothing && n_files > 1
+        send_progress(server, token,
+            WorkDoneProgressBegin(; title="Finding references", percentage=0))
+    end
+
+    seen_locations = Set{Tuple{URI,Range}}()
+    for (i, search_uri) in enumerate(uris_to_search)
+        if search_uri == uri
+            search_fi = fi
+        else
+            search_fi = get_file_info(server.state, search_uri)
+            if search_fi === nothing
+                search_fi = create_dummy_file_info(search_uri, fi)
+            end
+        end
+
+        if token !== nothing && n_files > 1
+            percentage = round(Int, 100 * (i - 1) / n_files)
+            message = "Searching $(basename(uri2filename(search_uri))) ($i/$n_files)"
+            send_progress(server, token,
+                WorkDoneProgressReport(; message, percentage))
+        end
+
+        search_st0_top = build_syntax_tree(search_fi)
+        global_find_references_in_file!(
+            seen_locations, server.state, search_uri, search_fi, search_st0_top, binfo;
+            include_declaration)
+    end
+
+    if token !== nothing && n_files > 1
+        send_progress(server, token,
+            WorkDoneProgressEnd(; message="Found $(length(seen_locations)) references"))
+    end
+
+    for (loc_uri, range) in seen_locations
+        push!(locations, Location(; uri=loc_uri, range))
+    end
+    return locations
+end
+
+function global_find_references_in_file!(
+        seen_locations::Set{Tuple{URI,Range}}, state::ServerState, uri::URI, fi::FileInfo,
+        st0_top::JL.SyntaxTree, binfo::JL.BindingInfo;
+        include_declaration::Bool=true,
+    )
+    for occurrence in find_global_binding_occurrences!(state, uri, fi, st0_top, binfo)
+        is_def = occurrence.kind === :def
+        if !is_def || include_declaration
+            range, _ = unadjust_range(state, uri, jsobj_to_range(occurrence.tree, fi))
+            push!(seen_locations, (uri, range))
+        end
+    end
+    return seen_locations
+end
+
+function find_local_references!(
+        locations::Vector{Location}, server::Server, uri::URI, fi::FileInfo,
+        ctx3, st3, binfo::JL.BindingInfo;
+        include_declaration::Bool=true,
+    )
+    ranges = Set{Range}()
+    binding_occurrences = compute_binding_occurrences(ctx3, st3)
+    if haskey(binding_occurrences, binfo)
+        for occurrence in binding_occurrences[binfo]
+            is_def = occurrence.kind === :def
+            if !is_def || include_declaration
+                range, _ = unadjust_range(server.state, uri, jsobj_to_range(occurrence.tree, fi))
+                push!(ranges, range)
+            end
+        end
+    end
+    for range in ranges
+        push!(locations, Location(; uri, range))
+    end
+    return locations
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,7 @@ end
     @testset "signature help" include("test_signature_help.jl")
     @testset "definition" include("test_definition.jl")
     @testset "document highlight" include("test_document_highlight.jl")
+    @testset "references" include("test_references.jl")
     @testset "hover" include("test_hover.jl")
     @testset "inlay hint" include("test_inlay_hint.jl")
     @testset "LSAnalyzer" include("test_LSAnalyzer.jl")

--- a/test/test_references.jl
+++ b/test/test_references.jl
@@ -1,0 +1,77 @@
+module test_references
+
+using Test
+using JETLS
+using JETLS.LSP
+
+include(normpath(pkgdir(JETLS), "test", "setup.jl"))
+
+function find_references(code::AbstractString, pos::Position; include_declaration::Bool=true)
+    server = JETLS.Server()
+    uri = URI("file:///test.jl")
+    fi = JETLS.FileInfo(#=version=#0, code, "test.jl")
+    JETLS.store!(server.state.file_cache) do cache
+        Base.PersistentDict(cache, uri => fi), nothing
+    end
+    locations = JETLS.find_references(server, uri, fi, pos; include_declaration)
+    return locations
+end
+
+@testset "find_references" begin
+    @testset "local binding references" begin
+        let code = """
+            function func(│xx│x│, yyy)
+                println(│xx│x│, yyy)
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            for pos in positions
+                refs = find_references(clean_code, pos)
+                @test length(refs) == 2
+                @test any(ref -> ref.range.start == positions[1] && ref.range.var"end" == positions[3], refs)
+                @test any(ref -> ref.range.start == positions[4] && ref.range.var"end" == positions[6], refs)
+            end
+        end
+    end
+
+    @testset "includeDeclaration=false" begin
+        let code = """
+            function func(│xx│x│, yyy)
+                println(│xx│x│, yyy)
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            for pos in positions
+                refs = find_references(clean_code, pos; include_declaration=false)
+                @test length(refs) == 1
+                ref = only(refs)
+                @test ref.range.start == positions[4] && ref.range.var"end" == positions[6]
+            end
+        end
+    end
+
+    @testset "global binding references" begin
+        let code = """
+            function │myfunc│(x)
+                x + 1
+            end
+
+            result1 = │myfunc│(1)
+
+            function │myfunc│(x, y)
+                x + y
+            end
+
+            result2 = │myfunc│(2, 3)
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 8
+            for pos in positions
+                refs = find_references(clean_code, pos; include_declaration=false)
+                @test length(refs) == 4
+            end
+        end
+    end
+end
+
+end # module test_references


### PR DESCRIPTION
Add `textDocument/references` support for bindings. Both local and global bindings are supported, although the support for the later is currently limited.

Release note:
- Added `textDocument/references` support for bindings. Both local and global
  bindings are supported, although currently the support for global references
  is experimental and has some notable limitations:
  - References can only be found within the same analysis unit. For example,
    when finding references to `somebinding` defined in `PkgA/src/somefile.jl`,
    usages in `PkgA/src/` can be found, but usages in `PkgA/test/` cannot be
    detected because test files are in a separate analysis unit.
  - Aliasing is not considered. Usages via `using ..PkgA: somebinding as otherbinding`
    or module-qualified access like `PkgA.somebinding` are not detected.