### PR TITLE
binding: fix unused argument diagnostics for keyword functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
 - Diff: [`048d9a5...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/048d9a5...HEAD)
 
+### Fixed
+
+- Fixed false negative unused argument diagnostics for functions with keyword
+  arguments. For example, `func(a; kw) = a` now correctly reports `kw` as unused.
+  Fixes aviatesk/JETLS.jl#390.
+
 ## 2025-12-12
 
 - Commit: [`048d9a5`](https://github.com/aviatesk/JETLS.jl/commit/048d9a5)

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -417,6 +417,9 @@ function is_kwcall_lambda(ctx3::JL.VariableAnalysisContext, st3::JL.SyntaxTree)
         end
 end
 
+is_selffunc(b::JL.BindingInfo) = b.name == "#self#"
+is_kwsorter_func(b::JL.BindingInfo) = startswith(b.name, '#') && endswith(b.name, r"#\d+$")
+
 function compute_binding_occurrences!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurence{Tree3}}},
         ctx3::JL.VariableAnalysisContext, st3::Tree3;
@@ -469,7 +472,7 @@ function compute_binding_occurrences!(
             end
         elseif infunc && k === JS.K"block" && nc ≥ 1
             blk1 = st[1]
-            if JS.kind(blk1) === JS.K"function_decl" && infunc && JS.numchildren(blk1) ≥ 1
+            if JS.kind(blk1) === JS.K"function_decl" && JS.numchildren(blk1) ≥ 1
                 # This is an inner function definition -- the binding of this inner function
                 # is "used" in the language constructs required to define the method,
                 # but what we're interested in is whether it's actually used in the outer scope.
@@ -506,7 +509,7 @@ function compute_binding_occurrences!(
                     # These bindings are never actually used, so simply recursing would cause
                     # this pass to report them as unused local bindings.
                     # We avoid this problem by setting `include_decls` when recursing.
-                    for i = 1:nc
+                    for i = start_idx:nc
                         compute_binding_occurrences!(occurrences, ctx3, st[i]; ismacro, include_decls=true)
                     end
                     continue
@@ -528,12 +531,26 @@ function compute_binding_occurrences!(
             end
         elseif k === JS.K"call" && nc ≥ 1
             arg1 = st[1]
-            if JS.kind(arg1) === JS.K"BindingId" && JL.lookup_binding(ctx3, arg1).name == "#self#"
-                # Don't count self arguments used in self calls as "usage".
-                # This is necessary to issue unused argument diagnostics for `x` in cases like:
-                # ```julia
-                # hasmatch(x::RegexMatch, y::Bool=false) = nothing
-                # ```
+            skip_arguments = false
+            if JS.kind(arg1) === JS.K"BindingId"
+                funcbind = JL.lookup_binding(ctx3, arg1)
+                if is_selffunc(funcbind)
+                    # Don't count self arguments used in self calls as "usage".
+                    # This is necessary to issue unused argument diagnostics for `x` in cases like:
+                    # ```julia
+                    # hasmatch(x::RegexMatch, y::Bool=false) = nothing
+                    # ```
+                    skip_arguments = true
+                elseif is_kwsorter_func(funcbind)
+                    # Argument uses in keyword function calls also need to be skipped for the same reason.
+                    # Without this, `:use` of `a` in `func(a; x) = x` would be counted.
+                    skip_arguments = true
+                end
+            elseif JS.kind(arg1) === JS.K"top" && get(arg1, :name_val, "") == "kwerr"
+                # Skip argument uses for `kwerr` calls as well
+                skip_arguments = true
+            end
+            if skip_arguments
                 for i = nc:-1:2 # reversed since we use `pop!`
                     argⱼ = st[i]
                     if JS.kind(argⱼ) === JS.K"BindingId" && JL.lookup_binding(ctx3, argⱼ).kind === :argument

--- a/test/test_lowering_diagnostics.jl
+++ b/test/test_lowering_diagnostics.jl
@@ -230,6 +230,62 @@ length_utf16(s::AbstractString) = sum(c::Char -> codepoint(c) < 0x10000 ? 1 : 2,
         @test isempty(diagnostics)
     end
 
+    @testset "keyword function" begin
+        # https://github.com/aviatesk/JETLS.jl/issues/390
+        @test isempty(get_lowered_diagnostics("func(a; kw) = a, kw"))
+        @test isempty(get_lowered_diagnostics("func(a; kw=a) = kw"))
+        @test isempty(get_lowered_diagnostics("func(a; kw1, kw2) = a, kw1, kw2"))
+        @test isempty(get_lowered_diagnostics("func(a; kws...) = a, kws"))
+        @test isempty(get_lowered_diagnostics("func(a; kw, kws...) = a, kw, kws"))
+        let diagnostics = get_lowered_diagnostics("func(a; kw) = a")
+            @test length(diagnostics) == 1
+            diagnostic = only(diagnostics)
+            @test diagnostic.message == "Unused argument `kw`"
+            @test diagnostic.range.start.line == 0
+        end
+        let diagnostics = get_lowered_diagnostics("func(a; kw) = kw")
+            @test length(diagnostics) == 1
+            diagnostic = only(diagnostics)
+            @test diagnostic.message == "Unused argument `a`"
+            @test diagnostic.range.start.line == 0
+        end
+        let diagnostics = get_lowered_diagnostics("func(a; kws...) = a")
+            @test length(diagnostics) == 1
+            diagnostic = only(diagnostics)
+            @test diagnostic.message == "Unused argument `kws`"
+            @test diagnostic.range.start.line == 0
+        end
+        let diagnostics = get_lowered_diagnostics("func(a; kw1, kw2) = kw1, kw2")
+            @test length(diagnostics) == 1
+            diagnostic = only(diagnostics)
+            @test diagnostic.message == "Unused argument `a`"
+            @test diagnostic.range.start.line == 0
+        end
+        let diagnostics = get_lowered_diagnostics("func(a; kw1, kw2) = a, kw2")
+            @test length(diagnostics) == 1
+            diagnostic = only(diagnostics)
+            @test diagnostic.message == "Unused argument `kw1`"
+            @test diagnostic.range.start.line == 0
+        end
+        let diagnostics = get_lowered_diagnostics("func(a; kw, kws...) = a, kw")
+            @test length(diagnostics) == 1
+            diagnostic = only(diagnostics)
+            @test diagnostic.message == "Unused argument `kws`"
+            @test diagnostic.range.start.line == 0
+        end
+        let diagnostics = get_lowered_diagnostics("func(a; kw) = nothing")
+            @test length(diagnostics) == 2
+            @test any(diagnostics) do diagnostic
+                diagnostic.message == "Unused argument `a`" &&
+                diagnostic.range.start.line == 0
+            end
+            @test any(diagnostics) do diagnostic
+                diagnostic.message == "Unused argument `kw`" &&
+                diagnostic.range.start.line == 0
+            end
+        end
+    end
+
     @testset "macro definition" begin
         @test isempty(get_lowered_diagnostics("macro mymacro() end"))
         @test isempty(get_lowered_diagnostics("macro mymacro(x) x end"))

--- a/test/utils/test_binding.jl
+++ b/test/utils/test_binding.jl
@@ -808,6 +808,33 @@ ismacro_callback(ismacro) = @test ismacro[]
             end
         end
     end
+
+    @testset "keyword arguments" begin
+        with_binding_occurrences("func(a; kw) = kw"; ismacro_callback = nomacro_callback) do binding_occurrences
+            @test !any(binding_occurrences) do (binding, occurrences)
+                binding.name == "a" && binding.kind === :argument && any(o->o.kind===:use, occurrences)
+            end
+            @test any(binding_occurrences) do (binding, occurrences)
+                binding.name == "kw" && binding.kind === :argument && any(o->o.kind===:use, occurrences)
+            end
+        end
+        with_binding_occurrences("func(a; kw) = a"; ismacro_callback = nomacro_callback) do binding_occurrences
+            @test any(binding_occurrences) do (binding, occurrences)
+                binding.name == "a" && binding.kind === :argument && any(o->o.kind===:use, occurrences)
+            end
+            @test !any(binding_occurrences) do (binding, occurrences)
+                binding.name == "kw" && binding.kind === :argument && any(o->o.kind===:use, occurrences)
+            end
+        end
+        with_binding_occurrences("func(a; kw) = nothing"; ismacro_callback = nomacro_callback) do binding_occurrences
+            @test !any(binding_occurrences) do (binding, occurrences)
+                binding.name == "a" && binding.kind === :argument && any(o->o.kind===:use, occurrences)
+            end
+            @test !any(binding_occurrences) do (binding, occurrences)
+                binding.name == "kw" && binding.kind === :argument && any(o->o.kind===:use, occurrences)
+            end
+        end
+    end
 end
 
 function with_global_binding_occurrences(


### PR DESCRIPTION
Previously, arguments used in keyword function calls (generated by Julia's lowering for functions with keyword arguments) were incorrectly counted as "used", preventing proper unused argument diagnostics. For example, in `func(a; kw) = a`, the `kw` argument would not be reported as unused.

This change extends the argument usage skip logic to handle:
- Keyword function calls (`#funcname#N` pattern)
- `kwerr` calls from `Core.TopNode`

Also fixes a minor bug where `start_idx` was not used in the loop.

Fixes aviatesk/JETLS.jl#390