### PR TITLE
diagnostic: Add `lowering/captured-boxed-variable` diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > Note that `analysis_overrides` is provided as a temporary workaround and may
 > be removed or changed at any time. A proper fix is being worked on.
 
+### Added
+
+- Added `lowering/captured-boxed-variable` diagnostic that reports variables
+  captured by closures requiring boxing. E.g.:
+  ```julia
+  function abmult1(r::Int)  # `r` is captured and boxed (JETLS lowering/captured-boxed-variable)
+      if r < 0
+          r = -r
+      end
+      f = x -> x * r        # RelatedInformation: Closure at L5:9 captures `r`
+      return f
+  end
+  ``` (https://github.com/aviatesk/JETLS.jl/pull/452)
+
 ### Changed
 
 - Keyword argument name completion items are now sorted according to their order

--- a/Project.toml
+++ b/Project.toml
@@ -25,8 +25,8 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [sources]
 JET = {rev = "8fe5f1b", url = "https://github.com/aviatesk/JET.jl"}
-JuliaLowering = {rev = "avi/JETLS-JSJL-head-2026-01-09", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
-JuliaSyntax = {rev = "avi/JETLS-JSJL-head-2026-01-09", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
+JuliaLowering = {rev = "avi/JETLS-JSJL-head-2026-01-10", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
+JuliaSyntax = {rev = "avi/JETLS-JSJL-head-2026-01-10", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
 LSP = {path = "LSP"}
 
 [compat]

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ the list itself is subject to change.
   - [x] Lowering errors
   - [x] Macro expansion error
   - [x] Unused bindings
+  - [x] Captured boxed variables
   - [x] Method overwrite
   - [x] Abstract struct field
   - [x] Undefined bindings

--- a/src/types.jl
+++ b/src/types.jl
@@ -376,6 +376,7 @@ const LOWERING_UNUSED_LOCAL_CODE = "lowering/unused-local"
 const LOWERING_ERROR_CODE = "lowering/error"
 const LOWERING_MACRO_EXPANSION_ERROR_CODE = "lowering/macro-expansion-error"
 const LOWERING_UNDEF_GLOBAL_VAR_CODE = "lowering/undef-global-var"
+const LOWERING_CAPTURED_BOXED_VARIABLE_CODE = "lowering/captured-boxed-variable"
 const TOPLEVEL_ERROR_CODE = "toplevel/error"
 const TOPLEVEL_METHOD_OVERWRITE_CODE = "toplevel/method-overwrite"
 const TOPLEVEL_ABSTRACT_FIELD_CODE = "toplevel/abstract-field"
@@ -393,6 +394,7 @@ const ALL_DIAGNOSTIC_CODES = Set{String}(String[
     LOWERING_ERROR_CODE,
     LOWERING_MACRO_EXPANSION_ERROR_CODE,
     LOWERING_UNDEF_GLOBAL_VAR_CODE,
+    LOWERING_CAPTURED_BOXED_VARIABLE_CODE,
     TOPLEVEL_ERROR_CODE,
     TOPLEVEL_METHOD_OVERWRITE_CODE,
     TOPLEVEL_ABSTRACT_FIELD_CODE,

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -52,6 +52,7 @@ function jl_lower_for_scope_resolution(
         mod::Module, st0::JS.SyntaxTree;
         trim_error_nodes::Bool = true,
         recover_from_macro_errors::Bool = true,
+        convert_closures::Bool = false,
     )
     if trim_error_nodes
         st0 = without_kinds(st0, JS.KSet"error")
@@ -66,13 +67,15 @@ function jl_lower_for_scope_resolution(
         st0 = without_kinds(st0, JS.KSet"macrocall")
         JL.expand_forms_1(mod, st0, true, Base.get_world_counter())
     end
-    return _jl_lower_for_scope_resolution(ctx1, st0, st1)
+    return _jl_lower_for_scope_resolution(ctx1, st0, st1; convert_closures)
 end
 
-function _jl_lower_for_scope_resolution(ctx1, st0, st1)
+function _jl_lower_for_scope_resolution(ctx1, st0, st1; convert_closures::Bool = false)
     ctx2, st2 = JL.expand_forms_2(ctx1, st1)
     ctx3, st3 = JL.resolve_scopes(ctx2, st2)
-    return (; st0, st1, st2, st3, ctx3)
+    convert_closures || return (; st0, st1, st2, st3, ctx3)
+    ctx4, st4 = JL.convert_closures(ctx3, st3)
+    return (; st0, st1, st2, st3, st4, ctx3, ctx4)
 end
 
 """


### PR DESCRIPTION
<img width="925" height="823" alt="Screenshot 2026-01-06 at 23 00 41" src="https://github.com/user-attachments/assets/406fe392-c0d7-47ab-9865-ba5b94540841" />

Add a new diagnostic that reports variables captured by closures that require boxing due to being assigned multiple times. Boxed variables are stored in `Core.Box`, which can cause type instability and hinder compiler optimizations.

The implementation uses JuliaLowering's `convert_closures` pass to detect boxed bindings via `JL.is_boxed(binfo)`. The diagnostic includes `relatedInformation` showing where the variable is captured, pointing to the actual reference location inside the closure.

However, JuliaLowering's closure conversion currently uses very primitive analysis for eliminating captured boxed variables, and reports captured boxed variables in more cases than the flisp lowerer, which implements a basic captured variable liveness analysis.
As a result, this commit's reports include a considerable number of false positives (in a sense that true positives are those that appear in flisp-based code execution).
However, this issue should be resolved by improvements on the JL side.