### PR TITLE
diagnostic: Add `all_files` configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added [`diagnostic.all_files`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/diagnostic-all_files)
+  configuration option to control whether diagnostics are reported for unopened
+  files. When disabled, diagnostics are only reported for files currently open
+  in the editor. This can be useful to reduce noise when there are many warnings
+  across the workspace. Note that analysis still runs; this setting only
+  controls whether results are reported.
+
 - Added `lowering/unsorted-import-names` diagnostic that reports when names in
   `import`, `using`, `export`, or `public` statements are not sorted
   alphabetically. This diagnostic is disabled by default and can be enabled via

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -18,6 +18,7 @@ executable_range = ""              # string (path), optional
 
 [diagnostic]
 enabled = true                     # boolean, default: true
+all_files = true                   # boolean, default: true
 allow_unused_underscore = false    # boolean, default: false
 
 [[diagnostic.patterns]]
@@ -45,6 +46,7 @@ executable = "testrunner"          # string, default: "testrunner" (or "testrunn
 - [`formatter`](@ref config/formatter)
 - [`[diagnostic]`](@ref config/diagnostic)
     - [`[diagnostic] enabled`](@ref config/diagnostic-enabled)
+    - [`[diagnostic] all_files`](@ref config/diagnostic-all_files)
     - [`[diagnostic] allow_unused_underscore`](@ref config/diagnostic-allow_unused_underscore)
     - [`[[diagnostic.patterns]]`](@ref config/diagnostic-patterns)
 - [`[completion]`](@ref config/completion)
@@ -147,6 +149,28 @@ messages will be shown.
 ```toml
 [diagnostic]
 enabled = false  # Disable all diagnostics
+```
+
+#### [`[diagnostic] all_files`](@id config/diagnostic-all_files)
+
+- **Type**: boolean
+- **Default**: `true`
+
+Enable or disable diagnostics for unopened files. When enabled, JETLS reports
+diagnostics for all Julia files in the workspace. When disabled, diagnostics
+are only reported for files currently open in the editor.
+
+This setting primarily affects [`JETLS/save`](@ref diagnostic/source) diagnostics.
+[`JETLS/live`](@ref diagnostic/source) diagnostics are only available for open
+files, so they are not reported for unopened files regardless of this setting.
+Note that full-analysis (triggered by file save) still runs even when disabled;
+this setting only controls whether results are reported to the editor.
+Disabling this can be useful to reduce noise when there are many warnings
+across the workspace.
+
+```toml
+[diagnostic]
+all_files = false  # Disable diagnostics for unopened files
 ```
 
 #### [`[diagnostic] allow_unused_underscore`](@id config/diagnostic-allow_unused_underscore)

--- a/src/did-change-watched-files.jl
+++ b/src/did-change-watched-files.jl
@@ -61,7 +61,7 @@ function handle_config_file_change!(
     source = "[.JETLSConfig.toml] $(dirname(changed_path)) ($kind)"
     notify_config_changes(server, tracker, source)
     if tracker.diagnostic_setting_changed
-        notify_diagnostics!(server)
+        notify_diagnostics!(server; ensure_cleared = true)
         request_diagnostic_refresh!(server)
     end
 end

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -113,9 +113,6 @@ function handle_DidCloseTextDocumentNotification(server::Server, msg::DidCloseTe
     store!(server.state.saved_file_cache) do cache
         Base.delete(cache, uri), nothing
     end
-    if clear_extra_diagnostics!(server, uri)
-        notify_diagnostics!(server; ensure_cleared=uri)
-    end
-
-    nothing
+    clear_extra_diagnostics!(server, uri)
+    notify_diagnostics!(server; ensure_cleared=uri)
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -432,8 +432,9 @@ merge_key(::Type{DiagnosticPattern}) = :__pattern_value__
 
 @option struct DiagnosticConfig <: ConfigSection
     enabled::Maybe{Bool}
-    patterns::Maybe{Vector{DiagnosticPattern}}
+    all_files::Maybe{Bool}
     allow_unused_underscore::Maybe{Bool}
+    patterns::Maybe{Vector{DiagnosticPattern}}
 end
 
 # Internal, undocumented configuration for full-analysis module overrides.
@@ -488,7 +489,7 @@ end
 end
 
 const DEFAULT_CONFIG = JETLSConfig(;
-    diagnostic = DiagnosticConfig(true, DiagnosticPattern[], true),
+    diagnostic = DiagnosticConfig(true, true, true, DiagnosticPattern[]),
     full_analysis = FullAnalysisConfig(1.0, true),
     testrunner = TestRunnerConfig(@static Sys.iswindows() ? "testrunner.bat" : "testrunner"),
     formatter = "Runic",

--- a/src/workspace-configuration.jl
+++ b/src/workspace-configuration.jl
@@ -108,7 +108,7 @@ function handle_lsp_config_change!(server::Server, tracker::ConfigChangeTracker,
         notify_config_changes(server, tracker, source)
     end
     if tracker.diagnostic_setting_changed
-        notify_diagnostics!(server)
+        notify_diagnostics!(server; ensure_cleared = true)
         request_diagnostic_refresh!(server)
     end
 end


### PR DESCRIPTION
Add `diagnostic.all_files` setting to control whether diagnostics are reported for unopened files. When disabled, diagnostics are only reported for files currently open in the editor.

This affects `textDocument/publishDiagnostics` notifications sent after full analysis - unopened files are skipped when `all_files` is false. Note that analysis still runs; this setting only controls whether results are reported to the editor. This can be useful to reduce noise when there are many warnings across the workspace.

This setting will also be applied to `workspace/diagnostic` (for workspace-wide syntax/lowering diagnostics) in subsequent commits (PRs).

Also simplifies `handle_DidCloseTextDocumentNotification` to always call `notify_diagnostics!` for proper cleanup regardless of whether extra diagnostics were cleared.