### PR TITLE
server: Make `build_syntax_tree` thread-safe for cached trees

### DIFF
--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -242,16 +242,16 @@ or simply be outside the active workspace scope.
 Results are cached in `state.unsynced_file_cache` and invalidated via
 `workspace/didChangeWatchedFiles`.
 """
-function get_unsynced_file_info!(state::ServerState, uri::URI)
-    cache = load(state.unsynced_file_cache)
-    if haskey(cache, uri)
-        return cache[uri]
-    end
-    return store_unsynced_file_info!(state, uri)
-end
+get_unsynced_file_info!(state::ServerState, uri::URI) =
+    _store_unsynced_file_info!(state, uri)
 
-function store_unsynced_file_info!(state::ServerState, uri::URI)
+store_unsynced_file_info!(state::ServerState, uri::URI) =
+    _store_unsynced_file_info!(state, uri; force=true)
+function _store_unsynced_file_info!(state::ServerState, uri::URI; force::Bool=false)
     return store!(state.unsynced_file_cache) do cache::UnsyncedFileCacheData
+        if !force && haskey(cache, uri)
+            return cache, cache[uri]
+        end
         version = time_ns() % Int
         filename = uri2filename(uri)
         isfile(filename) || return cache, nothing


### PR DESCRIPTION
Add `copy_syntax_tree` function that creates lightweight copies of `SyntaxTree` objects by copying only the mutable structures (`edge_ranges`, `edges`, and attribute dictionaries) while sharing the immutable data within.

This is needed because JuliaLowering's pipeline modifies the internal `SyntaxGraph` structure. When multiple threads access the same cached tree (via `get_unsynced_file_info!`), this causes data races and segfaults. By returning a copy instead of the cached tree itself, each thread gets an independent tree to work with.

Also fix a TOCTOU race in `get_unsynced_file_info!` by moving the `haskey` check inside the `store!` callback, ensuring the check and update happen atomically.

Performance: `copy_syntax_tree` is ~100x faster than `build_tree` (~1μs vs ~100μs per file), so the caching optimization from aviatesk/JETLS.jl#505 is preserved.