### PR TITLE
rename: Add file rename support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Initialization options can now be configured via `.JETLSConfig.toml` using the
   `[initialization_options]` section. See the [documentation](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options/configure)
   for details.
+- Added file rename support. When renaming a string literal that refers to a
+  valid file path (e.g., in `include("foo.jl")`), JETLS now renames both the
+  file on disk and updates the string reference in the source code.
 
 ### Fixed
 

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -516,6 +516,16 @@ function select_target_identifier(st0::JL.SyntaxTree, offset::Int)
     return select_target_node(filter, selector, st0, offset)
 end
 
+function select_target_string(st0::JL.SyntaxTree, offset::Int)
+    filter = function (bas)
+        JS.kind(first(bas)) === JS.K"String"
+    end
+    selector = function (bas)
+        return first(bas)
+    end
+    return select_target_node(filter, selector, st0, offset)
+end
+
 function select_target_node(filter, selector, st0::JL.SyntaxTree, offset::Int)
     bas = byte_ancestors(st0, offset)
 


### PR DESCRIPTION
Add the ability to rename files referenced in string literals. When the cursor is on a string that refers to an existing file path (e.g., in `include("foo.jl")`), the rename operation now renames both the file on disk and updates the string reference in the source code.