### PR TITLE
completions: add keyword completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
 - Diff: [`048d9a5...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/048d9a5...HEAD)
 
+### Added
+
+- Added completion support for Julia keywords. Closes aviatesk/JETLS.jl#386.
+
 ### Fixed
 
 - Fixed false negative unused argument diagnostics for functions with keyword

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -444,6 +444,10 @@ end
             @test !any(items) do item
                 item.label == "foo" || item.label == "xxx" || item.label == "yyy"
             end
+            # keywords should NOT appear in macro context
+            @test !any(items) do item
+                item.label == "function"
+            end
             cnt += 1
         end
         @test cnt == 1
@@ -722,6 +726,10 @@ end
             @test !any(items) do item
                 item.label == "foo" || # should not include global completions
                 item.label == "β"      # should not include local completions
+            end
+            # keywords should NOT appear in latex/emoji completion context
+            @test !any(items) do item
+                item.label == "function"
             end
             cnt += 1
         end


### PR DESCRIPTION
Add completion support for Julia keywords. Keywords are sourced from `REPL.REPLCompletions.sorted_keywords` and `sorted_keyvals`.

Keywords are given the lowest sort priority (`max_sort_text3`) so they should appear after local variables and globals. They are excluded from macro invocation and latex/emoji completion contexts.

Closes #386.