### PR TITLE
diagnostic: Replace `inference/undef-local-var` with lowering-based analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Replaced `inference/undef-local-var` with new `lowering/undef-local-var`
+  diagnostic. The new diagnostic uses CFG-aware analysis on lowered code
+  instead of the previuos inference-based analysis. This provides faster
+  feedback via on-change `textDocument/diagnostic` requests without waiting for
+  full-analysis to be completed that is triggered on-save, and offers precise
+  source location information by leveraging JuliaLowering's provenance tracking.
+
+  The new diagnostic is reported as follows:
+  ```julia
+  function maybe_undef(cond::Bool)
+      if cond
+          var = 1  # RelatedInformation: `var` is defined here
+      end
+      return var  # Variable `var` may be used before it is defined (JETLS lowering/undef-local-var)
+                  # Severity: Information (maybe undef)
+  end
+  ```
+
+  In cases when the analysis cannot determine the definedness of a binding like
+  the following, you can use a pattern like
+  `@assert @isdefined(var) "Assertion to tell the compiler about the definedness of this variable"`
+  to prevent the diagnostic from being reported:
+  ```julia
+  function must_be_defined(cond::Bool)
+      if cond
+          var = 1
+      end
+      if cond
+          @assert @isdefined(var) "Assertion to tell the compiler about the definedness of this variable"
+          return var  # No diagnostic is reported here
+      end
+  end
+  ```
+
 - `textDocument/documentSymbol` now uses `SymbolKind.Object` for function
   arguments instead of `SymbolKind.Variable`. This visually distinguishes
   arguments from local variables in the document outline. Since LSP does not

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -83,6 +83,7 @@ include("config.jl")
 include("workspace-configuration.jl")
 
 include("analysis/occurrence-analysis.jl")
+include("analysis/undef-analysis.jl")
 
 include("diagnostic.jl")
 

--- a/src/analysis/undef-analysis.jl
+++ b/src/analysis/undef-analysis.jl
@@ -1,0 +1,511 @@
+# CFG-based undef analysis for scope-resolved syntax tree `st3`.
+#
+# This analysis determines whether local variables may be used before being
+# assigned, using CFG path analysis. The result is a three-valued status:
+# - `false`: Variable is definitely defined at all uses (all CFG paths to uses go through assignments)
+# - `true`: Variable is definitely undefined at some use (use precedes assignment in straight-line code)
+# - `nothing`: Variable may or may not be defined (conservative - undef CFG path exists but use may not execute)
+#
+# The key technique is placing each assignment/use event in its own "event block"
+# (not traditional basic blocks - each block contains at most one event).
+# Event ordering is thus represented by CFG edges, allowing us to check:
+# "Can entry reach a use without going through any assignment?" as a graph reachability problem.
+
+"""
+    UndefInfo
+
+Information about a local variable's definition/use sites and undef status.
+
+Fields:
+- `defs::Vector{JS.SyntaxTree}`: Definition sites (assignments, function declarations)
+- `uses::Vector{JS.SyntaxTree}`: Use sites (reads of the variable)
+- `undef::Union{Nothing,Bool}`: Undef status
+  - `false`: Variable is definitely defined at all uses
+  - `true`: Variable is definitely undefined at some use
+  - `nothing`: Variable may or may not be defined (conservative)
+"""
+struct UndefInfo
+    defs::Vector{JS.SyntaxTree}
+    uses::Vector{JS.SyntaxTree}
+    undef::Union{Nothing,Bool}
+end
+
+UndefInfo(; undef::Union{Nothing,Bool}=nothing) = UndefInfo(JS.SyntaxTree[], JS.SyntaxTree[], undef)
+
+mutable struct EventBlock
+    const id::Int
+    const succs::Vector{Int}
+    # Event in this block (at most one per block due to emit creating new blocks)
+    # event_kind: :assign, :use, or :isdefined (hint for CFG analysis, not a real def)
+    event::Union{Nothing, Tuple{Symbol,JL.IdTag,JS.SyntaxTree}}
+end
+
+EventBlock(id::Int) = EventBlock(id, Int[], nothing)
+
+mutable struct EventLinearizer
+    const blocks::Vector{EventBlock}
+    current_block::Int
+    const label_to_block::Dict{Int,Int}
+    const pending_gotos::Vector{Tuple{Int,Int}}  # (from_block, label_id)
+    next_label::Int
+    function EventLinearizer()
+        blocks = EventBlock[EventBlock(1)]
+        new(blocks, 1, Dict{Int,Int}(), Tuple{Int,Int}[], 0)
+    end
+end
+
+function undef_new_block!(lin::EventLinearizer)
+    id = length(lin.blocks) + 1
+    push!(lin.blocks, EventBlock(id))
+    return id
+end
+
+function undef_switch_to_block!(lin::EventLinearizer, id::Int)
+    lin.current_block = id
+end
+
+function undef_add_edge!(lin::EventLinearizer, from::Int, to::Int)
+    if !(to in lin.blocks[from].succs)
+        push!(lin.blocks[from].succs, to)
+    end
+end
+
+function undef_emit_event!(lin::EventLinearizer, event_kind::Symbol, var_id::JL.IdTag, st::JS.SyntaxTree)
+    lin.blocks[lin.current_block].event = (event_kind, var_id, st)
+    # Create a new block to ensure proper ordering.
+    # This allows the path-based analysis to track intra-block event order:
+    # `x = 1; println(x)` becomes BB1(assign) → BB2(use), so the analysis
+    # correctly detects that all paths to use go through assignment.
+    next_block = undef_new_block!(lin)
+    undef_add_edge!(lin, lin.current_block, next_block)
+    undef_switch_to_block!(lin, next_block)
+end
+
+function undef_make_label!(lin::EventLinearizer)
+    return lin.next_label += 1
+end
+
+function undef_emit_label!(lin::EventLinearizer, label_id::Int)
+    block_id = undef_new_block!(lin)
+    lin.label_to_block[label_id] = block_id
+    undef_add_edge!(lin, lin.current_block, block_id)
+    undef_switch_to_block!(lin, block_id)
+    return block_id
+end
+
+function undef_emit_goto!(lin::EventLinearizer, label_id::Int)
+    push!(lin.pending_gotos, (lin.current_block, label_id))
+    unreachable = undef_new_block!(lin)
+    undef_switch_to_block!(lin, unreachable)
+end
+
+function undef_emit_gotoifnot!(lin::EventLinearizer, false_label::Int)
+    true_block = undef_new_block!(lin)
+    undef_add_edge!(lin, lin.current_block, true_block)
+    push!(lin.pending_gotos, (lin.current_block, false_label))
+    undef_switch_to_block!(lin, true_block)
+end
+
+function undef_finalize_cfg!(lin::EventLinearizer)
+    for (from_block, label_id) in lin.pending_gotos
+        if haskey(lin.label_to_block, label_id)
+            to_block = lin.label_to_block[label_id]
+            undef_add_edge!(lin, from_block, to_block)
+        end
+    end
+end
+
+function linearize_for_undef!(
+        lin::EventLinearizer, ctx3::JL.VariableAnalysisContext, ex::JS.SyntaxTree,
+        candidates::Set{JL.IdTag}, allow_throw_optimization::Bool
+    )
+    k = JS.kind(ex)
+
+    if k == JS.K"BindingId"
+        var_id = ex.var_id
+        if var_id in candidates
+            undef_emit_event!(lin, :use, var_id, ex)
+        end
+
+    elseif JS.is_leaf(ex) || JL.is_quoted(ex)
+        # Nothing to do
+
+    elseif k == JS.K"="
+        # Process RHS first
+        linearize_for_undef!(lin, ctx3, ex[2], candidates, allow_throw_optimization)
+        # Then record assignment
+        lhs = ex[1]
+        if JS.kind(lhs) == JS.K"BindingId"
+            var_id = lhs.var_id
+            if var_id in candidates
+                undef_emit_event!(lin, :assign, var_id, lhs)
+            end
+        end
+
+    elseif k == JS.K"function_decl"
+        # Process the RHS first (method_defs)
+        for i in 2:JS.numchildren(ex)
+            linearize_for_undef!(lin, ctx3, ex[i], candidates, allow_throw_optimization)
+        end
+        # Then emit the assign event for the function name
+        lhs = ex[1]
+        if JS.kind(lhs) == JS.K"BindingId"
+            var_id = lhs.var_id
+            if var_id in candidates
+                undef_emit_event!(lin, :assign, var_id, lhs)
+            end
+        end
+
+    elseif k == JS.K"isdefined"
+        # @isdefined(var) checks if var is defined but doesn't actually use it
+        # (won't cause UndefVarError), so don't emit use event for the BindingId inside
+
+    elseif k == JS.K"lambda"
+        # Handle captured variables from outer scope by recursing into lambda body
+        # We don't know when/if the closure is called, so wrap in an uncertain branch
+        nested_lb = ex.lambda_bindings
+        has_outer_capture = any(is_capt && id in candidates for (id, is_capt) in nested_lb.locals_capt)
+        if has_outer_capture && JS.numchildren(ex) >= 3
+            skip_label = undef_make_label!(lin)
+            undef_emit_gotoifnot!(lin, skip_label)
+            linearize_for_undef!(lin, ctx3, ex[3], candidates, allow_throw_optimization)
+            undef_emit_label!(lin, skip_label)
+        end
+
+    elseif k == JS.K"local"
+        # local declarations don't use or assign
+
+    elseif k == JS.K"decl"
+        # decl nodes: the BindingId is declaration, not use; only visit type expression
+        if JS.numchildren(ex) >= 2
+            linearize_for_undef!(lin, ctx3, ex[2], candidates, allow_throw_optimization)
+        end
+
+    elseif k == JS.K"if" || k == JS.K"elseif"
+        # if cond then_branch [else_branch]
+        cond = ex[1]
+        linearize_for_undef!(lin, ctx3, cond, candidates, allow_throw_optimization)
+
+        end_label = undef_make_label!(lin)
+        else_label = undef_make_label!(lin)
+
+        undef_emit_gotoifnot!(lin, else_label)
+
+        # Special case: if @isdefined(var), the var is definitely defined in the true branch
+        if JS.kind(cond) == JS.K"isdefined" && JS.numchildren(cond) >= 1
+            isdefined_arg = cond[1]
+            if JS.kind(isdefined_arg) == JS.K"BindingId"
+                var_id = isdefined_arg.var_id
+                if var_id in candidates
+                    # Emit :isdefined hint - affects CFG analysis but not a real def
+                    undef_emit_event!(lin, :isdefined, var_id, isdefined_arg)
+                end
+            end
+        end
+
+        linearize_for_undef!(lin, ctx3, ex[2], candidates, allow_throw_optimization)
+        undef_emit_goto!(lin, end_label)
+
+        undef_emit_label!(lin, else_label)
+        if JS.numchildren(ex) >= 3
+            linearize_for_undef!(lin, ctx3, ex[3], candidates, allow_throw_optimization)
+        end
+
+        undef_emit_label!(lin, end_label)
+
+    elseif k == JS.K"_while"
+        top_label = undef_make_label!(lin)
+        end_label = undef_make_label!(lin)
+
+        undef_emit_label!(lin, top_label)
+        linearize_for_undef!(lin, ctx3, ex[1], candidates, allow_throw_optimization)
+        undef_emit_gotoifnot!(lin, end_label)
+        linearize_for_undef!(lin, ctx3, ex[2], candidates, allow_throw_optimization)
+        undef_emit_goto!(lin, top_label)
+        undef_emit_label!(lin, end_label)
+
+    elseif k == JS.K"_do_while"
+        top_label = undef_make_label!(lin)
+        end_label = undef_make_label!(lin)
+
+        undef_emit_label!(lin, top_label)
+        linearize_for_undef!(lin, ctx3, ex[1], candidates, allow_throw_optimization)
+        linearize_for_undef!(lin, ctx3, ex[2], candidates, allow_throw_optimization)
+        undef_emit_gotoifnot!(lin, end_label)
+        undef_emit_goto!(lin, top_label)
+        undef_emit_label!(lin, end_label)
+
+    elseif k == JS.K"trycatchelse"
+        catch_label = undef_make_label!(lin)
+        end_label = undef_make_label!(lin)
+
+        # Try block can throw at any point
+        undef_emit_gotoifnot!(lin, catch_label)
+        linearize_for_undef!(lin, ctx3, ex[1], candidates, allow_throw_optimization)
+        undef_emit_goto!(lin, end_label)
+
+        undef_emit_label!(lin, catch_label)
+        linearize_for_undef!(lin, ctx3, ex[2], candidates, allow_throw_optimization)
+        if JS.numchildren(ex) >= 3
+            linearize_for_undef!(lin, ctx3, ex[3], candidates, allow_throw_optimization)
+        end
+
+        undef_emit_label!(lin, end_label)
+
+    elseif k == JS.K"tryfinally"
+        finally_label = undef_make_label!(lin)
+        end_label = undef_make_label!(lin)
+
+        undef_emit_gotoifnot!(lin, finally_label)
+        linearize_for_undef!(lin, ctx3, ex[1], candidates, allow_throw_optimization)
+
+        undef_emit_label!(lin, finally_label)
+        linearize_for_undef!(lin, ctx3, ex[2], candidates, allow_throw_optimization)
+
+        undef_emit_label!(lin, end_label)
+
+    elseif k == JS.K"return"
+        if JS.numchildren(ex) >= 1
+            linearize_for_undef!(lin, ctx3, ex[1], candidates, allow_throw_optimization)
+        end
+        unreachable = undef_new_block!(lin)
+        undef_switch_to_block!(lin, unreachable)
+
+    elseif k == JS.K"break"
+        unreachable = undef_new_block!(lin)
+        undef_switch_to_block!(lin, unreachable)
+
+    elseif allow_throw_optimization && k == JS.K"call"
+        # Process all children (function and arguments)
+        for child in JS.children(ex)
+            linearize_for_undef!(lin, ctx3, child, candidates, allow_throw_optimization)
+        end
+        # Check if this is a call to global `throw` - treat as noreturn
+        # Required to support the `@assert @isdefined(var) "compiler hint to tell the definedness of `var`"` pattern
+        if JS.numchildren(ex) >= 1
+            callee = ex[1]
+            if JS.kind(callee) == JS.K"BindingId"
+                binfo = JL.get_binding(ctx3, callee.var_id)
+                if binfo.kind === :global && binfo.name == "throw"
+                    unreachable = undef_new_block!(lin)
+                    undef_switch_to_block!(lin, unreachable)
+                end
+            end
+        end
+
+    else
+        # Default: process all children
+        for child in JS.children(ex)
+            linearize_for_undef!(lin, ctx3, child, candidates, allow_throw_optimization)
+        end
+    end
+end
+
+# Check if `start` can reach any block in `targets` WITHOUT going through any block in `avoid`
+function undef_can_reach_avoiding(blocks::Vector{EventBlock}, start::Int, targets::Set{Int}, avoid::Set{Int})
+    visited = Set{Int}()
+    worklist = Int[start]
+    while !isempty(worklist)
+        block_id = pop!(worklist)
+        block_id in visited && continue
+        push!(visited, block_id)
+        if block_id in targets
+            return true
+        end
+        if block_id in avoid
+            continue
+        end
+        for succ in blocks[block_id].succs
+            if !(succ in visited)
+                push!(worklist, succ)
+            end
+        end
+    end
+    return false
+end
+
+# Check if a block is "must-execute" (all paths from entry pass through it)
+# This is equivalent to: entry cannot reach exit without going through the block
+function undef_is_must_execute(blocks::Vector{EventBlock}, block_id::Int)
+    # Find exit blocks (blocks with no successors)
+    exit_blocks = Set{Int}()
+    for b in blocks
+        if isempty(b.succs)
+            push!(exit_blocks, b.id)
+        end
+    end
+
+    # If no exit blocks, consider block as must-execute (edge case)
+    isempty(exit_blocks) && return true
+
+    # Check if entry (block 1) can reach any exit without going through block_id
+    can_bypass = undef_can_reach_avoiding(blocks, 1, exit_blocks, Set{Int}([block_id]))
+
+    # If entry cannot reach exit without going through this block, it's must-execute
+    return !can_bypass
+end
+
+"""
+    analyze_undef(ctx3::JL.VariableAnalysisContext, ex::JS.SyntaxTree;
+                  allow_throw_optimization::Bool=false) -> Dict{JL.BindingInfo, UndefInfo}
+
+CFG-aware undef analysis local bindings.
+
+For each local variable in the lambda `ex`, determines:
+- Definition and use sites (as `SyntaxTree` nodes)
+- Undef status:
+  - `false`: Variable is definitely defined at all uses
+  - `true`: Variable is definitely undefined at some use
+  - `nothing`: Variable may or may not be defined (conservative)
+
+Each assign/use event is placed in its own event block, so event ordering
+is represented by CFG edges. This enables checking reachability to determine
+if a use can be reached from entry without going through any assignment.
+
+When `allow_throw_optimization=true`, calls to global `throw` are treated as
+noreturn (like `return`), allowing patterns like `@assert @isdefined(y)` to work
+as definedness hints.
+
+Returns a dictionary mapping `BindingInfo` to `UndefInfo` for all
+analyzed local variables.
+"""
+function analyze_undef(ctx3::JL.VariableAnalysisContext, ex::JS.SyntaxTree;
+                       allow_throw_optimization::Bool=false)
+    result = Dict{JL.BindingInfo, UndefInfo}()
+
+    JS.kind(ex) == JS.K"lambda" || return result
+
+    # Collect candidate variables: all local variables in this lambda
+    lambda_bindings = ex.lambda_bindings
+    candidates = Set{JL.IdTag}()
+    for (id, from_outer_lambda) in lambda_bindings.locals_capt
+        from_outer_lambda && continue
+        binfo = JL.get_binding(ctx3, id)
+        if binfo.kind == :local
+            push!(candidates, id)
+        end
+    end
+
+    isempty(candidates) && return result
+
+    lin = EventLinearizer()
+    if JS.numchildren(ex) >= 3
+        body = ex[3]
+        linearize_for_undef!(lin, ctx3, body, candidates, allow_throw_optimization)
+    end
+    undef_finalize_cfg!(lin)
+
+    # For each candidate, collect defs/uses and check if all uses are dominated by assignments
+    for var_id in candidates
+        binfo = JL.get_binding(ctx3, var_id)
+
+        # Collect all defs and uses for this variable
+        defs = JS.SyntaxTree[]
+        uses = JS.SyntaxTree[]
+        assign_blocks = Set{Int}()
+        use_blocks = Set{Int}()
+        for block in lin.blocks
+            (event_kind, id, st) = @something block.event continue
+            id == var_id || continue
+            if event_kind === :assign
+                push!(defs, st)
+                push!(assign_blocks, block.id)
+            elseif event_kind === :isdefined
+                # :isdefined hints affect CFG analysis but shouldn't appear in defs list
+                push!(assign_blocks, block.id)
+            else # :use
+                push!(uses, st)
+                push!(use_blocks, block.id)
+            end
+        end
+
+        # No uses means "definitely defined at all uses" (vacuously true)
+        if isempty(use_blocks)
+            result[binfo] = UndefInfo(defs, uses, false)
+            continue
+        end
+
+        # No assignments means all uses are before any definition
+        if isempty(assign_blocks)
+            result[binfo] = UndefInfo(defs, uses, true)
+            continue
+        end
+
+        # Check if entry can reach any use while avoiding all assignment blocks
+        # If yes, there's a CFG path where the variable is used without being assigned
+        has_undef_path = undef_can_reach_avoiding(lin.blocks, 1, use_blocks, assign_blocks)
+
+        if has_undef_path
+            # CFG path exists. Check if the use is "must-execute" (on all paths).
+            # If use is must-execute and precedes all assignments, it's definitely undef.
+            # Otherwise, we can't prove it's definitely executed (e.g., correlated branches).
+
+            # Find the earliest must-execute use block
+            min_must_execute_use_id = typemax(Int)
+            for ub in use_blocks
+                if undef_is_must_execute(lin.blocks, ub)
+                    min_must_execute_use_id = min(min_must_execute_use_id, ub)
+                end
+            end
+
+            if min_must_execute_use_id != typemax(Int)
+                # Check if all assignments come after the must-execute use
+                all_assigns_after = true
+                for assign in assign_blocks
+                    if assign < min_must_execute_use_id
+                        all_assigns_after = false
+                        break
+                    end
+                end
+                if all_assigns_after
+                    # Use is must-execute and all assignments come after → definitely undef
+                    result[binfo] = UndefInfo(defs, uses, true)
+                else
+                    # Some assignment might come before the use on some paths
+                    result[binfo] = UndefInfo(defs, uses, nothing)
+                end
+            else
+                # Use is not must-execute (conditional), can't prove definitely undef
+                result[binfo] = UndefInfo(defs, uses, nothing)
+            end
+        else
+            # All CFG paths to any use go through an assignment
+            result[binfo] = UndefInfo(defs, uses, false)
+        end
+    end
+
+    return result
+end
+
+"""
+    analyze_undef_all_lambdas(
+        ctx3::JL.VariableAnalysisContext, st3::JS.SyntaxTree;
+        allow_throw_optimization::Bool = false
+        ) -> Dict{JL.BindingInfo, UndefInfo}
+
+Analyze undef status for all lambdas in the syntax tree.
+
+This traverses the syntax tree and calls `analyze_undef` on each lambda,
+merging the results into a single dictionary. Each lambda must be analyzed
+separately because `analyze_undef` only analyzes that lambda's own local
+variables (not captured from outer scope). The recursion into nested lambdas
+within `linearize_for_undef!` handles uses/assigns of captured variables,
+but doesn't analyze the nested lambda's own locals.
+
+When `allow_throw_optimization=true`, calls to global `throw` are treated as
+noreturn. The caller should verify that `throw === Core.throw` in the current
+module context before enabling this optimization.
+"""
+function analyze_undef_all_lambdas(
+        ctx3::JL.VariableAnalysisContext, st3::JS.SyntaxTree;
+        allow_throw_optimization::Bool = false
+    )
+    result = Dict{JL.BindingInfo, UndefInfo}()
+    traverse(st3) do st3′::JS.SyntaxTree
+        if JS.kind(st3′) == JS.K"lambda"
+            merge!(result, analyze_undef(ctx3, st3′; allow_throw_optimization))
+        end
+        return nothing
+    end
+    return result
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -376,12 +376,12 @@ const LOWERING_UNUSED_LOCAL_CODE = "lowering/unused-local"
 const LOWERING_ERROR_CODE = "lowering/error"
 const LOWERING_MACRO_EXPANSION_ERROR_CODE = "lowering/macro-expansion-error"
 const LOWERING_UNDEF_GLOBAL_VAR_CODE = "lowering/undef-global-var"
+const LOWERING_UNDEF_LOCAL_VAR_CODE = "lowering/undef-local-var"
 const LOWERING_CAPTURED_BOXED_VARIABLE_CODE = "lowering/captured-boxed-variable"
 const TOPLEVEL_ERROR_CODE = "toplevel/error"
 const TOPLEVEL_METHOD_OVERWRITE_CODE = "toplevel/method-overwrite"
 const TOPLEVEL_ABSTRACT_FIELD_CODE = "toplevel/abstract-field"
 const INFERENCE_UNDEF_GLOBAL_VAR_CODE = "inference/undef-global-var"
-const INFERENCE_UNDEF_LOCAL_VAR_CODE = "inference/undef-local-var"
 const INFERENCE_UNDEF_STATIC_PARAM_CODE = "inference/undef-static-param" # currently not reported
 const INFERENCE_FIELD_ERROR_CODE = "inference/field-error"
 const INFERENCE_BOUNDS_ERROR_CODE = "inference/bounds-error"
@@ -394,12 +394,12 @@ const ALL_DIAGNOSTIC_CODES = Set{String}(String[
     LOWERING_ERROR_CODE,
     LOWERING_MACRO_EXPANSION_ERROR_CODE,
     LOWERING_UNDEF_GLOBAL_VAR_CODE,
+    LOWERING_UNDEF_LOCAL_VAR_CODE,
     LOWERING_CAPTURED_BOXED_VARIABLE_CODE,
     TOPLEVEL_ERROR_CODE,
     TOPLEVEL_METHOD_OVERWRITE_CODE,
     TOPLEVEL_ABSTRACT_FIELD_CODE,
     INFERENCE_UNDEF_GLOBAL_VAR_CODE,
-    INFERENCE_UNDEF_LOCAL_VAR_CODE,
     INFERENCE_UNDEF_STATIC_PARAM_CODE,
     INFERENCE_FIELD_ERROR_CODE,
     INFERENCE_BOUNDS_ERROR_CODE,

--- a/test/analysis/test_Analyzer.jl
+++ b/test/analysis/test_Analyzer.jl
@@ -31,7 +31,7 @@ function issue392()
     return x
 end
 
-@testset "LSAnalyzer" begin
+@testset "UndefVarErrorReport" begin
     # global undef variables
     let result = analyze_call() do
             sin(undefvar)
@@ -56,36 +56,6 @@ end
         @test length(reports) == 1
         r = only(reports)
         @test r isa UndefVarErrorReport && r.var == GlobalRef(TestTargetModule, :unexisting)
-    end
-
-    # local undef variables
-    let result = analyze_call() do
-            local x
-            sin(x)
-        end
-        reports = get_reports(result)
-        @test length(reports) == 1
-        r = only(reports)
-        @test r isa UndefVarErrorReport && r.var === :x && !r.maybeundef
-    end
-    let result = analyze_call((Bool,Float64)) do c, x
-            if c
-                y = x
-            end
-            return sin(y)
-        end
-        reports = get_reports(result)
-        @test length(reports) == 1
-        r = only(reports)
-        @test r isa UndefVarErrorReport && r.var === :y && r.maybeundef
-    end
-    let result = analyze_call((Any,)) do x
-            local y = x
-            callfunc() do
-                identity(y)
-            end
-        end
-        @test isempty(get_reports(result))
     end
 end
 

--- a/test/analysis/test_undef_analysis.jl
+++ b/test/analysis/test_undef_analysis.jl
@@ -1,0 +1,409 @@
+module test_undef_analysis
+
+using Test
+using JETLS
+using JETLS: JL, JS
+
+include(normpath(pkgdir(JETLS), "test", "setup.jl"))
+include(normpath(pkgdir(JETLS), "test", "jsjl-utils.jl"))
+
+module lowering_module end
+
+function get_undef_status(text::AbstractString; mod::Module=lowering_module, allow_throw_optimization::Bool=false)
+    st0 = jlparse(text; rule=:statement, filename=@__FILE__)
+    (; ctx3, st3) = JETLS.jl_lower_for_scope_resolution(mod, st0; trim_error_nodes=false, recover_from_macro_errors=false)
+    undef_info = JETLS.analyze_undef_all_lambdas(ctx3, st3; allow_throw_optimization)
+    result = Dict{String, Union{Nothing,Bool}}()
+    for (binfo, info) in undef_info
+        if !binfo.is_internal && binfo.kind == :local
+            if !haskey(result, binfo.name)
+                result[binfo.name] = info.undef
+            end
+        end
+    end
+    return result
+end
+
+@testset "sequential assignment then use" begin
+    # Variable is assigned before use - definitely defined
+    status = get_undef_status("""
+    function f()
+        y = 1
+        println(y)
+    end
+    """)
+    @test status["y"] === false
+end
+
+@testset "use before assignment" begin
+    # Variable is used before any assignment - definitely undefined
+    status = get_undef_status("""
+    function f()
+        println(y)
+        y = 1
+    end
+    """)
+    @test status["y"] === true
+end
+
+@testset "if-else both branches assign" begin
+    # All branches assign - definitely defined at use
+    status = get_undef_status("""
+    function f()
+        if rand() > 0.5
+            y = 1
+        else
+            y = 2
+        end
+        println(y)
+    end
+    """)
+    @test status["y"] === false
+end
+
+@testset "if-else one branch assigns" begin
+    # Only one branch assigns - may be undefined
+    status = get_undef_status("""
+    function f()
+        if rand() > 0.5
+            y = 1
+        else
+            nothing
+        end
+        println(y)
+    end
+    """)
+    @test status["y"] === nothing
+end
+
+@testset "nested if-else all paths assign" begin
+    # All nested paths assign - definitely defined
+    status = get_undef_status("""
+    function f()
+        if rand() > 0.5
+            if rand() > 0.5
+                y = 1
+            else
+                y = 2
+            end
+        else
+            y = 3
+        end
+        println(y)
+    end
+    """)
+    @test status["y"] === false
+end
+
+@testset "while loop" begin
+    # Loop may not execute - may be undefined
+    status = get_undef_status("""
+    function f()
+        local y
+        while rand() > 0.5
+            y = 1
+        end
+        println(y)
+    end
+    """)
+    @test status["y"] === nothing
+end
+
+@testset "for loop" begin
+    # Loop may not execute (empty range) - may be undefined
+    status = get_undef_status("""
+    function f()
+        local y
+        for i in 1:10
+            y = i
+        end
+        println(y)
+    end
+    """)
+    @test status["y"] === nothing
+end
+
+@testset "try-catch both assign" begin
+    # Both try and catch blocks assign y, so y is always defined at use
+    status = get_undef_status("""
+    function f()
+        local y
+        try
+            y = 1
+        catch
+            y = 2
+        end
+        println(y)
+    end
+    """)
+    @test status["y"] === false
+end
+
+@testset "multiple variables" begin
+    # Test multiple variables in same function
+    status = get_undef_status("""
+    function f()
+        x = 1
+        println(x)
+        if rand() > 0.5
+            y = 2
+        end
+        println(y)
+        println(z)
+        z = 3
+    end
+    """)
+    @test status["x"] === false    # assigned before use
+    @test status["y"] === nothing  # may not be assigned (branch)
+    @test status["z"] === true     # used before assigned (straight-line)
+end
+
+@testset "assignment in both if branches with nested control flow" begin
+    status = get_undef_status("""
+    function f()
+        if rand() > 0.5
+            while rand() > 0.5
+                nothing
+            end
+            y = 1
+        else
+            for i in 1:10
+                nothing
+            end
+            y = 2
+        end
+        println(y)
+    end
+    """)
+    @test status["y"] === false  # both branches assign at end
+end
+
+@testset "argument is always defined" begin
+    status = get_undef_status("""
+    function f(x)
+        println(x)
+    end
+    """)
+    # Arguments don't appear in our result (kind == :argument, not :local)
+    @test !haskey(status, "x")
+end
+
+@testset "variable only assigned, never used" begin
+    # If never used, "defined at all uses" is vacuously true
+    status = get_undef_status("""
+    function f()
+        y = 1
+    end
+    """)
+    @test status["y"] === false
+end
+
+@testset "correlated conditions" begin
+    # Same condition in two if statements - CFG path exists but is infeasible
+    status = get_undef_status("""
+    function func(x)
+        if x > 0
+            y = 42
+        end
+        if x > 0
+            return sin(y)
+        end
+    end
+    """)
+    @test status["y"] === nothing
+end
+
+@testset "closure capture" begin
+    # Variables assigned before closure and captured - definitely defined
+    status = get_undef_status("""
+    function f()
+        x = 1
+        y = 2
+        map([1,2,3]) do i
+            x + y + i
+        end
+    end
+    """)
+    @test status["x"] === false
+    @test status["y"] === false
+end
+
+@testset "if @isdefined(y) - use inside true branch" begin
+    # Variable is guarded by @isdefined in condition
+    status = get_undef_status("""
+    function f(x)
+        if x > 0
+            y = 42
+        end
+        if @isdefined(y)
+            return sin(y)
+        end
+    end
+    """)
+    @test status["y"] === false
+end
+
+@testset "nested closures" begin
+    # Variable assigned before outer closure, captured by inner closure
+    status = get_undef_status("""
+    function f()
+        x = 1
+        map([1,2,3]) do i
+            map([4,5,6]) do j
+                x + i + j
+            end
+        end
+    end
+    """)
+    @test status["x"] === false
+end
+
+@testset "nested closures - may be undefined" begin
+    # Variable conditionally assigned, captured by nested closure
+    status = get_undef_status("""
+    function f(cond)
+        if cond
+            y = 42
+        end
+        map([1,2,3]) do i
+            map([4,5,6]) do j
+                y + i + j
+            end
+        end
+    end
+    """)
+    @test status["y"] === nothing
+end
+
+@testset "generator expression" begin
+    # Variable assigned before generator
+    status = get_undef_status("""
+    function f()
+        x = 10
+        (x + i for i in 1:10)
+    end
+    """)
+    @test status["x"] === false
+end
+
+@testset "generator - may be undefined" begin
+    # Variable conditionally assigned, used in generator
+    status = get_undef_status("""
+    function f(cond)
+        if cond
+            y = 42
+        end
+        (y + i for i in 1:10)
+    end
+    """)
+    @test status["y"] === nothing
+end
+
+@testset "break in loop" begin
+    # Assignment after break is unreachable, but loop may not execute
+    status = get_undef_status("""
+    function f()
+        local y
+        for i in 1:10
+            if i > 5
+                break
+            end
+            y = i
+        end
+        println(y)
+    end
+    """)
+    @test status["y"] === nothing
+end
+
+@testset "continue in loop" begin
+    # Continue skips assignment sometimes
+    status = get_undef_status("""
+    function f()
+        local y
+        for i in 1:10
+            if i > 5
+                continue
+            end
+            y = i
+        end
+        println(y)
+    end
+    """)
+    @test status["y"] === nothing
+end
+
+@testset "closure assigns to captured variable" begin
+    # When a closure assigns to a captured variable, we can't know when/if
+    # the closure is called, so report "may be undefined" instead of
+    # "must be undefined"
+    status = get_undef_status("""
+    function func(a)
+        local x
+        function inner(y)
+            x = y
+        end
+        f = inner
+        f(a)
+        return x
+    end
+    """)
+    @test status["x"] === nothing  # may be undefined (not must be undefined)
+end
+
+@testset "throw optimization" begin
+    # @assert @isdefined(y) acts as a hint when allow_throw_optimization=true
+    # Because if y is not defined, throw() is called and code after is unreachable
+    status = get_undef_status("""
+    function f(x)
+        if x > 0
+            y = x
+        end
+        if x > 0
+            @assert @isdefined(y) "hint"
+            return sin(y)
+        end
+    end
+    """; allow_throw_optimization=true)
+    @test status["y"] === false
+
+    # Without allow_throw_optimization, the same code reports may-be-undefined
+    status_no_opt = get_undef_status("""
+    function f(x)
+        if x > 0
+            y = x
+        end
+        if x > 0
+            @assert @isdefined(y) "hint"
+            return sin(y)
+        end
+    end
+    """; allow_throw_optimization=false)
+    @test status_no_opt["y"] === nothing
+
+    # Direct throw() call also works as noreturn hint
+    # (if/else ensures all paths to sin(y) go through assignment)
+    status = get_undef_status("""
+    function f(x)
+        if x > 0
+            y = x
+        else
+            throw(ArgumentError("x must be positive"))
+        end
+        return sin(y)
+    end
+    """; allow_throw_optimization=true)
+    @test status["y"] === false
+end
+
+@testset "top-level block without function" begin
+    # Variable declared with let but never assigned - definitely undefined
+    status = get_undef_status("""
+    let x
+        println(x)
+    end
+    """)
+    @test status["x"] === true
+end
+
+end # module test_undef_analysis

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,7 @@ end
     end
     @testset "analysis" begin
         @testset "occurrence" include("analysis/test_occurrence_analysis.jl")
+        @testset "undef" include("analysis/test_undef_analysis.jl")
         @testset "LSAnalyzer" include("analysis/test_Analyzer.jl")
     end
     @testset "types" include("test_types.jl")


### PR DESCRIPTION
Replace the inference-based `inference/undef-local-var` diagnostic with a new `lowering/undef-local-var` diagnostic that is based on a CFG-aware analysis on scope resolved lowered code `st3`.

This approach provides two key benefits:
1. Faster feedback: Analysis runs on `textDocument/diagnostic` requests triggered by on-change events, without waiting for full analysis that is trigged by on-save
2. Precise provenance: Leverages JuliaLowering's provenance tracking to accurately report dianostic at variable use sites (with related information reported at variable definition sites if exist)

The algorithm places each assign/use event in its own "event block" and uses graph reachability to determine if a use can be reached from entry without going through any assignment. Special handling is included for `@isdefined` guards and optionally for `throw` calls as noreturn hints.

This same algorithm could potentially be used for closure box optimization in JuliaLowering in the future. However, JuliaLowering is currently focused on achieving implementation completeness and verifying inference parity with the flisp lowerer, making it premature to introduce this new algorithm there. For now, we manage this analysis in JETLS, using it exclusively for diagnostics while continuing to refine its correctness.

---

/cc @mlechu @topolarity Just a friendly ping for your reference (please feel free to skip!).
In this PR, I've implemented an algorithm that I think could potentially be a new main algorithm of `binding_analysis.jl` in JuliaLowering in the future (as a precaution, just potentially).
The basic idea is to create an "event block" for each assignment/use of a binding, and then analyze CFG-aware binding definedness based on the reachability within the graph of these event blocks. Of course, for closure box optimization, besides checking if a binding is assigned before its definition (which is what this algorithm mainly analyzes), we also need to check if it's re-assigned or not. But I think it might be possible to analyze this within the same framework.
Having said that introducing this algorithm into JuliaLowering right now isn't ideal, because we need to ensure inference-parity. So I decided to use it only for diagnostics in JETLS to improve the core algorithm's accuracy for now.