### PR TITLE
Update JuliaSyntax and JuliaLowering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   expectations about how requests with no `section` are handled.
   (https://github.com/aviatesk/JETLS.jl/pull/483; thanks [danielwe](https://github.com/danielwe))
 
+- Updated JuliaSyntax.jl and JuliaLowering.jl dependency versions to latest.
+
 ### Fixed
 
 - Fixed LSP features not working inside `@main` functions.
@@ -121,6 +123,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   struct's inner constructor defines a local variable with the same name as a
   type parameter (e.g., `struct Foo{T}` with `T = typeof(x)` in the constructor).
   (https://github.com/aviatesk/JETLS.jl/issues/508)
+
+- Fixed severe performance issue when analyzing test files containing many
+  `@test` and `@testset` macros. The underlying JuliaLowering issue caused
+  macro expansion to be 40-300x slower for test files compared to regular source
+  files. (JuliaLang/julia#60756)
 
 ## 2026-01-17
 

--- a/Project.toml
+++ b/Project.toml
@@ -25,8 +25,8 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [sources]
 JET = {rev = "8fe5f1b", url = "https://github.com/aviatesk/JET.jl"}
-JuliaLowering = {rev = "avi/JETLS-JSJL-head-2026-01-18", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
-JuliaSyntax = {rev = "avi/JETLS-JSJL-head-2026-01-18", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
+JuliaLowering = {rev = "avi/JETLS-JSJL-head-2026-01-23", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
+JuliaSyntax = {rev = "avi/JETLS-JSJL-head-2026-01-23", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
 LSP = {path = "LSP"}
 
 [compat]

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -697,6 +697,14 @@ end
         @test diagnostic.range.var"end".line == 1
         @test diagnostic.range.var"end".character == 13
     end
+
+    @test_broken isempty(get_lowered_diagnostics(@__MODULE__, """
+        struct Issue492
+            global function make_issue492()
+                new()
+            end
+        end
+    """))
 end
 
 @testset "Undefined local binding report" begin


### PR DESCRIPTION
Update JuliaSyntax.jl and JuliaLowering.jl to the latest versions,
which include the fix for performance degradation (40-300x slower) when
analyzing test files with many `@test`/`@testset` macros
(https://github.com/JuliaLang/julia/issues/60756)