### PR TITLE
code-action: Add quickfix to prefix unused variables with '_'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added `diagnostic.allow_unused_underscore` configuration option (default: `true`).
   When enabled, unused variable diagnostics (`lowering/unused-argument` and
   `lowering/unused-local`) are suppressed for names starting with `_`.
+- Added code action to prefix unused variables with `_`. When triggered on an
+  unused variable diagnostic, this quickfix inserts `_` at the beginning of
+  the variable name to suppress the warning.
 
 ### Fixed
 

--- a/src/code-action.jl
+++ b/src/code-action.jl
@@ -39,8 +39,39 @@ function handle_CodeActionRequest(
     testsetinfos = fi.testsetinfos
     isempty(testsetinfos) ||
         testrunner_code_actions!(code_actions, uri, fi, testsetinfos, msg.params.range)
+    allow_unused_underscore = get_config(server.state.config_manager, :diagnostic, :allow_unused_underscore)
+    unused_variable_code_actions!(code_actions, uri, msg.params.context.diagnostics; allow_unused_underscore)
     return send(server,
         CodeActionResponse(;
             id = msg.id,
             result = isempty(code_actions) ? null : code_actions))
+end
+
+function unused_variable_code_actions!(
+        code_actions::Vector{Union{CodeAction,Command}},
+        uri::URI,
+        diagnostics::Vector{Diagnostic};
+        allow_unused_underscore::Bool = true
+    )
+    for diagnostic in diagnostics
+        code = diagnostic.code
+        if code == LOWERING_UNUSED_ARGUMENT_CODE || code == LOWERING_UNUSED_LOCAL_CODE
+            range = diagnostic.range
+            insert_pos = Position(; line=range.start.line, character=range.start.character)
+            edit = WorkspaceEdit(;
+                changes = Dict(
+                    uri => [TextEdit(;
+                        range = Range(; start=insert_pos, var"end"=insert_pos),
+                        newText = "_")]))
+            push!(code_actions, CodeAction(;
+                title = "Prefix with '_' to indicate intentionally unused",
+                kind = CodeActionKind.QuickFix,
+                diagnostics = [diagnostic],
+                isPreferred = allow_unused_underscore,
+                disabled = allow_unused_underscore ? nothing :
+                    (; reason = "Disabled because `diagnostic.allow_unused_underscore` is false"),
+                edit))
+        end
+    end
+    return code_actions
 end


### PR DESCRIPTION
Add a code action that inserts `_` prefix for unused variable diagnostics (`lowering/unused-argument` and `lowering/unused-local`). This allows users to quickly suppress unused variable warnings by marking variables as intentionally unused.

The code action respects the `diagnostic.allow_unused_underscore` configuration:
- When enabled (default): action is available and marked as preferred
- When disabled: action is shown as disabled with an explanation

Written by Claude