### PR TITLE
completion: Add method signature completion

### DIFF
--- a/LSP/src/language-features/completions.jl
+++ b/LSP/src/language-features/completions.jl
@@ -231,7 +231,13 @@ end
 struct GlobalCompletionData
     name::String
 end
-export GlobalCompletionData
+struct MethodSignatureCompletionData
+    moduleidx::Int
+    names::Vector{String}
+    methodname::String
+    methodidx::Int
+end
+export GlobalCompletionData, MethodSignatureCompletionData
 
 @interface CompletionItem begin
     """
@@ -414,7 +420,7 @@ export GlobalCompletionData
     A data entry field that is preserved on a completion item between
     a completion and a completion resolve request.
     """
-    data::Union{GlobalCompletionData, Nothing} = nothing
+    data::Union{GlobalCompletionData, MethodSignatureCompletionData, Nothing} = nothing
 end
 
 """
@@ -489,7 +495,8 @@ presented in the editor.
         # Tags
         - since - 3.17.0
         """
-        data::Union{GlobalCompletionData, Nothing} = nothing
+
+        data::Union{GlobalCompletionData, MethodSignatureCompletionData, Nothing} = nothing
     end} = nothing
 
     """

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ the list itself is subject to change.
   - [x] Global symbol completion
   - [x] Local binding completion
   - [x] LaTeX/Emoji completion
-  - [ ] Method signature completion
-  - [ ] Juno-like return type annotation for method completions
+  - [x] Method signature completion
+  - [x] Juno-like return type annotation for method completions
   - [x] Keyword argument name completion
   - [ ] Property completion
 - Signature help

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -19,7 +19,7 @@ module __demo__ end
         uri = filepath2uri(filename)
         @compile_workload let
             fi = cache_file_info!(server, uri, #=version=#1, text)
-            let items = get_completion_items(server.state, uri, fi, position, nothing)
+            let (items, _) = get_completion_items(server.state, uri, fi, position, nothing)
                 any(item->item.label=="out", items) || @warn "completion seems to be broken"
                 any(item->item.label=="bar", items) || @warn "completion seems to be broken"
             end

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -255,7 +255,7 @@ function make_paraminfo(p::JL.SyntaxTree)
     if JS.is_leaf(p)
         documentation = nothing
     elseif kind(p) in JS.KSet"= kw"
-        @assert JS.numchildren(p) === 2
+        @assert JS.numchildren(p) == 2
         label = extract_kwarg_name(p; sig=true).name_val
     elseif kind(p) === K"::"
         if JS.numchildren(p) === 1


### PR DESCRIPTION
https://github.com/user-attachments/assets/19d320a6-459f-4788-9669-d3936920b625

When typing inside a function call (triggered by `(`, `,`, or ` `), suggest compatible method signatures based on already-provided arguments. The completion inserts remaining positional arguments as snippet placeholders, respecting type annotations and varargs.

Key implementation details:
- `CallArgs` determines already-provided positional/keyword arguments
- `compatible_method` filters methods by arity and keyword compatibility
- `make_insert_text` generates snippet text from the method signature
- Returns `isIncomplete=true` so the client re-requests completions as the user continues typing, allowing transition to identifier completions
- Lazy resolution (`completionItem/resolve`) adds return type via type inference and documentation lookup