### PR TITLE
definition: Support global binding definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
 - Diff: [`4cf9994...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/4cf9994...HEAD)
 
+### Added
+
+- `textDocument/definition` now supports global bindings. Previously,
+  go-to-definition for global variables couldn't find their definition sites
+  since runtime reflection doesn't provide binding location information.
+  Now it uses binding occurrence analysis to find definition sites across
+  the package, benefiting from the binding occurrences cache.
+
 ### Changed
 
 - Improved `workspace/symbol` performance by enabling document symbol caching for

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ the list itself is subject to change.
   - [/] Argument type based matched method filtering
 - Definition
   - [x] Method defintion
-  - [ ] Global binding definition
+  - [x] Global binding definition
   - [x] Local binding definition
   - [ ] Type-aware method definition
 - Hover


### PR DESCRIPTION
Add `find_global_binding_definitions` to find definition sites for global bindings across the package using binding occurrence analysis. Previously, go-to-definition for global variables couldn't find their definition sites since runtime reflection doesn't provide binding location information.

The implementation benefits from the binding occurrences cache, avoiding redundant lowering for consecutive definition requests.

Also refactors `handle_DefinitionRequest` to call
`_select_target_binding` once and reuse the result for both local and global binding paths.