### PR TITLE
signature-help/completion: Use type-based method filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   out once the user enters the keyword argument region (e.g., `g(42;│)` no longer
   shows `g(x, y)` which requires 2 positional arguments). (https://github.com/aviatesk/JETLS.jl/pull/426)
 
+- Signature help and method completion now use type-based filtering. Method
+  candidates are filtered based on the inferred types of already-provided
+  arguments. For example, signature help and method completions triggered by
+  typing `sin(1,│` now shows only `sin(::Real)` instead of all `sin` methods.
+  Global constants are also resolved (e.g., `sin(gx,│)` with `const gx = 42`
+  correctly infers `Int`). Note that local variable types are not yet resolved,
+  (e.g., `let x = 1; sin(x,│); end` would still show all `sin` methods).
+
 - Updated Revise.jl dependency version to v3.13.
 
 ## 2026-01-01

--- a/README.md
+++ b/README.md
@@ -63,13 +63,14 @@ the list itself is subject to change.
   - [x] Local binding completion
   - [x] LaTeX/Emoji completion
   - [x] Method signature completion
+  - [/] Argument type based matched method filtering
   - [x] [Juno](https://junolab.org/)-like return type annotation for method completions
   - [x] Keyword argument name completion
   - [ ] Property completion
 - Signature help
   - [x] Basic implementation
   - [x] Macro support
-  - [ ] Argument type based matched method filtering
+  - [/] Argument type based matched method filtering
 - Definition
   - [x] Method defintion
   - [ ] Global binding definition

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -866,11 +866,53 @@ end
         cnt = 0
         with_completion_request(text; context) do _, result, _
             items = result.items
-            @test any(items) do item
+            @test count(items) do item
                 item.labelDetails !== nothing &&
                     item.labelDetails.description == "method" &&
-                    !isnothing(get_newText(item))
-            end
+                    !isnothing(get_newText(item)) &&
+                    occursin("sin", item.label)
+            end == length(methods(sin))
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    # Type-based filtering
+    let text = """
+        sin(42,│
+        """
+        context = CompletionContext(;
+            triggerKind = CompletionTriggerKind.TriggerCharacter,
+            triggerCharacter = ",")
+        cnt = 0
+        with_completion_request(text; context) do _, result, _
+            items = result.items
+            @test count(items) do item
+                item.labelDetails !== nothing &&
+                    item.labelDetails.description == "method" &&
+                    !isnothing(get_newText(item)) &&
+                    occursin("sin", item.label)
+            end == 1
+            cnt += 1
+        end
+        @test cnt == 1
+    end
+
+    let text = """let x = 42
+            sin(x,│
+        end"""
+        context = CompletionContext(;
+            triggerKind = CompletionTriggerKind.TriggerCharacter,
+            triggerCharacter = ",")
+        cnt = 0
+        with_completion_request(text; context) do _, result, _
+            items = result.items
+            @test_broken count(items) do item
+                item.labelDetails !== nothing &&
+                    item.labelDetails.description == "method" &&
+                    !isnothing(get_newText(item)) &&
+                    occursin("sin", item.label)
+            end == 1
             cnt += 1
         end
         @test cnt == 1

--- a/test/test_signature_help.jl
+++ b/test/test_signature_help.jl
@@ -316,6 +316,22 @@ end
     @test 0 === n_si(M_invalid, "f1(fake= \n │)")
 end
 
+module M_argtype_filtering
+const gx1 = 42
+const gx2 = 43
+func(x::Int) = x
+func(x::Int, y::Int) = x + y
+func(x::Float64) = x
+func(x::Float64, y::Float64) = x + y
+end
+@testset "Argument type based filtering" begin
+    @test 2 == n_si(M_argtype_filtering, "func(1,│)")
+    @test 1 == n_si(M_argtype_filtering, "func(1,2,│)")
+    @test 2 == n_si(M_argtype_filtering, "func(gx1,│)")
+    @test 1 == n_si(M_argtype_filtering, "func(gx1,gx2,│)")
+    @test_broken 2 == n_si(M_argtype_filtering, "let x = 1; func(x,│); end")
+end
+
 include("setup.jl")
 
 function with_signature_help_request(tester, text::AbstractString; kwargs...)


### PR DESCRIPTION
Replace `methods()` enumeration with type-based matching using `CC._findall`.
This filters signature help and completion candidates more accurately by considering the inferred types of call arguments.

For example, given:
```julia
func(x::Int) = x
func(x::Int, y::Int) = x + y
func(x::Float64) = x
func(x::Float64, y::Float64) = x + y
```

- `func(1,│)` now shows only 2 methods (`Int` variants) instead of all 4
- `func(1,2,│)` narrows down to just `func(::Int, ::Int)`
- `func(gx1,│)` with `const gx1 = 42` correctly shows only the 2 methods

  with `Int` variants

`compatible_method` is preserved alongside type-based filtering because it can still filter candidates in cases where type inference fails. For example, in `func(xs...,1,2,3│)`, if the type of `xs` cannot be resolved, `find_all_matches` would falls back to lookup all methods that match the signature of `Tuple{typeof(func),Vararg{Any}}`, but `compatible_method` can still exclude `func(::Int,::Int)` using the argument count information after the splat.

Current limitations:
- Type resolution is done in global scope only; local bindings are ignored (e.g. `let x = 1; func(x,│); end` cannot resolve `x::Int`)
- Splat handling is a crude approximation of `abstract_apply` and bails out conservatively when the iterated type cannot be fully resolved