### PR TITLE
Fix instructions for eglot configuration

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -91,14 +91,15 @@ Minimal [Emacs](https://www.gnu.org/software/emacs/)
 ([eglot](https://github.com/joaotavora/eglot) client) setup:
 
 ```lisp
-(add-to-list 'eglot-server-programs
-              '(((julia-mode :language-id "julia")
-                (julia-ts-mode :language-id "julia"))
-                "jetls"
-                "--threads=auto"
-                "--"
-                "--socket"
-                :autoport))
+(with-eval-after-load 'eglot
+  (add-to-list 'eglot-server-programs
+               '(((julia-mode :language-id "julia")
+                  (julia-ts-mode :language-id "julia"))
+                 "jetls"
+                 "--threads=auto"
+                 "--"
+                 "--socket"
+                 :autoport)))
 ```
 
 ### Vim


### PR DESCRIPTION
You can't just add to a non-existing list in the top-level, you only get an error.  `add-to-list` must be wrapped in a macro which defers its evaluation, like `with-eval-after-load`.  That's also the recommended syntax in [Eglot documentation](https://elpa.gnu.org/devel/doc/eglot.html#Setting-Up-LSP-Servers-1) (and really the standard approach when configuring Elisp packages)