### PR TITLE
code-lens: Add reference count code lens for top-level symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
 - Diff: [`9c00dfe...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/9c00dfe...HEAD)
 
-### Added
-
-- Added [`code_lens.testrunner`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/code_lens-testrunner)
-  configuration option to enable or disable TestRunner code lenses. Some editors
-  (e.g., Zed) display code lenses as code actions, causing duplication.
-  The [aviatesk/zed-julia](https://github.com/aviatesk/zed-julia) extension
-  automatically defaults this to `false`.
-
 ### Announcement
 
 > [!warning]
@@ -52,6 +44,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > might work, but most LSP features will be unfunctional.
 > Note that `analysis_overrides` is provided as a temporary workaround and may
 > be removed or changed at any time. A proper fix is being worked on.
+
+### Added
+
+- Added reference count code lens for top-level symbols (functions, structs,
+  constants, abstract types, primitive types, modules). When enabled, a code
+  lens showing "N references" appears above each symbol definition. Clicking it
+  opens the references panel. This feature is opt-in and can be enabled via
+  [`code_lens.references`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/code_lens-references)
+  configuration.
+
+- Added [`code_lens.testrunner`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/code_lens-testrunner)
+  configuration option to enable or disable TestRunner code lenses. Some editors
+  (e.g., Zed) display code lenses as code actions, causing duplication.
+  The [aviatesk/zed-julia](https://github.com/aviatesk/zed-julia) extension
+  automatically defaults this to `false`.
 
 ## 2026-01-23
 

--- a/LSP/src/language-features/code-lens.jl
+++ b/LSP/src/language-features/code-lens.jl
@@ -28,6 +28,14 @@ end
     refreshSupport::Union{Nothing, Bool} = nothing
 end
 
+# JETLS specific data structures for `data` field of `CodeLens`
+struct ReferencesCodeLensData
+    uri::URI
+    line::Int
+    character::Int
+end
+export ReferencesCodeLensData
+
 """
 A code lens represents a command that should be shown along with
 source text, like the number of references, a way to run tests, etc.
@@ -52,7 +60,7 @@ in two stages.
     A data entry field that is preserved on a code lens item between
     a code lens and a code lens resolve request.
     """
-    data::Union{Nothing, LSPAny} = nothing
+    data::Union{Nothing, ReferencesCodeLensData} = nothing
 end
 
 @interface CodeLensParams @extends WorkDoneProgressParams, PartialResultParams begin

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -35,6 +35,7 @@ strip_prefix = false               # boolean, default: (unset) auto-detect
 prepend_inference_result = false   # boolean, default: (unset) auto-detect
 
 [code_lens]
+references = false                 # boolean, default: false
 testrunner = true                  # boolean, default: true
 
 [testrunner]
@@ -56,6 +57,7 @@ executable = "testrunner"          # string, default: "testrunner" (or "testrunn
     - [`[completion.latex_emoji] strip_prefix`](@ref config/completion-latex_emoji-strip_prefix)
     - [`[completion.method_signature] prepend_inference_result`](@ref config/completion-method_signature-prepend_inference_result)
 - [`[code_lens]`](@ref config/code_lens)
+    - [`[code_lens] references`](@ref config/code_lens-references)
     - [`[code_lens] testrunner`](@ref config/code_lens-testrunner)
 - [`[testrunner]`](@ref config/testrunner)
     - [`[testrunner] executable`](@ref config/testrunner-executable)
@@ -429,6 +431,23 @@ prepend_inference_result = true  # Show return type in documentation
     consider submitting a PR to add your client to the [auto-detection](https://github.com/aviatesk/JETLS.jl/blob/14fdc847252579c27e41cd50820aee509f8fd7bd/src/completions.jl#L386) logic.
 
 ### [`[code_lens]`](@id config/code_lens)
+
+Configure code lens behavior.
+
+#### [`[code_lens] references`](@id config/code_lens-references)
+
+- **Type**: boolean
+- **Default**: `false`
+
+Show reference counts for top-level symbols (functions, structs, constants,
+abstract types, primitive types, modules). When enabled, JETLS displays a code
+lens above each symbol showing how many times it is referenced in the codebase.
+Clicking the code lens opens the references panel.
+
+```toml
+[code_lens]
+references = true  # Enable reference count code lenses
+```
 
 #### [`[code_lens] testrunner`](@id config/code_lens-testrunner)
 

--- a/jetls-client/jetls-client.ts
+++ b/jetls-client/jetls-client.ts
@@ -657,6 +657,53 @@ export function activate(context: ExtensionContext) {
       },
     ),
   );
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "jetls.showReferences",
+      async (uriString: string, line: number, character: number) => {
+        if (!languageClient) {
+          return;
+        }
+        const uri = vscode.Uri.parse(uriString);
+        const position = new vscode.Position(line, character);
+        interface LspLocation {
+          uri: string;
+          range: {
+            start: { line: number; character: number };
+            end: { line: number; character: number };
+          };
+        }
+        const locations = await languageClient.sendRequest<LspLocation[]>(
+          "textDocument/references",
+          {
+            textDocument: { uri: uriString },
+            position: { line, character },
+            context: { includeDeclaration: false },
+          },
+        );
+        if (locations && locations.length > 0) {
+          const vsLocations = locations.map(
+            (loc) =>
+              new vscode.Location(
+                vscode.Uri.parse(loc.uri),
+                new vscode.Range(
+                  loc.range.start.line,
+                  loc.range.start.character,
+                  loc.range.end.line,
+                  loc.range.end.character,
+                ),
+              ),
+          );
+          vscode.commands.executeCommand(
+            "editor.action.showReferences",
+            uri,
+            position,
+            vsLocations,
+          );
+        }
+      },
+    ),
+  );
 
   outputChannel = vscode.window.createOutputChannel("JETLS", { log: true });
 

--- a/jetls-client/package.json
+++ b/jetls-client/package.json
@@ -43,6 +43,10 @@
       {
         "command": "jetls-client.restartLanguageServer",
         "title": "JETLS Client: Restart JETLS Language Server"
+      },
+      {
+        "command": "jetls.showReferences",
+        "title": "JETLS: Show References"
       }
     ],
     "configuration": {
@@ -271,6 +275,17 @@
                   "type": "string",
                   "default": "testrunner",
                   "markdownDescription": "Path to the TestRunner.jl executable. If not set, uses `'testrunner'` from `PATH`."
+                }
+              }
+            },
+            "code_lens": {
+              "type": "object",
+              "markdownDescription": "Code lens configuration.",
+              "properties": {
+                "references": {
+                  "type": "boolean",
+                  "default": false,
+                  "markdownDescription": "Show reference counts for top-level symbols (functions, structs, constants, etc.)."
                 }
               }
             }

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -432,6 +432,8 @@ function handle_request_message(server::Server, @nospecialize(msg), cancel_flag:
         handle_WorkspaceDiagnosticRequest(server, msg, cancel_flag)
     elseif msg isa CodeLensRequest
         handle_CodeLensRequest(server, msg, cancel_flag)
+    elseif msg isa CodeLensResolveRequest
+        handle_CodeLensResolveRequest(server, msg, cancel_flag)
     elseif msg isa CodeActionRequest
         handle_CodeActionRequest(server, msg, cancel_flag)
     elseif msg isa InlayHintRequest

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -403,6 +403,8 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
     # lowering/macro-expansion-error and lowering/undef-global-var diagnostics
     # to be properly reported.
     request_diagnostic_refresh!(server)
+    # Also request code lens for references recalculation
+    request_codelens_refresh!(server)
 
     @label next_request
 

--- a/src/code-lens.jl
+++ b/src/code-lens.jl
@@ -1,9 +1,10 @@
 const CODE_LENS_REGISTRATION_ID = "jetls-code-lens"
 const CODE_LENS_REGISTRATION_METHOD = "textDocument/codeLens"
+const COMMAND_SHOW_REFERENCES = "jetls.showReferences"
 
 function code_lens_options()
     return CodeLensOptions(;
-        resolveProvider = false)
+        resolveProvider = true)
 end
 
 function code_lens_registration()
@@ -12,7 +13,7 @@ function code_lens_registration()
         method = CODE_LENS_REGISTRATION_METHOD,
         registerOptions = CodeLensRegistrationOptions(;
             documentSelector = DEFAULT_DOCUMENT_SELECTOR,
-            resolveProvider = false))
+            resolveProvider = true))
 end
 
 # For dynamic code lens registrations during development
@@ -35,10 +36,87 @@ function handle_CodeLensRequest(server::Server, msg::CodeLensRequest, cancel_fla
     if !isempty(testsetinfos) && get_config(server, :code_lens, :testrunner)
         testrunner_code_lenses!(code_lenses, uri, fi, testsetinfos)
     end
+    if get_config(server, :code_lens, :references)
+        references_code_lenses!(code_lenses, server.state, uri, fi)
+    end
     return send(server,
         CodeLensResponse(;
             id = msg.id,
             result = @somereal code_lenses null))
+end
+
+const REFERENCES_CODE_LENS_SYMBOL_KINDS = (
+    SymbolKind.Function,
+    SymbolKind.Struct,
+    SymbolKind.Constant,
+    SymbolKind.Interface,
+    SymbolKind.Class,
+    SymbolKind.Module,
+    SymbolKind.Enum,
+)
+
+function references_code_lenses!(
+        code_lenses::Vector{CodeLens}, state::ServerState, uri::URI, fi::FileInfo
+    )
+    symbols = get_document_symbols!(state, uri, fi)
+    isnothing(symbols) && return code_lenses
+    collect_references_code_lenses!(code_lenses, uri, symbols)
+    return code_lenses
+end
+
+function collect_references_code_lenses!(
+        code_lenses::Vector{CodeLens}, uri::URI, symbols::Vector{DocumentSymbol}
+    )
+    for symbol in symbols
+        if symbol.kind in REFERENCES_CODE_LENS_SYMBOL_KINDS
+            occursin('.', symbol.name) && continue # Qualified defintions are not supported
+            range = symbol.selectionRange
+            data = ReferencesCodeLensData(uri, range.start.line, range.start.character)
+            push!(code_lenses, CodeLens(; range, data))
+        end
+        children = symbol.children
+        if children !== nothing
+            collect_references_code_lenses!(code_lenses, uri, children)
+        end
+    end
+    return nothing
+end
+
+function handle_CodeLensResolveRequest(
+        server::Server, msg::CodeLensResolveRequest, cancel_flag::CancelFlag
+    )
+    code_lens = msg.params
+    data = code_lens.data
+    isa(data, ReferencesCodeLensData) ||
+        return send(server, CodeLensResolveResponse(; id = msg.id, result = code_lens))
+
+    pos = Position(; line = data.line, character = data.character)
+    arguments = Any[string(data.uri), pos.line, pos.character]
+
+    if !has_analyzed_context(server.state, data.uri)
+        command = Command(;
+            title = "? references",
+            command = COMMAND_SHOW_REFERENCES,
+            arguments)
+        resolved = CodeLens(; range = code_lens.range, command, data = code_lens.data)
+        return send(server, CodeLensResolveResponse(; id = msg.id, result = resolved))
+    end
+
+    result = get_file_info(server.state, data.uri, cancel_flag)
+    if isnothing(result) || result isa ResponseError
+        return send(server, CodeLensResolveResponse(; id = msg.id, result = code_lens))
+    end
+
+    fi = result
+    locations = find_references(server, data.uri, fi, pos;
+        include_declaration = false, cancel_flag)
+    count = locations isa Vector ? length(locations) : 0
+
+    title = count == 1 ? "1 reference" : "$count references"
+    command = Command(; title, command = COMMAND_SHOW_REFERENCES, arguments)
+    resolved = CodeLens(; range = code_lens.range, command, data = code_lens.data)
+    return send(server,
+        CodeLensResolveResponse(; id = msg.id, result = resolved))
 end
 
 struct CodeLensRefreshRequestCaller <: RequestCaller end

--- a/src/types.jl
+++ b/src/types.jl
@@ -484,6 +484,7 @@ end
 end
 
 @option struct CodeLensConfig <: ConfigSection
+    references::Maybe{Bool}
     testrunner::Maybe{Bool}
 end
 
@@ -507,7 +508,7 @@ const DEFAULT_CONFIG = JETLSConfig(;
     testrunner = TestRunnerConfig(@static Sys.iswindows() ? "testrunner.bat" : "testrunner"),
     formatter = "Runic",
     completion = CompletionConfig(LaTeXEmojiConfig(missing), MethodSignatureConfig(missing)),
-    code_lens = CodeLensConfig(true),
+    code_lens = CodeLensConfig(false, true),
     initialization_options = DEFAULT_INIT_OPTIONS)
 
 function get_default_config(path::Symbol...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,7 @@ end
     @testset "diagnostics" include("test_diagnostic.jl")
     @testset "did-change-watched-files" include("test_did_change_watched_files.jl")
     @testset "rename" include("test_rename.jl")
+    @testset "code lens" include("test_code_lens.jl")
     @testset "testrunner" include("test_testrunner.jl")
     @testset "full lifecycle" include("test_full_lifecycle.jl")
     @testset "notebook" include("test_notebook.jl")

--- a/test/test_code_lens.jl
+++ b/test/test_code_lens.jl
@@ -1,0 +1,102 @@
+module test_code_lens
+
+using Test
+using JETLS
+using JETLS.LSP
+using JETLS.URIs2
+
+function get_code_lenses_with_counts(code::AbstractString)
+    server = JETLS.Server()
+    uri = URI("file:///test.jl")
+    fi = JETLS.FileInfo(#=version=#0, code, "test.jl")
+    JETLS.store!(server.state.file_cache) do cache
+        Base.PersistentDict(cache, uri => fi), nothing
+    end
+    code_lenses = CodeLens[]
+    JETLS.references_code_lenses!(code_lenses, server.state, uri, fi)
+    results = Tuple{CodeLens,Int}[]
+    for lens in code_lenses
+        data = lens.data::ReferencesCodeLensData
+        pos = Position(; line = data.line, character = data.character)
+        locations = JETLS.find_references(server, uri, fi, pos;
+            include_declaration = false)
+        count = locations isa Vector ? length(locations) : 0
+        push!(results, (lens, count))
+    end
+    return results
+end
+
+@testset "references code lens" begin
+    @testset "function with references" begin
+        let code = """
+            function myfunc(x)
+                x + 1
+            end
+            result = myfunc(42)
+            """
+            results = get_code_lenses_with_counts(code)
+            @test length(results) == 1
+            lens, count = results[1]
+            @test lens.data isa ReferencesCodeLensData
+            @test count ≥ 1
+        end
+    end
+
+    @testset "function with multiple references" begin
+        let code = """
+            function foo(x)
+                x + 1
+            end
+            a = foo(1)
+            b = foo(2)
+            c = foo(3)
+            """
+            results = get_code_lenses_with_counts(code)
+            @test length(results) == 1
+            _, count = results[1]
+            @test count ≥ 3
+        end
+    end
+
+    @testset "struct with references" begin
+        let code = """
+            struct MyStruct
+                x::Int
+            end
+            obj = MyStruct(1)
+            """
+            results = get_code_lenses_with_counts(code)
+            @test length(results) == 1
+            _, count = results[1]
+            @test count ≥ 1
+        end
+    end
+
+    @testset "multiple symbols with different reference counts" begin
+        let code = """
+            struct Foo end
+            function bar(x::Foo)
+                x
+            end
+            obj = Foo()
+            result = bar(obj)
+            """
+            results = get_code_lenses_with_counts(code)
+            @test length(results) == 2
+            counts = sort([c for (_, c) in results])
+            @test counts[1] < counts[2]
+        end
+    end
+
+    @testset "qualified names" begin # currently supported
+        let code = """
+            struct X end
+            Base.show(io::IO, ::X) = print(io, "X")
+            """
+            results = get_code_lenses_with_counts(code)
+            @test length(results) == 1
+        end
+    end
+end
+
+end # module test_code_lens


### PR DESCRIPTION
Implement a code lens feature that displays the number of references for top-level symbols (functions, structs, constants, abstract types, primitive types, modules). The reference count is fetched lazily via `codeLens/resolve`, and clicking the code lens triggers the `jetls.showReferences` command which opens the references panel.

Key implementation details:
- Reuse `get_document_symbols!` cache to collect symbols for code lens
- Add `ReferencesCodeLensData` struct in LSP.jl for type-safe data
- Add `handle_CodeLensResolveRequest` handler that calls `find_references` to count references
- Display "? references" when analysis is not yet complete
- Add `jetls.showReferences` command handler in jetls-client

The feature is opt-in (disabled by default) and can be enabled via the `code_lens.references` configuration option.

<img width="824" height="596" alt="Screenshot 2026-01-23 at 01 16 41" src="https://github.com/user-attachments/assets/6b60a3c2-71ea-48e9-af86-9b1c6cd0010c" />