### PR TITLE
file-cache: Return empty results for unsynced documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed `textDocument/formatting` and `textDocument/rangeFormatting` for
   notebook cells (https://github.com/aviatesk/JETLS.jl/issues/442).
 
+- Return empty results instead of errors for LSP requests on documents that
+  haven't been synchronized via `textDocument/didOpen`
+  (Fixed https://github.com/aviatesk/JETLS.jl/issues/442).
+
 - Fixed `lowering/undef-global-var` diagnostic incorrectly reporting
   non-constant but defined symbols as undefined in the file-analysis mode.
 

--- a/src/code-action.jl
+++ b/src/code-action.jl
@@ -27,12 +27,10 @@ function handle_CodeActionRequest(
         server::Server, msg::CodeActionRequest, cancel_flag::CancelFlag)
     uri = msg.params.textDocument.uri
     result = get_file_info(server.state, uri, cancel_flag)
-    if result isa ResponseError
-        return send(server,
-            CodeActionResponse(;
-                id = msg.id,
-                result = nothing,
-                error = result))
+    if isnothing(result)
+        return send(server, CodeActionResponse(; id = msg.id, result = null))
+    elseif result isa ResponseError
+        return send(server, CodeActionResponse(; id = msg.id, result = nothing, error = result))
     end
     fi = result
     code_actions = Union{CodeAction,Command}[]

--- a/src/code-lens.jl
+++ b/src/code-lens.jl
@@ -24,12 +24,10 @@ end
 function handle_CodeLensRequest(server::Server, msg::CodeLensRequest, cancel_flag::CancelFlag)
     uri = msg.params.textDocument.uri
     result = get_file_info(server.state, uri, cancel_flag)
-    if result isa ResponseError
-        return send(server,
-            CodeLensResponse(;
-                id = msg.id,
-                result = nothing,
-                error = result))
+    if isnothing(result)
+        return send(server, CodeLensResponse(; id = msg.id, result = null))
+    elseif result isa ResponseError
+        return send(server, CodeLensResponse(; id = msg.id, result = nothing, error = result))
     end
     fi = result
     code_lenses = CodeLens[]

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -853,12 +853,10 @@ function handle_CompletionRequest(
     state = server.state
     uri = msg.params.textDocument.uri
     result = get_file_info(state, uri, cancel_flag)
-    if result isa ResponseError
-        return send(server,
-            CompletionResponse(;
-                id = msg.id,
-                result = nothing,
-                error = result))
+    if isnothing(result)
+        return send(server, CompletionResponse(; id = msg.id, result = null))
+    elseif result isa ResponseError
+        return send(server, CompletionResponse(; id = msg.id, result = nothing, error = result))
     end
     fi = result
     pos = adjust_position(state, uri, msg.params.position)

--- a/src/definition.jl
+++ b/src/definition.jl
@@ -68,12 +68,10 @@ function handle_DefinitionRequest(
     origin_position = adjust_position(state, uri, msg.params.position)
 
     result = get_file_info(state, uri, cancel_flag)
-    if result isa ResponseError
-        return send(server,
-            DefinitionResponse(;
-                id = msg.id,
-                result = nothing,
-                error = result))
+    if isnothing(result)
+        return send(server, DefinitionResponse(; id = msg.id, result = null))
+    elseif result isa ResponseError
+        return send(server, DefinitionResponse(; id = msg.id, result = nothing, error = result))
     end
     fi = result
 

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -980,14 +980,13 @@ function handle_DocumentDiagnosticRequest(
         resultId = string(resultId+1)
     end
 
-    result = get_file_info(server.state, uri, cancel_flag;
-        cache_error_data = DiagnosticServerCancellationData(; retriggerRequest = true))
-    if result isa ResponseError
-        return send(server,
-            DocumentDiagnosticResponse(;
-                id = msg.id,
-                result = nothing,
-                error = result))
+    result = get_file_info(server.state, uri, cancel_flag)
+    if isnothing(result)
+        return send(server, DocumentDiagnosticResponse(;
+            id = msg.id,
+            result = RelatedFullDocumentDiagnosticReport(; resultId, items = Diagnostic[])))
+    elseif result isa ResponseError
+        return send(server, DocumentDiagnosticResponse(; id = msg.id, result = nothing, error = result))
     end
     file_info = result
 

--- a/src/document-highlight.jl
+++ b/src/document-highlight.jl
@@ -30,12 +30,10 @@ function handle_DocumentHighlightRequest(
     pos = adjust_position(state, uri, msg.params.position)
 
     result = get_file_info(state, uri, cancel_flag)
-    if result isa ResponseError
-        return send(server,
-            DocumentHighlightResponse(;
-                id = msg.id,
-                result = nothing,
-                error = result))
+    if isnothing(result)
+        return send(server, DocumentHighlightResponse(; id = msg.id, result = null))
+    elseif result isa ResponseError
+        return send(server, DocumentHighlightResponse(; id = msg.id, result = nothing, error = result))
     end
     fi = result
 

--- a/src/formatting.jl
+++ b/src/formatting.jl
@@ -140,7 +140,9 @@ function do_format(
         msg_id::MessageId, cancel_flag::AbstractCancelFlag
     )
     result = format_result(server.state, uri, options, cancel_flag)
-    if result isa ResponseError
+    if isnothing(result)
+        return send(server, DocumentFormattingResponse(; id = msg_id, result = null))
+    elseif result isa ResponseError
         return send(server, DocumentFormattingResponse(; id = msg_id, result = nothing, error = result))
     else
         return send(server, DocumentFormattingResponse(; id = msg_id, result))
@@ -199,7 +201,7 @@ end
 function format_result(
         state::ServerState, uri::URI, options::FormattingOptions, cancel_flag::AbstractCancelFlag
     )
-    result = get_file_info(state, uri, cancel_flag)
+    result = @something get_file_info(state, uri, cancel_flag) return nothing
     result isa ResponseError && return result
     fi = result
 
@@ -269,7 +271,9 @@ function do_range_format(
         msg_id::MessageId, cancel_flag::AbstractCancelFlag
     )
     result = range_format_result(server.state, uri, range, options, cancel_flag)
-    if result isa ResponseError
+    if isnothing(result)
+        return send(server, DocumentRangeFormattingResponse(; id = msg_id, result = null))
+    elseif result isa ResponseError
         return send(server, DocumentRangeFormattingResponse(; id = msg_id, result = nothing, error = result))
     else
         return send(server, DocumentRangeFormattingResponse(; id = msg_id, result))
@@ -280,7 +284,7 @@ function range_format_result(
         state::ServerState, uri::URI, range::Range, options::FormattingOptions,
         cancel_flag::AbstractCancelFlag
     )
-    result = get_file_info(state, uri, cancel_flag)
+    result = @something get_file_info(state, uri, cancel_flag) return nothing
     result isa ResponseError && return result
     fi = result
 

--- a/src/hover.jl
+++ b/src/hover.jl
@@ -62,12 +62,10 @@ function handle_HoverRequest(
     pos = adjust_position(state, uri, msg.params.position)
 
     result = get_file_info(state, uri, cancel_flag)
-    if result isa ResponseError
-        return send(server,
-            HoverResponse(;
-                id = msg.id,
-                result = nothing,
-                error = result))
+    if isnothing(result)
+        return send(server, HoverResponse(; id = msg.id, result = null))
+    elseif result isa ResponseError
+        return send(server, HoverResponse(; id = msg.id, result = nothing, error = result))
     end
     fi = result
 

--- a/src/inlay-hint.jl
+++ b/src/inlay-hint.jl
@@ -28,12 +28,10 @@ function handle_InlayHintRequest(
     range = msg.params.range
 
     result = get_file_info(server.state, uri, cancel_flag)
-    if result isa ResponseError
-        return send(server,
-            InlayHintResponse(;
-                id = msg.id,
-                result = nothing,
-                error = result))
+    if isnothing(result)
+        return send(server, InlayHintResponse(; id = msg.id, result = null))
+    elseif result isa ResponseError
+        return send(server, InlayHintResponse(; id = msg.id, result = nothing, error = result))
     end
     fi = result
 

--- a/src/references.jl
+++ b/src/references.jl
@@ -33,12 +33,10 @@ function handle_ReferencesRequest(
     include_declaration = msg.params.context.includeDeclaration
 
     result = get_file_info(server.state, uri, cancel_flag)
-    if result isa ResponseError
-        return send(server,
-            ReferencesResponse(;
-                id = msg.id,
-                result = nothing,
-                error = result))
+    if isnothing(result)
+        return send(server, ReferencesResponse(; id = msg.id, result = null))
+    elseif result isa ResponseError
+        return send(server, ReferencesResponse(; id = msg.id, result = nothing, error = result))
     end
     fi = result
 

--- a/src/rename.jl
+++ b/src/rename.jl
@@ -41,12 +41,10 @@ function handle_PrepareRenameRequest(
     pos = adjust_position(state, uri, msg.params.position)
 
     result = get_file_info(state, uri, cancel_flag)
-    if result isa ResponseError
-        return send(server,
-            PrepareRenameResponse(;
-                id = msg.id,
-                result = nothing,
-                error = result))
+    if isnothing(result)
+        return send(server, PrepareRenameResponse(; id = msg.id, result = null))
+    elseif result isa ResponseError
+        return send(server, PrepareRenameResponse(; id = msg.id, result = nothing, error = result))
     end
     fi = result
 
@@ -124,12 +122,10 @@ function handle_RenameRequest(
     newName = msg.params.newName
 
     result = get_file_info(state, uri, cancel_flag)
-    if result isa ResponseError
-        return send(server,
-            RenameResponse(;
-                id = msg.id,
-                result = nothing,
-                error = result))
+    if isnothing(result)
+        return send(server, RenameResponse(; id = msg.id, result = null))
+    elseif result isa ResponseError
+        return send(server, RenameResponse(; id = msg.id, result = nothing, error = result))
     end
     fi = result
 

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -586,12 +586,10 @@ function handle_SignatureHelpRequest(
     state = server.state
     uri = msg.params.textDocument.uri
     result = get_file_info(state, uri, cancel_flag)
-    if result isa ResponseError
-        return send(server,
-            SignatureHelpResponse(;
-                id = msg.id,
-                result = nothing,
-                error = result))
+    if isnothing(result)
+        return send(server, SignatureHelpResponse(; id = msg.id, result = null))
+    elseif result isa ResponseError
+        return send(server, SignatureHelpResponse(; id = msg.id, result = nothing, error = result))
     end
     fi = result
     pos = adjust_position(state, uri, msg.params.position)

--- a/test/test_diagnostic.jl
+++ b/test/test_diagnostic.jl
@@ -278,12 +278,8 @@ end
                         textDocument = TextDocumentIdentifier(; uri)
                     )))
                 @test raw_res isa DocumentDiagnosticResponse
-                @test raw_res.result === nothing
-                @test raw_res.error isa ResponseError
-                @test raw_res.error.code == ErrorCodes.RequestFailed
-                @test occursin("File cache for $uri is not found", raw_res.error.message)
-                @test raw_res.error.data isa DiagnosticServerCancellationData
-                @test raw_res.error.data.retriggerRequest === true
+                @test raw_res.result isa RelatedFullDocumentDiagnosticReport
+                @test isempty(raw_res.result.items)
             end
         end
     end


### PR DESCRIPTION
Return empty results instead of errors for LSP requests on documents that haven't been synchronized via `textDocument/didOpen`.

Previously, JETLS would return `ResponseError` when a file wasn't in the cache. This violated the LSP specification which states that "a server's ability to fulfill requests is independent of whether a text document is open or closed."

Now `get_file_info` returns `nothing` on timeout (reduced from 30s to 10s), and all request handlers return valid empty results (`null` or empty collections) instead of errors.

---

- Fixes aviatesk/JETLS.jl#442