### PR TITLE
Correct configuration schema

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -6,11 +6,11 @@ This documentation uses TOML format to describe the configuration schema.
 ## [Configuration schema](@id config/schema)
 
 ```toml
+formatter = "Runic"                # String preset: "Runic" (default) or "JuliaFormatter"
+
 [full_analysis]
 debounce = 1.0                     # number (seconds), default: 1.0
 auto_instantiate = true            # boolean, default: true
-
-formatter = "Runic"                # String preset: "Runic" (default) or "JuliaFormatter"
 
 [formatter.custom]                 # Or custom formatter configuration
 executable = ""                    # string (path), optional


### PR DESCRIPTION
Correct schema for config file, formatter name is supposed to be outside any section.

<img width="662" height="182" alt="image" src="https://github.com/user-attachments/assets/adf85a08-7afe-433a-9a71-1568ede3e0b7" />
