### PR TITLE
document-symbol: Add `@testset` and `@test` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   now appear in the document outline as `SymbolKind.Namespace` symbols, with
   all definitions from `if`/`elseif`/`else` branches flattened as children.
 
+- Added document symbol support for `@testset` and `@test` macros. `@testset`
+  blocks appear in the document outline with the test name, and `@test`
+  expressions appear as children showing the test expression.
+
 ### Deprecated
 
 - Running `jetls` without a subcommand (e.g., `jetls --stdio`) is deprecated.

--- a/src/workspace-symbol.jl
+++ b/src/workspace-symbol.jl
@@ -171,7 +171,9 @@ function flatten_document_symbols!(
             # Namespace symbols (if/let/for/while/@static if blocks) are introduced for
             # hierarchical structure in document outline, not representing actual definitions.
             # Exclude them from workspace symbols to reduce noise.
-        else
+        elseif doc_sym.kind == SymbolKind.Boolean && doc_sym.kind == SymbolKind.Event
+            # Ignore `@test` and `@testset` symbols
+        elseif doc_sym.name != " " # Just a safe guard
             push!(workspace_symbols, WorkspaceSymbol(;
                 name = doc_sym.name,
                 kind = doc_sym.kind,

--- a/test/test_document_symbol.jl
+++ b/test/test_document_symbol.jl
@@ -1036,4 +1036,240 @@ end
     end
 end
 
+@testset "@testset and @test" begin
+    @testset "@testset" begin
+        let code = """
+            @testset "my tests" begin
+                @test 1 == 1
+            end
+            """
+            fi = make_file_info(code)
+            st0 = JETLS.build_syntax_tree(fi)
+            symbols = JETLS.extract_document_symbols(st0, fi)
+            @test length(symbols) == 1
+            @test symbols[1].name == "my tests"
+            @test symbols[1].kind == SymbolKind.Event
+            @test symbols[1].detail == "@testset \"my tests\" begin"
+            @test symbols[1].children !== nothing
+            @test length(symbols[1].children) == 1
+            @test symbols[1].children[1].kind == SymbolKind.Boolean
+        end
+    end
+
+    @testset "@testset without description" begin
+        let code = """
+            @testset begin
+                @test true
+            end
+            """
+            fi = make_file_info(code)
+            st0 = JETLS.build_syntax_tree(fi)
+            symbols = JETLS.extract_document_symbols(st0, fi)
+            @test length(symbols) == 1
+            @test symbols[1].name == " "
+            @test symbols[1].kind == SymbolKind.Event
+            @test symbols[1].detail == "@testset begin"
+            @test symbols[1].children !== nothing
+            @test length(symbols[1].children) == 1
+            @test symbols[1].children[1].kind == SymbolKind.Boolean
+        end
+    end
+
+    @testset "module-qualified @testset" begin
+        let code = """
+            Test.@testset "qualified" begin
+                @test true
+            end
+            """
+            fi = make_file_info(code)
+            st0 = JETLS.build_syntax_tree(fi)
+            symbols = JETLS.extract_document_symbols(st0, fi)
+            @test length(symbols) == 1
+            @test symbols[1].name == "qualified"
+            @test symbols[1].kind == SymbolKind.Event
+        end
+    end
+
+    @testset "nested @testset" begin
+        let code = """
+            @testset "outer" begin
+                @testset "inner" begin
+                    @test true
+                end
+            end
+            """
+            fi = make_file_info(code)
+            st0 = JETLS.build_syntax_tree(fi)
+            symbols = JETLS.extract_document_symbols(st0, fi)
+            @test length(symbols) == 1
+            @test symbols[1].name == "outer"
+            @test symbols[1].children !== nothing
+            @test length(symbols[1].children) == 1
+            @test symbols[1].children[1].name == "inner"
+            @test symbols[1].children[1].children !== nothing
+            @test length(symbols[1].children[1].children) == 1
+        end
+    end
+
+    @testset "@test" begin
+        let code = """
+            @testset "tests" begin
+                @test x == 1
+                @test length(arr) > 0
+            end
+            """
+            fi = make_file_info(code)
+            st0 = JETLS.build_syntax_tree(fi)
+            symbols = JETLS.extract_document_symbols(st0, fi)
+            @test length(symbols) == 1
+            children = symbols[1].children
+            @test children !== nothing
+            @test length(children) == 2
+            @test children[1].name == "x == 1"
+            @test children[1].detail == "@test x == 1"
+            @test children[1].kind == SymbolKind.Boolean
+            @test children[2].name == "length(arr) > 0"
+            @test children[2].detail == "@test length(arr) > 0"
+        end
+    end
+
+    @testset "@test inside let block" begin
+        let code = """
+            @testset "tests" begin
+                let x = 1
+                    @test x == 1
+                end
+                for i in 1:3
+                    @test i > 0
+                end
+            end
+            """
+            fi = make_file_info(code)
+            st0 = JETLS.build_syntax_tree(fi)
+            symbols = JETLS.extract_document_symbols(st0, fi)
+            @test length(symbols) == 1
+            children = symbols[1].children
+            @test children !== nothing
+            @test length(children) == 2
+            # let block with its children
+            let_sym = children[1]
+            @test let_sym.kind == SymbolKind.Namespace
+            @test let_sym.children !== nothing
+            let_children = let_sym.children
+            x_sym = only(filter(c -> c.name == "x", let_children))
+            @test x_sym.kind == SymbolKind.Variable
+            test_sym = only(filter(c -> c.name == "x == 1", let_children))
+            @test test_sym.kind == SymbolKind.Boolean
+            # for block with its children
+            for_sym = children[2]
+            @test for_sym.kind == SymbolKind.Namespace
+            @test for_sym.children !== nothing
+            for_children = for_sym.children
+            i_sym = only(filter(c -> c.name == "i", for_children))
+            @test i_sym.kind == SymbolKind.Variable
+            test_sym2 = only(filter(c -> c.name == "i > 0", for_children))
+            @test test_sym2.kind == SymbolKind.Boolean
+        end
+    end
+
+    @testset "@testset for loop" begin
+        let code = raw"""
+            @testset "test $v" for v in 1:3
+                @test v > 0
+            end
+            """
+            fi = make_file_info(code)
+            st0 = JETLS.build_syntax_tree(fi)
+            symbols = JETLS.extract_document_symbols(st0, fi)
+            @test length(symbols) == 1
+            @test symbols[1].name == "test \$v"
+            @test symbols[1].kind == SymbolKind.Event
+            @test symbols[1].detail == "@testset \"test \$v\" for v in 1:3"
+            @test symbols[1].children !== nothing
+            @test length(symbols[1].children) == 1
+            @test symbols[1].children[1].kind == SymbolKind.Boolean
+        end
+    end
+
+    @testset "@testset nested for loop" begin
+        let code = raw"""
+            @testset "test $v, $w" for v in 1:2, w in 1:3
+                @test v + w > 0
+            end
+            """
+            fi = make_file_info(code)
+            st0 = JETLS.build_syntax_tree(fi)
+            symbols = JETLS.extract_document_symbols(st0, fi)
+            @test length(symbols) == 1
+            @test symbols[1].name == "test \$v, \$w"
+            @test symbols[1].kind == SymbolKind.Event
+        end
+    end
+
+    @testset "@testset function call" begin
+        let code = """
+            @testset "test" test_func()
+            """
+            fi = make_file_info(code)
+            st0 = JETLS.build_syntax_tree(fi)
+            symbols = JETLS.extract_document_symbols(st0, fi)
+            @test length(symbols) == 1
+            @test symbols[1].name == "test"
+            @test symbols[1].kind == SymbolKind.Event
+            @test symbols[1].detail == "@testset \"test\" test_func()"
+            # Function call variant has no children
+            @test symbols[1].children === nothing || isempty(symbols[1].children)
+        end
+    end
+
+    @testset "@testset let" begin
+        let code = """
+            @testset let v = 1, w = 2
+                @test v + w == 3
+            end
+            """
+            fi = make_file_info(code)
+            st0 = JETLS.build_syntax_tree(fi)
+            symbols = JETLS.extract_document_symbols(st0, fi)
+            @test length(symbols) == 1
+            @test symbols[1].name == " "
+            @test symbols[1].kind == SymbolKind.Event
+            @test symbols[1].detail == "@testset let v = 1, w = 2"
+            @test symbols[1].children !== nothing
+            @test length(symbols[1].children) == 1
+            @test symbols[1].children[1].kind == SymbolKind.Boolean
+        end
+    end
+
+    @testset "@testset with CustomTestSet" begin
+        let code = """
+            @testset CustomTestSet "my test" begin
+                @test true
+            end
+            """
+            fi = make_file_info(code)
+            st0 = JETLS.build_syntax_tree(fi)
+            symbols = JETLS.extract_document_symbols(st0, fi)
+            @test length(symbols) == 1
+            @test symbols[1].name == "my test"
+            @test symbols[1].kind == SymbolKind.Event
+        end
+    end
+
+    @testset "@testset with options" begin
+        let code = """
+            @testset verbose=true "with options" begin
+                @test true
+            end
+            """
+            fi = make_file_info(code)
+            st0 = JETLS.build_syntax_tree(fi)
+            symbols = JETLS.extract_document_symbols(st0, fi)
+            @test length(symbols) == 1
+            @test symbols[1].name == "with options"
+            @test symbols[1].kind == SymbolKind.Event
+        end
+    end
+end
+
 end # module test_document_symbol


### PR DESCRIPTION
Add document symbol extraction for `@testset` and `@test` macros. `@testset` blocks appear as `SymbolKind.Boolean` symbols with the test name, and `@test` expressions appear as children with the test expression as the symbol name.

Also extract `@testset` and `@test` symbols from namespace blocks (`let`, `for`, `while`) via `extract_macrocalls_from_block!`.