### PR TITLE
code-action: Add actions to delete unused variable assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > improves behavior for your client, consider submitting a PR to add your client
 > to the [auto-detection](https://github.com/aviatesk/JETLS.jl/blob/14fdc847252579c27e41cd50820aee509f8fd7bd/src/completions.jl#L386) logic.
 
+- Added code actions to delete unused variable assignments. For unused local
+  bindings like `y = println(x)`, two new quick fix actions are now available:
+  - "Delete assignment": removes `y = `, leaving just `println(x)`
+  - "Delete statement": removes the entire assignment statement
+  These actions are not shown for (named)tuple destructuring patterns like
+  `x, y, z = func()` where deletion would change semantics.
+
 ### Changed
 
 - Enhanced global completion items with detailed kind information (`[function]`,

--- a/LSP/src/basic-json-structures.jl
+++ b/LSP/src/basic-json-structures.jl
@@ -503,6 +503,14 @@ Structure to capture a description for an error code.
     href::URI
 end
 
+# JETLS specific data structures for `data` field of `Diagnostic`
+struct UnusedVariableData
+    is_tuple_unpacking::Bool
+    assignment_range::Union{Nothing,Range}
+    lhs_eq_range::Union{Nothing,Range}
+end
+export UnusedVariableData
+
 """
 Represents a diagnostic, such as a compiler error or warning.
 Diagnostic objects are only valid in the scope of a resource.
@@ -560,7 +568,7 @@ Diagnostic objects are only valid in the scope of a resource.
     # Tags
     - since – 3.16.0
     """
-    data::Union{Any, Nothing} = nothing
+    data::Union{UnusedVariableData, Nothing} = nothing
 end
 
 # Command

--- a/src/code-action.jl
+++ b/src/code-action.jl
@@ -56,28 +56,70 @@ function unused_variable_code_actions!(
     for diagnostic in diagnostics
         code = diagnostic.code
         if code == LOWERING_UNUSED_ARGUMENT_CODE || code == LOWERING_UNUSED_LOCAL_CODE
-            range = diagnostic.range
-            if allow_unused_underscore
-                insert_pos = Position(; line=range.start.line, character=range.start.character)
-                edit = WorkspaceEdit(;
-                    changes = Dict(
-                        uri => [TextEdit(;
-                            range = Range(; start=insert_pos, var"end"=insert_pos),
-                            newText = "_")]))
-                title = "Prefix with '_' to indicate intentionally unused"
-            else
-                edit = WorkspaceEdit(;
-                    changes = Dict(
-                        uri => [TextEdit(; range, newText = "_")]))
-                title = "Replace with '_' to indicate intentionally unused"
+            add_rename_unused_var_code_actions!(code_actions, uri, diagnostic; allow_unused_underscore)
+            if code == LOWERING_UNUSED_LOCAL_CODE
+                add_delete_unused_var_code_actions!(code_actions, uri, diagnostic)
             end
-            push!(code_actions, CodeAction(;
-                title,
-                kind = CodeActionKind.QuickFix,
-                diagnostics = [diagnostic],
-                isPreferred = true,
-                edit))
         end
     end
     return code_actions
+end
+
+# Add rename actions for unused bindings (both local and arguments)
+function add_rename_unused_var_code_actions!(
+        code_actions::Vector{Union{CodeAction,Command}}, uri::URI, diagnostic::Diagnostic;
+        allow_unused_underscore::Bool = true
+    )
+    range = diagnostic.range
+    if allow_unused_underscore
+        insert_pos = Position(; line=range.start.line, character=range.start.character)
+        edit = WorkspaceEdit(;
+            changes = Dict{URI,Vector{TextEdit}}(
+                uri => TextEdit[TextEdit(;
+                    range = Range(; start=insert_pos, var"end"=insert_pos),
+                    newText = "_")]))
+        title = "Prefix with '_' to indicate intentionally unused"
+    else
+        edit = WorkspaceEdit(;
+            changes = Dict{URI,Vector{TextEdit}}(
+                uri => TextEdit[TextEdit(; range, newText = "_")]))
+        title = "Replace with '_' to indicate intentionally unused"
+    end
+    push!(code_actions, CodeAction(;
+        title,
+        kind = CodeActionKind.QuickFix,
+        diagnostics = Diagnostic[diagnostic],
+        isPreferred = true,
+        edit))
+end
+
+# Add delete actions for unused local bindings (not arguments)
+function add_delete_unused_var_code_actions!(
+        code_actions::Vector{Union{CodeAction,Command}}, uri::URI, diagnostic::Diagnostic
+    )
+    data = diagnostic.data
+    if data isa UnusedVariableData && !data.is_tuple_unpacking
+        if data.lhs_eq_range !== nothing
+            push!(code_actions, CodeAction(;
+                title = "Delete assignment",
+                kind = CodeActionKind.QuickFix,
+                diagnostics = Diagnostic[diagnostic],
+                edit = WorkspaceEdit(;
+                    changes = Dict{URI,Vector{TextEdit}}(
+                        uri => TextEdit[TextEdit(;
+                            range = data.lhs_eq_range,
+                            newText = "")]))))
+        end
+        if data.assignment_range !== nothing
+            push!(code_actions, CodeAction(;
+                title = "Delete statement",
+                kind = CodeActionKind.QuickFix,
+                diagnostics = Diagnostic[diagnostic],
+                edit = WorkspaceEdit(;
+                    changes = Dict{URI,Vector{TextEdit}}(
+                        uri => TextEdit[TextEdit(;
+                            range = data.assignment_range,
+                            newText = "")]))))
+        end
+    end
 end


### PR DESCRIPTION
Add two new quick fix actions for unused local bindings:
- "Delete assignment": removes just the LHS and `=`, e.g., `y = ` from `y = println(x)`, leaving the RHS expression
- "Delete statement": removes the entire assignment statement

These actions are skipped for (named)tuple destructuring patterns like `x, y, z = func()` or `(; x) = obj` where deletion would change semantics.