### PR TITLE
utils: Add `@somereal` macro for concise fallback handling

### DIFF
--- a/src/code-action.jl
+++ b/src/code-action.jl
@@ -44,7 +44,7 @@ function handle_CodeActionRequest(
     return send(server,
         CodeActionResponse(;
             id = msg.id,
-            result = isempty(code_actions) ? null : code_actions))
+            result = @somereal code_actions null))
 end
 
 function unused_variable_code_actions!(

--- a/src/code-lens.jl
+++ b/src/code-lens.jl
@@ -39,7 +39,7 @@ function handle_CodeLensRequest(server::Server, msg::CodeLensRequest, cancel_fla
     return send(server,
         CodeLensResponse(;
             id = msg.id,
-            result = isempty(code_lenses) ? null : code_lenses))
+            result = @somereal code_lenses null))
 end
 
 struct CodeLensRefreshRequestCaller <: RequestCaller end

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -380,11 +380,10 @@ function add_emoji_latex_completions!(
     # we strip `\\` and `:` from `label` so sorting works correctly.
     # Other clients (e.g., VSCode) properly handles `\` character appearing in `sortText`,
     # so we keep `label` as-is.
-    strip_prefix = get_config(state.config_manager, :completion, :latex_emoji, :strip_prefix)
-    if strip_prefix === missing
+    strip_prefix = @somereal(
+        get_config(state.config_manager, :completion, :latex_emoji, :strip_prefix),
         # auto-detect based on client
-        strip_prefix = getobjpath(state, :init_params, :clientInfo, :name) ∈ ("Zed", "Zed Dev")
-    end
+        getobjpath(state, :init_params, :clientInfo, :name) ∈ ("Zed", "Zed Dev"))
 
     function create_ci(key, val, is_emoji::Bool)
         description = is_emoji ? "emoji" : "latex-symbol"
@@ -787,11 +786,10 @@ function resolve_completion_item(state::ServerState, item::CompletionItem)
         # TODO Show effects and exception type?
         typstr = completion_resolver_info.postprocessor(string(rettyp))
         detail = " ::" * typstr
-        prepend_inference_result = get_config(state.config_manager, :completion, :method_signature, :prepend_inference_result)
-        if prepend_inference_result === missing
+        prepend_inference_result = @somereal(
+            get_config(state.config_manager, :completion, :method_signature, :prepend_inference_result),
             # auto-detect based on client
-            prepend_inference_result = getobjpath(state, :init_params, :clientInfo, :name) ∈ ("Zed", "Zed Dev")
-        end
+            getobjpath(state, :init_params, :clientInfo, :name) ∈ ("Zed", "Zed Dev"))
         if prepend_inference_result
             documentation = """
             ```julia

--- a/src/document-highlight.jl
+++ b/src/document-highlight.jl
@@ -43,7 +43,7 @@ function handle_DocumentHighlightRequest(
     document_highlights!(highlights, fi, pos, (state, uri))
     return send(server, DocumentHighlightResponse(;
         id = msg.id,
-        result = isempty(highlights) ? null : highlights
+        result = @somereal highlights null
     ))
 end
 

--- a/src/inlay-hint.jl
+++ b/src/inlay-hint.jl
@@ -42,7 +42,7 @@ function handle_InlayHintRequest(
 
     return send(server, InlayHintResponse(;
         id = msg.id,
-        result = isempty(inlay_hints) ? null : inlay_hints))
+        result = @somereal inlay_hints null))
 end
 
 function syntactic_inlay_hints!(inlay_hints::Vector{InlayHint}, fi::FileInfo, range::Range)

--- a/src/references.jl
+++ b/src/references.jl
@@ -71,7 +71,7 @@ function do_find_references_with_progress(
     locations = find_references(server, uri, fi, pos; token, include_declaration)
     return send(server, ReferencesResponse(;
         id = msg_id,
-        result = isempty(locations) ? null : locations))
+        result = @somereal locations null))
 end
 
 function do_find_references(
@@ -80,7 +80,7 @@ function do_find_references(
     locations = find_references(server, uri, fi, pos; include_declaration)
     return send(server, ReferencesResponse(;
         id = msg_id,
-        result = isempty(locations) ? null : locations))
+        result = @somereal locations null))
 end
 
 function find_references(

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -514,20 +514,16 @@ function select_target_string(st0::JL.SyntaxTree, offset::Int)
 end
 
 function select_target_node(filter, selector, st0::JL.SyntaxTree, offset::Int)
-    bas = byte_ancestors(st0, offset)
-
-    isempty(bas) && @goto minus1
+    bas = @somereal byte_ancestors(st0, offset) @goto minus1
     if !filter(bas)
         @label minus1
         offset > 0 || return nothing
         # Support cases like `var│`, `func│(5)`
-        bas = byte_ancestors(st0, offset - 1)
-        isempty(bas) && return nothing
+        bas = @somereal byte_ancestors(st0, offset - 1) return nothing
         if !filter(bas)
             return nothing
         end
     end
-
     return selector(bas)
 end
 

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -224,8 +224,7 @@ has no definitions. Otherwise returns a tuple of `(binding, definitions)` where:
 function select_target_binding_definitions(st0_top::JL.SyntaxTree, offset::Int, mod::Module)
     (; ctx3, st3, binding) = @something _select_target_binding(st0_top, offset, mod) return nothing
     binfo = JL.lookup_binding(ctx3, binding)
-    definitions = lookup_binding_definitions(st3, binfo)
-    isempty(definitions) && return nothing
+    definitions = @somereal lookup_binding_definitions(st3, binfo) return nothing
     return binding, definitions
 end
 


### PR DESCRIPTION
Add `@somereal` macro and `somereal` function as an extension of `@something`/`something` that additionally skips `missing` values and empty `AbstractVector`s. This enables more concise fallback patterns:

```julia
xs = @somereal getxs(args) return nothing
dowith(xs)
```

instead of

```julia
xs = @something getxs(args) return nothing
isempty(xs) && return nothing
dowith(xs)
```