### PR TITLE
server: Implement graceful shutdown of worker tasks

### DIFF
--- a/LSP/src/communication.jl
+++ b/LSP/src/communication.jl
@@ -49,20 +49,19 @@ mutable struct Endpoint
         local endpoint::Endpoint
 
         read_task = Threads.@spawn :interactive while true
-            if @isdefined(endpoint) && !isopen(endpoint)
-                break
-            end
             msg = @something try
                 readlsp(in)
             catch err
                 err_handler(#=isread=#true, err, catch_backtrace())
                 continue
-            end break
+            end break # terminate this task loop when the stream is closed
+            (!@isdefined(endpoint) || isopen(endpoint)) || break
             put!(in_msg_queue, msg)
             GC.safepoint()
         end
 
         write_task = Threads.@spawn :interactive for msg in out_msg_queue
+            msg === nothing && break # terminate this task loop when taking this special token
             if isopen(out)
                 try
                     writelsp(out, msg)
@@ -71,7 +70,7 @@ mutable struct Endpoint
                     continue
                 end
             else
-                @error "Output channel has been closed before message serialization:" msg
+                @error "Output channel has been closed before message serialization" msg
                 break
             end
             GC.safepoint()
@@ -104,7 +103,7 @@ function read_transport_layer(io::IO)
         end
         line = chomp(readline(io))
     end
-    @isdefined(var"Content-Length") || error("Got header without Content-Length")
+    @isdefined(var"Content-Length") || throw(ErrorException("Got header without Content-Length"))
     message_length = parse(Int, var"Content-Length")
     return String(read(io, message_length))
 end
@@ -139,14 +138,14 @@ to_lsp_json(@nospecialize msg) = JSON3.write(msg)
 
 function Base.close(endpoint::Endpoint)
     flush(endpoint)
-    close(endpoint.in_msg_queue)
+    put!(endpoint.out_msg_queue, nothing) # send a special token to terminate the write task
     close(endpoint.out_msg_queue)
-    # TODO we would also like to close the read Task
-    # But unclear how to do that without also closing
-    # the socket, which we don't want to do
-    # fetch(endpoint.read_task)
-    fetch(endpoint.write_task)
+    wait(endpoint.write_task)
     @atomic :release endpoint.isopen = false
+    close(endpoint.in_msg_queue)
+    # TODO we would also like to fetch the read task here, but it may be blocked on
+    # `readlsp(in)`. Unclear how to unblock it without closing the socket.
+    # wait(endpoint.read_task)
     return endpoint
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -219,20 +219,22 @@ const InstantiatedEnvs = LWContainer{Dict{String,Union{Nothing,Tuple{Base.PkgId,
 struct AnalysisManager
     cache::AnalysisCache
     pending_analyses::PendingAnalyses
-    queue::Channel{AnalysisRequest}
+    queue::Channel{Union{Nothing,AnalysisRequest}}
     current_generations::CurrentGenerations
     analyzed_generations::AnalyzedGenerations
     debounced::DebouncedRequests
     instantiated_envs::InstantiatedEnvs
+    worker_tasks::Vector{Task}
     function AnalysisManager()
         return new(
             AnalysisCache(Dict{URI,AnalysisInfo}()),
             PendingAnalyses(Dict{AnalysisEntry,Union{Nothing,AnalysisRequest}}()),
-            Channel{AnalysisRequest}(Inf),
+            Channel{Union{Nothing,AnalysisRequest}}(Inf),
             CurrentGenerations(Dict{AnalysisEntry,Int}()),
             AnalyzedGenerations(Dict{AnalysisEntry,Int}()),
             DebouncedRequests(Dict{AnalysisEntry,Timer}()),
-            InstantiatedEnvs(Dict{String,Union{Nothing,Tuple{Base.PkgId,URI}}}())
+            InstantiatedEnvs(Dict{String,Union{Nothing,Tuple{Base.PkgId,URI}}}()),
+            Task[], # initialized by start_analysis_workers!
         )
     end
 end


### PR DESCRIPTION
Ensure all `Threads.@spawn`ed tasks are properly terminated before the server exits. This avoids the segfault issue described in JuliaLang/julia#32983, where Julia can crash on exit if spawned tasks are still running.

Also fix race condition in `Endpoint.close`:
- Add `isopen` check before `put!` in `read_task` to prevent putting into a closed channel when `close` is called while blocked on `readlsp`
- Move `isopen = false` after `wait(write_task)` to ensure proper shutdown ordering
- Remove redundant `isopen` checks at loop heads (they could never fire given the shutdown sequence)