### PR TITLE
full-analysis: Initial incremental analysis implementation

### DIFF
--- a/.JETLSConfig.toml
+++ b/.JETLSConfig.toml
@@ -11,3 +11,19 @@ pattern = "^Lowering TODO:"
 match_by = "message"
 match_type = "regex"
 severity = "info"
+
+[[initialization_options.analysis_overrides]]
+module_name = "JETLS"
+path = "src/**/*.jl"
+
+[[initialization_options.analysis_overrides]]
+module_name = "LSP"
+path = "LSP/**/*.jl"
+
+# Just disable analysis for test files for now
+
+[[initialization_options.analysis_overrides]]
+path = "test/**/*.jl"
+
+[[initialization_options.analysis_overrides]]
+path = "LSP/test/**/*.jl"

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -305,7 +305,15 @@ function jet_result_to_diagnostics!(uri2diagnostics::URI2Diagnostics, result::JE
         end
         push!(uri2diagnostics[uri], diagnostic)
     end
-    for report in result.res.inference_error_reports
+    jet_inference_error_reports_to_diagnostics!(uri2diagnostics, postprocessor, result.res.inference_error_reports)
+    return uri2diagnostics
+end
+
+function jet_inference_error_reports_to_diagnostics!(
+        uri2diagnostics::URI2Diagnostics, postprocessor::JET.PostProcessor,
+        reports::Vector{JET.InferenceErrorReport}
+    )
+    for report in reports
         diagnostic = jet_inference_error_report_to_diagnostic(postprocessor, report)
         topframeidx = first(inference_error_report_stack(report))
         topframe = report.vst[topframeidx]


### PR DESCRIPTION
This commit implements a prototype of Revise-based incremental full-analysis. The idea is to delegate package state management to Revise, similar to JET v0.11, enabling fast updates of analysis results when incremental changes are made while avoiding issues like #357.

Although this implementation is incomplete, it works at least for JETLS itself and its dependencies, making it possible to experiment with various feature extensions that Revise-based incremental analysis enables. For example, this approach makes it practical to cache type inference results in `FileInfo` and update them on `DidChange` (though memory leak risks return). This would make dynamic diagnostics, type on hover, and inlay hints more feasible.

The following incomplete aspects need to be addressed for complete migration to this new analysis approach:

- Code loading is not yet implemented. This could be easily implemented using `Base.require`, but currently we use the approach of looking up `module_name` specified in `analysis_overrides` of initialization options from `Base.loaded_modules`. This means external packages cannot be analyzed with this new method - only packages already loaded as JETLS dependencies at server initialization. This is also related to the fact that this mode currently only works for package code. We need to reconsider how to load and analyze script code as well.

- The Revise-based tracking system needs adjustment for special packages like `Base` and `Compiler`.

- Generally, my understanding of Revise is still insufficient and the package monitoring approach may be immature.

Currently, this feature is only enabled if you explicitly specify `analysis_overrides` along with `module_name` in [[Initialization options]].

Also checks in the changes for .JETLSConfig.toml to enable this new analysis mode for JETLS itself.

---

Demo on JETLS codebase (instant analysis result update):

https://github.com/user-attachments/assets/c973197a-3db3-475e-a7f7-eb66c44fb175

