### PR TITLE
completion: Support anonymous typed parameters in method signatures

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -485,20 +485,23 @@ end
 function extract_param_text(p::JL.SyntaxTree)
      k = JS.kind(p)
     if k === JS.K"Identifier"
-        hasproperty(p, :name_val) || return nothing
-        return p.name_val::String
+        return extract_name_val(p)
     elseif k === JS.K"::"
-        if JS.numchildren(p) ≠ 2
-            return nothing
-        else
+        n = JS.numchildren(p)
+        if n == 1
+            typ = JS.sourcetext(p[1])
+            return String("::" * typ)
+        elseif n == 2
             name = @something extract_param_text(p[1]) return nothing
             typ = JS.sourcetext(p[2])
             return String(name * "::" * typ)
+        else
+            return nothing
         end
     elseif k === JS.K"var" && JS.numchildren(p) == 1
         inner = p[1]
-        if JS.kind(inner) === JS.K"Identifier" && hasproperty(inner, :name_val)
-            return inner.name_val::String
+        if JS.kind(inner) === JS.K"Identifier"
+            return extract_name_val(inner)
         end
     end
     return nothing
@@ -575,8 +578,7 @@ end
 
 function extract_kwarg_name_str(p::JL.SyntaxTree)
     node = @something extract_kwarg_name(p; sig=true) return nothing
-    hasproperty(node, :name_val) || return nothing
-    return node.name_val::String
+    return extract_name_val(node)
 end
 
 function should_insert_spaces_around_equal(fi::FileInfo, ca::CallArgs)

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -105,6 +105,9 @@ function unwrap_where(node::JL.SyntaxTree)
     return node
 end
 
+extract_name_val(node::JL.SyntaxTree) =
+    hasproperty(node, :name_val) ? node.name_val::String : nothing
+
 """
 Like `Base.unique`, but over node ids, and with this comment promising that the
 lowest-index copy of each node is kept.

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -777,8 +777,8 @@ end
     let p = parse_param("x::Int")
         @test JETLS.extract_param_text(p) == "x::Int"
     end
-    let p = parse_param("::Int")
-        @test JETLS.extract_param_text(p) === nothing
+    let p = parse_param("::Nothing")
+        @test JETLS.extract_param_text(p) === "::Nothing"
     end
     let p = parse_param("x::Vector{Int}")
         @test JETLS.extract_param_text(p) == "x::Vector{Int}"
@@ -818,6 +818,16 @@ end
         end
         let msig = "foo(x::T) where T where S"
             @test JETLS.make_insert_text(msig, 0, true) == "\${1:x::T}"
+        end
+        # anonymous typed parameters
+        let msig = "foo(::Nothing)"
+            @test JETLS.make_insert_text(msig, 0, true) == "\${1:::Nothing}"
+            @test JETLS.make_insert_text(msig, 1, true) === nothing
+        end
+        let msig = "foo(x, ::Nothing)"
+            @test JETLS.make_insert_text(msig, 0, true) == "\${1:x}, \${2:::Nothing}"
+            @test JETLS.make_insert_text(msig, 1, true) == "\${1:::Nothing}"
+            @test JETLS.make_insert_text(msig, 2, true) === nothing
         end
     end
 


### PR DESCRIPTION
Add `extract_name_val` helper to `src/utils/ast.jl` and refactor `extract_param_text` to handle `::Type` syntax (anonymous typed parameters like `::Nothing`). Previously these were returned as `nothing` and skipped; now they are properly extracted as `"::Type"`.