### PR TITLE
init-options: support initialization options in .JETLSConfig.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added completion support for Julia keywords. Closed aviatesk/JETLS.jl#386.
 - Added hover documentation for Julia keywords.
+- Initialization options can now be configured via `.JETLSConfig.toml` using the
+  `[initialization_options]` section. See the [documentation](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options/configure)
+  for details.
 
 ### Fixed
 

--- a/docs/src/launching.md
+++ b/docs/src/launching.md
@@ -130,10 +130,10 @@ client cannot execute the normal LSP shutdown sequence.
 
 ## [Initialization options](@id init-options)
 
-JETLS accepts static initialization options via the LSP `initializationOptions`
-field in the `initialize` request. Unlike [dynamic configuration](@ref config/schema)
-that can be changed at runtime, these options are set once at server startup and
-require a server restart to take effect.
+JETLS accepts static initialization options that are set once at server startup
+and require a server restart to take effect. Unlike
+[dynamic configuration](@ref config/schema) that can be changed at runtime,
+these options configure fundamental server behavior.
 
 ### [Schema](@id init-options/schema)
 
@@ -169,9 +169,37 @@ another can begin code loading concurrently.
     parallelization is independent of `n_analysis_workers` and provides
     significant speedups (e.g., ~4x faster with 4 threads for large packages).
 
-### [Client configuration](@id init-options/client-config)
+### [How to configure initialization options](@id init-options/configure)
 
-#### [VSCode (`jetls-client` extension)](@id init-options/client-config/vscode)
+Initialization options can be configured via:
+- [Editor-specific settings](@ref init-options/client-config)
+- The `[initialization_options]` section in [`.JETLSConfig.toml`](@ref init-options/file-config)
+
+When both sources are present, file-based configuration takes precedence
+(file > client > default), as like [JETLS configuration priority](@ref config/priority).
+
+#### [File-based configuration](@id init-options/file-config)
+
+Configure initialization options in [`.JETLSConfig.toml`](@ref config/file-based-config)
+at your project root:
+
+```toml
+[initialization_options]
+n_analysis_workers = 2
+```
+
+This method is client-agnostic and can be easily committed to version control.
+
+#### [Client configuration](@id init-options/client-config)
+
+The method and format for specifying initialization options varies by editor.
+Consult your editor's documentation on how to configure LSP initialization
+options. Below are examples for VSCode and Zed.
+
+If your editor does not support specifying initialization options, use the
+[file-based configuration](@ref init-options/file-config) instead.
+
+##### [VSCode (`jetls-client` extension)](@id init-options/client-config/vscode)
 
 Configure initialization options in VSCode's `settings.json`:
 
@@ -183,7 +211,7 @@ Configure initialization options in VSCode's `settings.json`:
 }
 ```
 
-#### [Zed (`aviatesk/zed-julia` extension)](@id init-options/client-config/zed)
+##### [Zed (`aviatesk/zed-julia` extension)](@id init-options/client-config/zed)
 
 Configure initialization options in Zed's `settings.json`:
 

--- a/src/init_options.jl
+++ b/src/init_options.jl
@@ -28,3 +28,18 @@ function parse_init_options(@nospecialize init_options)
 end
 
 get_init_option(opts::InitOptions, key::Symbol) = @something getfield(opts, key) error(lazy"Invalid init option: $key")
+
+function load_file_init_options(filepath::AbstractString)
+    isfile(filepath) || return nothing
+    parsed = TOML.tryparsefile(filepath)
+    parsed isa TOML.ParserError && return nothing
+    init_options_dict = get(parsed, "initialization_options", nothing)
+    init_options_dict === nothing && return nothing
+    init_options_dict isa AbstractDict || return nothing
+    try
+        return validate_init_options(Configurations.from_dict(InitOptions, init_options_dict))
+    catch err
+        @warn "Failed to parse initialization_options from config file, ignoring" filepath err
+        return nothing
+    end
+end

--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -17,12 +17,6 @@ function handle_InitializeRequest(
     state = server.state
     init_params = state.init_params = msg.params
 
-    # NOTE: Static server settings that require a server restart to take effect should be
-    # accessed during server initialization via `state.init_params.initializationOptions`.
-    # These settings differ from dynamic configuration options managed by `ConfigManager`
-    # that can be changed at throughout server lifecycle.
-    state.init_options = parse_init_options(init_params.initializationOptions)
-
     workspaceFolders = init_params.workspaceFolders
     if workspaceFolders !== nothing
         state.workspaceFolders = URI[uri for (; uri) in workspaceFolders]
@@ -54,6 +48,20 @@ function handle_InitializeRequest(
     else
         @warn "Multiple workspaceFolders are not supported - using limited functionality" state.workspaceFolders
         # leave Refs undefined
+    end
+
+    # NOTE: Static server settings that require a server restart to take effect should be
+    # accessed during server initialization via `state.init_params.initializationOptions`.
+    # These settings differ from dynamic configuration options managed by `ConfigManager`
+    # that can be changed at throughout server lifecycle.
+    # Priority: file config > client config > default
+    state.init_options = parse_init_options(init_params.initializationOptions)
+    if isdefined(state, :root_path)
+        config_path = joinpath(state.root_path, ".JETLSConfig.toml")
+        file_init_options = load_file_init_options(config_path)
+        if file_init_options !== nothing
+            state.init_options = merge_init_options(state.init_options, file_init_options)
+        end
     end
 
     start_analysis_workers!(server)


### PR DESCRIPTION
Initialization options can now be configured via the `[initialization_options]` section in `.JETLSConfig.toml`, in addition to editor-specific LSP settings. This provides a client-agnostic way to configure initialization options that can be committed to version control.

When both sources are present, file-based configuration takes precedence (file > client > default), as like the dynamic configuration. But I may revise this priority rule in the very near future.