### PR TITLE
analyzer: FieldError & BoundsError analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added `inference/field-error` diagnostic for detecting access to non-existent
+  struct fields (e.g., `x.propert` when the field is `property`).
+  Closes aviatesk/JETLS.jl#392.
+- Added `inference/bounds-error` diagnostic for detecting out-of-bounds field
+  access by index (e.g., `tpl[2]` on a `tpl::Tuple{Int}`).
+  Note that this diagnostic is for struct/tuple field access, not array indexing.
 - Added completion support for Julia keywords. Closed aviatesk/JETLS.jl#386.
 - Added hover documentation for Julia keywords.
 - Initialization options can now be configured via `.JETLSConfig.toml` using the

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -67,6 +67,8 @@ Here is a summary table of the diagnostics explained in this section:
 | [`toplevel/error`](@ref diagnostic/toplevel/error)                                 | `Error`               | Errors during code loading (missing deps, type failures, etc.) |
 | [`inference/undef-global-var`](@ref diagnostic/inference/undef-global-var)         | `Warning`             | References to undefined global variables                       |
 | [`inference/undef-local-var`](@ref diagnostic/inference/undef-local-var)           | `Information/Warning` | References to undefined local variables                        |
+| [`inference/field-error`](@ref diagnostic/inference/field-error)                   | `Warning`             | Access to non-existent struct fields                           |
+| [`inference/bounds-error`](@ref diagnostic/inference/bounds-error)                 | `Warning`             | Out-of-bounds field access by index                            |
 | [`testrunner/test-failure`](@ref diagnostic/testrunner/test-failure)               | `Error`               | Test failures from TestRunner integration                      |
 
 ### [Syntax diagnostic (`syntax/*`)](@id diagnostic/syntax)
@@ -238,6 +240,45 @@ function undef_local_var()
         x = 1
     end
     return x  # local variable `x` may be undefined (JETLS inference/undef-local-var)
+end
+```
+
+#### [Field error (`inference/field-error`)](@id diagnostic/inference/field-error)
+
+**Default severity:** `Warning`
+
+Access to non-existent struct fields. This diagnostic is reported when code
+attempts to access a field that doesn't exist on a struct type.
+
+Example:
+
+```julia
+struct MyStruct
+    property::Int
+end
+function field_error()
+    x = MyStruct(42)
+    return x.propert  # FieldError: type MyStruct has no field `propert`, available fields: `property` (JETLS inference/field-error)
+end
+```
+
+#### [Bounds error (`inference/bounds-error`)](@id diagnostic/inference/bounds-error)
+
+**Default severity:** `Warning`
+
+Out-of-bounds field access by index. This diagnostic is reported when code
+attempts to access a struct field using an integer index that is out of bounds,
+such as `getfield(x, i)` or tuple indexing `tpl[i]`.
+
+!!! note
+    This diagnostic is not reported for arrays, since the compiler doesn't
+    track array shape information.
+
+Example:
+
+```julia
+function bounds_error(tpl::Tuple{Int})
+    return tpl[2]  # BoundsError: attempt to access Tuple{Int64} at index [2] (JETLS inference/bounds-error)
 end
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,8 +23,7 @@ You need to install the `jetls` executable separately before using any editor in
 
 ### Prerequisites
 
-JETLS requires [Julia `v"1.12"`](https://julialang.org/downloads) or higher,
-so ensure that the Julia version of the `julia` command you use is v1.12 or higher.
+JETLS requires [Julia `v"1.12"`](https://julialang.org/downloads) or higher (1.12.2+ recommended).
 
 ### Installing the `jetls` executable
 

--- a/jetls-client/README.md
+++ b/jetls-client/README.md
@@ -20,7 +20,7 @@ diagnostic, macro-aware go-to definition and such.
 ## Requirements
 
 - [VSCode](https://code.visualstudio.com/) v1.96.0 or higher
-- [Julia `v"1.12"`](https://julialang.org/downloads) or higher
+- [Julia `v"1.12"`](https://julialang.org/downloads) or higher (1.12.2+ recommended)
 
 ## Installation
 

--- a/src/analysis/Interpreter.jl
+++ b/src/analysis/Interpreter.jl
@@ -58,10 +58,10 @@ JET.ToplevelAbstractAnalyzer(interp::LSInterpreter) = interp.analyzer
 function JET.ToplevelAbstractAnalyzer(
         interp::LSInterpreter, concretized::BitVector;
         refresh_local_cache::Bool = true,    # This option is used by JET v0.10. TODO We can remove this once we update JET to v0.11.
-        refresh_target_modules::Bool = true, # LSInterpreter specific option
+        reset_report_target_modules::Bool = true, # LSInterpreter specific option
     )
-    if refresh_target_modules
-        initialize_target_modules!(interp.analyzer, JET.InterpretationState(interp).res.analyzed_files)
+    if reset_report_target_modules
+        reset_report_target_modules!(interp.analyzer, JET.InterpretationState(interp).res.analyzed_files)
     end
     return @invoke JET.ToplevelAbstractAnalyzer(
         interp::JET.ConcreteInterpreter, concretized::BitVector;
@@ -106,7 +106,7 @@ function JET.analyze_from_definitions!(interp::LSInterpreter, config::JET.Toplev
     cache_intermediate_analysis_result!(interp)
 
     res = JET.InterpretationState(interp).res
-    initialize_target_modules!(interp.analyzer, res.analyzed_files)
+    reset_report_target_modules!(interp.analyzer, res.analyzed_files)
 
     entrypoint = config.analyze_from_definitions
     n_sigs = length(res.toplevel_signatures)
@@ -135,7 +135,7 @@ function JET.analyze_from_definitions!(interp::LSInterpreter, config::JET.Toplev
             # Create a new analyzer with fresh local caches (`inf_cache` and `analysis_results`)
             # to avoid data races between concurrent signature analysis tasks
             analyzer = JET.ToplevelAbstractAnalyzer(interp, JET.non_toplevel_concretized;
-                refresh_target_modules = false,
+                reset_report_target_modules = false,
                 refresh_local_cache = true)
             match = Base._which(tt;
                 # NOTE use the latest world counter with `method_table(analyzer)` unwrapped,

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -305,7 +305,8 @@ function jet_result_to_diagnostics!(uri2diagnostics::URI2Diagnostics, result::JE
         end
         push!(uri2diagnostics[uri], diagnostic)
     end
-    jet_inference_error_reports_to_diagnostics!(uri2diagnostics, postprocessor, result.res.inference_error_reports)
+    displayable_reports = collect_displayable_reports(result.res.inference_error_reports, keys(uri2diagnostics))
+    jet_inference_error_reports_to_diagnostics!(uri2diagnostics, postprocessor, displayable_reports)
     return uri2diagnostics
 end
 
@@ -318,13 +319,8 @@ function jet_inference_error_reports_to_diagnostics!(
         topframeidx = first(inference_error_report_stack(report))
         topframe = report.vst[topframeidx]
         topframe.file === :none && continue # TODO Figure out why this is necessary
-        filename = String(topframe.file)
-        if startswith(filename, "Untitled")
-            uri = filename2uri(filename)
-        else
-            uri = filepath2uri(to_full_path(filename))
-        end
-        push!(uri2diagnostics[uri], diagnostic)
+        uri = jet_frame_to_uri(topframe)
+        push!(uri2diagnostics[uri], diagnostic) # collect_displayable_reports asserts that this `uri` key exists for `uri2diagnostics`
     end
     return uri2diagnostics
 end
@@ -374,7 +370,7 @@ function jet_inference_error_report_to_diagnostic(postprocessor::JET.PostProcess
 end
 
 function inference_error_report_code(@nospecialize report::JET.InferenceErrorReport)
-    if report isa Analyzer.UndefVarErrorReport
+    if report isa UndefVarErrorReport
         if report.var isa GlobalRef
             return INFERENCE_UNDEF_GLOBAL_VAR_CODE
         elseif report.var isa TypeVar
@@ -382,6 +378,10 @@ function inference_error_report_code(@nospecialize report::JET.InferenceErrorRep
         else
             return INFERENCE_UNDEF_LOCAL_VAR_CODE
         end
+    elseif report isa FieldErrorReport
+        return INFERENCE_FIELD_ERROR_CODE
+    elseif report isa BoundsErrorReport
+        return INFERENCE_BOUNDS_ERROR_CODE
     end
     error(lazy"Diagnostic code is not defined for this report: $report")
 end
@@ -389,8 +389,19 @@ end
 function jet_frame_to_location(frame)
     frame.file === :none && return nothing
     return Location(;
-        uri = filepath2uri(to_full_path(frame.file)),
+        uri = something(jet_frame_to_uri(frame)),
         range = jet_frame_to_range(frame))
+end
+
+function jet_frame_to_uri(frame)
+    frame.file === :none && return nothing
+    filename = String(frame.file)
+    # TODO Clean this up and make we can always use `filename2uri` here.
+    if startswith(filename, "Untitled")
+        return filename2uri(filename)
+    else
+        return filepath2uri(to_full_path(filename))
+    end
 end
 
 function jet_frame_to_range(frame)

--- a/src/types.jl
+++ b/src/types.jl
@@ -337,6 +337,8 @@ const TOPLEVEL_ERROR_CODE = "toplevel/error"
 const INFERENCE_UNDEF_GLOBAL_VAR_CODE = "inference/undef-global-var"
 const INFERENCE_UNDEF_LOCAL_VAR_CODE = "inference/undef-local-var"
 const INFERENCE_UNDEF_STATIC_PARAM_CODE = "inference/undef-static-param" # currently not reported
+const INFERENCE_FIELD_ERROR_CODE = "inference/field-error"
+const INFERENCE_BOUNDS_ERROR_CODE = "inference/bounds-error"
 const TESTRUNNER_TEST_FAILURE_CODE = "testrunner/test-failure"
 
 const ALL_DIAGNOSTIC_CODES = Set{String}(String[
@@ -349,6 +351,8 @@ const ALL_DIAGNOSTIC_CODES = Set{String}(String[
     INFERENCE_UNDEF_GLOBAL_VAR_CODE,
     INFERENCE_UNDEF_LOCAL_VAR_CODE,
     INFERENCE_UNDEF_STATIC_PARAM_CODE,
+    INFERENCE_FIELD_ERROR_CODE,
+    INFERENCE_BOUNDS_ERROR_CODE,
     TESTRUNNER_TEST_FAILURE_CODE,
 ])
 

--- a/test/interactive-utils.jl
+++ b/test/interactive-utils.jl
@@ -1,10 +1,15 @@
 using JETLS: JET, JETLS
+using JETLS.Analyzer
 using InteractiveUtils: InteractiveUtils
 
 # interactive entry points for LSAnalyzer
 
-function analyze_call(args...; jetconfigs...)
-    analyzer = JETLS.LSAnalyzer(; jetconfigs...)
+function analyze_call(
+        args...;
+        report_target_modules = nothing,
+        jetconfigs...
+    )
+    analyzer = JETLS.LSAnalyzer(; report_target_modules, jetconfigs...)
     return JET.analyze_and_report_call!(analyzer, args...; jetconfigs...)
 end
 macro analyze_call(ex0...)

--- a/test/test_Analyzer.jl
+++ b/test/test_Analyzer.jl
@@ -3,13 +3,30 @@ module test_Analyzer
 using Test
 include("interactive-utils.jl")
 using JETLS.JET: get_reports
-using JETLS.Analyzer: UndefVarErrorReport
+using JETLS.Analyzer
+
+baremodule ExternalModule end
+
+baremodule TestTargetModule
+    function func()
+        undefvar
+    end
+end
 
 # test basic analysis abilities of `LSAnalyzer`
 function report_global_undef()
     return sin(undefvar)
 end
 @noinline callfunc(f) = f()
+
+struct Issue392
+    property::Int
+end
+function issue392()
+    x = Issue392(42)
+    println(x.propert)
+    return x
+end
 
 @testset "LSAnalyzer" begin
     # global undef variables
@@ -26,6 +43,16 @@ end
         @test length(reports) == 1
         r = only(reports)
         @test r isa UndefVarErrorReport && r.var == GlobalRef(@__MODULE__, :undefvar)
+    end
+
+    # getglobal(::Module, ::Symbol)
+    let result = analyze_call() do
+            TestTargetModule.unexisting
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa UndefVarErrorReport && r.var == GlobalRef(TestTargetModule, :unexisting)
     end
 
     # local undef variables
@@ -59,25 +86,198 @@ end
     end
 end
 
-module TestTargetModule
-    function func()
-        undefvar
+@testset "FieldError analysis" begin
+    let result = analyze_call((Some{Int},)) do some
+            some.value
+        end
+        @test isempty(get_reports(result))
+    end
+    let result = analyze_call((Some{Int},)) do some
+            some.val
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa FieldErrorReport && r.type === Some{Int} && r.field === :val
+    end
+    let result = analyze_call((Some,)) do some
+            some.val
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa FieldErrorReport && r.field === :val
+    end
+
+    let result = analyze_call(issue392)
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa FieldErrorReport && r.field === :propert
+    end
+
+    let result = analyze_call((Some,)) do some
+            fieldtype(some, :val)
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa FieldErrorReport && r.field === :val
     end
 end
 
-@testset "target_modules" begin
-    let result = analyze_call(; target_modules=()) do
+@testset "BoundsError analysis" begin
+    # `getindex(::Tuple, ::Int)`
+    let result = analyze_call((Tuple{Int},)) do tpl1
+            tpl1[1]
+        end
+        @test isempty(get_reports(result))
+    end
+    let result = analyze_call((Tuple{Int},)) do tpl1
+            tpl1[0]
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa BoundsErrorReport && r.a === Tuple{Int} && r.i === 0
+    end
+    let result = analyze_call((Tuple{Any},)) do tpl1
+            tpl1[2]
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa BoundsErrorReport && r.a === Tuple{Any} && r.i === 2
+    end
+
+    # `getindex(::NamedTuple, ::Int)`
+    let result = analyze_call((Int,)) do x
+            (;x)[1]
+        end
+        @test isempty(get_reports(result))
+    end
+    let result = analyze_call((Int,Int)) do x, y
+            (;x,y)[2]
+        end
+        @test isempty(get_reports(result))
+    end
+    let result = analyze_call((Int,)) do x
+            (;x)[2]
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa BoundsErrorReport && r.a === @NamedTuple{x::Int} && r.i === 2
+    end
+
+    # `getindex(::Pair, ::Int)`
+    let result = analyze_call((Int,Int)) do x, y
+            (x=>y)[1]
+        end
+        @test isempty(get_reports(result))
+    end
+    let result = analyze_call((Int,Int)) do x, y
+            (x=>y)[0]
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa BoundsErrorReport && r.a === Pair{Int,Int} && r.i === 0
+    end
+
+    # `Base.indexed_iterate`
+    let result = analyze_call((Tuple{Any,Any},)) do tpl2
+            a, b = tpl2
+        end
+        @test isempty(get_reports(result))
+    end
+    let result = analyze_call((Pair{Any,Any},)) do pair
+            a, b = pair
+        end
+        @test isempty(get_reports(result))
+    end
+    let result = analyze_call((Tuple{Any,Any},)) do tpl2
+            a, b, c = tpl2
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa BoundsErrorReport && r.a === Tuple{Any,Any} && r.i === 3
+    end
+    let result = analyze_call((Pair{Any,Any},)) do pair
+            a, b, c = pair
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa BoundsErrorReport && r.a === Pair{Any,Any} && r.i === 3
+    end
+
+    # `fieldtype`
+    let result = analyze_call((Int,Int)) do x, y
+            fieldtype((;x,y), 3)
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa BoundsErrorReport && r.a === @NamedTuple{x::Int,y::Int} && r.i === 3
+    end
+end
+
+@testset "report_target_modules" begin
+    let result = analyze_call(; report_target_modules=()) do
             TestTargetModule.func()
         end
         @test isempty(get_reports(result))
     end
-    let result = analyze_call(; target_modules=(TestTargetModule,)) do
+
+    # UndefVarErrorReport
+    let result = analyze_call(; report_target_modules=(@__MODULE__,TestTargetModule,)) do
             TestTargetModule.func()
         end
         reports = get_reports(result)
         @test length(reports) == 1
         r = only(reports)
-        @test r isa UndefVarErrorReport && r.var == GlobalRef(TestTargetModule, :undefvar)
+        @test r isa UndefVarErrorReport && r.var == GlobalRef(TestTargetModule, :undefvar) && r.vst_offset == 0
+    end
+    let result = analyze_call(; report_target_modules=(@__MODULE__,)) do
+            TestTargetModule.unexisting
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa UndefVarErrorReport && r.var == GlobalRef(TestTargetModule, :unexisting) && r.vst_offset == 1
+    end
+    let result = analyze_call(; report_target_modules=(ExternalModule,)) do
+            TestTargetModule.func()
+        end
+        @test isempty(get_reports(result))
+    end
+
+    # FieldErrorReport
+    let result = analyze_call(issue392; report_target_modules=(@__MODULE__,))
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa FieldErrorReport && r.field === :propert && r.vst_offset == 1
+    end
+    let result = analyze_call(issue392; report_target_modules=(ExternalModule,))
+        @test isempty(get_reports(result))
+    end
+
+    # BoundsErrorReport
+    let result = analyze_call((Pair{Any,Any},); report_target_modules=(@__MODULE__,)) do pair
+            a, b, c = pair
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa BoundsErrorReport && r.a === Pair{Any,Any} && r.i === 3 && r.vst_offset == 1
+    end
+    let result = analyze_call((Pair{Any,Any},); report_target_modules=(ExternalModule,)) do pair
+            a, b, c = pair
+        end
+        @test isempty(get_reports(result))
     end
 end
 


### PR DESCRIPTION
Analyzer: FieldError & BoundsError analysis

Add static analysis for field access errors by hooking into
`CC.builtin_tfunction` to intercept `getfield`, `setfield!`,
`fieldtype`, and `getglobal` calls.

Two new report types are introduced:
- `FieldErrorReport` (`inference/field-error`): reported when accessing
  a non-existent field by name
- `BoundsErrorReport` (`inference/bounds-error`): reported when
  accessing a field by an out-of-bounds integer index
  
Note that the `inference/bounds-error` diagnostic is reported when code
attempts to access a struct field using an integer index that is out of
bounds, such as `getfield(x, i)` or tuple indexing `tpl[i]`, and not
reported for  arrays, since the compiler doesn't track array shape 
information.

Reports from invalid `setfield!` and `fieldtype`, and general invalid
argument types are left as future TODO.

Also adjusts concrete evaluation logic to enable ad-hoc constant
propagation after failed concrete evaluation for better accuracy.

Closes #392 
Also fixes #327 