### PR TITLE
diagnostic: Fix false positive undef-global-var for imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
 - Diff: [`368e0a1...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/368e0a1...HEAD)
 
+### Fixed
+
+- Fixed `lowering/undef-global-var` diagnostic incorrectly reporting imported
+  symbols from dependency packages as undefined. The issue occurred because
+  `isdefinedglobal` was not seeing the latest module bindings
+  when `!JETLS_DEV_MODE`. (https://github.com/aviatesk/JETLS.jl/issues/457)
+
 ### Announcement
 
 > [!warning]

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -647,7 +647,7 @@ function analyze_undefined_global_bindings!(
         binfo.is_internal && continue
         startswith(binfo.name, '#') && continue
         any(o->o.kind===:def, occurrences) && continue
-        isdefinedglobal(binfo.mod, Symbol(binfo.name)) && continue
+        invokelatest(isdefinedglobal, binfo.mod, Symbol(binfo.name))::Bool && continue
         bn = binfo.name
         provs = JS.flattened_provenance(JL.binding_ex(ctx3, binfo.id))
         range = jsobj_to_range(first(provs), fi)


### PR DESCRIPTION
Use `invokelatest` when calling `isdefinedglobal` to ensure we see the latest module bindings for dependency packages. Without this, imported symbols could be incorrectly reported as undefined when `!JETLS_DEV_MODE` because Revise isn't tracking the changes.

Fixes https://github.com/aviatesk/JETLS.jl/issues/457