### PR TITLE
server: Optimize `build_syntax_tree` for unsynced files

### DIFF
--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -1,5 +1,5 @@
 function build_syntax_tree(fi::FileInfo)
-    return JS.build_tree(JS.SyntaxTree, fi.parsed_stream; filename = fi.filename)
+    return @something fi.syntax_tree0 JS.build_tree(JS.SyntaxTree, fi.parsed_stream; filename = fi.filename)
 end
 
 """

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -262,7 +262,7 @@ function store_unsynced_file_info!(state::ServerState, uri::URI)
             JETLS_DEV_MODE && Base.showerror(stderr, e, catch_backtrace)
             return cache, nothing
         end
-        fi = FileInfo(version, parsed_stream, filename, state.encoding)
+        fi = FileInfo(version, parsed_stream, filename, state.encoding; cache_tree=true)
         return UnsyncedFileCacheData(cache, uri => fi), fi
     end
 end


### PR DESCRIPTION
Add `syntax_tree0` field to `FileInfo` to cache the syntax tree for unsynced files. When `cache_tree=true` is passed to the constructor, the syntax tree is built eagerly and stored, allowing `build_syntax_tree` to return the cached tree instead of rebuilding it each time.

This optimization benefits existing features like references, rename, and definition by reducing their latency. However, the primary motivation is to support `analyze_unused_imports!` (implemented in the following commit), which scans all workspace files and can be called frequently via `workspace/diagnostic` and `textDocument/diagnostic`. For a workspace with ~50 files, this reduces the syntax tree building time from ~150ms to ~25ms.

Only unsynced files cache their syntax trees because they are expected to change infrequently (only when saved to disk). Synced files, which are actively being edited, would have poor cache hit rates, making caching counterproductive.

Since `JS.SyntaxTree` consumes significant memory, `JS.prune` is applied to cached trees to minimize memory overhead (thanks for this work, @mlechu ).