### PR TITLE
diagnostic: Filter macro-generated bindings with `is_from_user_ast`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Lowering diagnostics no longer report issues in macro-generated code that
+  users cannot control. User-written identifiers processed by new-style macros
+  are still reported, but old-style macros are not yet supported due to
+  JuliaLowering limitations. (https://github.com/aviatesk/JETLS.jl/issues/522)
+
 - Fixed potential segfault on server exit by implementing graceful shutdown of
   worker tasks. All `Threads.@spawn`ed tasks are now properly terminated before
   the server exits. (xref: https://github.com/JuliaLang/julia/issues/32983, https://github.com/aviatesk/JETLS.jl/pull/523)

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -602,7 +602,8 @@ function analyze_unused_bindings!(
             continue
         end
         provs = JS.flattened_provenance(JL.binding_ex(ctx3, binfo.id))
-        prov = first(provs)
+        is_from_user_ast(provs) || continue
+        prov = last(provs)
         range = jsobj_to_range(prov, fi)
         key = LoweringDiagnosticKey(range, bk, bn)
         key in reported ? continue : push!(reported, key)
@@ -657,7 +658,8 @@ function analyze_undefined_global_bindings!(
         end
         bn = binfo.name
         provs = JS.flattened_provenance(JL.binding_ex(ctx3, binfo.id))
-        range = jsobj_to_range(first(provs), fi)
+        is_from_user_ast(provs) || continue
+        range = jsobj_to_range(last(provs), fi)
         key = LoweringDiagnosticKey(range, bk, bn)
         key in reported ? continue : push!(reported, key)
         code = LOWERING_UNDEF_GLOBAL_VAR_CODE
@@ -691,11 +693,8 @@ function analyze_undefined_local_bindings!(
         undef_status === false && continue
         first_use_tree = first(uinfo.uses)
         provs = JL.flattened_provenance(first_use_tree)
-        isempty(provs) && continue
-        if length(provs) > 1 # From macro expanded code, ignore it for now
-            continue
-        end
-        range = jsobj_to_range(first(provs), fi)
+        is_from_user_ast(provs) || continue
+        range = jsobj_to_range(last(provs), fi)
         key = LoweringDiagnosticKey(range, binfo.kind, binfo.name)
         key in reported ? continue : push!(reported, key)
         relatedInformation = DiagnosticRelatedInformation[]
@@ -763,7 +762,8 @@ function analyze_captured_boxes!(
         is_captured_binding(binfo, ctx4) || continue
         bn = binfo.name
         provs = JL.flattened_provenance(JL.binding_ex(ctx4, binfo.id))
-        range = jsobj_to_range(first(provs), fi)
+        is_from_user_ast(provs) || continue
+        range = jsobj_to_range(last(provs), fi)
         key = LoweringDiagnosticKey(range, :boxed, bn)
         key in reported ? continue : push!(reported, key)
         code = LOWERING_CAPTURED_BOXED_VARIABLE_CODE


### PR DESCRIPTION
Add `is_from_user_ast` utility to determine whether a binding with multiple provenances originates from user-written code. When a binding has multiple provenances due to macro expansion, this checks if the final provenance location falls within the byte range of the first provenance.

Apply this filter to all lowering diagnostics:
- `analyze_unused_bindings!`
- `analyze_undefined_global_bindings!`
- `analyze_undefined_local_bindings!`
- `analyze_captured_boxes!`

This allows reporting on user-written identifiers like `x` in `func(@nospecialize x) = ()`, while filtering out purely macro-generated bindings like internal variables from `@ast`.

~~Fixes aviatesk/JETLS.jl#522.~~ It turned out that this issue is actually unrelated to this fix.