### PR TITLE
sighelp: Fix parameter highlight for methods with variadic arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,10 +96,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Improved type resolver robustness, eliminating `UndefVarError` messages that
   could appear in server logs during signature help. Fixed https://github.com/aviatesk/JETLS.jl/issues/391. (https://github.com/aviatesk/JETLS.jl/pull/435)
-- Fixed signature help parameter highlighting for vararg functions. When the
-  number of positional arguments exceeds the number of positional parameters,
-  the last (vararg) parameter is now correctly highlighted instead of showing
-  no highlight (e.g. `println(stdout,"foo","bar",│)`).
+
+- Fixed signature help parameter highlighting when cursor is not inside any
+  argument. For positional arguments exceeding the parameter count, the last
+  (vararg) parameter is now highlighted (e.g. `println(stdout,"foo","bar",│)`).
+  For keyword arguments after a semicolon, the next unspecified keyword
+  parameter is highlighted (e.g., `printstyled("foo"; bold=true,│)` highlights `italic`).
 
 ## 2026-01-01
 

--- a/test/test_signature_help.jl
+++ b/test/test_signature_help.jl
@@ -213,6 +213,7 @@ end
 module M_highlight
 f(a0, a1, a2, va3...; kw4=0, kw5=0, kws6...) = 0
 f1(x, xs...) = 0
+kwfunc(; kw0, kw1, kws2...) = nothing
 end
 @testset "Active param highlighting" begin
     function active_parameter(mod::Module, code::AbstractString; kwargs...)
@@ -238,6 +239,15 @@ end
     @test 1 == active_parameter(M_highlight, "f1(0, 1, 2,│)")
     @test 1 == active_parameter(M_highlight, "f1(0, 1, 2, 3│)")
     @test 1 == active_parameter(M_highlight, "f1(0, 1, 2, 3,│)")
+
+    @test 0 == active_parameter(M_highlight, "kwfunc(; │)")
+    @test 1 == active_parameter(M_highlight, "kwfunc(; kw0,│)")
+    @test 1 == active_parameter(M_highlight, "kwfunc(; kw0=0,│)")
+    @test 2 == active_parameter(M_highlight, "kwfunc(; kw0=0,kw1,│)")
+    @test 2 == active_parameter(M_highlight, "kwfunc(; kw0=0,kw1=1,│)")
+    @test 2 == active_parameter(M_highlight, "kwfunc(; kw0=0,kw1=1,kw2,│)")
+    @test 2 == active_parameter(M_highlight, "kwfunc(; kw0=0,kw1=1,kw2=2,│)")
+    @test 2 == active_parameter(M_highlight, "kwfunc(; kw0=0,kw1=1,kws2...,│)")
 
     # splat contains 0 or more args; use what we know
     @test nothing === active_parameter(M_highlight, "f(x...│, 0, 1, 2, 3, x...)")


### PR DESCRIPTION
Consists of the following three commits:

- [sighelp: Improve active_arg typing](https://github.com/aviatesk/JETLS.jl/commit/30f4a65c66df489138052865616b7024be9ed8e8) 30f4a65c66df489138052865616b7024be9ed8e8

- [sighelp: Fix parameter highlighting for vararg functions](https://github.com/aviatesk/JETLS.jl/commit/50ffa30bebc491a1733cc93f22275e4eabe3889d) 50ffa30bebc491a1733cc93f22275e4eabe3889d

  When the number of positional arguments exceeds the number of positional
  parameters, the last (vararg) parameter is now correctly highlighted
  instead of showing no highlight.

- [sighelp: Fix parameter highlighting for keyword arguments](https://github.com/aviatesk/JETLS.jl/commit/67721e965dde4d1c4d60b5e2b09b8172d88f1e0f) 67721e965dde4d1c4d60b5e2b09b8172d88f1e0f

  When cursor is not inside any argument after a semicolon, the next
  unspecified keyword parameter is now highlighted.