### PR TITLE
dogfooding: Fix issues detected by workspace-wide diagnostic

### DIFF
--- a/src/completions.jl
+++ b/src/completions.jl
@@ -241,8 +241,8 @@ function global_completions!(
         is_completed |= true
     end
     resolver_id = String(gensym("GlobalCompletionResolverInfo_resovler_id"))
-    store!(state.completion_resolver_info) do _
-        GlobalCompletionResolverInfo(resolver_id, completion_module, postprocessor), nothing
+    store!(state.completion_resolver_info, completion_module) do _, mod::Module
+        GlobalCompletionResolverInfo(resolver_id, mod, postprocessor), nothing
     end
 
     prioritized_names = let s = Set{Symbol}()

--- a/src/did-change-watched-files.jl
+++ b/src/did-change-watched-files.jl
@@ -56,7 +56,7 @@ function handle_config_file_change!(
         delete_file_config!(tracker, server.state.config_manager, changed_path)
         kind = "deleted"
         show_info_message(server, config_file_deleted_msg(changed_path))
-    else error("Unknown FileChangeType") end
+    else throw(ErrorException("Unknown FileChangeType")) end
 
     source = "[.JETLSConfig.toml] $(dirname(changed_path)) ($kind)"
     notify_config_changes(server, tracker, source)

--- a/src/document-highlight.jl
+++ b/src/document-highlight.jl
@@ -112,7 +112,7 @@ function local_document_highlights!(
 end
 
 # used by tests
-function document_highlights(fi::FileInfo, pos::Position, mod::Module=Main)
+function document_highlights(fi::FileInfo, pos::Position)
     state = ServerState()
     uri = filepath2uri(fi.filename)
     store!(state.file_cache) do cache

--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -261,8 +261,9 @@ function handle_InitializeRequest(
             name = "JETLS",
             version = JETLS_VERSION))
 
-    process_id = init_params.processId
-    if !isnothing(process_id)
+    processId = init_params.processId
+    if !isnothing(processId)
+        process_id = processId # avoid captured box
         if client_process_id !== nothing
             if client_process_id != process_id
                 @warn "Different client process IDs given" client_process_id process_id

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -228,19 +228,19 @@ function greatest_local(st0::JS.SyntaxTree, offset::Int)
         return nothing
     end
 
-    i = first_global - 1
-    while JS.kind(bas[i]) === JS.K"block"
-        if any(j::Int -> JS.kind(bas[i][j]) === JS.K"local", 1:JS.numchildren(bas[i]))
+    idx = Ref(first_global - 1)
+    while JS.kind(bas[idx[]]) === JS.K"block"
+        if any(j::Int -> JS.kind(bas[idx[]][j]) === JS.K"local", 1:JS.numchildren(bas[idx[]]))
             # If this `block` contains `local`, it may introduce local bindings.
             # For correct scope analysis, we need to analyze this entire block
             break
         end
         # `bas[i]` is a block within a global scope, so can't introduce local bindings.
         # Shrink the tree (mostly for performance).
-        i -= 1
-        i < 1 && return nothing
+        idx[] -= 1
+        idx[] < 1 && return nothing
     end
-    return bas[i]
+    return bas[idx[]]
 end
 
 """

--- a/src/utils/general.jl
+++ b/src/utils/general.jl
@@ -202,7 +202,7 @@ macro define_eq_overloads(Tyname)
     h_init = UInt === UInt64 ? rand(UInt64) : rand(UInt32)
     hash_body = quote h = $h_init end
     for fld2typ in fld2typs
-        fld, typ = fld2typ
+        fld, _ = fld2typ
         push!(hash_body.args, :(h = Base.hash(x.$fld, h)::UInt))
     end
     push!(hash_body.args, :(return h))

--- a/test/test_document_highlight.jl
+++ b/test/test_document_highlight.jl
@@ -213,7 +213,7 @@ end
             fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
             @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
             for pos in positions
-                highlights = JETLS.document_highlights(fi, pos, @__MODULE__)
+                highlights = JETLS.document_highlights(fi, pos)
                 @test length(highlights) == 4
                 @test count(highlights) do highlight
                     highlight.range.start == positions[1] &&
@@ -252,7 +252,7 @@ end
             fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
             @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
             for pos in positions
-                highlights = JETLS.document_highlights(fi, pos, @__MODULE__)
+                highlights = JETLS.document_highlights(fi, pos)
                 @test length(highlights) == 3
                 @test count(highlights) do highlight
                     highlight.range.start == positions[1] &&
@@ -284,7 +284,7 @@ end
             fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
             @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
             for pos in positions
-                highlights = JETLS.document_highlights(fi, pos, @__MODULE__)
+                highlights = JETLS.document_highlights(fi, pos)
                 @test length(highlights) == 2
                 @test count(highlights) do highlight
                     highlight.range.start == positions[1] &&
@@ -313,7 +313,7 @@ end
             fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
             @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
             for pos in positions
-                highlights = JETLS.document_highlights(fi, pos, @__MODULE__)
+                highlights = JETLS.document_highlights(fi, pos)
                 @test length(highlights) == 2
                 @test count(highlights) do highlight
                     highlight.range.start == positions[1] &&
@@ -344,7 +344,7 @@ end
             fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
             @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
             for pos in positions
-                highlights = JETLS.document_highlights(fi, pos, @__MODULE__)
+                highlights = JETLS.document_highlights(fi, pos)
                 @test length(highlights) == 3
                 @test count(highlights) do highlight
                     highlight.range.start == positions[1] &&


### PR DESCRIPTION
Address various code quality issues identified by the new workspace-wide diagnostic feature:

- Eliminate captured boxes by using `Ref`, `let` bindings, or `args...` in `full-analysis.jl`, `completions.jl`, `initialize.jl`, `ast.jl`
- Remove unused parameter `mod` from `document_highlights`
- Replace unused variable `typ` with `_` in `@define_eq_overloads`
- Use `throw(ErrorException(...))` instead of `error(...)` for type stability in `did-change-watched-files.jl`