### PR TITLE
diagnostic: Report `lowering/unused-import`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   lookup. The CLI now uses a subcommand structure: `jetls serve` starts the
   language server (default), while `jetls check` runs diagnostics.
 
+- Added [`lowering/unused-import`](https://aviatesk.github.io/JETLS.jl/release/diagnostic/#diagnostic/reference/lowering/unused-import)
+  diagnostic that reports explicitly imported names that are never used within
+  the same module space. The "Remove unused import" code action removes the
+  unused name from the import statement.
+
 - Added reference count code lens for top-level symbols (functions, structs,
   constants, abstract types, primitive types, modules). When enabled, a code
   lens showing "N references" appears above each symbol definition. Clicking it

--- a/LSP/src/basic-json-structures.jl
+++ b/LSP/src/basic-json-structures.jl
@@ -511,6 +511,11 @@ struct UnusedVariableData
 end
 export UnusedVariableData
 
+struct UnusedImportData
+    delete_range::Range
+end
+export UnusedImportData
+
 struct UnsortedImportData
     new_text::String
 end
@@ -573,7 +578,7 @@ Diagnostic objects are only valid in the scope of a resource.
     # Tags
     - since – 3.16.0
     """
-    data::Union{UnusedVariableData, UnsortedImportData, Nothing} = nothing
+    data::Union{UnusedVariableData, UnusedImportData, UnsortedImportData, Nothing} = nothing
 end
 
 # Command

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -103,6 +103,7 @@ Here is a summary table of the diagnostics explained in this section:
 | [`lowering/undef-global-var`](@ref diagnostic/reference/lowering/undef-global-var)               | `Warning`             | `JETLS/live`  | References to undefined global variables           |
 | [`lowering/undef-local-var`](@ref diagnostic/reference/lowering/undef-local-var)                 | `Warning/Information` | `JETLS/live`  | References to undefined local variables            |
 | [`lowering/captured-boxed-variable`](@ref diagnostic/reference/lowering/captured-boxed-variable) | `Information`         | `JETLS/live`  | Variables captured by closures that require boxing |
+| [`lowering/unused-import`](@ref diagnostic/reference/lowering/unused-import)                     | `Information`         | `JETLS/live`  | Imported names that are never used                 |
 | [`lowering/unsorted-import-names`](@ref diagnostic/reference/lowering/unsorted-import-names)     | `Hint`                | `JETLS/live`  | Import/export names not sorted alphabetically      |
 | [`toplevel/error`](@ref diagnostic/reference/toplevel/error)                                     | `Error`               | `JETLS/save`  | Errors during code loading                         |
 | [`toplevel/method-overwrite`](@ref diagnostic/reference/toplevel/method-overwrite)               | `Warning`             | `JETLS/save`  | Method definitions that overwrite previous ones    |
@@ -394,6 +395,62 @@ end
     them. Also note that the cases where the flisp lowerer (a.k.a. `code_lowered`)
     generates `Core.Box` do not necessarily match the cases where JETLS reports
     captured boxes.
+
+#### [Unused import (`lowering/unused-import`)](@id diagnostic/reference/lowering/unused-import)
+
+**Default severity**: `Information`
+
+Reported when an explicitly imported name is never used within the same module
+space. This diagnostic helps identify unnecessary imports that can be removed
+to keep your code clean.
+
+Example:
+
+```julia
+using Base: sin, cos  # Unused import `cos` (JETLS lowering/unused-import)
+
+examplefunc() = sin(1.0)  # Only `sin` is used
+```
+
+The diagnostic is reported for explicit imports (`using M: name` or
+`import M: name`), not for bulk imports like `using M` which bring in all
+exported names.
+
+This diagnostic scans all files within the module space to detect usages, so an
+import is only reported as unused if the name is not used anywhere in your
+module.
+
+!!! tip "Code action available"
+    Use the "Remove unused import" code action to delete the unused name.
+    If it's the only name in the statement, the entire statement is removed.
+
+!!! warning "Limitation"
+    Usages introduced only through macro expansion cannot be detected. For
+    example, in the following code, `sin` appears unused even though it is
+    used inside the macro-generated code:
+    ```julia
+    using Base: sin  # Incorrectly reported as unused
+
+    macro gensincall(x)
+        :(sin($(esc(x))))
+    end
+    @gensincall 42
+    ```
+
+    Workarounds include using the binding directly in the macro body:
+    ```julia
+    macro gensincall(x)
+        f = sin  # `sin` is used here
+        :($f($(esc(x))))
+    end
+    ```
+    or passing the binding as part of the macro argument:
+    ```julia
+    macro gencall(ex)
+        :($(esc(ex)))
+    end
+    @gencall sin(42)  # `sin` is used here
+    ```
 
 #### [Unsorted import names (`lowering/unsorted-import-names`)](@id diagnostic/reference/lowering/unsorted-import-names)
 

--- a/src/code-action.jl
+++ b/src/code-action.jl
@@ -38,6 +38,7 @@ function handle_CodeActionRequest(
     diagnostics = msg.params.context.diagnostics
     unused_variable_code_actions!(code_actions, uri, diagnostics;
         allow_unused_underscore = get_config(server, :diagnostic, :allow_unused_underscore))
+    unused_import_code_actions!(code_actions, uri, diagnostics)
     sort_imports_code_actions!(code_actions, uri, diagnostics)
     return send(server,
         CodeActionResponse(;
@@ -59,6 +60,29 @@ function unused_variable_code_actions!(
                 add_delete_unused_var_code_actions!(code_actions, uri, diagnostic)
             end
         end
+    end
+    return code_actions
+end
+
+function unused_import_code_actions!(
+        code_actions::Vector{Union{CodeAction,Command}},
+        uri::URI,
+        diagnostics::Vector{Diagnostic}
+    )
+    for diagnostic in diagnostics
+        diagnostic.code == LOWERING_UNUSED_IMPORT_CODE || continue
+        data = diagnostic.data
+        data isa UnusedImportData || continue
+        push!(code_actions, CodeAction(;
+            title = "Remove unused import",
+            kind = CodeActionKind.QuickFix,
+            diagnostics = Diagnostic[diagnostic],
+            isPreferred = true,
+            edit = WorkspaceEdit(;
+                changes = Dict{URI,Vector{TextEdit}}(
+                    uri => TextEdit[TextEdit(;
+                        range = data.delete_range,
+                        newText = "")]))))
     end
     return code_actions
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -391,6 +391,7 @@ const LOWERING_UNDEF_GLOBAL_VAR_CODE = "lowering/undef-global-var"
 const LOWERING_UNDEF_LOCAL_VAR_CODE = "lowering/undef-local-var"
 const LOWERING_CAPTURED_BOXED_VARIABLE_CODE = "lowering/captured-boxed-variable"
 const LOWERING_UNSORTED_IMPORT_NAMES_CODE = "lowering/unsorted-import-names"
+const LOWERING_UNUSED_IMPORT_CODE = "lowering/unused-import"
 const TOPLEVEL_ERROR_CODE = "toplevel/error"
 const TOPLEVEL_METHOD_OVERWRITE_CODE = "toplevel/method-overwrite"
 const TOPLEVEL_ABSTRACT_FIELD_CODE = "toplevel/abstract-field"
@@ -410,6 +411,7 @@ const ALL_DIAGNOSTIC_CODES = Set{String}(String[
     LOWERING_UNDEF_LOCAL_VAR_CODE,
     LOWERING_CAPTURED_BOXED_VARIABLE_CODE,
     LOWERING_UNSORTED_IMPORT_NAMES_CODE,
+    LOWERING_UNUSED_IMPORT_CODE,
     TOPLEVEL_ERROR_CODE,
     TOPLEVEL_METHOD_OVERWRITE_CODE,
     TOPLEVEL_ABSTRACT_FIELD_CODE,
@@ -583,7 +585,8 @@ end
 struct BindingInfoKey
     mod::Union{Nothing,Module}
     name::String
-    BindingInfoKey(binfo::JL.BindingInfo) = new(binfo.mod, binfo.name)
+    kind::Symbol
+    BindingInfoKey(binfo::JL.BindingInfo) = new(binfo.mod, binfo.name, binfo.kind)
 end
 
 """
@@ -615,9 +618,8 @@ struct CachedBindingOccurrence
     end
 end
 
-const BindingOccurrencesRangeKey = UnitRange{Int}
 const BindingOccurrencesResult = Dict{BindingInfoKey,Set{CachedBindingOccurrence}}
-const BindingOccurrencesCacheEntry = Base.PersistentDict{BindingOccurrencesRangeKey,BindingOccurrencesResult}
+const BindingOccurrencesCacheEntry = Base.PersistentDict{UnitRange{Int},BindingOccurrencesResult}
 
 const AnyBindingOccurrence = Union{BindingOccurrence,CachedBindingOccurrence}
 

--- a/src/utils/general.jl
+++ b/src/utils/general.jl
@@ -28,6 +28,20 @@ macro time(msg, ex)
 end
 
 """
+    @elapsed ex
+
+Internal `@elapsed` definition for JETLS that is only active in `JETLS_DEV_MODE`.
+When `JETLS_DEV_MODE` is `false`, this macro simply evaluates the expression without timing.
+"""
+macro elapsed(ex)
+    if JETLS_DEV_MODE
+        :(Base.@elapsed $(esc(ex)))
+    else
+        :(begin $(esc(ex)); 0.0; end)
+    end
+end
+
+"""
     @somereal(x...)
 
 Short-circuiting version of [`somereal`](@ref).

--- a/src/utils/lsp.jl
+++ b/src/utils/lsp.jl
@@ -1,4 +1,4 @@
-import Base: isless, ∈
+import Base: ∈
 
 Base.isless(pos1::Position, pos2::Position) =
     pos1.line < pos2.line || (pos1.line == pos2.line && pos1.character < pos2.character)

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -315,6 +315,15 @@ function get_context_module(analysis_result::AnalysisResult, uri::URI, pos::Posi
     end
     return curmod
 end
+function get_context_module(state::ServerState, uri::URI, pos::Position; lookup_func=nothing)
+    lookup_uri = @something get_notebook_uri_for_cell(state, uri) uri
+    if lookup_func !== nothing
+        analysis_info = get_analysis_info(lookup_func, state.analysis_manager, lookup_uri)
+    else
+        analysis_info = get_analysis_info(state.analysis_manager, lookup_uri)
+    end
+    return get_context_module(analysis_info, lookup_uri, pos)
+end
 
 get_context_analyzer(::Nothing, uri::URI) = LSAnalyzer(uri)
 get_context_analyzer(::OutOfScope, uri::URI) = LSAnalyzer(uri)


### PR DESCRIPTION
Add detection for unused imports (`using M: a, b` or `import M: a, b`) by scanning all files in the same analysis unit for usages of imported names.

The implementation:
- Collects explicitly imported names from the target file
- Scans all workspace files for binding usages via `get_binding_occurrences!`
- Tracks macro usages separately since macros are expanded away in lowered code (handles both `@foo` and `Module.@macro` forms)
- Reports unused imports with `DiagnosticTag.Unnecessary`

Performance considerations:
- Early return for files without import/using statements (~1ms depending on file size)
- Syntax tree caching for unsynced files (~150ms → ~25ms for ~50 files, thanks to `FileInfo.syntax_tree0`)
- Binding occurrences caching
- Unchanged file skipping in workspace/diagnostic With these optimizations, analyzing ~50 files typically takes ~50-100ms.

Also adds `@elapsed` macro to `general.jl` that is only active in `JETLS_DEV_MODE` for performance profiling.

<img width="824" height="596" alt="Screenshot 2026-01-20 at 22 19 56" src="https://github.com/user-attachments/assets/8c2f002d-2af2-495f-b3c6-9c18c77256c8" />
