### PR TITLE
diagnostic: Use distinct source values for different channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   the container name for arguments or fields respectively, making it clearer
   which function or struct they belong to during workspace symbol search.
 
+- Diagnostic `source` field now uses distinct values to indicate which channel
+  delivers the diagnostic: `JETLS/live` for on-change diagnostics, `JETLS/save`
+  for on-save full analysis, and `JETLS/extra` for external sources like the
+  TestRunner.jl integration. This helps users understand when diagnostics update
+  and enables filtering by source in editors that support it. See the
+  [Sources](https://aviatesk.github.io/JETLS.jl/release/diagnostic/#diagnostic/source)
+  documentation for details.
+
 ## 2026-01-17
 
 - Commit: [`c8e2012`](https://github.com/aviatesk/JETLS.jl/commit/c8e2012)

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -7,7 +7,7 @@ that identifies its category and type.
 This document describes all available diagnostic codes, their meanings, default
 severity levels, and how to configure them to match your project's needs.
 
-## [Diagnostic codes](@id diagnostic/code)
+## [Codes](@id diagnostic/code)
 
 JETLS reports diagnostics using hierarchical codes in the format
 `"category/kind"`, following the [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic).
@@ -22,7 +22,7 @@ Pages = ["diagnostic.md"]
 Depth = 3:4
 ```
 
-## [Diagnostic severity levels](@id diagnostic/severity)
+## [Severity levels](@id diagnostic/severity)
 
 Each diagnostic has a severity level that indicates how serious the issue is.
 JETLS supports four severity levels defined by the [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnosticSeverity):
@@ -45,41 +45,73 @@ You can change the severity of any diagnostic by
 Additionally, JETLS supports disabling diagnostics entirely using the special
 severity value `"off"` (or `0`).
 
-## [Diagnostic reference](@id diagnostic/reference)
+## [Sources](@id diagnostic/source)
+
+JETLS uses different diagnostic channels to balance analysis accuracy with
+response latency. Lightweight checks run as you edit for immediate feedback,
+while deeper analysis runs on save to avoid excessive resource consumption.
+
+Each diagnostic has a `source` field that identifies which diagnostic channel
+it comes from. This section explains what each source means, helping you
+understand when diagnostics update.
+Additionally, some editors also allow filtering diagnostics by source.
+
+!!! info
+    This section contains references to LSP protocol details. You don't need
+    to understand these details to use JETLS effectively - the key takeaway
+    is simply that different diagnostics update at different times (as you
+    edit, when you save, or when you run tests via [TestRunner integration](@ref)).
+
+JETLS uses three diagnostic sources:
+
+- **`JETLS/live`**: Diagnostics available on demand via the pull model
+  diagnostic channel [`textDocument/diagnostic`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_diagnostic).
+  Most clients request these as you edit, providing real-time feedback without
+  requiring a file save. Includes syntax errors and lowering-based analysis
+  (`syntax/*`, `lowering/*`).
+- **`JETLS/save`**: Diagnostics published by JETLS after on-save full analysis
+  via the push model channel [`textDocument/publishDiagnostics`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_publishDiagnostics).
+  These run full analysis including type inference and require loading your
+  code. Includes top-level errors and inference-based analysis (`toplevel/*`,
+  `inference/*`).
+- **`JETLS/extra`**: Diagnostics from external sources like the TestRunner
+  integration (`testrunner/*`). Published via [`textDocument/publishDiagnostics`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_publishDiagnostics).
+
+## [Reference](@id diagnostic/reference)
 
 This section provides detailed explanations for each diagnostic code. For every
 diagnostic, you'll find:
 
 - A description of what the diagnostic detects
-- Its default severity level
+- Its default severity level and source
 - Code examples demonstrating when the diagnostic is reported
 - Example diagnostic messages (shown in code comments)
 
 Here is a summary table of the diagnostics explained in this section:
 
-| Code                                                                                             | Default Severity      | Description                                                    |
-| ------------------------------------------------------------------------------------------------ | --------------------- | -------------------------------------------------------------- |
-| [`syntax/parse-error`](@ref diagnostic/reference/syntax/parse-error)                             | `Error`               | Syntax parsing errors detected by JuliaSyntax.jl               |
-| [`lowering/error`](@ref diagnostic/reference/lowering/error)                                     | `Error`               | General lowering errors                                        |
-| [`lowering/macro-expansion-error`](@ref diagnostic/reference/lowering/macro-expansion-error)     | `Error`               | Errors during macro expansion                                  |
-| [`lowering/unused-argument`](@ref diagnostic/reference/lowering/unused-argument)                 | `Information`         | Function arguments that are never used                         |
-| [`lowering/unused-local`](@ref diagnostic/reference/lowering/unused-local)                       | `Information`         | Local variables that are assigned but never read               |
-| [`lowering/undef-global-var`](@ref diagnostic/reference/lowering/undef-global-var)               | `Warning`             | References to undefined global variables (triggered on change) |
-| [`lowering/undef-local-var`](@ref diagnostic/reference/lowering/undef-local-var)                 | `Warning/Information` | References to undefined local variables (triggered on change)  |
-| [`lowering/captured-boxed-variable`](@ref diagnostic/reference/lowering/captured-boxed-variable) | `Information`         | Variables captured by closures that require boxing             |
-| [`toplevel/error`](@ref diagnostic/reference/toplevel/error)                                     | `Error`               | Errors during code loading (missing deps, type failures, etc.) |
-| [`toplevel/method-overwrite`](@ref diagnostic/reference/toplevel/method-overwrite)               | `Warning`             | Method definitions that overwrite previously defined methods   |
-| [`toplevel/abstract-field`](@ref diagnostic/reference/toplevel/abstract-field)                   | `Information`         | Struct fields with abstract types                              |
-| [`inference/undef-global-var`](@ref diagnostic/reference/inference/undef-global-var)             | `Warning`             | References to undefined global variables (triggered on save)   |
-| [`inference/field-error`](@ref diagnostic/reference/inference/field-error)                       | `Warning`             | Access to non-existent struct fields                           |
-| [`inference/bounds-error`](@ref diagnostic/reference/inference/bounds-error)                     | `Warning`             | Out-of-bounds field access by index                            |
-| [`testrunner/test-failure`](@ref diagnostic/reference/testrunner/test-failure)                   | `Error`               | Test failures from TestRunner integration                      |
+| Code                                                                                             | Default Severity      | Source        | Description                                        |
+| ------------------------------------------------------------------------------------------------ | --------------------- | ------------- | -------------------------------------------------- |
+| [`syntax/parse-error`](@ref diagnostic/reference/syntax/parse-error)                             | `Error`               | `JETLS/live`  | Syntax parsing errors detected by JuliaSyntax.jl   |
+| [`lowering/error`](@ref diagnostic/reference/lowering/error)                                     | `Error`               | `JETLS/live`  | General lowering errors                            |
+| [`lowering/macro-expansion-error`](@ref diagnostic/reference/lowering/macro-expansion-error)     | `Error`               | `JETLS/live`  | Errors during macro expansion                      |
+| [`lowering/unused-argument`](@ref diagnostic/reference/lowering/unused-argument)                 | `Information`         | `JETLS/live`  | Function arguments that are never used             |
+| [`lowering/unused-local`](@ref diagnostic/reference/lowering/unused-local)                       | `Information`         | `JETLS/live`  | Local variables that are assigned but never read   |
+| [`lowering/undef-global-var`](@ref diagnostic/reference/lowering/undef-global-var)               | `Warning`             | `JETLS/live`  | References to undefined global variables           |
+| [`lowering/undef-local-var`](@ref diagnostic/reference/lowering/undef-local-var)                 | `Warning/Information` | `JETLS/live`  | References to undefined local variables            |
+| [`lowering/captured-boxed-variable`](@ref diagnostic/reference/lowering/captured-boxed-variable) | `Information`         | `JETLS/live`  | Variables captured by closures that require boxing |
+| [`toplevel/error`](@ref diagnostic/reference/toplevel/error)                                     | `Error`               | `JETLS/save`  | Errors during code loading                         |
+| [`toplevel/method-overwrite`](@ref diagnostic/reference/toplevel/method-overwrite)               | `Warning`             | `JETLS/save`  | Method definitions that overwrite previous ones    |
+| [`toplevel/abstract-field`](@ref diagnostic/reference/toplevel/abstract-field)                   | `Information`         | `JETLS/save`  | Struct fields with abstract types                  |
+| [`inference/undef-global-var`](@ref diagnostic/reference/inference/undef-global-var)             | `Warning`             | `JETLS/save`  | References to undefined global variables           |
+| [`inference/field-error`](@ref diagnostic/reference/inference/field-error)                       | `Warning`             | `JETLS/save`  | Access to non-existent struct fields               |
+| [`inference/bounds-error`](@ref diagnostic/reference/inference/bounds-error)                     | `Warning`             | `JETLS/save`  | Out-of-bounds field access by index                |
+| [`testrunner/test-failure`](@ref diagnostic/reference/testrunner/test-failure)                   | `Error`               | `JETLS/extra` | Test failures from TestRunner integration          |
 
 ### [Syntax diagnostic (`syntax/*`)](@id diagnostic/reference/syntax)
 
 #### [Syntax parse error (`syntax/parse-error`)](@id diagnostic/reference/syntax/parse-error)
 
-**Default severity:** `Error`
+**Default severity**: `Error`
 
 Syntax parsing errors detected by JuliaSyntax.jl. These indicate invalid Julia
 syntax that prevents the code from being parsed.
@@ -94,12 +126,12 @@ end
 
 ### [Lowering diagnostic (`lowering/*`)](@id diagnostic/reference/lowering)
 
-Lowering diagnostic is detected during Julia's lowering phase, which
+Lowering diagnostics are detected during Julia's lowering phase, which
 transforms parsed syntax into a simpler intermediate representation.
 
 #### [Lowering error (`lowering/error`)](@id diagnostic/reference/lowering/error)
 
-**Default severity:** `Error`
+**Default severity**: `Error`
 
 General lowering errors that don't fit into more specific categories.
 
@@ -113,7 +145,7 @@ end
 
 #### [Macro expansion error (`lowering/macro-expansion-error`)](@id diagnostic/reference/lowering/macro-expansion-error)
 
-**Default severity:** `Error`
+**Default severity**: `Error`
 
 Errors that occur when expanding macros during the lowering phase.
 
@@ -138,7 +170,7 @@ end
 
 #### [Unused argument (`lowering/unused-argument`)](@id diagnostic/reference/lowering/unused-argument)
 
-**Default severity:** `Information`
+**Default severity**: `Information`
 
 Function arguments that are declared but never used in the function body.
 
@@ -159,7 +191,7 @@ end
 
 #### [Unused local variable (`lowering/unused-local`)](@id diagnostic/reference/lowering/unused-local)
 
-**Default severity:** `Information`
+**Default severity**: `Information`
 
 Local variables that are assigned but never read.
 
@@ -184,11 +216,10 @@ end
 
 #### [Undefined global variable (`lowering/undef-global-var`)](@id diagnostic/reference/lowering/undef-global-var)
 
-**Default severity:** `Warning`
+**Default severity**: `Warning`
 
 References to undefined global variables, detected during lowering analysis.
-This diagnostic is reported on change (as you type), providing immediate
-feedback.
+This diagnostic provides immediate feedback as you type.
 
 Example:
 
@@ -201,16 +232,16 @@ end
 
 This diagnostic detects simple undefined global variable references. For more
 comprehensive detection (including qualified references like `Base.undefvar`),
-see [`inference/undef-global-var`](@ref diagnostic/reference/inference/undef-global-var),
-which runs on save.
+see [`inference/undef-global-var`](@ref diagnostic/reference/inference/undef-global-var)
+(source: `JETLS/save`).
 
 #### [Undefined local variable (`lowering/undef-local-var`)](@id diagnostic/reference/lowering/undef-local-var)
 
-**Default severity:** `Warning` or `Information`
+**Default severity**: `Warning` or `Information`
 
 References to local variables that may be used before being defined. This
-diagnostic is reported on change (as you type), providing immediate feedback
-based on CFG-aware analysis on lowered code.
+diagnostic provides immediate feedback based on CFG-aware analysis on lowered
+code.
 
 The severity depends on the certainty of the undefined usage:
 - **`Warning`**: The variable is definitely used before any assignment (strict
@@ -278,7 +309,7 @@ pointing to definition sites to help understand the control flow.
 
 #### [Captured boxed variable (`lowering/captured-boxed-variable`)](@id diagnostic/reference/lowering/captured-boxed-variable)
 
-**Default severity:** `Information`
+**Default severity**: `Information`
 
 Reported when a variable is captured by a closure and requires "boxing" due to
 being assigned multiple times. Captured boxed variables are stored in heap-allocated
@@ -361,14 +392,15 @@ end
 
 ### [Top-level diagnostic (`toplevel/*`)](@id diagnostic/reference/toplevel)
 
-Top-level diagnostic are reported by JETLS's full analysis feature, which runs
-when you save a file. To prevent excessive analysis on frequent saves, JETLS
-uses a debounce mechanism. See the [`[full_analysis] debounce`](@ref config/full_analysis-debounce)
-configuration documentation to adjust the debounce period.
+Top-level diagnostics are reported by JETLS's full analysis feature (source:
+`JETLS/save`), which runs when you save a file. To prevent excessive analysis
+on frequent saves, JETLS uses a debounce mechanism. See the
+[`[full_analysis] debounce`](@ref config/full_analysis-debounce) configuration
+documentation to adjust the debounce period.
 
 #### [Top-level error (`toplevel/error`)](@id diagnostic/reference/toplevel/error)
 
-**Default severity:** `Error`
+**Default severity**: `Error`
 
 Errors that occur when JETLS loads your code for analysis. This diagnostic is
 commonly reported in several scenarios:
@@ -403,7 +435,7 @@ directory, and verify that your package can be loaded successfully in a Julia RE
 
 #### [Method overwrite (`toplevel/method-overwrite`)](@id diagnostic/reference/toplevel/method-overwrite)
 
-**Default severity:** `Warning`
+**Default severity**: `Warning`
 
 Reported when a method with the same signature is defined multiple times within
 a package. This typically indicates an unintentional redefinition that
@@ -427,7 +459,7 @@ The diagnostic includes a link to the original definition location via
 
 #### [Abstract field type (`toplevel/abstract-field`)](@id diagnostic/reference/toplevel/abstract-field)
 
-**Default severity:** `Information`
+**Default severity**: `Information`
 
 Reported when a struct field has an abstract type, which can cause performance
 issues due to type instability. Storing values in abstractly-typed fields
@@ -475,19 +507,19 @@ end
 
 ### [Inference diagnostic (`inference/*`)](@id diagnostic/reference/inference)
 
-Inference diagnostic uses JET.jl to perform type-aware analysis and detect
-potential errors through static analysis. These diagnostics are reported by
-JETLS's full analysis feature, which runs when you save a file (similar to
+Inference diagnostics use [JET.jl](https://github.com/aviatesk/JET.jl) to
+perform type-aware analysis and detect potential errors through static analysis.
+These diagnostics are reported by JETLS's full analysis feature
+(source: `JETLS/save`), which runs when you save a file (similar to
 [Top-level diagnostic](@ref diagnostic/reference/toplevel)).
 
 #### [Undefined global variable (`inference/undef-global-var`)](@id diagnostic/reference/inference/undef-global-var)
 
-**Default severity:** `Warning`
+**Default severity**: `Warning`
 
 References to undefined global variables, detected through full analysis. This
-diagnostic runs on save and can detect comprehensive cases including qualified
-references (e.g., `Base.undefvar`). Position information is reported on a line
-basis.
+diagnostic can detect comprehensive cases including qualified references
+(e.g., `Base.undefvar`). Position information is reported on a line basis.
 
 Example:
 
@@ -498,13 +530,13 @@ end
 ```
 
 For faster feedback while editing, see
-[`lowering/undef-global-var`](@ref diagnostic/reference/lowering/undef-global-var),
-which reports a subset of undefined variable cases on change with accurate
-position information.
+[`lowering/undef-global-var`](@ref diagnostic/reference/lowering/undef-global-var)
+(source: `JETLS/live`), which reports a subset of undefined variable cases with
+accurate position information.
 
 #### [Field error (`inference/field-error`)](@id diagnostic/reference/inference/field-error)
 
-**Default severity:** `Warning`
+**Default severity**: `Warning`
 
 Access to non-existent struct fields. This diagnostic is reported when code
 attempts to access a field that doesn't exist on a struct type.
@@ -523,7 +555,7 @@ end
 
 #### [Bounds error (`inference/bounds-error`)](@id diagnostic/reference/inference/bounds-error)
 
-**Default severity:** `Warning`
+**Default severity**: `Warning`
 
 Out-of-bounds field access by index. This diagnostic is reported when code
 attempts to access a struct field using an integer index that is out of bounds,
@@ -543,14 +575,23 @@ end
 
 ### [TestRunner diagnostic (`testrunner/*`)](@id diagnostic/reference/testrunner)
 
+TestRunner diagnostics are reported when you manually run tests via code lens
+or code actions through the [TestRunner integration](@ref) (source: `JETLS/extra`).
+Unlike other diagnostics, these are not triggered automatically by editing or saving files.
+
 #### [Test failure (`testrunner/test-failure`)](@id diagnostic/reference/testrunner/test-failure)
 
-**Default severity:** `Error`
+**Default severity**: `Error`
 
 Test failures reported by [TestRunner integration](@ref) that happened during
 running individual `@testset` blocks or `@test` cases.
 
-## [Configuring diagnostic](@id diagnostic/configuring)
+!!! note
+    Diagnostics from `@test` cases automatically disappear after 10 seconds,
+    while `@testset` diagnostics persist until you run the testset again,
+    restructure testsets, or clear them manually.
+
+## [Configuration](@id diagnostic/configuring)
 
 You can configure which diagnostics are shown and at what [severity level](@ref diagnostic/severity)
 under the `[diagnostic]` section. This allows you to customize JETLS's

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -314,7 +314,7 @@ function jsdiag_to_lspdiag(diagnostic::JS.Diagnostic, fi::FileInfo)
             diagnostic.level === :note ? DiagnosticSeverity.Information :
             DiagnosticSeverity.Hint,
         message = diagnostic.message,
-        source = DIAGNOSTIC_SOURCE,
+        source = DIAGNOSTIC_SOURCE_LIVE,
         code = SYNTAX_DIAGNOSTIC_CODE,
         codeDescription = diagnostic_code_description(SYNTAX_DIAGNOSTIC_CODE))
 end
@@ -362,7 +362,7 @@ function jet_toplevel_error_report_to_diagnostic(
         range = line_range(report.line),
         severity = DiagnosticSeverity.Error,
         message,
-        source = DIAGNOSTIC_SOURCE,
+        source = DIAGNOSTIC_SOURCE_SAVE,
         code = TOPLEVEL_ERROR_CODE,
         codeDescription = diagnostic_code_description(TOPLEVEL_ERROR_CODE))
 end
@@ -403,7 +403,7 @@ function jet_inference_error_report_to_diagnostic(@nospecialize(report::JET.Infe
         range = jet_frame_to_range(topframe),
         severity = inference_error_report_severity(report),
         message,
-        source = DIAGNOSTIC_SOURCE,
+        source = DIAGNOSTIC_SOURCE_SAVE,
         code,
         codeDescription = diagnostic_code_description(code),
         relatedInformation)
@@ -482,7 +482,7 @@ function toplevel_warning_report_to_diagnostic_impl(report::MethodOverwriteRepor
         range = lines_range(report.lines),
         severity = DiagnosticSeverity.Warning,
         message,
-        source = DIAGNOSTIC_SOURCE,
+        source = DIAGNOSTIC_SOURCE_SAVE,
         code = TOPLEVEL_METHOD_OVERWRITE_CODE,
         codeDescription = diagnostic_code_description(TOPLEVEL_METHOD_OVERWRITE_CODE),
         relatedInformation)
@@ -511,7 +511,7 @@ function toplevel_warning_report_to_diagnostic_impl(report::AbstractFieldReport,
         range,
         severity = DiagnosticSeverity.Information,
         message,
-        source = DIAGNOSTIC_SOURCE,
+        source = DIAGNOSTIC_SOURCE_SAVE,
         code = TOPLEVEL_ABSTRACT_FIELD_CODE,
         codeDescription = diagnostic_code_description(TOPLEVEL_ABSTRACT_FIELD_CODE))
 end
@@ -616,7 +616,7 @@ function analyze_unused_bindings!(
             range,
             severity = DiagnosticSeverity.Information,
             message,
-            source = DIAGNOSTIC_SOURCE,
+            source = DIAGNOSTIC_SOURCE_LIVE,
             code,
             codeDescription = diagnostic_code_description(code),
             tags = DiagnosticTag.Ty[DiagnosticTag.Unnecessary],
@@ -662,7 +662,7 @@ function analyze_undefined_global_bindings!(
             range,
             severity = DiagnosticSeverity.Warning,
             message = postprocessor("`$(binfo.mod).$(binfo.name)` is not defined"),
-            source = DIAGNOSTIC_SOURCE,
+            source = DIAGNOSTIC_SOURCE_LIVE,
             code,
             codeDescription = diagnostic_code_description(code)))
     end
@@ -713,7 +713,7 @@ function analyze_undefined_local_bindings!(
             message = undef_status === true ?
                 "Variable `$(binfo.name)` is used before it is defined" :
                 "Variable `$(binfo.name)` may be used before it is defined",
-            source = DIAGNOSTIC_SOURCE,
+            source = DIAGNOSTIC_SOURCE_LIVE,
             code = LOWERING_UNDEF_LOCAL_VAR_CODE,
             codeDescription = diagnostic_code_description(LOWERING_UNDEF_LOCAL_VAR_CODE),
             relatedInformation = @somereal relatedInformation Some(nothing)))
@@ -768,7 +768,7 @@ function analyze_captured_boxes!(
             range,
             severity = DiagnosticSeverity.Information,
             message = "`$bn` is captured and boxed",
-            source = DIAGNOSTIC_SOURCE,
+            source = DIAGNOSTIC_SOURCE_LIVE,
             code,
             codeDescription = diagnostic_code_description(code),
             relatedInformation))
@@ -847,7 +847,7 @@ function lowering_diagnostics!(
                 range = jsobj_to_range(err.ex, fi),
                 severity = DiagnosticSeverity.Error,
                 message = err.msg,
-                source = DIAGNOSTIC_SOURCE,
+                source = DIAGNOSTIC_SOURCE_LIVE,
                 code = LOWERING_ERROR_CODE,
                 codeDescription = diagnostic_code_description(LOWERING_ERROR_CODE)))
         elseif err isa JL.MacroExpansionError
@@ -872,7 +872,7 @@ function lowering_diagnostics!(
                     range = jsobj_to_range(first(provs), fi),
                     severity = DiagnosticSeverity.Error,
                     message = msg,
-                    source = DIAGNOSTIC_SOURCE,
+                    source = DIAGNOSTIC_SOURCE_LIVE,
                     code = LOWERING_MACRO_EXPANSION_ERROR_CODE,
                     codeDescription = diagnostic_code_description(LOWERING_MACRO_EXPANSION_ERROR_CODE),
                     relatedInformation))

--- a/src/testrunner/testrunner.jl
+++ b/src/testrunner/testrunner.jl
@@ -318,7 +318,7 @@ function testrunner_result_to_diagnostics(result::TestRunnerResult)
             range = line_range(diag.line),
             severity = DiagnosticSeverity.Error,
             message = diag.message,
-            source = DIAGNOSTIC_SOURCE,
+            source = DIAGNOSTIC_SOURCE_EXTRA,
             code = TESTRUNNER_TEST_FAILURE_CODE,
             codeDescription = diagnostic_code_description(TESTRUNNER_TEST_FAILURE_CODE),
             relatedInformation)

--- a/src/types.jl
+++ b/src/types.jl
@@ -360,7 +360,9 @@ function default_executable(formatter::String)
     end
 end
 
-const DIAGNOSTIC_SOURCE = "JETLS"
+const DIAGNOSTIC_SOURCE_LIVE = "JETLS/live"
+const DIAGNOSTIC_SOURCE_SAVE = "JETLS/save"
+const DIAGNOSTIC_SOURCE_EXTRA = "JETLS/extra"
 
 const VALID_DIAGNOSTIC_CATEGORIES = Set{String}((
     "syntax",

--- a/test/test_diagnostic.jl
+++ b/test/test_diagnostic.jl
@@ -39,7 +39,7 @@ using JETLS.Glob
 
                 found_diagnostic = false
                 for diag in raw_res.result.items
-                    if diag.source == JETLS.DIAGNOSTIC_SOURCE
+                    if diag.source == JETLS.DIAGNOSTIC_SOURCE_LIVE
                         found_diagnostic = true
                         break
                     end
@@ -69,7 +69,7 @@ end
 
             found_diagnostic = false
             for diag in raw_res.params.diagnostics
-                if (diag.source == JETLS.DIAGNOSTIC_SOURCE &&
+                if (diag.source == JETLS.DIAGNOSTIC_SOURCE_SAVE &&
                     diag.range.start.line == 0)
                     found_diagnostic = true
                     break
@@ -102,7 +102,7 @@ end
 
             found_diagnostic = false
             for diag in raw_res.params.diagnostics
-                if diag.source == JETLS.DIAGNOSTIC_SOURCE
+                if diag.source == JETLS.DIAGNOSTIC_SOURCE_SAVE
                     found_diagnostic = true
                     break
                 end
@@ -146,7 +146,7 @@ end
 
             found_diagnostic = false
             for diag in raw_res.params.diagnostics
-                if (diag.source == JETLS.DIAGNOSTIC_SOURCE &&
+                if (diag.source == JETLS.DIAGNOSTIC_SOURCE_SAVE &&
                     # this also tests that JETLS doesn't show the nonsensical `var"..."`
                     # string caused by JET's internal details
                     occursin("`TestPackageAnalysis.BadModule.y` is not defined", diag.message))
@@ -184,7 +184,7 @@ end
 
             found_diagnostic = false
             for diag in raw_res.params.diagnostics
-                if (diag.source == JETLS.DIAGNOSTIC_SOURCE &&
+                if (diag.source == JETLS.DIAGNOSTIC_SOURCE_SAVE &&
                     diag.code == JETLS.TOPLEVEL_METHOD_OVERWRITE_CODE &&
                     occursin("duplicate(::$Int)", diag.message) &&
                     occursin("overwritten", diag.message))
@@ -228,7 +228,7 @@ end
 
             found_diagnostic1 = false
             for diag in raw_res.params.diagnostics
-                if (diag.source == JETLS.DIAGNOSTIC_SOURCE &&
+                if (diag.source == JETLS.DIAGNOSTIC_SOURCE_SAVE &&
                     diag.code == JETLS.TOPLEVEL_ABSTRACT_FIELD_CODE &&
                     occursin("BadStruct1", diag.message) &&
                     occursin("xs::Vector{Integer}", diag.message))
@@ -240,7 +240,7 @@ end
 
             found_diagnostic2 = false
             for diag in raw_res.params.diagnostics
-                if (diag.source == JETLS.DIAGNOSTIC_SOURCE &&
+                if (diag.source == JETLS.DIAGNOSTIC_SOURCE_SAVE &&
                     diag.code == JETLS.TOPLEVEL_ABSTRACT_FIELD_CODE &&
                     occursin("BadStruct2", diag.message) &&
                     occursin("xs::Vector{<:Integer}", diag.message))
@@ -337,7 +337,7 @@ function make_test_diagnostic(;
             var"end" = Position(; line=0, character=10)),
         severity,
         message,
-        source = JETLS.DIAGNOSTIC_SOURCE,
+        source = JETLS.DIAGNOSTIC_SOURCE_LIVE,
         code,
         codeDescription = JETLS.diagnostic_code_description(code))
 end

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -545,7 +545,7 @@ end
         diagnostics = get_lowered_diagnostics(@__MODULE__, "macro foo(x, y) \$(x) end")
         @test length(diagnostics) == 1
         diagnostic = only(diagnostics)
-        @test diagnostic.source == JETLS.DIAGNOSTIC_SOURCE
+        @test diagnostic.source == JETLS.DIAGNOSTIC_SOURCE_LIVE
         @test diagnostic.message == "`\$` expression outside string or quote block"
     end
 
@@ -560,13 +560,13 @@ end
         diagnostics = JETLS.toplevel_lowering_diagnostics(server, uri, fi)
         @test length(diagnostics) == 2
         @test count(diagnostics) do diagnostic
-            diagnostic.source == JETLS.DIAGNOSTIC_SOURCE &&
+            diagnostic.source == JETLS.DIAGNOSTIC_SOURCE_LIVE &&
             diagnostic.message == "`\$` expression outside string or quote block" &&
             diagnostic.range.start.line == 0 &&
             diagnostic.range.var"end".line == 0
         end == 1
         @test count(diagnostics) do diagnostic
-            diagnostic.source == JETLS.DIAGNOSTIC_SOURCE &&
+            diagnostic.source == JETLS.DIAGNOSTIC_SOURCE_LIVE &&
             diagnostic.message == "`\$` expression outside string or quote block" &&
             diagnostic.range.start.line == 1 &&
             diagnostic.range.var"end".line == 1
@@ -577,7 +577,7 @@ end
         diagnostics = get_lowered_diagnostics(@__MODULE__, "x = @notexisting 42")
         @test length(diagnostics) == 1
         diagnostic = only(diagnostics)
-        @test diagnostic.source == JETLS.DIAGNOSTIC_SOURCE
+        @test diagnostic.source == JETLS.DIAGNOSTIC_SOURCE_LIVE
         @test diagnostic.message == "Macro name `@notexisting` not found"
         @test diagnostic.range.start.line == 0
         @test diagnostic.range.start.character == sizeof("x = ")
@@ -600,7 +600,7 @@ end
         diagnostics = get_lowered_diagnostics(@__MODULE__, "x = notexisting\"string\"")
         @test length(diagnostics) == 1
         diagnostic = only(diagnostics)
-        @test diagnostic.source == JETLS.DIAGNOSTIC_SOURCE
+        @test diagnostic.source == JETLS.DIAGNOSTIC_SOURCE_LIVE
         @test diagnostic.message == "Macro name `@notexisting_str` not found"
         @test diagnostic.range.start.line == 0
         @test diagnostic.range.start.character == sizeof("x = ")
@@ -612,7 +612,7 @@ end
         diagnostics = get_lowered_diagnostics(@__MODULE__, "x = @m_throw 42")
         @test length(diagnostics) == 1
         diagnostic = only(diagnostics)
-        @test diagnostic.source == JETLS.DIAGNOSTIC_SOURCE
+        @test diagnostic.source == JETLS.DIAGNOSTIC_SOURCE_LIVE
         @test diagnostic.message == "Error expanding macro\n\"show this error message\""
         @test diagnostic.range.start.line == 0
         @test diagnostic.range.start.character == sizeof("x = ")
@@ -626,7 +626,7 @@ end
         end""")
         @test length(diagnostics) == 1
         diagnostic = only(diagnostics)
-        @test diagnostic.source == JETLS.DIAGNOSTIC_SOURCE
+        @test diagnostic.source == JETLS.DIAGNOSTIC_SOURCE_LIVE
         @test diagnostic.message == "Error expanding macro\nError in foo"
         @test diagnostic.range.start.line == 1
         @test diagnostic.range.start.character == 4
@@ -640,7 +640,7 @@ end
         end""")
         @test length(diagnostics) == 1
         diagnostic = only(diagnostics)
-        @test diagnostic.source == JETLS.DIAGNOSTIC_SOURCE
+        @test diagnostic.source == JETLS.DIAGNOSTIC_SOURCE_LIVE
         @test diagnostic.message == "Error expanding macro\nError in foo"
         @test diagnostic.range.start.line == 1
         @test diagnostic.range.start.character == 4
@@ -656,7 +656,7 @@ end
         """)
         @test length(diagnostics) == 1
         diagnostic = only(diagnostics)
-        @test diagnostic.source == JETLS.DIAGNOSTIC_SOURCE
+        @test diagnostic.source == JETLS.DIAGNOSTIC_SOURCE_LIVE
         @test diagnostic.message == "`return` not allowed inside comprehension or generator"
         @test diagnostic.range.start.line == 2
         @test diagnostic.range.var"end".line == 2
@@ -675,7 +675,7 @@ end
         """)
         @test length(diagnostics) == 1
         diagnostic = only(diagnostics)
-        @test diagnostic.source == JETLS.DIAGNOSTIC_SOURCE
+        @test diagnostic.source == JETLS.DIAGNOSTIC_SOURCE_LIVE
         @test diagnostic.code == JETLS.LOWERING_UNDEF_GLOBAL_VAR_CODE
         @test diagnostic.message == "`$(@__MODULE__).undeffunc` is not defined"
         @test diagnostic.range.start.line == 1
@@ -691,7 +691,7 @@ end
         """)
         @test length(diagnostics) == 1
         diagnostic = only(diagnostics)
-        @test diagnostic.source == JETLS.DIAGNOSTIC_SOURCE
+        @test diagnostic.source == JETLS.DIAGNOSTIC_SOURCE_LIVE
         @test diagnostic.message == "`$(TestLoweringUndefGlobalBinding).undeffunc` is not defined"
         @test diagnostic.range.start.line == 1
         @test diagnostic.range.start.character == 4
@@ -1027,7 +1027,7 @@ end
                 var"end" = Position(; line=0, character=14)),
             severity = DiagnosticSeverity.Information,
             message = "Unused argument `y`",
-            source = JETLS.DIAGNOSTIC_SOURCE,
+            source = JETLS.DIAGNOSTIC_SOURCE_LIVE,
             code = JETLS.LOWERING_UNUSED_ARGUMENT_CODE)
         code_actions = Union{CodeAction,Command}[]
         JETLS.unused_variable_code_actions!(code_actions, uri, [diagnostic])
@@ -1052,7 +1052,7 @@ end
                 var"end" = Position(; line=1, character=11)),
             severity = DiagnosticSeverity.Information,
             message = "Unused local binding `x`",
-            source = JETLS.DIAGNOSTIC_SOURCE,
+            source = JETLS.DIAGNOSTIC_SOURCE_LIVE,
             code = JETLS.LOWERING_UNUSED_LOCAL_CODE)
         code_actions = Union{CodeAction,Command}[]
         JETLS.unused_variable_code_actions!(code_actions, uri, [diagnostic])
@@ -1069,7 +1069,7 @@ end
                 var"end" = Position(; line=0, character=14)),
             severity = DiagnosticSeverity.Information,
             message = "Unused argument `y`",
-            source = JETLS.DIAGNOSTIC_SOURCE,
+            source = JETLS.DIAGNOSTIC_SOURCE_LIVE,
             code = JETLS.LOWERING_UNUSED_ARGUMENT_CODE)
         code_actions = Union{CodeAction,Command}[]
         JETLS.unused_variable_code_actions!(code_actions, uri, [diagnostic]; allow_unused_underscore=false)
@@ -1091,7 +1091,7 @@ end
                 var"end" = Position(; line=0, character=10)),
             severity = DiagnosticSeverity.Error,
             message = "Some other error",
-            source = JETLS.DIAGNOSTIC_SOURCE,
+            source = JETLS.DIAGNOSTIC_SOURCE_LIVE,
             code = JETLS.LOWERING_ERROR_CODE)
         code_actions = Union{CodeAction,Command}[]
         JETLS.unused_variable_code_actions!(code_actions, uri, [diagnostic])
@@ -1112,7 +1112,7 @@ end
                 var"end" = Position(; line=1, character=5)),
             severity = DiagnosticSeverity.Information,
             message = "Unused local binding `y`",
-            source = JETLS.DIAGNOSTIC_SOURCE,
+            source = JETLS.DIAGNOSTIC_SOURCE_LIVE,
             code = JETLS.LOWERING_UNUSED_LOCAL_CODE,
             data)
         code_actions = Union{CodeAction,Command}[]
@@ -1138,7 +1138,7 @@ end
                 var"end" = Position(; line=1, character=8)),
             severity = DiagnosticSeverity.Information,
             message = "Unused local binding `y`",
-            source = JETLS.DIAGNOSTIC_SOURCE,
+            source = JETLS.DIAGNOSTIC_SOURCE_LIVE,
             code = JETLS.LOWERING_UNUSED_LOCAL_CODE,
             data)
         code_actions = Union{CodeAction,Command}[]

--- a/test/test_notebook.jl
+++ b/test/test_notebook.jl
@@ -212,7 +212,7 @@ end
                 end
                 @test cell3_notification !== nothing
                 @test any(cell3_notification.params.diagnostics) do diag
-                    diag.source == JETLS.DIAGNOSTIC_SOURCE &&
+                    diag.source == JETLS.DIAGNOSTIC_SOURCE_SAVE &&
                     occursin("undefhello", diag.message)
                 end
             end


### PR DESCRIPTION
Introduce three distinct diagnostic source values to indicate which channel delivers each diagnostic:
- `JETLS/live`: on-change diagnostics via `textDocument/diagnostic`
- `JETLS/save`: on-save full analysis via `textDocument/publishDiagnostics`
- `JETLS/extra`: external sources like TestRunner.jl integration

This helps users understand when diagnostics update and enables filtering by source in editors that support it.

Also updates `docs/src/diagnostic.md` with a new "Sources" section explaining the different channels, along with restructured section headers and simplified diagnostic reference format.

Written by Claude