### PR TITLE
analyzer: Fix false positive undef-global-var in dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added CHANGELOG page to the documentation.
 
+### Fixed
+
+- Fixed `inference/undef-global-var` diagnostic being unintentially reported for
+  undefined global bindings in dependency packages.
+
 ## 2025-12-18
 
 - Commit: [`c9c5729`](https://github.com/aviatesk/JETLS.jl/commit/c9c5729)

--- a/test/test_Analyzer.jl
+++ b/test/test_Analyzer.jl
@@ -254,6 +254,14 @@ end
         @test isempty(get_reports(result))
     end
 
+    # For `GlobalRef`s used directly at the source level (i.e. global binding access that is not `getglobal`),
+    # only analyze those from modules directly specified in `report_target_modules`
+    let result = analyze_call(; report_target_modules=(@__MODULE__,)) do
+            TestTargetModule.func()
+        end
+        @test isempty(get_reports(result))
+    end
+
     # FieldErrorReport
     let result = analyze_call(issue392; report_target_modules=(@__MODULE__,))
         reports = get_reports(result)


### PR DESCRIPTION
Previously, when calling a function from another module, undefined global variables inside that function could be reported if the caller's module was in `report_target_modules`. This was because the parent frame check in `should_analyze_for_builtins` allowed reporting with offset=1.

Now, direct source-level `GlobalRef`s (not accessed via `getglobal`) are analyzed with `allowed_offset=0`, ensuring they are only reported when their own module is explicitly in `report_target_modules`.