### PR TITLE
cli: Add `jetls check` command for running diagnostics

### DIFF
--- a/.JETLSConfig.toml
+++ b/.JETLSConfig.toml
@@ -1,19 +1,22 @@
-# TODO [JETLS] Need to properly set and parse line number information for `@namespace`
+# TODO [JETLS]
+# Need to properly set and parse line number information for `@namespace`
 [[diagnostic.patterns]]
 pattern = "Macro name `@namespace` not found"
 match_by = "message"
 match_type = "regex"
 severity = "off"
 path = "LSP/**/*.jl"
-# TODO [JETLS] Need to properly set module context when a single file contains multiple modules (for the new incremental full analysis mode)
+# TODO [JETLS]
+# Need to properly set module context when a single file contains multiple modules (for the new incremental full analysis mode)
 [[diagnostic.patterns]]
 pattern = ".*"
-match_by = "code"
+match_by = "message"
 match_type = "regex"
 severity = "off"
 path = "LSP/src/LSP.jl"
 
-# TODO [JuliaLowering] Temporarily downgrade some known JuliaLowering issues to information level
+# TODO [JuliaLowering]
+# Temporarily downgrade some known JuliaLowering issues to information level
 [[diagnostic.patterns]]
 pattern = "^Lowering TODO:"
 match_by = "message"
@@ -25,19 +28,36 @@ match_by = "message"
 match_type = "literal"
 severity = "info"
 path = "src/analysis/Analyzer.jl"
+[[diagnostic.patterns]] # https://github.com/aviatesk/JETLS.jl/issues/480
+pattern = "lowering/unused-argument"
+match_by = "code"
+match_type = "literal"
+severity = "info"
+path = "src/config.jl"
+
+# Treat all other diagnostics as warnings (for early detection via jetls check)
+[[diagnostic.patterns]]
+pattern = ".*"
+match_by = "code"
+match_type = "regex"
+severity = "warn"
+path = "src/**/*.jl"
+[[diagnostic.patterns]]
+pattern = ".*"
+match_by = "code"
+match_type = "regex"
+severity = "warn"
+path = "LSP/src/**/*.jl"
 
 [[initialization_options.analysis_overrides]]
 module_name = "JETLS"
 path = "src/**/*.jl"
-
 [[initialization_options.analysis_overrides]]
 module_name = "LSP"
 path = "LSP/**/*.jl"
 
 # Just disable analysis for test files for now
-
 [[initialization_options.analysis_overrides]]
 path = "test/**/*.jl"
-
 [[initialization_options.analysis_overrides]]
 path = "LSP/test/**/*.jl"

--- a/.github/workflows/JETLS.jl.yml
+++ b/.github/workflows/JETLS.jl.yml
@@ -141,8 +141,8 @@ jobs:
         env:
           JULIA_NUM_THREADS: "4,2"
 
-  test_jetls:
-    name: Test jetls executable
+  test_jetls_serve:
+    name: Test jetls serve
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -150,7 +150,47 @@ jobs:
         with:
           version: "1.12" # most stable version
           arch: x64
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@latest
       - name: run test
         run: |
-          julia --startup-file=no --project=./test ./test/test_jetls.jl
+          julia --startup-file=no --project=./test ./test/app/test_jetls_serve.jl
+
+  test_jetls_check:
+    name: Test jetls check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: "1.12" # most stable version
+          arch: x64
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: run test
+        run: |
+          julia --startup-file=no --project=./test ./test/app/test_jetls_check.jl
+
+  jetls_self_check:
+    name: Self diagnostics
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: "1.12" # most stable version
+          arch: x64
+      - uses: julia-actions/cache@v2
+      - name: set LocalPreferences.toml
+        working-directory: .
+        run: |
+          echo '
+          [JETLS]
+          JETLS_DEV_MODE = true
+
+          [JET]
+          JET_DEV_MODE = true # allow JET to be loaded on nightly
+          ' > LocalPreferences.toml
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: run jetls check
+        run: ./scripts/selfcheck.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,8 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
 
-  test_jetls:
-    name: Test jetls executable with release environment
+  test_jetls_serve:
+    name: Test jetls serve with release environment
     if: github.event_name == 'pull_request' && github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
@@ -42,7 +42,22 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - name: run test
         run: |
-          julia --startup-file=no --project=./test ./test/test_jetls.jl
+          julia --startup-file=no --project=./test ./test/app/test_jetls_serve.jl
+
+  test_jetls_check:
+    name: Test jetls check with release environment
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: "1.12"
+          arch: x64
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: run test
+        run: |
+          julia --startup-file=no --project=./test ./test/app/test_jetls_check.jl
 
   docs:
     name: Documentation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,14 @@ Running `Pkg.test()` takes about 8 minutes (as of December 2025), so avoid it un
 - The user explicitly requests the full test suite
 - You're unsure which tests are relevant
 
+# **Running `jetls check` for self diagnostics**
+**Please make sure to run `jetls check` after writing or modifying code**:
+```bash
+./scripts/selfcheck.sh
+```
+
+This is run in CI and will cause failures if new warnings are introduced.
+
 # Test code structure
 Testing language server functionality is challenging.
 To fully test such functionality, you need to start a server loop,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added [`jetls check`](https://aviatesk.github.io/JETLS.jl/release/cli-check/) command
+  for running JETLS diagnostics from the command line. This enables CI integration
+  and command-line workflows without requiring an editor. Features include
+  `--exit-severity` for controlling exit codes, `--show-severity` for filtering
+  output, `--context-lines` for output formatting, and `--root` for configuration
+  lookup. The CLI now uses a subcommand structure: `jetls serve` starts the
+  language server (default), while `jetls check` runs diagnostics.
+
 - Added reference count code lens for top-level symbols (functions, structs,
   constants, abstract types, primitive types, modules). When enabled, a code
   lens showing "N references" appears above each symbol definition. Clicking it
@@ -63,6 +71,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added document symbol support for `if` and `@static if` blocks. These blocks
   now appear in the document outline as `SymbolKind.Namespace` symbols, with
   all definitions from `if`/`elseif`/`else` branches flattened as children.
+
+### Deprecated
+
+- Running `jetls` without a subcommand (e.g., `jetls --stdio`) is deprecated.
+  Use `jetls serve` instead. This may be removed in a future release.
 
 ### Changed
 

--- a/LSP/src/URIs2/URIs2.jl
+++ b/LSP/src/URIs2/URIs2.jl
@@ -5,7 +5,7 @@
 # TODO Move this under LSP.jl?
 module URIs2
 
-export URI, uri2filename, uri2filepath, filename2uri, filepath2uri, @uri_str
+export @uri_str, URI, filename2uri, filepath2uri, uri2filename, uri2filepath
 
 using StructTypes: StructTypes
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -67,6 +67,7 @@ const pages = Any[
     "Notebook support" => "notebook.md",
     "Configuration" => "configuration.md",
     "Launching" => "launching.md",
+    "Diagnostic CLI" => "cli-check.md",
     "CHANGELOG" => "CHANGELOG.md"]
 const quick_links_pages = let pages = last.(pages)
     pop!(pages)      # exclude CHANGELOG.md

--- a/docs/src/cli-check.md
+++ b/docs/src/cli-check.md
@@ -1,0 +1,187 @@
+# [Diagnostic CLI](@id cli-check)
+
+The `jetls check` command runs JETLS diagnostics on Julia files from the command
+line, without requiring an editor or LSP client. This is useful for CI pipelines,
+pre-commit hooks, and workflows where editor integration is not available.
+
+For details on what each diagnostic code means, see the
+[Diagnostic reference](@ref diagnostic/reference).
+
+## [Basic usage](@id cli-check/usage)
+
+```bash
+# Check a package source file
+jetls check src/SomePkg.jl
+
+# Check multiple files
+jetls check src/SomePkg.jl test/runtests.jl
+
+# Check multiple files with multi threads
+jetls --threads=4,2 -- check src/SomePkg.jl test/runtests.jl
+```
+
+## [Command reference](@id cli-check/reference)
+
+> `jetls check --help`
+```@eval
+using JETLS
+using Markdown
+Markdown.parse('`'^3 * '\n' * JETLS.check_help_message * '\n' * '`'^3)
+```
+
+## [Input files and analysis mode](@id cli-check/input)
+
+Currently, `jetls check` accepts only file paths as input (not directories).
+The analysis mode is determined by the file's location within the directory
+structure:
+
+- **Package source files** (`src/SomePkg.jl`): Analyzed in package context with
+  full type inference
+- **Test files** (`test/*.jl`): Analyzed in test context
+- **Standalone scripts**: Analyzed as scripts
+
+For example, when analyzing package code, run `jetls check` from the package
+root directory:
+
+```bash
+# Correct: run from package root
+cd /path/to/MyPkg
+jetls check src/SomePkg.jl
+
+# Incorrect: running from src/ directory won't detect package context
+cd /path/to/MyPkg/src
+jetls check SomePkg.jl  # May not work as expected
+```
+
+The working directory (or `--root` path) is used to locate `Project.toml` for
+package context detection and `.JETLSConfig.toml` for configuration.
+
+## [Options](@id cli-check/options)
+
+### [`--root=<path>`](@id cli-check/options/root)
+
+Sets the root path for configuration file lookup and relative path display.
+By default, the current working directory is used.
+
+When specified, JETLS will:
+- Look for `.JETLSConfig.toml` in the specified root directory
+- Display file paths relative to this root in diagnostic output
+
+```bash
+# Use project root for configuration
+jetls check --root=/path/to/project src/SomePkg.jl
+
+# Useful when running from a different directory
+cd /tmp && jetls check --root=/path/to/project /path/to/project/src/SomePkg.jl
+```
+
+### [`--context-lines=<n>`](@id cli-check/options/context-lines)
+
+Controls how many lines of source code context are shown around each diagnostic.
+Default is `2`.
+
+```bash
+# Show more context
+jetls check --context-lines=5 src/SomePkg.jl
+
+# Show no context (just the diagnostic line)
+jetls check --context-lines=0 src/SomePkg.jl
+```
+
+### [`--exit-severity=<level>`](@id cli-check/options/exit-severity)
+
+Sets the minimum severity level that causes a non-zero exit code. This is useful
+for CI pipelines where you want to fail only on certain severity levels.
+
+Available levels (from most to least severe):
+- `error` - Only errors cause exit code 1
+- `warn` (default) - Warnings and errors cause exit code 1
+- `info` - Information, warnings, and errors cause exit code 1
+- `hint` - All diagnostics cause exit code 1
+
+```bash
+# Only fail CI on errors
+jetls check --exit-severity=error src/SomePkg.jl
+
+# Fail CI on any diagnostic
+jetls check --exit-severity=hint src/SomePkg.jl
+```
+
+### [`--show-severity=<level>`](@id cli-check/options/show-severity)
+
+Sets the minimum severity level to display in the output. Diagnostics below this
+level are hidden from the output but may still affect the exit code (depending
+on `--exit-severity`).
+
+Available levels (from most to least severe):
+- `error` - Only show errors
+- `warn` - Show warnings and errors
+- `info` - Show information, warnings, and errors
+- `hint` (default) - Show all diagnostics
+
+```bash
+# Only display warnings and errors (hide info and hints)
+jetls check --show-severity=warn src/SomePkg.jl
+
+# Show all diagnostics but only fail on errors
+jetls check --show-severity=hint --exit-severity=error src/SomePkg.jl
+```
+
+### [`--progress=<mode>`](@id cli-check/options/progress)
+
+Controls how progress is displayed during analysis.
+
+Available modes:
+- `auto` (default) - Uses spinner for interactive terminals, simple output
+  otherwise
+- `full` - Always show animated spinner with detailed progress
+- `simple` - One line per file (e.g., `Analyzing [1/5] src/foo.jl...`)
+- `none` - No progress output
+
+```bash
+# Suppress progress for cleaner CI logs
+jetls check --progress=none src/SomePkg.jl
+
+# Force simple output even in terminal
+jetls check --progress=simple src/SomePkg.jl
+```
+
+### [Julia runtime flags](@id cli-check/options/julia-flags)
+
+Since `jetls` is an executable Julia app, you can pass Julia runtime flags
+before `--` to configure the Julia runtime. This is especially useful for
+controlling threading behavior. JETLS's signature analysis phase is
+parallelized, so increasing thread count may improve analysis performance.
+
+```bash
+# Run with 4 default threads and 2 interactive threads
+jetls --threads=4,2 -- check src/SomePkg.jl
+```
+
+For more details on available runtime flags, see the [Pkg documentation on runtime flags](https://pkgdocs.julialang.org/v1/apps/#Runtime-Julia-Flags).
+
+## [Configuration](@id cli-check/configuration)
+
+`jetls check` loads `.JETLSConfig.toml` from the root path (specified by
+`--root`, or the current working directory by default). This is the same
+configuration file used by the language server, and includes:
+
+- [Diagnostic severity overrides](@ref diagnostic/configuring)
+- [Pattern-based diagnostic filtering](@ref config/diagnostic-patterns)
+- [Path-specific rules](@ref config/diagnostic-patterns)
+
+Example configuration to suppress certain diagnostics in CI:
+
+> `.JETLSConfig.toml`
+
+```toml
+# Ignore unused arguments in test files
+[[diagnostic.patterns]]
+pattern = "lowering/unused-argument"
+match_by = "code"
+match_type = "literal"
+severity = "off"
+path = "test/**/*.jl"
+```
+
+For complete configuration options, see the [JETLS configuration](@ref config/schema) page.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -96,6 +96,7 @@ Minimal [Emacs](https://www.gnu.org/software/emacs/)
                '(((julia-mode :language-id "julia")
                   (julia-ts-mode :language-id "julia"))
                  "jetls"
+                 "serve"
                  "--threads=auto"
                  "--"
                  "--socket"
@@ -111,6 +112,7 @@ call LspAddServer([#{name: 'JETLS.jl',
                  \   filetype: 'julia',
                  \   path: 'jetls',
                  \   args: [
+                 \       'serve',
                  \       '--threads=auto',
                  \       '--'
                  \   ]
@@ -125,6 +127,7 @@ Minimal [Neovim](https://neovim.io/) setup (requires Neovim v0.11):
 vim.lsp.config("jetls", {
     cmd = {
         "jetls",
+        "serve",
         "--threads=auto",
         "--",
     },
@@ -145,7 +148,7 @@ Minimal [Sublime](https://www.sublimetext.com/) setup using the
   "clients": {
     "jetls": {
       "enabled": true,
-      "command": ["jetls", "--threads=auto", "--", "--socket=${port}"],
+      "command": ["jetls", "serve", "--threads=auto", "--", "--socket=${port}"],
       "selector": "source.julia",
       "tcp_port": 0
     }
@@ -170,7 +173,7 @@ name = "julia"
 language-servers = [ "jetls" ]
 
 [language-server]
-jetls = { command = "jetls", args = ["--threads=auto", "--"] }
+jetls = { command = "jetls", args = ["serve", "--threads=auto", "--"] }
 ```
 
 ### Advanced: using local JETLS checkout
@@ -178,7 +181,7 @@ jetls = { command = "jetls", args = ["--threads=auto", "--"] }
 Advanced users can run JETLS directly from a local checkout by replacing
 the `jetls` executable with `julia -m JETLS`:
 ```bash
-julia --startup-file=no --project=/path/to/JETLS -m JETLS
+julia --startup-file=no --project=/path/to/JETLS -m JETLS serve
 ```
 
 !!! warning

--- a/docs/src/launching.md
+++ b/docs/src/launching.md
@@ -1,31 +1,32 @@
 # Launching JETLS
 
-This guide explains how to launch the JETLS language server using the `jetls`
-executable and describes the available communication channels.
+This guide explains how to launch the JETLS language server using
+`jetls serve` and describes the available communication channels.
 
-## Using the `jetls` executable
+## The `jetls` executable
 
-The JETLS server is launched using the `jetls` executable, which is the main
-entry point of launching JETLS that can be installed as an
+The `jetls` executable is the main entry point for JETLS, providing two commands:
+
+- `jetls serve` - Start the language server for editor integration (this page)
+- [`jetls check`](@ref cli-check) - Run diagnostics from the command line
+
+The executable can be installed as an
 [executable app](https://pkgdocs.julialang.org/dev/apps/) via Pkg.jl:
 ```bash
 julia -e 'using Pkg; Pkg.Apps.add(; url="https://github.com/aviatesk/JETLS.jl", rev="release")'
 ```
 
-You can run `jetls` with various options to configure how the server communicates
-with clients.
-
-> `jetls --help`
+> `jetls serve --help`
 ```@eval
 using JETLS
 using Markdown
-Markdown.parse('`'^3 * '\n' * JETLS.help_message * '\n' * '`'^3)
+Markdown.parse('`'^3 * '\n' * JETLS.serve_help_message * '\n' * '`'^3)
 ```
 
 ## Communication channels
 
-The `jetls` executable supports multiple communication channels between the
-client and server. Choose based on your environment and requirements:
+`jetls serve` supports multiple communication channels between the client and
+server. Choose based on your environment and requirements:
 
 ### `pipe-connect` / `pipe-listen` (Unix domain socket / named pipe)
 
@@ -35,7 +36,7 @@ client and server. Choose based on your environment and requirements:
 - **Limitations**: Not suitable for cross-container communication
 - **Note**: Client is responsible for socket file cleanup in both modes
 
-The `jetls` executable provides two pipe modes:
+`jetls serve` provides two pipe modes:
 
 #### `pipe-connect`
 
@@ -49,7 +50,7 @@ Server connects to a client-created socket. This is the mode used by the
 
 Example:
 ```bash
-jetls --pipe-connect=/tmp/jetls.sock
+jetls serve --pipe-connect=/tmp/jetls.sock
 ```
 
 #### `pipe-listen`
@@ -64,7 +65,7 @@ This is the traditional LSP server mode:
 
 Example:
 ```bash
-jetls --pipe-listen=/tmp/jetls.sock
+jetls serve --pipe-listen=/tmp/jetls.sock
 ```
 
 ### `socket` (TCP)
@@ -78,7 +79,7 @@ jetls --pipe-listen=/tmp/jetls.sock
 
 Example:
 ```bash
-jetls --socket=7777
+jetls serve --socket=7777
 ```
 
 The server will print `<JETLS-PORT>7777</JETLS-PORT>` to stdout once it starts
@@ -86,7 +87,7 @@ listening. This is especially useful when using `--socket=0` for automatic port
 assignment, as the actual port number will be announced:
 
 ```bash
-jetls --socket=0
+jetls serve --socket=0
 # Output: <JETLS-PORT>54321</JETLS-PORT>  (actual port assigned by OS)
 ```
 
@@ -105,9 +106,9 @@ ssh -L 8080:localhost:8080 user@remote
 
 Example:
 ```bash
-jetls --stdio
+jetls serve --stdio
 # or simply
-jetls
+jetls serve
 ```
 
 !!! warning

--- a/jetls-client/jetls-client.ts
+++ b/jetls-client/jetls-client.ts
@@ -200,7 +200,7 @@ async function startLanguageServer() {
     const defaultExecutable = "jetls";
     baseCommand = serverConfig.executable.path || defaultExecutable;
     const threads = serverConfig.executable.threads || "auto";
-    baseArgs = [`--threads=${threads}`, "--"];
+    baseArgs = ["serve", `--threads=${threads}`, "--"];
   }
 
   let commChannel = serverConfig.communicationChannel;

--- a/scripts/selfcheck.sh
+++ b/scripts/selfcheck.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Run JETLS self-diagnostics
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+exec julia --startup-file=no --project="$PROJECT_ROOT" --threads=auto -m JETLS check --root="$PROJECT_ROOT" --quiet "$PROJECT_ROOT/src/JETLS.jl" "$PROJECT_ROOT/LSP/src/LSP.jl" --exit-severity=warn --show-severity=warn "$@"

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -243,12 +243,9 @@ function runserver(server::Server; client_process_id::Union{Nothing,Int}=nothing
         @error "Message handling loop failed"
         Base.display_error(stderr, err, catch_backtrace())
     finally
-        for _ = 1:length(server.state.analysis_manager.worker_tasks)
-            put!(server.state.analysis_manager.queue, nothing)
-        end
+        stop_analysis_workers(server)
         put!(seq_queue, nothing); put!(con_queue, nothing);
         close(seq_queue); close(con_queue);
-        waitall(server.state.analysis_manager.worker_tasks)
         waitall((seq_task, con_task))
         close(server.endpoint)
     end
@@ -484,6 +481,7 @@ function handle_notification_message(server::Server, @nospecialize msg)
     nothing
 end
 
+include("cli-check.jl")
 include("app.jl")
 
 include("precompile.jl")

--- a/src/app.jl
+++ b/src/app.jl
@@ -1,33 +1,94 @@
 using Sockets: Sockets
 
+const serve_help_message = """
+    jetls serve - Start language server for editor integration
+
+    Starts JETLS as an LSP server for use with LSP client editors.
+    By default, communicates via stdin/stdout.
+
+    Usage: jetls serve [OPTIONS]
+
+    Options:
+      --stdio                     Use standard input/output (default)
+      --pipe-connect=<path>       Connect to client's Unix domain socket/named pipe
+      --pipe-listen=<path>        Listen on Unix domain socket/named pipe
+      --socket=<port>             Listen on TCP socket
+      --clientProcessId=<pid>     Monitor client process (enables crash detection)
+      --help, -h                  Show this help message
+
+    Examples:
+      jetls serve
+      jetls serve --pipe-listen=/tmp/jetls.sock
+      jetls serve --socket=8080
+    """
+
 const help_message = """
     JETLS - A Julia language server with runtime-aware static analysis,
     powered by JET.jl, JuliaSyntax.jl, and JuliaLowering.jl
 
     VERSION: $JETLS_VERSION
 
-    Usage: jetls [OPTIONS]
+    Usage: jetls [COMMAND] [OPTIONS]
 
-    Communication channel options (choose one, default: --stdio):
-      --stdio                     Use standard input/output (not recommended)
+    Commands:
+      check <file|dir>...         Run diagnostics on Julia files
+      serve                       Start language server (default)
+      version                     Show version information
+
+    Check options (for 'check' command):
+      --root=<path>               Set the root path for configuration (default: pwd)
+      --context-lines=<n>         Number of context lines to show (default: 2)
+      --exit-severity=<level>     Minimum severity for error exit (default: warn)
+      --show-severity=<level>     Minimum severity to display (default: hint)
+
+    Server options (for 'serve' command):
+      --stdio                     Use standard input/output (default)
       --pipe-connect=<path>       Connect to client's Unix domain socket/named pipe
       --pipe-listen=<path>        Listen on Unix domain socket/named pipe
       --socket=<port>             Listen on TCP socket
-
-    Options:
       --clientProcessId=<pid>     Monitor client process (enables crash detection)
+
+    Common options:
       --version, -v               Show version information
       --help, -h                  Show this help message
 
     Examples:
-      jetls --pipe-listen=/tmp/jetls.sock
-      jetls --pipe-connect=/tmp/jetls.sock --clientProcessId=12345
+      jetls serve --pipe-listen=/tmp/jetls.sock
       jetls --socket=8080
-      jetls --threads=auto -- --clientProcessId=12345
+      jetls check src/main.jl
+      jetls check --root=/path/to/project src/
     """
 
 @doc help_message
 function (@main)(args::Vector{String})::Cint
+    if any(arg -> arg in ("-v", "--version", "version"), args)
+        println(stdout, "JETLS version $JETLS_VERSION")
+        return Cint(0)
+    end
+
+    if !isempty(args)
+        first_arg = args[1]
+        if first_arg == "check"
+            if length(args) >= 2 && args[2] in ("-h", "--help", "help")
+                print(stdout, check_help_message)
+                return Cint(0)
+            end
+            return run_check(args[2:end])
+        elseif first_arg == "serve"
+            if length(args) >= 2 && args[2] in ("-h", "--help", "help")
+                print(stdout, serve_help_message)
+                return Cint(0)
+            end
+            args = args[2:end]
+        elseif first_arg in ("-h", "--help", "help", "-v", "--version", "version")
+            # Don't warn for help/version flags
+        else
+            @warn "Running `jetls` without a subcommand is deprecated and may be removed in a future release. Use `jetls serve` instead."
+        end
+    else
+        @warn "Running `jetls` without a subcommand is deprecated and may be removed in a future release. Use `jetls serve` instead."
+    end
+
     pipe_connect_path = pipe_listen_path = socket_port = client_process_id = nothing
 
     i = 1
@@ -35,9 +96,6 @@ function (@main)(args::Vector{String})::Cint
         arg = args[i]
         if occursin(r"^(?:-h|--help|help)$", arg)
             print(stdout, help_message)
-            return Cint(0)
-        elseif occursin(r"^(?:-v|--version)$", arg)
-            println(stdout, "JETLS version $JETLS_VERSION")
             return Cint(0)
         elseif occursin(r"^(?:--)?stdio$", arg)
         elseif occursin(r"^(?:--)?pipe-connect$", arg)

--- a/src/cli-check.jl
+++ b/src/cli-check.jl
@@ -1,0 +1,574 @@
+@enum ProgressMode::Int8 begin
+    PROGRESS_AUTO
+    PROGRESS_FULL
+    PROGRESS_SIMPLE
+    PROGRESS_NONE
+end
+
+function is_tty(io::IO)
+    io isa Base.TTY && return true
+    io isa IOContext && return is_tty(io.io)
+    return false
+end
+
+# Progress context that holds mode and io for unified progress handling
+struct ProgressContext{IOTyp<:IO}
+    mode::ProgressMode
+    io::IOTyp
+    function ProgressContext(mode::ProgressMode, io::IOTyp=stderr) where IOTyp<:IO
+        effective_mode = mode == PROGRESS_AUTO ? (is_tty(io) ? PROGRESS_FULL : PROGRESS_SIMPLE) : mode
+        return new{IOTyp}(effective_mode, io)
+    end
+end
+
+# Spinner-based progress (PROGRESS_FULL)
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+const SPINNER_INTERVAL = 0.1
+
+mutable struct SpinnerProgress{IOTyp<:IO}
+    const io::IOTyp
+    active::Bool
+    current_file::String
+    current_message::String
+    spinner_idx::Int
+    last_line_length::Int
+    spinner_task::Union{Nothing,Task}
+    const lock::ReentrantLock
+end
+
+function SpinnerProgress(io::IO)
+    return SpinnerProgress(io, false, "", "", 1, 0, nothing, ReentrantLock())
+end
+
+function clear_line(p::SpinnerProgress)
+    if p.last_line_length > 0
+        print(p.io, "\r", " "^p.last_line_length, "\r")
+        p.last_line_length = 0
+    end
+end
+
+function render_spinner(p::SpinnerProgress)
+    @lock p.lock begin
+        clear_line(p)
+        if !p.active
+            return
+        end
+        frame = SPINNER_FRAMES[p.spinner_idx]
+        prefix = "$(frame) $(p.current_file)"
+        term_width = displaysize(p.io)[2]
+        if isempty(p.current_message)
+            if length(prefix) > term_width - 1
+                prefix = prefix[1:term_width-2] * "…"
+            end
+            printstyled(p.io, prefix; color=:light_cyan)
+            p.last_line_length = length(prefix)
+        else
+            separator = ": "
+            message = p.current_message
+            total_len = length(prefix) + length(separator) + length(message)
+            if total_len > term_width - 1
+                available = term_width - 1 - length(prefix) - length(separator) - 1
+                if available > 0
+                    message = message[1:min(available, length(message))] * "…"
+                else
+                    message = "…"
+                end
+            end
+            printstyled(p.io, prefix, separator; color=:light_cyan)
+            printstyled(p.io, message; color=:light_black)
+            p.last_line_length = length(prefix) + length(separator) + length(message)
+        end
+    end
+end
+
+function start_spinner!(p::SpinnerProgress, file::AbstractString)
+    @lock p.lock begin
+        p.current_file = file
+        p.current_message = ""
+    end
+    p.active = true
+    p.spinner_task = Threads.@spawn :interactive begin
+        while p.active
+            render_spinner(p)
+            sleep(SPINNER_INTERVAL)
+            p.spinner_idx = mod1(p.spinner_idx + 1, length(SPINNER_FRAMES))
+        end
+    end
+end
+
+function stop_spinner!(p::SpinnerProgress)
+    p.active = false
+    if p.spinner_task !== nothing
+        wait(p.spinner_task)
+        p.spinner_task = nothing
+    end
+    @lock p.lock clear_line(p)
+end
+
+function update_spinner!(p::SpinnerProgress, message::AbstractString)
+    @lock p.lock p.current_message = message
+end
+
+struct SpinnerProgressToken
+    progress::SpinnerProgress
+end
+
+function send_progress(::Server, token::SpinnerProgressToken, value::WorkDoneProgressValue)
+    if (value isa WorkDoneProgressBegin || value isa WorkDoneProgressReport ||
+        value isa WorkDoneProgressEnd)
+        message = value.message
+        if message !== nothing && !isempty(message)
+            update_spinner!(token.progress, message)
+        end
+    end
+end
+
+# Simple line-based progress (PROGRESS_SIMPLE)
+mutable struct SimpleProgress{IOTyp<:IO}
+    const io::IOTyp
+    last_phase::String
+end
+SimpleProgress(io::IO) = SimpleProgress(io, "")
+
+function start_simple!(p::SimpleProgress, prefix::AbstractString, name::AbstractString)
+    p.last_phase = ""
+    printstyled(p.io, prefix, " ", name; color=:light_cyan)
+end
+
+function update_simple!(p::SimpleProgress, phase::AbstractString)
+    if phase != p.last_phase
+        printstyled(p.io, ' ', phase; color=:light_black)
+        p.last_phase = phase
+    else
+        printstyled(p.io, '.'; color=:light_black)
+    end
+end
+
+function stop_simple!(p::SimpleProgress)
+    printstyled(p.io, " done"; color=:light_black)
+    println(p.io)
+end
+
+struct SimpleProgressToken
+    progress::SimpleProgress
+end
+
+function send_progress(::Server, token::SimpleProgressToken, value::WorkDoneProgressValue)
+    if value isa WorkDoneProgressBegin
+        update_simple!(token.progress, value.title)
+    elseif value isa WorkDoneProgressReport
+        message = @something value.message return
+        if occursin("[file analysis]", message)
+            update_simple!(token.progress, "[file analysis]")
+        elseif occursin("[signature analysis]", message)
+            update_simple!(token.progress, "[signature analysis]")
+        elseif occursin("[lowering analysis]", message)
+            update_simple!(token.progress, "[lowering analysis]")
+        end
+    end
+end
+
+function with_progress(f::Function, ctx::ProgressContext, prefix::String, name::String)
+    if ctx.mode == PROGRESS_FULL
+        p = SpinnerProgress(ctx.io)
+        start_spinner!(p, "$prefix $name")
+        try
+            token = SpinnerProgressToken(p)
+            return f(CancellableToken(token, DUMMY_CANCEL_FLAG))
+        finally
+            stop_spinner!(p)
+        end
+    elseif ctx.mode == PROGRESS_SIMPLE
+        p = SimpleProgress(ctx.io)
+        start_simple!(p, prefix, name)
+        try
+            token = SimpleProgressToken(p)
+            return f(CancellableToken(token, DUMMY_CANCEL_FLAG))
+        finally
+            stop_simple!(p)
+        end
+    else # PROGRESS_NONE
+        return f(nothing)
+    end
+end
+
+const check_help_message = """
+    jetls check - Run diagnostics on Julia files
+
+    Analyzes Julia source files and reports errors, warnings, and suggestions.
+    Useful for CI pipelines and command-line workflows.
+
+    Analysis mode is determined by the file's directory structure.
+    For package analysis, run from the package root: jetls check src/SomePkg.jl
+
+    Usage: jetls check [OPTIONS] <file>...
+
+    Options:
+      --help, -h               Show this help message
+      --quiet, -q              Suppress info and warning log messages
+      --exit-severity=<level>  Minimum severity to exit with error code 1
+                               (error, warn, info, hint; default: warn)
+      --show-severity=<level>  Minimum severity to display in output
+                               (error, warn, info, hint; default: hint)
+      --root=<path>            Set the root path for configuration and relative paths
+                               (default: current working directory)
+      --context-lines=<n>      Number of context lines to show (default: 2)
+      --progress=<mode>        Progress display mode (default: auto)
+                               auto   - spinner if TTY, simple otherwise
+                               full   - always show spinner
+                               simple - one line per file
+                               none   - no progress output
+
+    Exit codes:
+      0  No diagnostics at or above the exit severity level
+      1  One or more diagnostics found, or invalid arguments
+
+    Examples:
+      jetls check src/SomePkg.jl
+      jetls check src/SomePkg.jl test/runtests.jl
+      jetls check --root=/path/to/project src/SomePkg.jl
+      jetls check --context-lines=0 src/SomePkg.jl
+      jetls check --exit-severity=error src/SomePkg.jl
+      jetls check --show-severity=warn src/SomePkg.jl
+      jetls check --progress=none src/SomePkg.jl
+    """
+
+function run_check(args::Vector{String})::Cint
+    root_path_opt = nothing
+    context_lines = 2
+    exit_severity = DiagnosticSeverity.Warning
+    show_severity = DiagnosticSeverity.Hint
+    progress_mode = PROGRESS_AUTO
+    skip_analysis = false # Undocumented option to skip analysis (only used for test)
+    quiet = false
+    paths = String[]
+    for arg in args
+        if arg in ("--quiet", "-q")
+            quiet = true
+        elseif startswith(arg, "--root=")
+            root_path_opt = arg[8:end]
+        elseif startswith(arg, "--context-lines=")
+            context_lines = tryparse(Int, arg[17:end])
+            if context_lines === nothing
+                @error "Invalid value for --context-lines (must be a non-negative integer)"
+                return 1
+            end
+        elseif startswith(arg, "--exit-severity=")
+            level = arg[17:end]
+            if level in ("error", "1")
+                exit_severity = DiagnosticSeverity.Error
+            elseif level in ("warn", "warning", "2")
+                exit_severity = DiagnosticSeverity.Warning
+            elseif level in ("info", "information", "3")
+                exit_severity = DiagnosticSeverity.Information
+            elseif level in ("hint", "4")
+                exit_severity = DiagnosticSeverity.Hint
+            else
+                @error "Invalid value for --exit-severity (must be error, warn, info, or hint)"
+                return 1
+            end
+        elseif startswith(arg, "--show-severity=")
+            level = arg[17:end]
+            if level in ("error", "1")
+                show_severity = DiagnosticSeverity.Error
+            elseif level in ("warn", "warning", "2")
+                show_severity = DiagnosticSeverity.Warning
+            elseif level in ("info", "information", "3")
+                show_severity = DiagnosticSeverity.Information
+            elseif level in ("hint", "4")
+                show_severity = DiagnosticSeverity.Hint
+            else
+                @error "Invalid value for --show-severity (must be error, warn, info, or hint)"
+                return 1
+            end
+        elseif startswith(arg, "--progress=")
+            mode = arg[12:end]
+            if mode == "auto"
+                progress_mode = PROGRESS_AUTO
+            elseif mode == "full"
+                progress_mode = PROGRESS_FULL
+            elseif mode == "simple"
+                progress_mode = PROGRESS_SIMPLE
+            elseif mode == "none"
+                progress_mode = PROGRESS_NONE
+            else
+                @error "Invalid value for --progress (must be auto, full, simple, or none)"
+                return 1
+            end
+        elseif arg == "--skip-full-analysis"
+            skip_analysis = true
+        else
+            push!(paths, arg)
+        end
+    end
+
+    if isempty(paths)
+        print(stderr, check_help_message)
+        return 1
+    end
+
+    quiet && Base.CoreLogging.disable_logging(Base.CoreLogging.Warn)
+
+    root_path = root_path_opt !== nothing ? abspath(root_path_opt) : pwd()
+    server = cli_server(root_path)
+    skip_analysis || start_analysis_workers!(server)
+    progress_ctx = ProgressContext(progress_mode, stderr)
+
+    start_time = time()
+
+    if skip_analysis
+        analysis_uris = Set{URI}()
+        for path in paths
+            filepath = abspath(path)
+            if !isfile(filepath)
+                @error "File not found: $filepath"
+                return 1
+            end
+            uri = filepath2uri(filepath)
+            push!(analysis_uris, uri)
+        end
+        lookup_func = Returns(OutOfScope(Main))
+    else
+        # Full analysis phase (textDocument/publishDiagnostics equivalent)
+        run_full_analysis(server, root_path, paths, progress_ctx)
+        analysis_uris = collect_workspace_uris(server)
+        if isempty(analysis_uris)
+            @error "Full analysis failed: could not find any files to analyze"
+            return 1
+        end
+        lookup_func = nothing
+    end
+
+    uri2diagnostics = get_full_diagnostics(server)
+
+    # Lowering analysis phase (workspace/diagnostic equivalent)
+    total_uris = run_lowering_analysis!(uri2diagnostics, analysis_uris, server, root_path, progress_ctx; lookup_func)
+
+    for (uri, diagnostics) in uri2diagnostics
+        apply_diagnostic_config!(diagnostics, server.state.config_manager, uri, root_path)
+        unique!(d::Diagnostic -> (d.range, d.message, d.code), diagnostics)
+    end
+
+    elapsed_time = time() - start_time
+    print_stats(uri2diagnostics, total_uris, elapsed_time, show_severity)
+    has_errors = print_diagnostics(uri2diagnostics, root_path, context_lines, exit_severity, show_severity)
+
+    cleanup_cli_tasks(server)
+
+    return has_errors
+end
+
+function cli_server(root_path::AbstractString)
+    server = Server(; suppress_notifications=true)
+
+    server.state.root_path = root_path
+    server.state.workspaceFolders = URI[filepath2uri(root_path)]
+    env_path = find_env_path(root_path)
+    if env_path !== nothing
+        server.state.root_env_path = env_path
+    end
+
+    config_path = joinpath(root_path, ".JETLSConfig.toml")
+    if isfile(config_path)
+        load_file_init_options!(server, config_path)
+        load_file_config!(Returns(nothing), server, config_path)
+    end
+
+    return server
+end
+
+function run_full_analysis(
+        server::Server, root_path::AbstractString, paths::Vector{String},
+        progress_ctx::ProgressContext
+    )
+    total_files = length(paths)
+    for (idx, path) in enumerate(paths)
+        filepath = abspath(path)
+        rel_path = relpath(filepath, root_path)
+        display_name = "[$idx/$total_files] $rel_path"
+        with_progress(progress_ctx, "Full analysis", display_name) do cancellable_token
+            uri = filepath2uri(filepath)
+            cache_file_info!(server, uri, 1, read(filepath))
+            request_analysis!(server, uri, false;
+                wait=true, notify_diagnostics=false, cancellable_token, debounce=0.0)
+        end
+    end
+end
+
+mutable struct Counter
+    @atomic count::Int
+end
+
+function run_lowering_analysis!(
+        uri2diagnostics::Dict{URI,Vector{Diagnostic}}, analyzed_uris::Set{URI},
+        server::Server, root_path::AbstractString,
+        progress_ctx::ProgressContext;
+        lookup_func = nothing
+    )
+    total_uris = length(analyzed_uris)
+    uri2diagnostics_lock = ReentrantLock()
+    with_progress(progress_ctx, "Lowering analysis", "[$total_uris files]") do cancellable_token
+        if cancellable_token !== nothing
+            send_progress(server, cancellable_token.token, WorkDoneProgressBegin(; title="Analyzing", message="Started lowering analysis"))
+        end
+
+        counter = Counter(0)
+        run_lowering_analysis_for_uri = function (uri::URI, lock::Bool)
+            fi = @something get_file_info(server.state, uri) begin
+                get_unsynced_file_info!(server.state, uri)
+            end return
+            diagnostics = toplevel_lowering_diagnostics(server, uri, fi; lookup_func)
+            if !isempty(diagnostics)
+                if lock
+                    @lock uri2diagnostics_lock append!(get!(Vector{Diagnostic}, uri2diagnostics, uri), diagnostics)
+                else
+                    append!(get!(Vector{Diagnostic}, uri2diagnostics, uri), diagnostics)
+                end
+            end
+            @atomic counter.count += 1
+            if cancellable_token !== nothing
+                filepath = uri2filepath(uri)
+                if filepath !== nothing
+                    rel_path = relpath(filepath, root_path)
+                    send_progress(server, cancellable_token.token,
+                        WorkDoneProgressReport(; message = rel_path * " ($(counter.count)/$total_uris) [lowering analysis]"))
+                    yield()
+                end
+            end
+        end
+
+        if Threads.nthreads() > 1
+            map(collect(analyzed_uris)) do uri
+                Threads.@spawn :default run_lowering_analysis_for_uri(uri, false)
+            end |> waitall
+        else
+            for uri in analyzed_uris
+                run_lowering_analysis_for_uri(uri, false)
+            end
+        end
+
+        if cancellable_token !== nothing
+            send_progress(server, cancellable_token.token, WorkDoneProgressEnd(; message="Completed lowering analysis"))
+        end
+    end
+    return total_uris
+end
+
+function print_stats(
+        uri2diagnostics::URI2Diagnostics, total_files::Int, elapsed_time::Float64,
+        show_severity::DiagnosticSeverity.Ty
+    )
+    n_errors = n_warnings = n_info = n_hints = 0
+    files_with_diagnostics = 0
+    for (_, diagnostics) in uri2diagnostics
+        file_has_diagnostics = false
+        for d in diagnostics
+            d.severity > show_severity && continue
+            file_has_diagnostics = true
+            if d.severity == DiagnosticSeverity.Error
+                n_errors += 1
+            elseif d.severity == DiagnosticSeverity.Warning
+                n_warnings += 1
+            elseif d.severity == DiagnosticSeverity.Information
+                n_info += 1
+            else
+                n_hints += 1
+            end
+        end
+        file_has_diagnostics && (files_with_diagnostics += 1)
+    end
+    total_diagnostics = n_errors + n_warnings + n_info + n_hints
+
+    println(stdout, "# Analyzed $total_files files in $(format_duration(elapsed_time))")
+    if total_diagnostics == 0
+        println(stdout, "# No diagnostics found")
+    else
+        if total_diagnostics == 1
+            print(stdout, "# Found 1 diagnostic")
+        else
+            print(stdout, "# Found $total_diagnostics diagnostics")
+        end
+        print(stdout, " in $files_with_diagnostics files")
+        parts = String[]
+        n_errors > 0 && push!(parts, "$n_errors errors")
+        n_warnings > 0 && push!(parts, "$n_warnings warnings")
+        n_info > 0 && push!(parts, "$n_info info")
+        n_hints > 0 && push!(parts, "$n_hints hints")
+        println(stdout, " (", join(parts, ", "), ")")
+        println(stdout)
+    end
+end
+
+function print_diagnostics(
+        uri2diagnostics::URI2Diagnostics, root_path::String,
+        context_lines::Int, exit_severity::DiagnosticSeverity.Ty,
+        show_severity::DiagnosticSeverity.Ty
+    )
+    has_errors = false
+    sorted_uris = sort(collect(keys(uri2diagnostics)); by=string)
+
+    for uri in sorted_uris
+        diagnostics = uri2diagnostics[uri]
+        isempty(diagnostics) && continue
+        filepath = uri2filepath(uri)
+        filepath === nothing && continue
+        text = try
+            read(filepath, String)
+        catch
+            continue
+        end
+        src = JS.SourceFile(text; filename=filepath)
+
+        rel_path = relpath(filepath, root_path)
+        sorted_diagnostics = sort(diagnostics; by=d->(d.range.start.line, d.range.start.character))
+        for (i, diagnostic) in enumerate(sorted_diagnostics)
+            severity = diagnostic.severity
+            if severity <= exit_severity
+                has_errors = true
+            end
+            severity > show_severity && continue
+            if severity == DiagnosticSeverity.Error
+                color = :light_red
+                severity_str = "error"
+            elseif severity == DiagnosticSeverity.Warning
+                color = :light_yellow
+                severity_str = "warn"
+            elseif severity == DiagnosticSeverity.Information
+                color = :light_blue
+                severity_str = "info"
+            else
+                color = :light_black
+                severity_str = "hint"
+            end
+
+            textbuf = Vector{UInt8}(text)
+            start_byte = _xy_to_offset(textbuf, diagnostic.range.start, PositionEncodingKind.UTF16)
+            end_byte = _xy_to_offset(textbuf, diagnostic.range.var"end", PositionEncodingKind.UTF16)
+            note = diagnostic.message
+            if diagnostic.code !== nothing
+                note *= " [$severity_str:$(diagnostic.code)]"
+            else
+                note *= " [$severity_str]"
+            end
+            line = diagnostic.range.start.line + 1
+            character = diagnostic.range.start.character + 1
+            i == 1 || println(stdout)
+            printstyled(stdout, "# @ $rel_path:$line,$character\n"; color=:light_black)
+            output = let note=note, notecolor=color, context_lines=context_lines
+                sprint(; context=IOContext(stdout)) do io
+                    JS.highlight(io, src, start_byte:end_byte;
+                        note, notecolor=notecolor,
+                        context_lines_before=context_lines, context_lines_after=context_lines)
+                end
+            end
+            println(stdout, strip(output, '\n'))
+        end
+    end
+
+    return has_errors
+end
+
+function cleanup_cli_tasks(server::Server)
+    stop_analysis_workers(server)
+    close(server.endpoint)
+end

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -5,14 +5,14 @@ function ParseStream!(s::Union{AbstractString,Vector{UInt8}})
 end
 
 """
-    cache_file_info!(server::Server, uri::URI, version::Int, text::String)
+    cache_file_info!(server::Server, uri::URI, version::Int, text::Union{AbstractString,Vector{UInt8}})
     cache_file_info!(server::Server, uri::URI, version::Int, parsed_stream::JS.ParseStream)
 
 Cache or update file information in the server state's file cache.
 Computes testsetinfos atomically as part of the caching operation,
 preserving test results from previous testsetinfos where possible.
 """
-cache_file_info!(server::Server, uri::URI, version::Int, text::String) =
+cache_file_info!(server::Server, uri::URI, version::Int, text::Union{AbstractString,Vector{UInt8}}) =
     cache_file_info!(server, uri, version, ParseStream!(text))
 function cache_file_info!(
         server::Server, uri::URI, version::Int, parsed_stream::JS.ParseStream

--- a/src/init-options.jl
+++ b/src/init-options.jl
@@ -54,3 +54,8 @@ function load_file_init_options(server::Server, filepath::AbstractString)
         return nothing
     end
 end
+
+function load_file_init_options!(server::Server, filepath::AbstractString)
+    server.state.init_options = merge_init_options(server.state.init_options,
+        @something load_file_init_options(server, filepath) return nothing)
+end

--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -58,10 +58,7 @@ function handle_InitializeRequest(
     state.init_options = parse_init_options(server, init_params.initializationOptions)
     if isdefined(state, :root_path)
         config_path = joinpath(state.root_path, ".JETLSConfig.toml")
-        file_init_options = load_file_init_options(server, config_path)
-        if file_init_options !== nothing
-            state.init_options = merge_init_options(state.init_options, file_init_options)
-        end
+        load_file_init_options!(server, config_path)
     end
 
     start_analysis_workers!(server)

--- a/src/types.jl
+++ b/src/types.jl
@@ -158,8 +158,8 @@ struct CombinedCancelFlag <: AbstractCancelFlag
 end
 is_cancelled(cf::CombinedCancelFlag) = is_cancelled(cf.flag1) || is_cancelled(cf.flag2)
 
-struct CancellableToken
-    token::ProgressToken
+struct CancellableToken{T}
+    token::T
     cancel_flag::CancelFlag
 end
 

--- a/src/utils/path.jl
+++ b/src/utils/path.jl
@@ -1,7 +1,8 @@
 find_env_path(path::AbstractString) = search_up_file(path, "Project.toml")
 
 function search_up_file(path::AbstractString, basename::AbstractString)
-    traverse_dir(dirname(path)) do dir
+    startpath = isdir(path) ? path : dirname(path)
+    traverse_dir(startpath) do dir
         project_file = joinpath(dir, basename)
         if isfile(project_file)
             return project_file

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -324,9 +324,13 @@ get_post_processor(::Nothing) = LSPostProcessor(JET.PostProcessor())
 get_post_processor(::OutOfScope) = LSPostProcessor(JET.PostProcessor())
 get_post_processor(analysis_result::AnalysisResult) = LSPostProcessor(JET.PostProcessor(analysis_result.actual2virtual))
 
-function has_analyzed_context(state::ServerState, uri::URI)
+function has_analyzed_context(state::ServerState, uri::URI; lookup_func=nothing)
     lookup_uri = @something get_notebook_uri_for_cell(state, uri) uri
-    analysis_info = get_analysis_info(state.analysis_manager, lookup_uri)
+    if lookup_func !== nothing
+        analysis_info = get_analysis_info(lookup_func, state.analysis_manager, lookup_uri)
+    else
+        analysis_info = get_analysis_info(state.analysis_manager, lookup_uri)
+    end
     return _has_analyzed_context(analysis_info, lookup_uri)
 end
 _has_analyzed_context(::Nothing, ::URI) = false

--- a/test/app/test_jetls_check.jl
+++ b/test/app/test_jetls_check.jl
@@ -1,0 +1,219 @@
+module test_jetls_check
+
+"""
+Test file for exercising the `jetls check` command.
+
+This test spawns actual `julia -m JETLS check` processes and verifies:
+
+1. Basic diagnostic output
+2. CLI options (--exit-severity, --show-severity, --context-lines)
+3. Configuration file (.JETLSConfig.toml) application
+
+To run this test independently:
+    julia --startup-file=no --project=./test ./test/app/test_jetls_check.jl
+"""
+
+using Test
+using JETLS
+
+const JULIA_CMD = normpath(Sys.BINDIR, "julia")
+const JETLS_DIR = pkgdir(JETLS)
+
+function run_jetls_check(
+        args::Vector{String};
+        root::Union{String,Nothing} = nothing,
+        skip_analysis::Bool = true # Enabled for faster test execution (this file doesn't test functionalities that depend on full-analysis)
+    )
+    cmd_args = String[JULIA_CMD, "--startup-file=no", "--project=$JETLS_DIR", "-m", "JETLS", "check"]
+    if root !== nothing
+        push!(cmd_args, "--root=$root")
+    end
+    push!(cmd_args, "--progress=none")
+    skip_analysis && push!(cmd_args, "--skip-full-analysis")
+    append!(cmd_args, args)
+    cmd = ignorestatus(Cmd(cmd_args))
+    stdout_buf = IOBuffer()
+    stderr_buf = IOBuffer()
+    proc = run(pipeline(cmd; stdout=stdout_buf, stderr=stderr_buf); wait=true)
+    return (;
+        exitcode = proc.exitcode,
+        stdout = String(take!(stdout_buf)),
+        stderr = String(take!(stderr_buf)),
+    )
+end
+
+function write_test_file(dir::String, filename::String, content::String)
+    filepath = joinpath(dir, filename)
+    write(filepath, content)
+    return filepath
+end
+
+function write_config_file(dir::String, content::String)
+    filepath = joinpath(dir, ".JETLSConfig.toml")
+    write(filepath, content)
+    return filepath
+end
+
+@testset "basic functionality" begin
+    mktempdir() do dir
+        filepath = write_test_file(dir, "test.jl", """
+            module TestModule
+            function foo()
+                x = 1
+                return nothing
+            end
+            end
+            """)
+
+        result = run_jetls_check([filepath]; root=dir)
+        @test occursin("lowering/unused-local", result.stdout)
+        @test occursin("test.jl", result.stdout)
+    end
+end
+
+@testset "--exit-severity" begin
+    mktempdir() do dir
+        # Create a file with info-level diagnostic (unused local)
+        filepath = write_test_file(dir, "test.jl", """
+            module TestModule
+            function foo()
+                x = 1
+                return nothing
+            end
+            end
+            """)
+
+        # Default exit-severity is warn, so info diagnostic should not cause exit 1
+        let result = run_jetls_check([filepath]; root=dir)
+            @test result.exitcode == 0
+            @test occursin("lowering/unused-local", result.stdout)
+        end
+
+        # With exit-severity=info, info diagnostic should cause exit 1
+        let result = run_jetls_check(["--exit-severity=info", filepath]; root=dir)
+            @test result.exitcode == 1
+            @test occursin("lowering/unused-local", result.stdout)
+        end
+    end
+end
+
+@testset "--show-severity" begin
+    mktempdir() do dir
+        filepath = write_test_file(dir, "test.jl", """
+            module TestModule
+            function foo()
+                x = 1
+                return nothing
+            end
+            end
+            """)
+
+        # Default show-severity is hint, should show info diagnostic
+        let result = run_jetls_check([filepath]; root=dir)
+            @test occursin("lowering/unused-local", result.stdout)
+        end
+
+        # With show-severity=warn, info diagnostic should be hidden
+        let result = run_jetls_check(["--show-severity=warn", filepath]; root=dir)
+            @test !occursin("lowering/unused-local", result.stdout)
+            @test occursin("No diagnostics found", result.stdout)
+        end
+    end
+end
+
+@testset "--context-lines" begin
+    mktempdir() do dir
+        filepath = write_test_file(dir, "test.jl", """
+            module TestModule
+            function foo()
+                x = 1
+                return nothing
+            end
+            end
+            """)
+
+        # With context-lines=0, should show minimal context
+        let result = run_jetls_check(["--context-lines=0", filepath]; root=dir)
+            @test occursin("lowering/unused-local", result.stdout)
+            # Should not show "function foo()" line (which is context)
+            lines = split(result.stdout, '\n')
+            diagnostic_lines = filter(l -> occursin("x = 1", l), lines)
+            @test !isempty(diagnostic_lines)
+        end
+    end
+end
+
+@testset "configuration file" begin
+    mktempdir() do dir
+        filepath = write_test_file(dir, "test.jl", """
+            module TestModule
+            function foo()
+                x = 1
+                return nothing
+            end
+            end
+            """)
+
+        # Without config, should show diagnostic
+        let result = run_jetls_check([filepath]; root=dir)
+            @test occursin("lowering/unused-local", result.stdout)
+        end
+
+        # With config to disable diagnostic
+        write_config_file(dir, """
+            [[diagnostic.patterns]]
+            pattern = "lowering/unused-local"
+            match_by = "code"
+            match_type = "literal"
+            severity = "off"
+            """)
+        let result = run_jetls_check([filepath]; root=dir)
+            @test !occursin("lowering/unused-local", result.stdout)
+            @test occursin("No diagnostics found", result.stdout)
+        end
+    end
+end
+
+@testset "multiple files" begin
+    mktempdir() do dir
+        file1 = write_test_file(dir, "file1.jl", """
+            module File1
+            function foo()
+                x = 1
+                return nothing
+            end
+            end
+            """)
+        file2 = write_test_file(dir, "file2.jl", """
+            module File2
+            function bar()
+                y = 2
+                return nothing
+            end
+            end
+            """)
+
+        result = run_jetls_check([file1, file2]; root=dir)
+        @test occursin("file1.jl", result.stdout)
+        @test occursin("file2.jl", result.stdout)
+        @test occursin("Analyzed 2 files", result.stdout)
+        @test occursin("Found 2 diagnostics in 2 files", result.stdout)
+    end
+end
+
+@testset "invalid arguments" begin
+    let result = run_jetls_check(["/nonexistent/path/file.jl"])
+        @test result.exitcode == 1 || occursin("error", lowercase(result.stderr))
+    end
+    mktempdir() do dir
+        filepath = write_test_file(dir, "test.jl", "x = 1")
+        result = run_jetls_check(["--exit-severity=invalid", filepath]; root=dir)
+        @test result.exitcode == 1
+        @test occursin("Invalid value", result.stderr)
+        result = run_jetls_check(["--show-severity=invalid", filepath]; root=dir)
+        @test result.exitcode == 1
+        @test occursin("Invalid value", result.stderr)
+    end
+end
+
+end # module test_jetls_check

--- a/test/app/test_jetls_serve.jl
+++ b/test/app/test_jetls_serve.jl
@@ -1,4 +1,4 @@
-module test_jetls
+module test_jetls_serve
 
 """
 Test file for exercising the `jetls` executable app with raw JSON communication.
@@ -10,7 +10,7 @@ with them via stdin/stdout using raw JSON-RPC messages, testing:
 2. Process management and graceful termination
 
 To run this test independently:
-    julia --startup-file=no -e 'using Test; @testset "jetls" include("test/test_jetls.jl")'
+    julia --startup-file=no -e 'using Test; @testset "jetls serve" include("test/app/test_jetls_serve.jl")'
 """
 
 using Test
@@ -21,7 +21,7 @@ const JULIA_CMD = normpath(Sys.BINDIR, "julia")
 const JETLS_DIR = pkgdir(JETLS)
 
 function withserverprocess(f)
-    cmd = `$JULIA_CMD --project=$JETLS_DIR -m JETLS`
+    cmd = `$JULIA_CMD --project=$JETLS_DIR -m JETLS serve`
     proc = open(cmd; write=true, read=true)
     try
         return f(proc)
@@ -166,4 +166,4 @@ withserverprocess() do proc
     @test process_exited(proc) && proc.exitcode == 1
 end
 
-end # module test_jetls
+end # module test_jetls_serve


### PR DESCRIPTION
Introduce a subcommand-based CLI structure with two commands:
- `jetls serve` - Start the language server (default, for editor integration)
- `jetls check` - Run diagnostics from command line (for CI/automation)

The `jetls check` command provides:
- `jetls check <file|dir>...` to analyze Julia source files
- `--root=<path>` to set root path for configuration lookup
- `--context-lines=<n>` to control source context in output
- `--exit-severity=<level>` to set minimum severity for non-zero exit
- `--show-severity=<level>` to set minimum severity to display
- Diagnostic output uses `JuliaSyntax.highlight` for readable display

CI now runs `jetls check` on JETLS itself (`jetls_self_check` job) to catch issues that regular tests might miss.

Running `jetls` without a subcommand now emits a deprecation warning.

Documentation updates:
- Add new "CLI diagnostics" page (`docs/src/cli-check.md`)
- Update `launching.md` to reflect `jetls serve` subcommand
- Update editor setup examples in `index.md` to use `jetls serve`
- Add `jetls check` instructions to AGENTS.md

Also updates `jetls-client` to use `jetls serve` explicitly.