### PR TITLE
completions: Change type annotation syntax from `->` to `::`

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -784,7 +784,7 @@ function resolve_completion_item(state::ServerState, item::CompletionItem)
         _, result = infer_match!(CC.NativeInterpreter(Base.get_world_counter()), match)
         rettyp = CC.widenconst(result.result)
         # TODO Show effects and exception type?
-        detail = " -> " * completion_resolver_info.postprocessor(string(rettyp))
+        detail = " ::" * completion_resolver_info.postprocessor(string(rettyp))
         return CompletionItem(item;
             labelDetails = CompletionItemLabelDetails(; detail, description = "method"),
             detail,


### PR DESCRIPTION
Updates the completion detail format to use Julia's type annotation syntax `::` instead of function return type syntax `->` for better consistency with Julia conventions.

xref:
https://github.com/aviatesk/JETLS.jl/pull/437#issuecomment-3708079156

> Before (VSCode)
<img width="765" height="279" alt="Screenshot 2026-01-04 at 23 30 20" src="https://github.com/user-attachments/assets/031da261-7aa5-4e2a-9dd2-d0ca049b03db" />

> After (VSCode)
<img width="1530" height="558" alt="image" src="https://github.com/user-attachments/assets/9dc82cb7-3e6b-4928-b14e-cb1df1668170" />
