### PR TITLE
diagnostic: Report method overwrite warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added code action to prefix unused variables with `_`. When triggered on an
   unused variable diagnostic, this quickfix inserts `_` at the beginning of
   the variable name to suppress the warning.
+- Added warning diagnostic for method overwrites (`toplevel/method-overwrite`).
+  When a method with the same signature is defined multiple times within a
+  package, a warning is reported at the overwriting definition with a link to
+  the original definition. Addresses
+  https://github.com/aviatesk/JETLS.jl/issues/387.
 
 ### Fixed
 

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [sources]
-JET = {rev = "f577f65", url = "https://github.com/aviatesk/JET.jl"}
+JET = {rev = "3e04eb6", url = "https://github.com/aviatesk/JET.jl"}
 JuliaLowering = {rev = "avi/JETLS-JSJL-head-2025-12-22", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
 JuliaSyntax = {rev = "avi/JETLS-JSJL-head-2025-12-22", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
 LSP = {path = "LSP"}

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -65,6 +65,7 @@ Here is a summary table of the diagnostics explained in this section:
 | [`lowering/unused-argument`](@ref diagnostic/lowering/unused-argument)             | `Information`         | Function arguments that are never used                         |
 | [`lowering/unused-local`](@ref diagnostic/lowering/unused-local)                   | `Information`         | Local variables that are assigned but never read               |
 | [`toplevel/error`](@ref diagnostic/toplevel/error)                                 | `Error`               | Errors during code loading (missing deps, type failures, etc.) |
+| [`toplevel/method-overwrite`](@ref diagnostic/toplevel/method-overwrite)           | `Warning`             | Method definitions that overwrite previously defined methods   |
 | [`inference/undef-global-var`](@ref diagnostic/inference/undef-global-var)         | `Warning`             | References to undefined global variables                       |
 | [`inference/undef-local-var`](@ref diagnostic/inference/undef-local-var)           | `Information/Warning` | References to undefined local variables                        |
 | [`inference/field-error`](@ref diagnostic/inference/field-error)                   | `Warning`             | Access to non-existent struct fields                           |
@@ -208,6 +209,30 @@ These errors prevent JETLS from fully analyzing your code, which means
 the top-level errors are resolved. To fix these errors, ensure your package
 environment is properly set up by running `Pkg.instantiate()` in your package
 directory, and verify that your package can be loaded successfully in a Julia REPL.
+
+#### [Method overwrite (`toplevel/method-overwrite`)](@id diagnostic/toplevel/method-overwrite)
+
+**Default severity:** `Warning`
+
+Reported when a method with the same signature is defined multiple times within
+a package. This typically indicates an unintentional redefinition that
+overwrites the previous method.
+
+Example:
+
+```julia
+function duplicate(x::Int)
+    return x + 1
+end
+
+function duplicate(x::Int, y::Int=2)  # Method definition duplicate(x::Int) in module MyPkg overwritten
+                                      # (JETLS toplevel/method-overwrite)
+    return x + y
+end
+```
+
+The diagnostic includes a link to the original definition location via
+`relatedInformation`, making it easy to navigate to the first definition.
 
 ### [Inference diagnostic (`inference/*`)](@id inference-diagnostic)
 

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -82,6 +82,21 @@ include("init-options.jl")
 include("config.jl")
 include("workspace-configuration.jl")
 
+abstract type ToplevelWarningReport end
+
+struct MethodOverwriteReport <: ToplevelWarningReport
+    mod::Module
+    sig::Type
+    filepath::String
+    lines::Pair{Int,Int}
+    original_filepath::String
+    original_lines::Pair{Int,Int}
+    MethodOverwriteReport(
+        mod::Module, @nospecialize(sig::Type), filepath::AbstractString, lines::Pair{Int,Int},
+        original_filepath::AbstractString, original_lines::Pair{Int,Int}
+    ) = new(mod, sig, filepath, lines, original_filepath, original_lines)
+end
+
 include("analysis/Interpreter.jl")
 using .Interpreter
 

--- a/src/analysis/Interpreter.jl
+++ b/src/analysis/Interpreter.jl
@@ -24,18 +24,21 @@ struct LSInterpreter{S<:Server} <: JET.ConcreteInterpreter
     analyzer::LSAnalyzer
     counter::Counter
     activation_done::Union{Nothing,Base.Event}
+    warning_reports::Vector{JETLS.ToplevelWarningReport}
     state::JET.InterpretationState
     function LSInterpreter(
             server::S, request::AnalysisRequest, analyzer::LSAnalyzer, counter::Counter,
             activation_done::Union{Nothing,Base.Event}
         ) where S<:Server
-        return new{S}(server, request, analyzer, counter, activation_done)
+        return new{S}(server, request, analyzer, counter, activation_done, JETLS.ToplevelWarningReport[])
     end
     function LSInterpreter(
             server::S, request::AnalysisRequest, analyzer::LSAnalyzer, counter::Counter,
-            activation_done::Union{Nothing,Base.Event}, state::JET.InterpretationState
+            activation_done::Union{Nothing,Base.Event},
+            warning_reports::Vector{JETLS.ToplevelWarningReport},
+            state::JET.InterpretationState,
         ) where S<:Server
-        return new{S}(server, request, analyzer, counter, activation_done, state)
+        return new{S}(server, request, analyzer, counter, activation_done, warning_reports, state)
     end
 end
 
@@ -52,7 +55,7 @@ JET.InterpretationState(interp::LSInterpreter) = interp.state
 function JET.ConcreteInterpreter(interp::LSInterpreter, state::JET.InterpretationState)
     return LSInterpreter(
         interp.server, interp.request, interp.analyzer, interp.counter,
-        interp.activation_done, state)
+        interp.activation_done, interp.warning_reports, state)
 end
 JET.ToplevelAbstractAnalyzer(interp::LSInterpreter) = interp.analyzer
 function JET.ToplevelAbstractAnalyzer(
@@ -70,6 +73,27 @@ end
 
 # overloads
 # =========
+
+struct MethodDefinitionInfo
+    filename::String
+    mod::Module
+    src::Core.CodeInfo
+end
+
+const empty_lines_range = typemax(Int) => typemin(Int)
+
+function get_lines_in_src(filepath::AbstractString, src::Core.CodeInfo)
+    lines = empty_lines_range
+    for pc in 1:length(src.code)
+        lins = Base.IRShow.buildLineInfoNode(src.debuginfo, nothing, pc)
+        for lin in lins
+            if filepath == String(lin.file)
+                lines = min(lin.line,first(lines)) => max(lin.line,last(lines))
+            end
+        end
+    end
+    return lines
+end
 
 mutable struct SignatureAnalysisProgress
     const reports::Vector{JET.InferenceErrorReport}
@@ -89,7 +113,7 @@ end
 
 function cache_intermediate_analysis_result!(interp::LSInterpreter)
     result = JET.JETToplevelResult(interp.analyzer, interp.state.res, "LSInterpreter (intermediate result)", ())
-    intermediate_result = JETLS.new_analysis_result(interp.request, result)
+    intermediate_result = JETLS.new_analysis_result(interp, interp.request, result)
     JETLS.update_analysis_cache!(interp.server.state.analysis_manager, intermediate_result)
 end
 
@@ -108,8 +132,23 @@ function JET.analyze_from_definitions!(interp::LSInterpreter, config::JET.Toplev
     res = JET.InterpretationState(interp).res
     reset_report_target_modules!(interp.analyzer, res.analyzed_files)
 
+    # Detect method overwrites
+    seen_sigs = IdDict{Type,MethodDefinitionInfo}()
+    for signature_info in res.signature_infos
+        (; filename, mod, tt, src) = signature_info
+        if haskey(seen_sigs, tt)
+            lines = get_lines_in_src(filename, src)
+            original_definition = seen_sigs[tt]
+            original_filename = original_definition.filename
+            original_lines = get_lines_in_src(original_filename, original_definition.src)
+            push!(interp.warning_reports, JETLS.MethodOverwriteReport(mod, tt, filename, lines, original_filename, original_lines))
+        else
+            seen_sigs[tt] = MethodDefinitionInfo(filename, mod, src)
+        end
+    end
+
     entrypoint = config.analyze_from_definitions
-    n_sigs = length(res.toplevel_signatures)
+    n_sigs = length(res.signature_infos)
     n_sigs == 0 && return
     cancellable_token = interp.request.cancellable_token
     if cancellable_token !== nothing
@@ -131,7 +170,7 @@ function JET.analyze_from_definitions!(interp::LSInterpreter, config::JET.Toplev
             if cancellable_token !== nothing && is_cancelled(cancellable_token.cancel_flag)
                 return
             end
-            tt = res.toplevel_signatures[i]
+            (; tt) = res.signature_infos[i]
             # Create a new analyzer with fresh local caches (`inf_cache` and `analysis_results`)
             # to avoid data races between concurrent signature analysis tasks
             analyzer = JET.ToplevelAbstractAnalyzer(interp, JET.non_toplevel_concretized;

--- a/src/types.jl
+++ b/src/types.jl
@@ -334,6 +334,7 @@ const LOWERING_UNUSED_LOCAL_CODE = "lowering/unused-local"
 const LOWERING_ERROR_CODE = "lowering/error"
 const LOWERING_MACRO_EXPANSION_ERROR_CODE = "lowering/macro-expansion-error"
 const TOPLEVEL_ERROR_CODE = "toplevel/error"
+const TOPLEVEL_METHOD_OVERWRITE_CODE = "toplevel/method-overwrite"
 const INFERENCE_UNDEF_GLOBAL_VAR_CODE = "inference/undef-global-var"
 const INFERENCE_UNDEF_LOCAL_VAR_CODE = "inference/undef-local-var"
 const INFERENCE_UNDEF_STATIC_PARAM_CODE = "inference/undef-static-param" # currently not reported
@@ -348,6 +349,7 @@ const ALL_DIAGNOSTIC_CODES = Set{String}(String[
     LOWERING_ERROR_CODE,
     LOWERING_MACRO_EXPANSION_ERROR_CODE,
     TOPLEVEL_ERROR_CODE,
+    TOPLEVEL_METHOD_OVERWRITE_CODE,
     INFERENCE_UNDEF_GLOBAL_VAR_CODE,
     INFERENCE_UNDEF_LOCAL_VAR_CODE,
     INFERENCE_UNDEF_STATIC_PARAM_CODE,


### PR DESCRIPTION

<img width="850" height="345" alt="Screenshot 2025-12-31 at 04 31 44" src="https://github.com/user-attachments/assets/5c4aa6f7-ebd8-4e07-b3c6-ad6159a76508" />

Add `toplevel/method-overwrite` diagnostic that warns when a method with the same signature is defined multiple times within a package.

The diagnostic message shows the method signature and module name, with a link to navigate to the first definition location.

Closes #387 