### PR TITLE
diagnostic: Improve abstract field info location

### DIFF
--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -594,7 +594,7 @@ function new_analysis_result(interp::LSInterpreter, request::AnalysisRequest, re
 
     uri2diagnostics = URI2Diagnostics(uri => Diagnostic[] for uri in keys(analyzed_file_infos))
     postprocessor = JET.PostProcessor(result.res.actual2virtual)
-    toplevel_warning_reports_to_diagnostics!(uri2diagnostics, interp.warning_reports, postprocessor)
+    toplevel_warning_reports_to_diagnostics!(uri2diagnostics, interp.warning_reports, interp.server, postprocessor)
     jet_result_to_diagnostics!(uri2diagnostics, result, postprocessor)
 
     (; entry, prev_analysis_result) = request
@@ -840,7 +840,7 @@ function analyze_package_with_revise(
     uri2diagnostics = URI2Diagnostics(uri => Diagnostic[] for uri in keys(analyzed_file_infos))
     postprocessor = JET.PostProcessor()
 
-    toplevel_warning_reports_to_diagnostics!(uri2diagnostics, warning_reports, postprocessor)
+    toplevel_warning_reports_to_diagnostics!(uri2diagnostics, warning_reports, interp.server, postprocessor)
     inference_reports = collect_displayable_reports(progress.reports, keys(uri2diagnostics))
     unique!(JET.aggregation_policy(analyzer), inference_reports)
     jet_inference_error_reports_to_diagnostics!(uri2diagnostics, inference_reports, postprocessor)

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -49,7 +49,7 @@ Otherwise, creates a new `SavedFileInfo` entry in the cache.
 cache_saved_file_info!(state::ServerState, uri::URI, text::String) =
     cache_saved_file_info!(state, uri, ParseStream!(text))
 function cache_saved_file_info!(state::ServerState, uri::URI, parsed_stream::JS.ParseStream)
-    sfi = SavedFileInfo(parsed_stream, uri)
+    sfi = SavedFileInfo(parsed_stream, uri, state.encoding)
     store!(state.saved_file_cache) do cache
         Base.PersistentDict(cache, uri => sfi), sfi
     end

--- a/src/notebook.jl
+++ b/src/notebook.jl
@@ -33,7 +33,7 @@ end
 function cache_notebook_saved_file_info!(server::Server, notebook_uri::URI, notebook_info::NotebookInfo)
     state = server.state
     parsed_stream = ParseStream!(notebook_info.concat.source)
-    sfi = SavedFileInfo(parsed_stream, notebook_uri)
+    sfi = SavedFileInfo(parsed_stream, notebook_uri, state.encoding)
     return store!(state.saved_file_cache) do cache
         Base.PersistentDict(cache, notebook_uri => sfi), sfi
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -60,11 +60,12 @@ end
 struct SavedFileInfo
     parsed_stream::JS.ParseStream
     syntax_node::JS.SyntaxNode
+    encoding::LSP.PositionEncodingKind.Ty
 
-    function SavedFileInfo(parsed_stream::JS.ParseStream, uri::URI)
+    function SavedFileInfo(parsed_stream::JS.ParseStream, uri::URI, encoding::LSP.PositionEncodingKind.Ty)
         filename = uri2filename(uri)
         syntax_node = JS.build_tree(JS.SyntaxNode, parsed_stream; filename)
-        new(parsed_stream, syntax_node)
+        new(parsed_stream, syntax_node, encoding)
     end
 end
 

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -547,7 +547,7 @@ end
 
 """
     jsobj_to_range(
-            obj, fi::FileInfo;
+            obj, fi::Union{FileInfo,SavedFileInfo};
             adjust_first::Int = 0, adjust_last::Int = 0
         ) -> range::LSP.Range
 
@@ -579,7 +579,7 @@ This follows the standard convention where the end position points to the first
 character/byte that is NOT part of the range.
 """
 function jsobj_to_range(
-        obj, fi::FileInfo;
+        obj, fi::Union{FileInfo,SavedFileInfo};
         adjust_first::Int = 0, adjust_last::Int = 0
     )
     fb = JS.first_byte(obj)

--- a/src/utils/string.jl
+++ b/src/utils/string.jl
@@ -116,6 +116,7 @@ end
 
 """
     offset_to_xy(fi::FileInfo, byte::Integer) -> pos::Position
+    offset_to_xy(sfi::SavedFileInfo, byte::Integer) -> pos::Position
 
 Convert a 1-based byte offset to a 0-based line and character number.
 
@@ -136,6 +137,8 @@ to the specified encoding per LSP specification:
 function offset_to_xy end
 
 offset_to_xy(fi::FileInfo, byte::Integer) = _offset_to_xy(fi.parsed_stream.textbuf, byte, fi.encoding)
+offset_to_xy(sfi::SavedFileInfo, byte::Integer) = _offset_to_xy(sfi.parsed_stream.textbuf, byte, sfi.encoding)
+
 offset_to_xy( # used by tests
     s::Union{Vector{UInt8},AbstractString}, byte::Integer, filename::AbstractString,
     encoding::PositionEncodingKind.Ty = PositionEncodingKind.UTF16

--- a/test/utils/test_ast.jl
+++ b/test/utils/test_ast.jl
@@ -547,4 +547,29 @@ end
     end
 end
 
+@testset "`_try_extract_field_line`" begin
+    @test JETLS.Interpreter._try_extract_field_line(jsparse("""
+        struct A
+            xs::Vector{Int}
+        end
+    """), :A, :xs) |> !isnothing
+    @test JETLS.Interpreter._try_extract_field_line(jsparse("""
+        struct A{T}
+            xs::Vector{T}
+        end
+    """), :A, :xs) |> !isnothing
+    @test JETLS.Interpreter._try_extract_field_line(jsparse("""
+        struct A
+            xs
+        end
+    """), :A, :xs) |> !isnothing
+    @test JETLS.Interpreter._try_extract_field_line(jsparse("""
+        begin
+            struct A
+                xs
+            end
+        end
+    """), :A, :xs) |> !isnothing
+end
+
 end # module test_ast


### PR DESCRIPTION
<img width="985" height="808" alt="Screenshot 2025-12-31 at 03 48 52" src="https://github.com/user-attachments/assets/b5f925bb-d518-4e6c-893d-2f91fb1965f6" />

Previously, `AbstractFieldReport` used the line where `Core._typebody!` was called, which didn't accurately reflect the field definition location.

This change extracts the actual field definition node from the AST by:
- Adding `current_node` field to `LSInterpreter` to track the current `SyntaxNode` being lowered
- Overloading `JET.lower_with_err_handling` to capture the node
- Implementing `try_extract_field_line` to find field definitions within struct declarations

Also adds `encoding` field to `SavedFileInfo` and extends `jsobj_to_range` and `offset_to_xy` to work with `SavedFileInfo`, enabling proper range calculation from `SyntaxNode`.