### PR TITLE
formatting: Fix notebook cell formatting support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed `textDocument/diagnostic` for notebook cells.
+- Fixed `textDocument/formatting` and `textDocument/rangeFormatting` for
+  notebook cells (https://github.com/aviatesk/JETLS.jl/issues/442).
 
 ## 2026-01-09
 

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -447,9 +447,9 @@ function (dispatcher::RequestMessageDispatcher)(server::Server, @nospecialize ms
     elseif msg isa InlayHintRequest
         handle_InlayHintRequest(server, msg, cancel_flag)
     elseif msg isa DocumentFormattingRequest
-        handle_DocumentFormattingRequest(server, msg)
+        handle_DocumentFormattingRequest(server, msg, cancel_flag)
     elseif msg isa DocumentRangeFormattingRequest
-        handle_DocumentRangeFormattingRequest(server, msg)
+        handle_DocumentRangeFormattingRequest(server, msg, cancel_flag)
     elseif msg isa RenameRequest
         handle_RenameRequest(server, msg, cancel_flag)
     elseif msg isa PrepareRenameRequest

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -20,7 +20,8 @@ end
 function withserver(f;
                     capabilities::ClientCapabilities=ClientCapabilities(),
                     workspaceFolders::Union{Nothing,Vector{WorkspaceFolder}}=nothing,
-                    rootUri::Union{Nothing,URI}=nothing)
+                    rootUri::Union{Nothing,URI}=nothing,
+                    settings::Union{Nothing,AbstractDict}=nothing)
     in = Base.BufferStream()
     out = Base.BufferStream()
     received_queue = Channel{Any}(Inf)
@@ -182,6 +183,13 @@ function withserver(f;
         (; raw_msg, raw_res) = writereadmsg(InitializedNotification())
         @test raw_msg isa InitializedNotification
         @test raw_res isa RegisterCapabilityRequest && raw_res.id isa String
+
+        # apply initial settings if provided
+        # read=1: ShowMessageNotification for config change
+        if settings !== nothing
+            writereadmsg(DidChangeConfigurationNotification(;
+                params = DidChangeConfigurationParams(; settings)); read=1)
+        end
     end
 
     argnt = (; server, writemsg, readmsg, writereadmsg, id_counter)


### PR DESCRIPTION
Fix `textDocument/formatting` and `textDocument/rangeFormatting` for notebook cells. Previously, formatting requests for notebook cells failed with "file cache not found" errors because the handlers used the 2-argument `get_file_info` which doesn't perform notebook URI lookup.

Changes:
- Add `cancel_flag` to formatting handlers and use 3-argument `get_file_info` for proper notebook URI lookup
- Add `get_cell_text` to extract individual cell text from notebook
- Add `cell_range` to compute cell-local range with proper encoding
- Refactor `format_file` to handle notebook cells by formatting only the target cell's text and returning cell-local edit ranges
- Rename internal formatter execution to `run_formatter`
- Add `settings` parameter to test `withserver` for custom formatter configuration
- Add notebook formatting tests using `cat` as test formatter

Fixes the first issue of aviatesk/JETLS.jl#442.