### PR TITLE
completion: Use call-site types for return type inference

### DIFF
--- a/LSP/src/language-features/completions.jl
+++ b/LSP/src/language-features/completions.jl
@@ -229,13 +229,12 @@ end
 
 # JETLS specific data structures for `data` field of `CompletionItem`
 struct GlobalCompletionData
+    resolver_id::String
     name::String
 end
 struct MethodSignatureCompletionData
-    moduleidx::Int
-    names::Vector{String}
-    methodname::String
-    methodidx::Int
+    resolver_id::String
+    match_idx::Int
 end
 export GlobalCompletionData, MethodSignatureCompletionData
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -486,6 +486,18 @@ function ConfigManagerData(
     return ConfigManagerData(file_config, lsp_config, file_config_path, initialized)
 end
 
+struct GlobalCompletionResolverInfo
+    id::String
+    mod::Module
+    postprocessor::LSPostProcessor
+end
+
+struct MethodSignatureCompletionResolverInfo
+    id::String
+    matches::CC.MethodLookupResult
+    postprocessor::LSPostProcessor
+end
+
 # Type aliases for document-synchronization caches using `SWContainer` (sequential-only updates)
 const FileCache = SWContainer{Base.PersistentDict{URI,FileInfo}, SWStats}
 const SavedFileCache = SWContainer{Base.PersistentDict{URI,SavedFileInfo}, SWStats}
@@ -496,7 +508,7 @@ const CellToNotebookMap = SWContainer{Base.PersistentDict{URI,URI}, SWStats} # c
 const ExtraDiagnostics = CASContainer{ExtraDiagnosticsData, CASStats}
 const CurrentlyRequested = CASContainer{Base.PersistentDict{String,RequestCaller}, CASStats}
 const CurrentlyRegistered = CASContainer{Set{Registered}, CASStats}
-const CompletionResolverInfo = CASContainer{Union{Nothing,Tuple{Module,LSPostProcessor}}, CASStats}
+const CompletionResolverInfo = CASContainer{Union{Nothing,GlobalCompletionResolverInfo,MethodSignatureCompletionResolverInfo}, CASStats}
 
 # Type aliases for concurrent updates using LWContainer (non-retriable operations)
 const ConfigManager = LWContainer{ConfigManagerData, LWStats}

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -842,17 +842,6 @@ end
     end
 end
 
-@testset "MethodSignatureCompletionData de/serialization cycle" begin
-    modules = Base.loaded_modules_array()
-    for (i, m) in enumerate(methods(sin))
-        data = JETLS.prepare_method_signature_data(m, i, modules)
-        @test !isnothing(data)
-        mfunc, m′ = JETLS.lookup_method_from_data(data)
-        @test mfunc == sin
-        @test m == m′
-    end
-end
-
 @testset "method signature completion" begin
     get_newText(item::CompletionItem) =
         (@something item.textEdit return nothing).newText


### PR DESCRIPTION
Store `Core.MethodMatch` objects directly in the resolver info instead of navigating through modules to look up methods during resolution. The completion data now contains just a resolver ID and match index, which is used to retrieve the original match when resolving.

This simplifies the code significantly by removing `prepare_method_signature_data`, `lookup_method_from_data`, and `method_sparams`. The new `infer_match!` function uses `CC.specialize_method(match)` directly, which provides more precise return type inference since `MethodMatch` contains the actual argument types from the call site rather than the generic method signature types.

Also changes the return type display from `::Type` to ` -> Type` for better readability.

> Before
<img width="627" height="156" alt="Screenshot 2026-01-04 at 18 48 22" src="https://github.com/user-attachments/assets/4df5881c-1a2c-488b-a0d8-08ada37349c7" />

> After
<img width="627" height="156" alt="Screenshot 2026-01-04 at 18 47 17" src="https://github.com/user-attachments/assets/a97e14f4-cd1f-4223-ad23-7ba29703594a" />

