### PR TITLE
completion: Add `prepend_inference_result` config for method signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   only a limited set of known clients, so users experiencing sorting issues
   should explicitly set this option.
 
+- Added `completion.method_signature.prepend_inference_result` configuration
+  option to control whether to prepend inferred return type information to the
+  documentation of method signature completion items. In some editors (e.g., Zed),
+  additional information like inferred return type displayed when an item is
+  selected may be cut off in the UI when method signature text is long. Set to
+  `true` to show return type in documentation. If not set, JETLS auto-detects
+  based on client. The auto-detection covers only a limited set of known clients,
+  so users experiencing visibility issues should explicitly set this option.
+
+> [!tip]
+> Some completion configuration options (e.g., `completion.latex_emoji.strip_prefix`,
+> `completion.method_signature.prepend_inference_result`) use client-based
+> auto-detection for default behavior. If explicitly setting these options clearly
+> improves behavior for your client, consider submitting a PR to add your client
+> to the auto-detection logic.
+
 ### Changed
 
 - Enhanced global completion items with detailed kind information (`[function]`,

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -7,31 +7,34 @@ This documentation uses TOML format to describe the configuration schema.
 
 ```toml
 [full_analysis]
-debounce = 1.0                   # number (seconds), default: 1.0
-auto_instantiate = true          # boolean, default: true
+debounce = 1.0                     # number (seconds), default: 1.0
+auto_instantiate = true            # boolean, default: true
 
-formatter = "Runic"              # String preset: "Runic" (default) or "JuliaFormatter"
+formatter = "Runic"                # String preset: "Runic" (default) or "JuliaFormatter"
 
-[formatter.custom]               # Or custom formatter configuration
-executable = ""                  # string (path), optional
-executable_range = ""            # string (path), optional
+[formatter.custom]                 # Or custom formatter configuration
+executable = ""                    # string (path), optional
+executable_range = ""              # string (path), optional
 
 [diagnostic]
-enabled = true                   # boolean, default: true
-allow_unused_underscore = false  # boolean, default: false
+enabled = true                     # boolean, default: true
+allow_unused_underscore = false    # boolean, default: false
 
 [[diagnostic.patterns]]
-pattern = ""                     # string, required
-match_by = ""                    # string, required, "code" or "message"
-match_type = ""                  # string, required, "literal" or "regex"
-severity = ""                    # string or number, required, "error"/"warning"/"warn"/"information"/"info"/"hint"/"off" or 0/1/2/3/4
-path = ""                        # string (optional), glob pattern for file paths
+pattern = ""                       # string, required
+match_by = ""                      # string, required, "code" or "message"
+match_type = ""                    # string, required, "literal" or "regex"
+severity = ""                      # string or number, required, "error"/"warning"/"warn"/"information"/"info"/"hint"/"off" or 0/1/2/3/4
+path = ""                          # string (optional), glob pattern for file paths
 
 [completion.latex_emoji]
-strip_prefix = false             # boolean, default: (unset) auto-detect
+strip_prefix = false               # boolean, default: (unset) auto-detect
+
+[completion.method_signature]
+prepend_inference_result = false   # boolean, default: (unset) auto-detect
 
 [testrunner]
-executable = "testrunner"        # string, default: "testrunner" (or "testrunner.bat" on Windows)
+executable = "testrunner"          # string, default: "testrunner" (or "testrunner.bat" on Windows)
 ```
 
 ## [Configuration reference](@id config/reference)
@@ -46,6 +49,7 @@ executable = "testrunner"        # string, default: "testrunner" (or "testrunner
     - [`[[diagnostic.patterns]]`](@ref config/diagnostic-patterns)
 - [`[completion]`](@ref config/completion)
     - [`[completion.latex_emoji] strip_prefix`](@ref config/completion-latex_emoji-strip_prefix)
+    - [`[completion.method_signature] prepend_inference_result`](@ref config/completion-method_signature-prepend_inference_result)
 - [`[testrunner]`](@ref config/testrunner)
     - [`[testrunner] executable`](@ref config/testrunner-executable)
 
@@ -359,6 +363,42 @@ option.
 [completion.latex_emoji]
 strip_prefix = true  # Force prefix stripping for clients with sortText issues
 ```
+
+!!! tip
+    If explicitly setting this option clearly improves behavior for your client,
+    consider submitting a PR to add your client to the auto-detection logic.
+
+#### [`[completion.method_signature] prepend_inference_result`](@id config/completion-method_signature-prepend_inference_result)
+
+- **Type**: boolean
+- **Default**: (unset) auto-detect based on client
+
+Controls whether to prepend inferred return type information to the documentation
+of method signature completion items.
+
+In some editors (e.g., Zed), additional information like inferred return type
+displayed when an item is selected may be cut off in the UI when the method
+signature text is long.
+
+When set to `true`, JETLS prepends the return type as a code block to the
+documentation, ensuring it is always visible.
+
+When set to `false`, the return type is only shown alongside the completion item
+(as `CompletionItem.detail` in LSP terms, which may be cut off in some editors).
+
+When not set (default), JETLS auto-detects based on the client name and applies
+the appropriate behavior. Note that the auto-detection only covers a limited set
+of known clients, so if you experience issues with return type visibility, try
+explicitly setting this option.
+
+```toml
+[completion.method_signature]
+prepend_inference_result = true  # Show return type in documentation
+```
+
+!!! tip
+    If explicitly setting this option clearly improves behavior for your client,
+    consider submitting a PR to add your client to the auto-detection logic.
 
 ### [`[testrunner]`](@id config/testrunner)
 

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -785,7 +785,20 @@ function resolve_completion_item(state::ServerState, item::CompletionItem)
         _, result = infer_match!(CC.NativeInterpreter(Base.get_world_counter()), match)
         rettyp = CC.widenconst(result.result)
         # TODO Show effects and exception type?
-        detail = " ::" * completion_resolver_info.postprocessor(string(rettyp))
+        typstr = completion_resolver_info.postprocessor(string(rettyp))
+        detail = " ::" * typstr
+        prepend_inference_result = get_config(state.config_manager, :completion, :method_signature, :prepend_inference_result)
+        if prepend_inference_result === missing
+            # auto-detect based on client
+            prepend_inference_result = getobjpath(state, :init_params, :clientInfo, :name) ∈ ("Zed", "Zed Dev")
+        end
+        if prepend_inference_result
+            documentation = """
+            ```julia
+            ::$(typstr)
+            ```
+            """ * documentation
+        end
         return CompletionItem(item;
             labelDetails = CompletionItemLabelDetails(; detail, description = "method"),
             detail,

--- a/src/types.jl
+++ b/src/types.jl
@@ -416,8 +416,13 @@ const DEFAULT_INIT_OPTIONS = InitOptions(; n_analysis_workers=1, analysis_overri
     strip_prefix::Maybe{Union{Missing,Bool}} # missing is used as sentinel for default setting value
 end
 
+@option struct MethodSignatureConfig <: ConfigSection
+    prepend_inference_result::Maybe{Union{Missing,Bool}} # missing is used as sentinel for default setting value
+end
+
 @option struct CompletionConfig <: ConfigSection
     latex_emoji::Maybe{LaTeXEmojiConfig}
+    method_signature::Maybe{MethodSignatureConfig}
 end
 
 @option struct JETLSConfig <: ConfigSection
@@ -438,7 +443,7 @@ const DEFAULT_CONFIG = JETLSConfig(;
     full_analysis = FullAnalysisConfig(1.0, true),
     testrunner = TestRunnerConfig(@static Sys.iswindows() ? "testrunner.bat" : "testrunner"),
     formatter = "Runic",
-    completion = CompletionConfig(LaTeXEmojiConfig(missing)),
+    completion = CompletionConfig(LaTeXEmojiConfig(missing), MethodSignatureConfig(missing)),
     initialization_options = DEFAULT_INIT_OPTIONS)
 
 function get_default_config(path::Symbol...)


### PR DESCRIPTION
In some editors (e.g., Zed), additional information like inferred return type displayed when a completion item is selected may be cut off in the UI when the method signature text is long.

This change adds `completion.method_signature.prepend_inference_result` configuration option to prepend the return type as a code block to the documentation, ensuring it is always visible.

Like `strip_prefix`, the default behavior uses client-based auto-detection. Added tip admonitions encouraging users to submit PRs if explicit settings improve behavior for their client.