### PR TITLE
completion: Merge method signature and keyword argument completions

### DIFF
--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -98,6 +98,13 @@ as information inside macros is often not needed for these features.
 """
 remove_macrocalls(st0::JL.SyntaxTree) = first(_remove_macrocalls(st0))
 
+function unwrap_where(node::JL.SyntaxTree)
+    while JS.kind(node) === JS.K"where" && JS.numchildren(node) ≥ 1
+        node = node[1]
+    end
+    return node
+end
+
 """
 Like `Base.unique`, but over node ids, and with this comment promising that the
 lowest-index copy of each node is kept.


### PR DESCRIPTION
Combine `method_signature_completions!` and `keyword_argument_completions!` into a single `call_completions!` function to avoid redundant computation.

Both completions share the same setup: syntax tree building, `CallArgs` construction, `get_context_info()`, `resolve_type()`, and the `methods()` call. The merged function performs this setup once and iterates over candidate methods a single time, adding method signatures and/or keyword argument completions based on the cursor context.

Written by Claude