### PR TITLE
diagnostic: Fix false positive captured-boxed-variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed LSP features not working inside `@main` functions.
 
+- Fixed false positive `lowering/captured-boxed-variable` diagnostic when a
+  struct's inner constructor defines a local variable with the same name as a
+  type parameter (e.g., `struct Foo{T}` with `T = typeof(x)` in the constructor).
+  (https://github.com/aviatesk/JETLS.jl/issues/508)
+
 ## 2026-01-17
 
 - Commit: [`c8e2012`](https://github.com/aviatesk/JETLS.jl/commit/c8e2012)

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -1015,6 +1015,19 @@ end
         """)
         @test isempty(diagnostics)
     end
+
+    # https://github.com/aviatesk/JETLS.jl/issues/508
+    let diagnostics = get_lowered_diagnostics("""
+        struct Foo{T}
+            x::T
+            function Foo(x)
+                T = typeof(x)
+                return new{T}(x)
+            end
+        end
+        """)
+        @test isempty(diagnostics)
+    end
 end
 
 is_unsorted_import_names_diagnostic(diagnostic) =


### PR DESCRIPTION
Fix false positive `lowering/captured-boxed-variable` diagnostic when a struct's inner constructor defines a local variable with the same name as a type parameter (e.g., `struct Foo{T}` with `T = typeof(x)` in the constructor).

The issue was that JuliaLowering introduces binding info for variables that aren't actually captured in certain edge cases. The fix adds `is_captured_binding` check to verify the binding is genuinely captured by some closure before reporting the diagnostic.

This is a workaround; the fundamental issue should be resolved on the JuliaLowering side.

- Fixes aviatesk/JETLS.jl#508