### PR TITLE
hover: add keyword documentation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Added completion support for Julia keywords. Closes aviatesk/JETLS.jl#386.
+- Added hover documentation for Julia keywords (`if`, `for`, `true`, etc.).
 
 ### Fixed
 

--- a/src/hover.jl
+++ b/src/hover.jl
@@ -81,6 +81,21 @@ function handle_HoverRequest(
         result = local_hover))
 
     node = @something select_target_node(st0_top, offset) begin
+        tok = @something token_at_offset(fi, pos) begin
+            return send(server, HoverResponse(; id = msg.id, result = null))
+        end
+        byterng = JS.byte_range(tok)
+        tokstr = String(fi.parsed_stream.textbuf[byterng])
+        if haskey(KEYWORD_DOCS, tokstr)
+            contents = KEYWORD_DOCS[tokstr]
+            range = Range(;
+                start = offset_to_xy(fi, first(byterng)),
+                var"end" = offset_to_xy(fi, last(byterng)+1))
+            range, _ = unadjust_range(state, uri, range)
+            return send(server, HoverResponse(;
+                id = msg.id,
+                result = Hover(; contents, range)))
+        end
         return send(server, HoverResponse(; id = msg.id, result = null))
     end
 


### PR DESCRIPTION
Display documentation when hovering over Julia keywords like `function`, `&&`, `$` etc.