### PR TITLE
inlay-hint: Add block end inlay hints with configurable threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   blocks appear in the document outline with the test name, and `@test`
   expressions appear as children showing the test expression.
 
+- Added inlay hints for block `end` keywords. For long blocks (`module`,
+  `function`, `macro`, `struct`, `if`/`@static if`, `let`, `for`, `while`,
+  `@testset`), an inlay hint is displayed at the `end` keyword showing what
+  construct is ending, such as `module Foo` or `function bar`. The minimum
+  block length can be configured via
+  [`inlay_hint.block_end_min_lines`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/inlay_hint-block_end_min_lines)
+  (default: 25 lines).
+
 ### Deprecated
 
 - Running `jetls` without a subcommand (e.g., `jetls --stdio`) is deprecated.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -38,6 +38,9 @@ prepend_inference_result = false   # boolean, default: (unset) auto-detect
 references = false                 # boolean, default: false
 testrunner = true                  # boolean, default: true
 
+[inlay_hint]
+block_end_min_lines = 25           # integer, default: 25
+
 [testrunner]
 executable = "testrunner"          # string, default: "testrunner" (or "testrunner.bat" on Windows)
 ```
@@ -59,6 +62,8 @@ executable = "testrunner"          # string, default: "testrunner" (or "testrunn
 - [`[code_lens]`](@ref config/code_lens)
     - [`[code_lens] references`](@ref config/code_lens-references)
     - [`[code_lens] testrunner`](@ref config/code_lens-testrunner)
+- [`[inlay_hint]`](@ref config/inlay_hint)
+    - [`[inlay_hint] block_end_min_lines`](@ref config/inlay_hint-block_end_min_lines)
 - [`[testrunner]`](@ref config/testrunner)
     - [`[testrunner] executable`](@ref config/testrunner-executable)
 
@@ -467,6 +472,27 @@ functionality. In such cases, you may want to disable this setting.
 ```toml
 [code_lens]
 testrunner = false  # Disable TestRunner code lenses
+```
+
+### [`[inlay_hint]`](@id config/inlay_hint)
+
+Configure inlay hint behavior.
+
+#### [`[inlay_hint] block_end_min_lines`](@id config/inlay_hint-block_end_min_lines)
+
+- **Type**: integer
+- **Default**: `25`
+
+Minimum number of lines a block must span before JETLS displays an inlay hint
+at its `end` keyword. Inlay hints show what construct is ending, such as
+`module Foo`, `function foo` or `@testset "foo"`, helping navigate long blocks.
+
+Supported block types include `module`, `function`, `macro`, `struct`,
+`if`/`@static if`, `let`, `for`, `while`, and `@testset`.
+
+```toml
+[inlay_hint]
+block_end_min_lines = 10  # Show hints for blocks with 10+ lines
 ```
 
 ### [`[testrunner]`](@id config/testrunner)

--- a/src/types.jl
+++ b/src/types.jl
@@ -493,6 +493,10 @@ end
     testrunner::Maybe{Bool}
 end
 
+@option struct InlayHintConfig <: ConfigSection
+    block_end_min_lines::Maybe{Int}
+end
+
 @option struct JETLSConfig <: ConfigSection
     diagnostic::Maybe{DiagnosticConfig}
     full_analysis::Maybe{FullAnalysisConfig}
@@ -500,6 +504,7 @@ end
     formatter::Maybe{FormatterConfig}
     completion::Maybe{CompletionConfig}
     code_lens::Maybe{CodeLensConfig}
+    inlay_hint::Maybe{InlayHintConfig}
     # This initialization options are read once at the server initialization and held in
     # `server.state.init_options`, so it might seem strange to hold them here also,
     # but they need to be set here for cases where initialization options are set in
@@ -514,6 +519,7 @@ const DEFAULT_CONFIG = JETLSConfig(;
     formatter = "Runic",
     completion = CompletionConfig(LaTeXEmojiConfig(missing), MethodSignatureConfig(missing)),
     code_lens = CodeLensConfig(false, true),
+    inlay_hint = InlayHintConfig(25),
     initialization_options = DEFAULT_INIT_OPTIONS)
 
 function get_default_config(path::Symbol...)

--- a/test/test_inlay_hint.jl
+++ b/test/test_inlay_hint.jl
@@ -17,10 +17,10 @@ include(normpath(pkgdir(JETLS), "test", "jsjl-utils.jl"))
             fi = JETLS.FileInfo(1, code, @__FILE__)
             range = Range(; start = Position(; line = 0, character = 0),
                             var"end" = Position(; line = 3, character = 0))
-            inlay_hints = JETLS.syntactic_inlay_hints(fi, range)
+            inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
             @test length(inlay_hints) == 1
             @test inlay_hints[1].position == Position(; line = 2, character = 3)
-            @test inlay_hints[1].label == " #= module TestModule =#"
+            @test inlay_hints[1].label == "module TestModule"
         end
 
         let code = """
@@ -32,7 +32,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl-utils.jl"))
             fi = JETLS.FileInfo(1, code, @__FILE__)
             range = Range(; start = Position(; line = 0, character = 0),
                             var"end" = Position(; line = 4, character = 0))
-            inlay_hints = JETLS.syntactic_inlay_hints(fi, range)
+            inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
             @test isempty(inlay_hints)
         end
 
@@ -44,7 +44,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl-utils.jl"))
             fi = JETLS.FileInfo(1, code, @__FILE__)
             range = Range(; start = Position(; line = 0, character = 0),
                             var"end" = Position(; line = 3, character = 0))
-            inlay_hints = JETLS.syntactic_inlay_hints(fi, range)
+            inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
             @test isempty(inlay_hints)
         end
 
@@ -55,7 +55,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl-utils.jl"))
                 fi = JETLS.FileInfo(1, code, @__FILE__)
                 range = Range(; start = Position(; line = 0, character = 0),
                                 var"end" = Position(; line = 1, character = 0))
-                inlay_hints = JETLS.syntactic_inlay_hints(fi, range)
+                inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
                 @test isempty(inlay_hints)
             end
         end
@@ -71,14 +71,13 @@ include(normpath(pkgdir(JETLS), "test", "jsjl-utils.jl"))
                 fi = JETLS.FileInfo(1, code, @__FILE__)
                 range = Range(; start = Position(; line = 0, character = 0),
                                 var"end" = Position(; line = 5, character = 0))
-                inlay_hints = JETLS.syntactic_inlay_hints(fi, range)
+                inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
                 @test length(inlay_hints) == 2
-                # The order depends on the tree traversal, so we sort by line number
-                sort!(inlay_hints, by = hint -> hint.position.line)
+                sort!(inlay_hints; by = hint -> hint.position.line)
                 @test inlay_hints[1].position == Position(; line = 3, character = 3)
-                @test inlay_hints[1].label == " #= module Inner =#"
+                @test inlay_hints[1].label == "module Inner"
                 @test inlay_hints[2].position == Position(; line = 4, character = 3)
-                @test inlay_hints[2].label == " #= module Outer =#"
+                @test inlay_hints[2].label == "module Outer"
             end
         end
 
@@ -91,7 +90,7 @@ include(normpath(pkgdir(JETLS), "test", "jsjl-utils.jl"))
                 fi = JETLS.FileInfo(1, code, @__FILE__)
                 range = Range(; start = Position(; line = 0, character = 0),
                                 var"end" = Position(; line = 1, character = 0))
-                inlay_hints = JETLS.syntactic_inlay_hints(fi, range)
+                inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
                 @test isempty(inlay_hints)
             end
         end
@@ -105,10 +104,259 @@ include(normpath(pkgdir(JETLS), "test", "jsjl-utils.jl"))
                 fi = JETLS.FileInfo(1, code, @__FILE__)
                 range = Range(; start = Position(; line = 0, character = 0),
                                 var"end" = Position(; line = 3, character = 0))
-                inlay_hints = JETLS.syntactic_inlay_hints(fi, range)
+                inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
                 @test length(inlay_hints) == 1
                 @test inlay_hints[1].position == Position(; line = 2, character = 3)
-                @test inlay_hints[1].label == " #= module TestModule =#"
+                @test inlay_hints[1].label == "module TestModule"
+            end
+        end
+
+        @testset "baremodule" begin
+            let code = """
+                baremodule TestModule
+                x = 1
+                end
+                """
+                fi = JETLS.FileInfo(1, code, @__FILE__)
+                range = Range(; start = Position(; line = 0, character = 0),
+                                var"end" = Position(; line = 3, character = 0))
+                inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
+                @test length(inlay_hints) == 1
+                @test inlay_hints[1].label == "baremodule TestModule"
+            end
+        end
+    end
+
+    @testset "function inlay hints" begin
+        let code = """
+            function foo(x, y)
+                x + y
+            end
+            """
+            fi = JETLS.FileInfo(1, code, @__FILE__)
+            range = Range(; start = Position(; line = 0, character = 0),
+                            var"end" = Position(; line = 3, character = 0))
+            inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
+            @test length(inlay_hints) == 1
+            @test inlay_hints[1].position == Position(; line = 2, character = 3)
+            @test inlay_hints[1].label == "function foo"
+        end
+
+        @testset "short form function" begin
+            let code = """
+                foo(x) = begin
+                    x + 1
+                end
+                """
+                fi = JETLS.FileInfo(1, code, @__FILE__)
+                range = Range(; start = Position(; line = 0, character = 0),
+                                var"end" = Position(; line = 3, character = 0))
+                inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
+                @test length(inlay_hints) == 1
+                @test inlay_hints[1].label == "foo(...) ="
+            end
+        end
+
+        @testset "one-liner function" begin
+            let code = """
+                function foo(x) x + 1 end
+                """
+                fi = JETLS.FileInfo(1, code, @__FILE__)
+                range = Range(; start = Position(; line = 0, character = 0),
+                                var"end" = Position(; line = 1, character = 0))
+                inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
+                @test isempty(inlay_hints)
+            end
+        end
+
+        @testset "existing comment" begin
+            let code = """
+                function foo(x)
+                    x + 1
+                end # function foo
+                """
+                fi = JETLS.FileInfo(1, code, @__FILE__)
+                range = Range(; start = Position(; line = 0, character = 0),
+                                var"end" = Position(; line = 3, character = 0))
+                inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
+                @test isempty(inlay_hints)
+            end
+        end
+    end
+
+    @testset "macro inlay hints" begin
+        let code = """
+            macro mymacro(x)
+                esc(x)
+            end
+            """
+            fi = JETLS.FileInfo(1, code, @__FILE__)
+            range = Range(; start = Position(; line = 0, character = 0),
+                            var"end" = Position(; line = 3, character = 0))
+            inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
+            @test length(inlay_hints) == 1
+            @test inlay_hints[1].label == "macro @mymacro"
+        end
+    end
+
+    @testset "struct inlay hints" begin
+        let code = """
+            struct Foo
+                x::Int
+                y::String
+            end
+            """
+            fi = JETLS.FileInfo(1, code, @__FILE__)
+            range = Range(; start = Position(; line = 0, character = 0),
+                            var"end" = Position(; line = 4, character = 0))
+            inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
+            @test length(inlay_hints) == 1
+            @test inlay_hints[1].label == "struct Foo"
+        end
+
+        @testset "mutable struct" begin
+            let code = """
+                mutable struct Bar
+                    x::Int
+                end
+                """
+                fi = JETLS.FileInfo(1, code, @__FILE__)
+                range = Range(; start = Position(; line = 0, character = 0),
+                                var"end" = Position(; line = 3, character = 0))
+                inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
+                @test length(inlay_hints) == 1
+                @test inlay_hints[1].label == "mutable struct Bar"
+            end
+        end
+    end
+
+    @testset "control flow inlay hints" begin
+        @testset "if block" begin
+            let code = """
+                if condition
+                    x = 1
+                end
+                """
+                fi = JETLS.FileInfo(1, code, @__FILE__)
+                range = Range(; start = Position(; line = 0, character = 0),
+                                var"end" = Position(; line = 3, character = 0))
+                inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
+                @test length(inlay_hints) == 1
+                @test inlay_hints[1].label == "if condition"
+            end
+
+            let code = """
+                if x > 0
+                    y = 1
+                elseif x < 0
+                    y = -1
+                else
+                    y = 0
+                end
+                """
+                fi = JETLS.FileInfo(1, code, @__FILE__)
+                range = Range(; start = Position(; line = 0, character = 0),
+                                var"end" = Position(; line = 7, character = 0))
+                inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
+                @test length(inlay_hints) == 1
+                @test inlay_hints[1].label == "if x > 0"
+            end
+        end
+
+        @testset "@static if block" begin
+            let code = """
+                @static if Sys.iswindows()
+                    const PATH_SEP = '\\\\'
+                else
+                    const PATH_SEP = '/'
+                end
+                """
+                fi = JETLS.FileInfo(1, code, @__FILE__)
+                range = Range(; start = Position(; line = 0, character = 0),
+                                var"end" = Position(; line = 5, character = 0))
+                inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
+                @test length(inlay_hints) == 1
+                @test inlay_hints[1].label == "@static if Sys.iswindows()"
+            end
+        end
+
+        @testset "let block" begin
+            let code = """
+                let x = 1,
+                    y = 2
+                    z = x + y
+                end
+                """
+                fi = JETLS.FileInfo(1, code, @__FILE__)
+                range = Range(; start = Position(; line = 0, character = 0),
+                                var"end" = Position(; line = 4, character = 0))
+                inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
+                @test length(inlay_hints) == 1
+                @test inlay_hints[1].label == "let x = 1,"
+            end
+        end
+
+        @testset "for loop" begin
+            let code = """
+                for i in 1:10
+                    println(i)
+                end
+                """
+                fi = JETLS.FileInfo(1, code, @__FILE__)
+                range = Range(; start = Position(; line = 0, character = 0),
+                                var"end" = Position(; line = 3, character = 0))
+                inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
+                @test length(inlay_hints) == 1
+                @test inlay_hints[1].label == "for i in 1:10"
+            end
+        end
+
+        @testset "while loop" begin
+            let code = """
+                while x > 0
+                    x -= 1
+                end
+                """
+                fi = JETLS.FileInfo(1, code, @__FILE__)
+                range = Range(; start = Position(; line = 0, character = 0),
+                                var"end" = Position(; line = 3, character = 0))
+                inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
+                @test length(inlay_hints) == 1
+                @test inlay_hints[1].label == "while x > 0"
+            end
+        end
+    end
+
+    @testset "@testset inlay hints" begin
+        let code = """
+            @testset "my tests" begin
+                @test 1 == 1
+            end
+            """
+            fi = JETLS.FileInfo(1, code, @__FILE__)
+            range = Range(; start = Position(; line = 0, character = 0),
+                            var"end" = Position(; line = 3, character = 0))
+            inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
+            @test length(inlay_hints) == 1
+            @test inlay_hints[1].label == "@testset \"my tests\" begin"
+        end
+
+        @testset "nested @testset" begin
+            let code = """
+                @testset "outer" begin
+                    @testset "inner" begin
+                        @test true
+                    end
+                end
+                """
+                fi = JETLS.FileInfo(1, code, @__FILE__)
+                range = Range(; start = Position(; line = 0, character = 0),
+                                var"end" = Position(; line = 5, character = 0))
+                inlay_hints = JETLS.syntactic_inlay_hints(fi, range; min_lines=0)
+                @test length(inlay_hints) == 2
+                sort!(inlay_hints; by = hint -> hint.position.line)
+                @test inlay_hints[1].label == "@testset \"inner\" begin"
+                @test inlay_hints[2].label == "@testset \"outer\" begin"
             end
         end
     end


### PR DESCRIPTION
Add inlay hints at block `end` keywords showing what construct is ending (e.g., `module Foo`, `function bar`, `@testset "tests"`). The hints are based on document symbols rather than direct syntax tree traversal.

Supported block types: `module`, `function`, `macro`, `struct`, `if`/`@static if`, `let`, `for`, `while`, and `@testset`.

Add `inlay_hint.block_end_min_lines` configuration option (default: 25) to control the minimum block length before hints are displayed.