### PR TITLE
Use video elements on notebook docs

### DIFF
--- a/docs/src/notebook.md
+++ b/docs/src/notebook.md
@@ -16,8 +16,12 @@ state of client implementations
 
 ```@raw html
 <center>
-<iframe class="display-light-only" style="width:100%;height:min(500px,70vh);aspect-ratio:16/9" src="https://github.com/user-attachments/assets/b5bb5201-d735-4a37-b430-932b519254ee" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-<iframe class="display-dark-only" style="width:100%;height:min(500px,70vh);aspect-ratio:16/9" src="https://github.com/user-attachments/assets/f7476257-7a53-44a1-8c8c-1ad57e136a63" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<video class="display-light-only" style="width:100%;height:min(500px,70vh);aspect-ratio:16/9" controls>
+  <source src="https://github.com/user-attachments/assets/b5bb5201-d735-4a37-b430-932b519254ee" type="video/mp4">
+</video>
+<video class="display-dark-only" style="width:100%;height:min(500px,70vh);aspect-ratio:16/9" controls>
+  <source src="https://github.com/user-attachments/assets/f7476257-7a53-44a1-8c8-1ad57e136a63" type="video/mp4">
+</video>
 </center>
 ```
 


### PR DESCRIPTION
When going to this pages it starts to download the videos to disk instead of embedding it: https://aviatesk.github.io/JETLS.jl/dev/notebook/

<img width="1083" height="825" alt="image" src="https://github.com/user-attachments/assets/bd959750-d0dc-4e6a-844d-b055cebdb879" />


This PR fixes that:


<img width="1068" height="808" alt="image" src="https://github.com/user-attachments/assets/efd3ba1a-d1cc-47f9-b9de-0dbcc5d2ba6f" />
