### PR TITLE
diagnostic: Add `lowering/undef-global-var` for on-change feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added `lowering/undef-global-var` diagnostic that reports undefined global
+  variable references on document change (as you type). This provides faster
+  feedback compared to `inference/undef-global-var`, which runs on save.
+  The on-change diagnostic detects simple undefined references with accurate
+  position information, while the on-save version detects a superset of
+  undefined global binding references, including qualified references like
+  `Base.undefvar`.
+
 - Method signature completion for function calls. When typing inside a function
   call (triggered by `(`, `,`, or ` `), compatible method signatures are
   suggested based on already-provided arguments. Selecting a completion inserts

--- a/src/types.jl
+++ b/src/types.jl
@@ -334,6 +334,7 @@ const LOWERING_UNUSED_ARGUMENT_CODE = "lowering/unused-argument"
 const LOWERING_UNUSED_LOCAL_CODE = "lowering/unused-local"
 const LOWERING_ERROR_CODE = "lowering/error"
 const LOWERING_MACRO_EXPANSION_ERROR_CODE = "lowering/macro-expansion-error"
+const LOWERING_UNDEF_GLOBAL_VAR_CODE = "lowering/undef-global-var"
 const TOPLEVEL_ERROR_CODE = "toplevel/error"
 const TOPLEVEL_METHOD_OVERWRITE_CODE = "toplevel/method-overwrite"
 const TOPLEVEL_ABSTRACT_FIELD_CODE = "toplevel/abstract-field"
@@ -350,6 +351,7 @@ const ALL_DIAGNOSTIC_CODES = Set{String}(String[
     LOWERING_UNUSED_LOCAL_CODE,
     LOWERING_ERROR_CODE,
     LOWERING_MACRO_EXPANSION_ERROR_CODE,
+    LOWERING_UNDEF_GLOBAL_VAR_CODE,
     TOPLEVEL_ERROR_CODE,
     TOPLEVEL_METHOD_OVERWRITE_CODE,
     TOPLEVEL_ABSTRACT_FIELD_CODE,


### PR DESCRIPTION
https://github.com/user-attachments/assets/7825c938-5dae-4bb8-9c84-b95e788461e8

Add a new `lowering/undef-global-var` diagnostic that reports undefined global variable references on document change. This provides faster feedback compared to `inference/undef-global-var`, which runs on save.

The on-change diagnostic uses JuliaLowering's variable analysis to detect simple undefined references with accurate position information (exact character range). The on-save version detects a superset of cases including qualified references like `Base.undefvar`, but reports position on a line basis.