### PR TITLE
diagnostic: Add `workspace/diagnostic` support for unopened files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,12 +47,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added [`workspace/diagnostic`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_diagnostic)
+  support to provide `JETLS/live` diagnostics (syntax errors and lowering-based
+  analysis) for unopened files in the workspace.
+
 - Added [`diagnostic.all_files`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/diagnostic-all_files)
   configuration option to control whether diagnostics are reported for unopened
-  files. When disabled, diagnostics are only reported for files currently open
-  in the editor. This can be useful to reduce noise when there are many warnings
-  across the workspace. Note that analysis still runs; this setting only
-  controls whether results are reported.
+  files. Disabling this can be useful to reduce noise when there are many
+  warnings across the workspace.
 
 - Added `lowering/unsorted-import-names` diagnostic that reports when names in
   `import`, `using`, `export`, or `public` statements are not sorted

--- a/LSP/src/language-features/diagnostic.jl
+++ b/LSP/src/language-features/diagnostic.jl
@@ -437,6 +437,7 @@ A workspace diagnostic document report.
 """
 const WorkspaceDocumentDiagnosticReport =
     Union{WorkspaceFullDocumentDiagnosticReport, WorkspaceUnchangedDocumentDiagnosticReport}
+export WorkspaceDocumentDiagnosticReport
 
 @interface WorkspaceDiagnosticReport begin
     items::Vector{WorkspaceDocumentDiagnosticReport}

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -160,13 +160,12 @@ Enable or disable diagnostics for unopened files. When enabled, JETLS reports
 diagnostics for all Julia files in the workspace. When disabled, diagnostics
 are only reported for files currently open in the editor.
 
-This setting primarily affects [`JETLS/save`](@ref diagnostic/source) diagnostics.
-[`JETLS/live`](@ref diagnostic/source) diagnostics are only available for open
-files, so they are not reported for unopened files regardless of this setting.
-Note that full-analysis (triggered by file save) still runs even when disabled;
-this setting only controls whether results are reported to the editor.
-Disabling this can be useful to reduce noise when there are many warnings
-across the workspace.
+This setting affects both [`JETLS/live` and `JETLS/save`](@ref diagnostic/source)
+diagnostics. For `JETLS/live`, lowering-based analysis for unopened files is
+skipped when disabled (though the performance impact is minimal since lowering
+analysis is usually pretty fast). For `JETLS/save`, full analysis still runs;
+only reporting is suppressed. Disabling this can be useful to reduce noise when
+there are many warnings across the workspace.
 
 ```toml
 [diagnostic]

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -65,7 +65,11 @@ Additionally, some editors also allow filtering diagnostics by source.
 JETLS uses three diagnostic sources:
 
 - **`JETLS/live`**: Diagnostics available on demand via the pull model
-  diagnostic channel [`textDocument/diagnostic`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_diagnostic).
+  diagnostic channels
+  [`textDocument/diagnostic`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_diagnostic)
+  (for open files) and
+  [`workspace/diagnostic`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_diagnostic)
+  (for unopened files when [`diagnostic.all_files`](@ref config/diagnostic-all_files) is enabled).
   Most clients request these as you edit, providing real-time feedback without
   requiring a file save. Includes syntax errors and lowering-based analysis
   (`syntax/*`, `lowering/*`).

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -429,7 +429,7 @@ function handle_request_message(server::Server, @nospecialize(msg), cancel_flag:
     elseif msg isa DocumentDiagnosticRequest
         handle_DocumentDiagnosticRequest(server, msg, cancel_flag)
     elseif msg isa WorkspaceDiagnosticRequest
-        @assert false "workspace/diagnostic should not be enabled"
+        handle_WorkspaceDiagnosticRequest(server, msg, cancel_flag)
     elseif msg isa CodeLensRequest
         handle_CodeLensRequest(server, msg, cancel_flag)
     elseif msg isa CodeActionRequest


### PR DESCRIPTION
Enable `workspace/diagnostic` LSP request to provide `JETLS/live` diagnostics (syntax errors and lowering-based analysis) for unopened files in the workspace. This complements `textDocument/diagnostic` which handles open files.

Key changes:
- Enable `workspaceDiagnostics = true` in diagnostic options
- Add `handle_WorkspaceDiagnosticRequest` with partial result support
- Use `time_ns() % Int` as version for unsynced files to properly detect file changes and return unchanged results when appropriate
- Add `store_unsynced_file_info!` to proactively cache file info on `didChangeWatchedFiles` events
- Call `request_diagnostic_refresh!` on file changes and close events to keep workspace diagnostics up-to-date
- Invalidate unsynced file cache when a file is opened (transitions from unsynced to synced state)

The `diagnostic.all_files` setting controls whether these diagnostics are reported for unopened files. When disabled, lowering analysis is skipped entirely for unopened files.