### PR TITLE
diagnostic: Add cancellation support to lowering diagnostics

### DIFF
--- a/src/analysis/occurrence-analysis.jl
+++ b/src/analysis/occurrence-analysis.jl
@@ -338,7 +338,7 @@ function collect_macrocall_occurrences!(
         (; ctx3) = try
             jl_lower_for_scope_resolution(mod, macrocall_name)
         catch
-            return TraversalNoRecurse()
+            return traversal_no_recurse
         end
         for binfo in ctx3.bindings.info
             if binfo.kind === :global

--- a/src/testrunner/testrunner.jl
+++ b/src/testrunner/testrunner.jl
@@ -103,7 +103,7 @@ function find_executable_testsets(st0_top::SyntaxTree0)
     traverse(st0_top) do st0::SyntaxTree0
         if JS.kind(st0) in JS.KSet"function macro"
             # avoid visit inside function scope
-            return TraversalNoRecurse()
+            return traversal_no_recurse
         elseif JS.kind(st0) === JS.K"macrocall" && JS.numchildren(st0) ≥ 2
             macroname = st0[1]
             if hasproperty(macroname, :name_val) && macroname.name_val == "@testset"
@@ -252,7 +252,7 @@ function testrunner_testcase_code_actions!(
     traverse(st0_top) do st0::SyntaxTree0
         if JS.kind(st0) in JS.KSet"function macro"
             # avoid visit inside function scope
-            return TraversalNoRecurse()
+            return traversal_no_recurse
         elseif JS.kind(st0) === JS.K"macrocall" && JS.numchildren(st0) ≥ 1
             macroname = st0[1]
             if hasproperty(macroname, :name_val) && macroname.name_val in TEST_MACROS

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -159,7 +159,7 @@ function find_target_binding(ctx3::JL.VariableAnalysisContext, st3::JS.SyntaxTre
         if k === JS.K"lambda" && is_kwcall_lambda(ctx3, st)
             # Don't select a binding with `kwcall` definition.
             # What usually interesting to us is information about the main method.
-            return TraversalNoRecurse()
+            return traversal_no_recurse
         end
         offset in JS.byte_range(st) || return nothing
         k === JS.K"BindingId" || return nothing


### PR DESCRIPTION
Add `cancel_flag` parameter to `toplevel_lowering_diagnostics` to allow early termination during `textDocument/diagnostic` requests. The cancellation check is performed at each top-level statement iteration.

Also refactor AST traversal utilities:
- Move `iterate_toplevel_tree` from `diagnostic.jl` to `utils/ast.jl`
- Add `traversal_terminator` and `traversal_no_recurse` constants instead of creating new singleton instances on each comparison