### PR TITLE
Add `code_lens.testrunner` configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
 - Diff: [`9c00dfe...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/9c00dfe...HEAD)
 
+### Added
+
+- Added [`code_lens.testrunner`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/code_lens-testrunner)
+  configuration option to enable or disable TestRunner code lenses. Some editors
+  (e.g., Zed) display code lenses as code actions, causing duplication.
+  The [aviatesk/zed-julia](https://github.com/aviatesk/zed-julia) extension
+  automatically defaults this to `false`.
+
 ### Announcement
 
 > [!warning]

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -34,6 +34,9 @@ strip_prefix = false               # boolean, default: (unset) auto-detect
 [completion.method_signature]
 prepend_inference_result = false   # boolean, default: (unset) auto-detect
 
+[code_lens]
+testrunner = true                  # boolean, default: true
+
 [testrunner]
 executable = "testrunner"          # string, default: "testrunner" (or "testrunner.bat" on Windows)
 ```
@@ -52,6 +55,8 @@ executable = "testrunner"          # string, default: "testrunner" (or "testrunn
 - [`[completion]`](@ref config/completion)
     - [`[completion.latex_emoji] strip_prefix`](@ref config/completion-latex_emoji-strip_prefix)
     - [`[completion.method_signature] prepend_inference_result`](@ref config/completion-method_signature-prepend_inference_result)
+- [`[code_lens]`](@ref config/code_lens)
+    - [`[code_lens] testrunner`](@ref config/code_lens-testrunner)
 - [`[testrunner]`](@ref config/testrunner)
     - [`[testrunner] executable`](@ref config/testrunner-executable)
 
@@ -423,6 +428,28 @@ prepend_inference_result = true  # Show return type in documentation
     If explicitly setting this option clearly improves behavior for your client,
     consider submitting a PR to add your client to the [auto-detection](https://github.com/aviatesk/JETLS.jl/blob/14fdc847252579c27e41cd50820aee509f8fd7bd/src/completions.jl#L386) logic.
 
+### [`[code_lens]`](@id config/code_lens)
+
+#### [`[code_lens] testrunner`](@id config/code_lens-testrunner)
+
+- **Type**: boolean
+- **Default**: `true`
+
+Enable or disable [TestRunner code lenses](@ref testrunner/features/code-lens).
+When enabled, JETLS shows "Run" and "Debug" code lenses above `@testset` blocks
+for running individual tests.
+
+Some editors (e.g., Zed[^zed_code_lens_testrunner]) display code lenses as code actions, which can cause
+duplication when both code lenses and code actions are shown for the same
+functionality. In such cases, you may want to disable this setting.
+
+[^zed_code_lens_testrunner]: The [aviatesk/zed-julia](https://github.com/aviatesk/zed-julia) extension defaults this setting to `false` unless explicitly configured.
+
+```toml
+[code_lens]
+testrunner = false  # Disable TestRunner code lenses
+```
+
 ### [`[testrunner]`](@id config/testrunner)
 
 #### [`[testrunner] executable`](@id config/testrunner-executable)
@@ -438,7 +465,7 @@ executable for running individual `@testset` blocks and `@test` cases.
 executable = "/path/to/custom/testrunner"
 ```
 
-See [TestRunner integration](@ref) for setup instructions.
+See [TestRunner integration](@ref testrunner) for setup instructions.
 
 ## How to configure JETLS
 

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -60,7 +60,7 @@ Additionally, some editors also allow filtering diagnostics by source.
     This section contains references to LSP protocol details. You don't need
     to understand these details to use JETLS effectively - the key takeaway
     is simply that different diagnostics update at different times (as you
-    edit, when you save, or when you run tests via [TestRunner integration](@ref)).
+    edit, when you save, or when you run tests via [TestRunner integration](@ref testrunner)).
 
 JETLS uses three diagnostic sources:
 
@@ -610,14 +610,14 @@ end
 ### [TestRunner diagnostic (`testrunner/*`)](@id diagnostic/reference/testrunner)
 
 TestRunner diagnostics are reported when you manually run tests via code lens
-or code actions through the [TestRunner integration](@ref) (source: `JETLS/extra`).
+or code actions through the [TestRunner integration](@ref testrunner) (source: `JETLS/extra`).
 Unlike other diagnostics, these are not triggered automatically by editing or saving files.
 
 #### [Test failure (`testrunner/test-failure`)](@id diagnostic/reference/testrunner/test-failure)
 
 **Default severity**: `Error`
 
-Test failures reported by [TestRunner integration](@ref) that happened during
+Test failures reported by [TestRunner integration](@ref testrunner) that happened during
 running individual `@testset` blocks or `@test` cases.
 
 !!! note

--- a/docs/src/testrunner.md
+++ b/docs/src/testrunner.md
@@ -1,11 +1,11 @@
-# TestRunner integration
+# [TestRunner integration](@id testrunner)
 
 JETLS integrates with [TestRunner.jl](https://github.com/aviatesk/TestRunner.jl)
 to provide an enhanced testing experience directly within your editor. This
 feature allows you to run individual `@testset` blocks directly from your
 development environment.
 
-## Prerequisites
+## [Prerequisites](@id testrunner/prerequisites)
 
 To use this feature, you need to install the `testrunner` executable:
 ```bash
@@ -16,9 +16,9 @@ Note that you need to manually make `~/.julia/bin` available on the `PATH`
 environment for the `testrunner` executable to be accessible.
 See <https://pkgdocs.julialang.org/dev/apps/> for the details.
 
-## Features
+## [Features](@id testrunner/features)
 
-### Code lens
+### [Code lens](@id testrunner/features/code-lens)
 
 When you open a Julia file containing `@testset` blocks, JETLS displays
 interactive code lenses above each `@testset`:
@@ -38,7 +38,7 @@ After running tests, the code lens is refreshed as follows:
 > <img class="display-dark-only" src="../assets/testrunner-code-lens-refreshed-dark.png" alt="TestRunner Code Lens with Results"/>
 > ```
 
-### Code actions
+### [Code actions](@id testrunner/features/code-actions)
 
 You can trigger test runs via "code actions" that are explicitly requested by the user:
 
@@ -58,7 +58,7 @@ Note that when running individual `@test` cases, the error results are displayed
 as temporary diagnostics for 10 seconds. Click `☰ Open logs` button in the
 pop up message to view detailed error messages that persist.
 
-### Test diagnostics
+### [Test diagnostics](@id testrunner/features/test-diagnostics)
 
 Failed tests are displayed as diagnostics (red squiggly lines) at the exact
 lines where the failures occurred, making it easy to identify and fix issues:
@@ -67,12 +67,12 @@ lines where the failures occurred, making it easy to identify and fix issues:
 > <img class="display-dark-only" src="../assets/testrunner-diagnostics-dark.png" alt="TestRunner Diagnostics"/>
 > ```
 
-### Progress notifications
+### [Progress notifications](@id testrunner/features/progress-notifications)
 
 For clients that support work done progress, JETLS shows progress notifications
 while tests are running, keeping you informed about long-running test suites.
 
-## Supported patterns
+## [Supported patterns](@id testrunner/supported-patterns)
 
 The TestRunner integration supports:
 
@@ -135,7 +135,7 @@ The TestRunner integration supports:
 
 See the [TestRunner.jl README](https://github.com/aviatesk/TestRunner.jl) for more details.
 
-## Troubleshooting
+## [Troubleshooting](@id testrunner/troubleshooting)
 
 If you see an error about `testrunner` not being found:
 

--- a/src/code-lens.jl
+++ b/src/code-lens.jl
@@ -32,8 +32,9 @@ function handle_CodeLensRequest(server::Server, msg::CodeLensRequest, cancel_fla
     fi = result
     code_lenses = CodeLens[]
     testsetinfos = fi.testsetinfos
-    isempty(testsetinfos) ||
+    if !isempty(testsetinfos) && get_config(server, :code_lens, :testrunner)
         testrunner_code_lenses!(code_lenses, uri, fi, testsetinfos)
+    end
     return send(server,
         CodeLensResponse(;
             id = msg.id,

--- a/src/types.jl
+++ b/src/types.jl
@@ -483,12 +483,17 @@ end
     method_signature::Maybe{MethodSignatureConfig}
 end
 
+@option struct CodeLensConfig <: ConfigSection
+    testrunner::Maybe{Bool}
+end
+
 @option struct JETLSConfig <: ConfigSection
     diagnostic::Maybe{DiagnosticConfig}
     full_analysis::Maybe{FullAnalysisConfig}
     testrunner::Maybe{TestRunnerConfig}
     formatter::Maybe{FormatterConfig}
     completion::Maybe{CompletionConfig}
+    code_lens::Maybe{CodeLensConfig}
     # This initialization options are read once at the server initialization and held in
     # `server.state.init_options`, so it might seem strange to hold them here also,
     # but they need to be set here for cases where initialization options are set in
@@ -502,6 +507,7 @@ const DEFAULT_CONFIG = JETLSConfig(;
     testrunner = TestRunnerConfig(@static Sys.iswindows() ? "testrunner.bat" : "testrunner"),
     formatter = "Runic",
     completion = CompletionConfig(LaTeXEmojiConfig(missing), MethodSignatureConfig(missing)),
+    code_lens = CodeLensConfig(true),
     initialization_options = DEFAULT_INIT_OPTIONS)
 
 function get_default_config(path::Symbol...)


### PR DESCRIPTION
Add a new configuration option to enable or disable TestRunner code lenses. Some editors (e.g., Zed) display [code lenses as code actions](https://github.com/zed-industries/zed/issues/11565#issuecomment-2979040214), causing duplication when both are shown for the same functionality.

The setting defaults to `true` (enabled), but the `aviatesk/zed-julia` extension automatically defaults this to `false` for Zed users.