### PR TITLE
Use `"jetls"` as namespace for `workspace/configuration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 `textDocument/rename`, and `textDocument/definition` by avoiding re-parsing of
   already analyzed files not opened in the editor.
 
+- `workspace/configuration` requests now expect settings to be found under the
+  top-level `"jetls"` key, such that a request with `section = "jetls"` produces
+  the full configuration. This is to ensure compatibility with generic clients,
+  e.g., the neovim client, which may not conform to JETLS's previous
+  expectations about how requests with no `section` are handled.
+
 ### Fixed
 
 - Fixed LSP features not working inside `@main` functions.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -552,6 +552,42 @@ section:
 }
 ```
 
+#### Server-agnostic clients (e.g., neovim, emacs lsp-mode, helix)(@id config/lsp-config/server-agnostic)
+
+Settings should be placed under the `"jetls"` key, such that a request for the
+`"jetls"` section produces an instance of the JETLS configuration
+[schema](@ref config/schema). For example, neovim's built-in LSP client may be
+configured as follows:
+
+```lua
+vim.lsp.config("jetls", {
+  settings = {
+    jetls = {
+      full_analysis = {
+        debounce = 2.0,
+      },
+      -- Use JuliaFormatter instead of Runic
+      formatter = "JuliaFormatter",
+      diagnostic = {
+        patterns = [
+          -- Suppress toplevel/inference warnings in test folder
+          {
+            pattern = "(toplevel|inference)/.*",
+            match_by = "code",
+            match_type = "regex",
+            severity = "off",
+            path = "test/**/*.jl",
+          },
+        ],
+      },
+      testrunner = {
+        executable = "/path/to/custom/testrunner"
+      },
+    },
+  },
+})
+```
+
 ## [Configuration priority](@id config/priority)
 
 When multiple configuration sources are present, they are merged in priority

--- a/src/workspace-configuration.jl
+++ b/src/workspace-configuration.jl
@@ -1,3 +1,5 @@
+const WORKSPACE_CONFIGURATION_NAMESPACE = "jetls"
+
 struct LoadLSPConfigHandler
     server::Server
     source::String
@@ -50,7 +52,7 @@ end
 
 function load_lsp_config!(server::Server, source::AbstractString; on_init::Bool=false)
     handler = LoadLSPConfigHandler(server, source, on_init)
-    request_workspace_configuration(handler, server, nothing)
+    request_workspace_configuration(handler, server, WORKSPACE_CONFIGURATION_NAMESPACE)
     nothing
 end
 


### PR DESCRIPTION
Fixes #482.

Also makes it so that empty strings are no longer omitted, i.e., equivalent to no value, when encoding JSON messages. Omitting them is why neovim wasn't returning any configuration even when I tried to use `section = ""`---neovim was still just seeing `nil` on it's end. (UPDATE: The PR now uses `"jetls"` instead of `""` as the top-level config section, see discussion below, but I'm keeping the change to empty string handling as it seems like the right thing for correctness.)