### PR TITLE
diagnostic: Use `remove_macrocalls` for macrocall removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Lowering diagnostics no longer report issues in macro-generated code that
   users cannot control. User-written identifiers processed by new-style macros
   are still reported, but old-style macros are not yet supported due to
-  JuliaLowering limitations. (https://github.com/aviatesk/JETLS.jl/issues/522)
+  JuliaLowering limitations.
+
+- Fixed false positive `lowering/unused-argument` and `lowering/unused-local`
+  diagnostics that could appear before full-analysis completes when macros
+  cannot be expanded. Fixed https://github.com/aviatesk/JETLS.jl/issues/522.
 
 - Fixed potential segfault on server exit by implementing graceful shutdown of
   worker tasks. All `Threads.@spawn`ed tasks are now properly terminated before

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -1039,7 +1039,7 @@ function lowering_diagnostics!(
             JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
         end
 
-        st0 = without_kinds(st0, JS.KSet"error macrocall")
+        st0 = remove_macrocalls(without_kinds(st0, JS.KSet"error"))
         try
             ctx1, st1 = JL.expand_forms_1(mod, st0, true, world)
             _jl_lower_for_scope_resolution(ctx1, st0, st1; convert_closures=true)

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -6,7 +6,6 @@ function binding_scope_layer(ctx3, binding::JL.BindingInfo)
         JS.hasattr(st3, :scope_layer) && return st3.scope_layer
         st3 = JS.SyntaxTree(JS.syntax_graph(st3), st3.source)
     end
-    # JETLS_DEBUG_LOWERING && @warn "No scope layer found for binding" binding
     return 1
 end
 
@@ -65,7 +64,7 @@ function jl_lower_for_scope_resolution(
         JETLS_DEBUG_LOWERING && @warn "Error in macro expansion; trimming and retrying"
         JETLS_DEBUG_LOWERING && showerror(stderr, err)
         JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
-        st0 = without_kinds(st0, JS.KSet"macrocall")
+        st0 = remove_macrocalls(st0)
         JL.expand_forms_1(mod, st0, true, world)
     end
     return _jl_lower_for_scope_resolution(ctx1, st0, st1; convert_closures)

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -548,7 +548,21 @@ length_utf16(s::AbstractString) = sum(c::Char -> codepoint(c) < 0x10000 ? 1 : 2,
     end
 end
 
-macro m_throw(x)
+module EmptyModule end
+@testset "unused binding detection (before full-analysis, without macro expansion)" begin
+    # `@sprintf` is not available yet for EmptyModule (simulating the lowering analysis behavior before full-analysis complete)
+    # https://github.com/aviatesk/JETLS.jl/issues/522
+    diagnostics = get_lowered_diagnostics(EmptyModule, """
+        let
+            OLR = SW_in = 0.0
+            @info @sprintf("OLR: %.1f W/m², SW_in: %.1f W/m², net: %.1f W/m²",
+                            OLR, SW_in, SW_in - OLR)
+        end
+        """; skip_analysis_requiring_context=true)
+    @test isempty(diagnostics)
+end
+
+macro m_throw(_)
     throw("show this error message")
 end
 macro m_gen_invalid(n)


### PR DESCRIPTION
Replace `without_kinds(st0, JS.KSet"macrocall")` with the dedicated `remove_macrocalls` function for cleaner and more consistent macrocall removal during lowering analysis.

Also adds a test case for handling macro expansion when the target module doesn't have access to required macros (e.g., `@sprintf` in an empty module). Closes aviatesk/JETLS.jl#522.