### PR TITLE
diagnostic: Report abstract field type information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   package, a warning is reported at the overwriting definition with a link to
   the original definition. Addresses
   https://github.com/aviatesk/JETLS.jl/issues/387.
+- Added information diagnostic for abstract field types (`toplevel/abstract-field`).
+  Reports when a struct field has an abstract type (e.g., `Vector{Integer}` or
+  `AbstractVector{Int}`), which often causes performance issues due to type
+  instability.
 
 ### Fixed
 

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -82,20 +82,7 @@ include("init-options.jl")
 include("config.jl")
 include("workspace-configuration.jl")
 
-abstract type ToplevelWarningReport end
-
-struct MethodOverwriteReport <: ToplevelWarningReport
-    mod::Module
-    sig::Type
-    filepath::String
-    lines::Pair{Int,Int}
-    original_filepath::String
-    original_lines::Pair{Int,Int}
-    MethodOverwriteReport(
-        mod::Module, @nospecialize(sig::Type), filepath::AbstractString, lines::Pair{Int,Int},
-        original_filepath::AbstractString, original_lines::Pair{Int,Int}
-    ) = new(mod, sig, filepath, lines, original_filepath, original_lines)
-end
+include("diagnostics.jl")
 
 include("analysis/Interpreter.jl")
 using .Interpreter
@@ -112,7 +99,6 @@ include("definition.jl")
 include("references.jl")
 include("hover.jl")
 include("document-highlight.jl")
-include("diagnostics.jl")
 include("code-action.jl")
 include("code-lens.jl")
 include("formatting.jl")

--- a/src/types.jl
+++ b/src/types.jl
@@ -335,6 +335,7 @@ const LOWERING_ERROR_CODE = "lowering/error"
 const LOWERING_MACRO_EXPANSION_ERROR_CODE = "lowering/macro-expansion-error"
 const TOPLEVEL_ERROR_CODE = "toplevel/error"
 const TOPLEVEL_METHOD_OVERWRITE_CODE = "toplevel/method-overwrite"
+const TOPLEVEL_ABSTRACT_FIELD_CODE = "toplevel/abstract-field"
 const INFERENCE_UNDEF_GLOBAL_VAR_CODE = "inference/undef-global-var"
 const INFERENCE_UNDEF_LOCAL_VAR_CODE = "inference/undef-local-var"
 const INFERENCE_UNDEF_STATIC_PARAM_CODE = "inference/undef-static-param" # currently not reported
@@ -350,6 +351,7 @@ const ALL_DIAGNOSTIC_CODES = Set{String}(String[
     LOWERING_MACRO_EXPANSION_ERROR_CODE,
     TOPLEVEL_ERROR_CODE,
     TOPLEVEL_METHOD_OVERWRITE_CODE,
+    TOPLEVEL_ABSTRACT_FIELD_CODE,
     INFERENCE_UNDEF_GLOBAL_VAR_CODE,
     INFERENCE_UNDEF_LOCAL_VAR_CODE,
     INFERENCE_UNDEF_STATIC_PARAM_CODE,

--- a/src/utils/general.jl
+++ b/src/utils/general.jl
@@ -230,3 +230,24 @@ function check_settings_message(setting_path::Symbol...)
 end
 
 app_notfound_message(app::AbstractString) = "`$app` executable is not found on the `PATH`."
+
+function is_abstract_fieldtype(@nospecialize typ)
+    if typ isa Type
+        if typ isa UnionAll
+            # If field type is `UnionAll`, then it's always an abstract field type, e.g.
+            # `struct A; xs::Vector{<:Integer}; end`
+            return true
+        end
+        if isabstracttype(typ)
+            return true
+        end
+        if typ isa DataType
+            for i = 1:length(typ.parameters)
+                if is_abstract_fieldtype(typ.parameters[i])
+                    return true
+                end
+            end
+        end
+    end
+    return false
+end

--- a/test/utils/test_general.jl
+++ b/test/utils/test_general.jl
@@ -34,4 +34,13 @@ using JETLS
     @test JETLS.format_duration(119.99) == "1m 60.0s" # 119.99s = 1m 59.99s, rounds to 60.0s
 end
 
+@testset "is_abstract_fieldtype" begin
+    @test !JETLS.is_abstract_fieldtype(Int)
+    @test !JETLS.is_abstract_fieldtype(Vector{Int})
+    @test JETLS.is_abstract_fieldtype(AbstractVector{Int})
+    @test JETLS.is_abstract_fieldtype(Vector{Integer})
+    @test JETLS.is_abstract_fieldtype(Vector{<:Integer})
+    @test !JETLS.is_abstract_fieldtype(Vector{TypeVar(:T)}) # For cases like `struct A{T}; xs::Vector{T}; end`
+end
+
 end # module test_general


### PR DESCRIPTION
Add a new `Information` level diagnostic (`toplevel/abstract-field`) that reports when a struct field has an abstract type. This helps catch potential performance issues caused by type instability.

The detection works by hooking into `JuliaInterpreter.step_expr!` and checking for `Core._typebody!` calls. When a struct is being defined, the field types are inspected using the new `is_abstract_fieldtype` helper function.

Currently detects cases like `Vector{Integer}` and `AbstractVector{Int}` but does not yet handle `UnionAll` types like `Vector{<:Integer}`.