### PR TITLE
Analyzer: Simplify `target_modules` state management

### DIFF
--- a/src/analysis/Interpreter.jl
+++ b/src/analysis/Interpreter.jl
@@ -51,7 +51,7 @@ end
 JET.InterpretationState(interp::LSInterpreter) = interp.state
 function JET.ConcreteInterpreter(interp::LSInterpreter, state::JET.InterpretationState)
     # add `state` to `interp`, and update `interp.analyzer.cache`
-    initialize_cache!(interp.analyzer, state.res.analyzed_files)
+    initialize_target_modules!(interp.analyzer, state.res.analyzed_files)
     return LSInterpreter(
         interp.server, interp.request, interp.analyzer, interp.counter,
         interp.activation_done, state)
@@ -95,8 +95,10 @@ function JET.analyze_from_definitions!(interp::LSInterpreter, config::JET.Toplev
     # This makes module context information available immediately for LS features
     cache_intermediate_analysis_result!(interp)
 
-    entrypoint = config.analyze_from_definitions
     res = JET.InterpretationState(interp).res
+    initialize_target_modules!(interp.analyzer, res.analyzed_files)
+
+    entrypoint = config.analyze_from_definitions
     n_sigs = length(res.toplevel_signatures)
     n_sigs == 0 && return
     cancellable_token = interp.request.cancellable_token

--- a/test/test_Analyzer.jl
+++ b/test/test_Analyzer.jl
@@ -59,4 +59,26 @@ end
     end
 end
 
+module TestTargetModule
+    function func()
+        undefvar
+    end
+end
+
+@testset "target_modules" begin
+    let result = analyze_call(; target_modules=()) do
+            TestTargetModule.func()
+        end
+        @test isempty(get_reports(result))
+    end
+    let result = analyze_call(; target_modules=(TestTargetModule,)) do
+            TestTargetModule.func()
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa UndefVarErrorReport && r.var == GlobalRef(TestTargetModule, :undefvar)
+    end
+end
+
 end # module test_LSAnalyzer


### PR DESCRIPTION
Refactor `InterpretationStateCache` to use an explicit `target_modules` field instead of a lazily-computed cache, simplifying the code.

Also allows the interactive `[@]analyze_call` utilities to set `target_modules` for testing purposes.