### PR TITLE
completions: disable completions when dot-prefix type is unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   arguments. For example, `func(a; kw) = a` now correctly reports `kw` as unused.
   Fixes aviatesk/JETLS.jl#390.
 
+### Changed
+
+- Completions now return no results when the prefix type is unknown.
+  Previously, irrelevant completions were shown for expressions like
+  `xarg.x` where `xarg`'s type could not be resolved. Fixes aviatesk/JETLS.jl#389.
+
 ## 2025-12-12
 
 - Commit: [`048d9a5`](https://github.com/aviatesk/JETLS.jl/commit/048d9a5)

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -215,12 +215,17 @@ function global_completions!(
     dotprefix = select_dotprefix_node(st, offset)
     if !isnothing(dotprefix)
         prefixtyp = resolve_type(analyzer, completion_module, dotprefix)
+        # If dotprefix is not a module, cancel completion entirely.
+        # TODO In the future, let's add property completions and such.
+        enable_completions = false
         if prefixtyp isa Core.Const
             prefixval = prefixtyp.val
             if prefixval isa Module
                 completion_module = prefixval
+                enable_completions = true
             end
         end
+        enable_completions || return items
         # disable local completions for dot-prefixed code for now
         is_completed |= true
     end

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -305,6 +305,7 @@ end
         end
         function dot_completion_test(xarg)
             ModuleCompletion.x│
+            xarg.x│
         end
 
         function str_macro_test()
@@ -363,6 +364,11 @@ end
             @test isnothing(findfirst(item->item.label=="xarg", items)) # local completion should be disabled
             cnt += 1
         elseif i == 4
+            # `dot_completion_test`: dot-prefixed global completion
+            # https://github.com/aviatesk/JETLS.jl/issues/389
+            @test isempty(items) # completions should be disabled if the prefix type/value is unknown
+            cnt += 1
+        elseif i == 5
             # `str_macro_test`: string macro case
             @test any(items) do item
                 item.label == "text\"\"" &&
@@ -371,7 +377,7 @@ end
             cnt += 1
         end
     end
-    @test cnt == 4
+    @test cnt == 5
 end
 
 @testset "local completion for methods with `@nospecialize`" begin


### PR DESCRIPTION
Previously, dot-prefixed completions like `xarg.x` would show irrelevant
global completions when the prefix type could not be resolved.
For now, let's just disable completions entirely in such cases, to
provide a cleaner user experience by not showing unrelated suggestions.

Property completions for non-module values may be added in the future.

Fixes aviatesk/JETLS.jl#389