### PR TITLE
deps: Update JET version for improved cache generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   the same cached tree during lowering could cause data races and segfaults.
   Cached trees are now copied before use. (https://github.com/aviatesk/JETLS.jl/pull/525)
 
+- Fixed cache not being generated in some cases in the experimental incremental
+  analysis mode. The cache is now always created when `CodeInstance` is
+  available, ensuring cache reuse works reliably.
+
 ## 2026-01-23
 
 - Commit: [`9c00dfe`](https://github.com/aviatesk/JETLS.jl/commit/9c00dfe)

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [sources]
-JET = {rev = "8fe5f1b", url = "https://github.com/aviatesk/JET.jl"}
+JET = {rev = "dde2e70", url = "https://github.com/aviatesk/JET.jl"}
 JuliaLowering = {rev = "avi/JETLS-JSJL-head-2026-01-29", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
 JuliaSyntax = {rev = "avi/JETLS-JSJL-head-2026-01-29", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
 LSP = {path = "LSP"}

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -824,6 +824,8 @@ function analyze_package_with_revise(
                 # Cache the result if CodeInstance is available
                 if isdefined(result, :ci)
                     siginfos[index] = Revise.replace_extended_data(siginfo, :JETLS, SigAnalysisResult(reports, result.ci))
+                else
+                    JETLS_DEV_MODE && @warn "Missing CodeInstance for method analysis instance for" siginfo.sig
                 end
             else
                 JETLS_DEV_MODE && @warn "Couldn't find a single matching method for the signature" siginfo.sig


### PR DESCRIPTION
Update JET dependency to ensure `CodeInstance` is always created during the experimental incremental analysis mode. Previously, cache generation could fail silently in some cases, causing cache reuse to not work. The JET update ensures that `CodeInstance` is always available when caching analysis results.

Also adds a development mode warning when `CodeInstance` is missing, to help detect any remaining edge cases.