### PR TITLE
completion: Omit `=` for keyword args matching local variables

### DIFF
--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -1023,6 +1023,30 @@ end
         end
         @test cnt == 1
     end
+
+    # Don't insert `=` if the same local variable exists in the scope
+    let text = """
+        let bold = false
+            printstyled(; │
+        end
+        """
+        context = CompletionContext(;
+            triggerKind = CompletionTriggerKind.TriggerCharacter,
+            triggerCharacter = " ")
+        cnt = 0
+        with_completion_request(text; context) do _, result, _
+            items = result.items
+            keyword_items = filter(items) do item
+                item.labelDetails !== nothing &&
+                    item.labelDetails.description == "keyword argument"
+            end
+            @test !isempty(keyword_items)
+            @test any(item -> item.label == "bold" && item.insertText == "bold", keyword_items)
+            @test any(item -> item.label == "color" && item.insertText == "color = ", keyword_items)
+            cnt += 1
+        end
+        @test cnt == 1
+    end
 end
 
 @testset "should_insert_spaces_around_equal" begin


### PR DESCRIPTION
When completing keyword argument names, check if a local variable with the same name exists in scope. If so, omit the trailing `=` from the completion text. This supports Julia's shorthand syntax `f(; kwarg)` which is equivalent to `f(; kwarg=kwarg)`, making it faster to pass local variables as keyword arguments when the names match.