### PR TITLE
completions: enhance global completion items via lazy resolution

### DIFF
--- a/LSP/src/language-features/completions.jl
+++ b/LSP/src/language-features/completions.jl
@@ -227,11 +227,11 @@ Additional details for a completion item label
     description::Union{String, Nothing} = nothing
 end
 
-# our own data structure for `data` field of `CompletionItem`
-struct CompletionData
+# JETLS specific data structures for `data` field of `CompletionItem`
+struct GlobalCompletionData
     name::String
 end
-export CompletionData
+export GlobalCompletionData
 
 @interface CompletionItem begin
     """
@@ -414,7 +414,7 @@ export CompletionData
     A data entry field that is preserved on a completion item between
     a completion and a completion resolve request.
     """
-    data::Union{CompletionData, Nothing} = nothing
+    data::Union{GlobalCompletionData, Nothing} = nothing
 end
 
 """
@@ -489,7 +489,7 @@ presented in the editor.
         # Tags
         - since - 3.17.0
         """
-        data::Union{CompletionData, Nothing} = nothing
+        data::Union{GlobalCompletionData, Nothing} = nothing
     end} = nothing
 
     """

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -372,7 +372,7 @@ end
             # `str_macro_test`: string macro case
             @test any(items) do item
                 item.label == "text\"\"" &&
-                item.data isa CompletionData && item.data.name == "@text_str"
+                item.data isa GlobalCompletionData && item.data.name == "@text_str"
             end
             cnt += 1
         end
@@ -387,7 +387,7 @@ end
     end
     """
 
-    context = CompletionContext(; triggerKind=CompletionTriggerKind.Invoked)
+    context = CompletionContext(; triggerKind = CompletionTriggerKind.Invoked)
     cnt = 0
     with_completion_request(text; context) do _, result, _
         items = result.items
@@ -432,8 +432,8 @@ end
         end
         """
         context = CompletionContext(;
-            triggerKind=CompletionTriggerKind.TriggerCharacter,
-            triggerCharacter="@")
+            triggerKind = CompletionTriggerKind.TriggerCharacter,
+            triggerCharacter = "@")
         cnt = 0
         with_completion_request(text; context) do _, result, _
             items = result.items
@@ -459,7 +459,7 @@ end
             @no│
         end
         """
-        context = CompletionContext(; triggerKind=CompletionTriggerKind.Invoked)
+        context = CompletionContext(; triggerKind = CompletionTriggerKind.Invoked)
         cnt = 0
         with_completion_request(text; context) do _, result, _
             items = result.items
@@ -481,7 +481,7 @@ end
             @nospecialize xxx y│
         end
         """
-        context = CompletionContext(; triggerKind=CompletionTriggerKind.Invoked)
+        context = CompletionContext(; triggerKind = CompletionTriggerKind.Invoked)
         cnt = 0
         with_completion_request(text; context) do _, result, _
             items = result.items
@@ -499,7 +499,7 @@ end
             nospecia│
         end
         """
-        context = CompletionContext(; triggerKind=CompletionTriggerKind.Invoked)
+        context = CompletionContext(; triggerKind = CompletionTriggerKind.Invoked)
         cnt = 0
         with_completion_request(text; context) do _, result, _
             items = result.items
@@ -715,8 +715,8 @@ end
         end
         """
         context = CompletionContext(;
-            triggerKind=CompletionTriggerKind.TriggerCharacter,
-            triggerCharacter="\\")
+            triggerKind = CompletionTriggerKind.TriggerCharacter,
+            triggerCharacter = "\\")
         cnt = 0
         with_completion_request(text; context) do _, result, _
             items = result.items
@@ -742,8 +742,8 @@ end
         end
         """
         context = CompletionContext(;
-            triggerKind=CompletionTriggerKind.TriggerCharacter,
-            triggerCharacter=":")
+            triggerKind = CompletionTriggerKind.TriggerCharacter,
+            triggerCharacter = ":")
         cnt = 0
         with_completion_request(text; context) do _, result, _
             items = result.items

--- a/test/test_full_lifecycle.jl
+++ b/test/test_full_lifecycle.jl
@@ -53,7 +53,7 @@ let (pkgcode, positions) = JETLS.get_text_and_positions("""
             if idx !== nothing
                 item = result.items[idx]
                 data = item.data
-                @test data isa CompletionData
+                @test data isa GlobalCompletionData
                 @test isnothing(item.documentation)
 
                 let id = id_counter[] += 1, raw_res, result


### PR DESCRIPTION
Enrich `detail` and `kind` information for global completion items by performing `getglobal`-based reflection at completion resolve time. This approach maintains completion performance while providing more detailed information such as `[function]`, `[type]`, `[module]`, etc.

The visibility of these enhancements varies by client, as some clients do not update `kind` or `labelDetails` through resolve requests. In VSCode, only the `detail` field (displayed above documentation) is updated. In Zed, which supports lazy updates for all `CompletionItem` fields, combining this with aviatesk/zed-julia#1 enables richer presentation including `label` highlighting based on `kind`.

Also extract `should_invoke_auto_completion` helper to consolidate auto-completion trigger logic, and rename `CompletionData` to `GlobalCompletionData` for clarity.

> [aviatesk/zed-julia](https://github.com/aviatesk/zed-julia) demo

https://github.com/user-attachments/assets/a39d7bc5-c46e-40c8-a9ee-0458b3abdcae

> VSCode demo

https://github.com/user-attachments/assets/0f9e0de3-38ed-4bcc-aa63-2d4fcba1bffc