### PR TITLE
Don't `touch(manifest_path)`

### DIFF
--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -1140,14 +1140,8 @@ end
 
 function ensure_instantiated!(server::Server, env_path::String)
     if get_config(server, :full_analysis, :auto_instantiate)
-        manifest_name = "Manifest-v$(VERSION.major).$(VERSION.minor).toml"
-        manifest_path = joinpath(dirname(env_path), manifest_name)
         io = IOBuffer()
         try
-            if !isfile(manifest_path)
-                JETLS_DEV_MODE && @info "Touching versioned manifest file" env_path
-                touch(manifest_path)
-            end
             JETLS_DEV_MODE && @info "Resolving package environment" env_path
             Pkg.resolve(; io)
             JETLS_DEV_MODE && @info "Instantiating package environment" env_path


### PR DESCRIPTION
Fixes https://github.com/aviatesk/JETLS.jl/issues/511

I ran this in a few scenarios and don't see why this is needed.

Outside a project.
It does not write a Manifest.toml, as expected.

```
2026-02-05 15:48:07.552 [info] [JETLS-stderr] ┌ Info: Initialized JETLS with the following setup:
2026-02-05 15:48:07.552 [info] [JETLS-stderr] │   Sys.BINDIR = "C:\\ProgramData\\DevDrives\\.julia\\juliaup\\julia-1.12.4+0.x64.w64.mingw32\\bin"
2026-02-05 15:48:07.552 [info] [JETLS-stderr] │   pkgdir(JETLS) = "C:\\ProgramData\\DevDrives\\.julia\\dev\\JETLS"
2026-02-05 15:48:07.552 [info] [JETLS-stderr] │   Threads.nthreads() = 24
2026-02-05 15:48:07.552 [info] [JETLS-stderr] │   JETLS_VERSION = "dev"
2026-02-05 15:48:07.552 [info] [JETLS-stderr] │   JETLS_DEV_MODE = true
2026-02-05 15:48:07.552 [info] [JETLS-stderr] │   JETLS_TEST_MODE = false
2026-02-05 15:48:07.552 [info] [JETLS-stderr] └   JETLS_DEBUG_LOWERING = false
2026-02-05 15:48:08.636 [info] [JETLS-stderr] ┌ Info: JETLS intialization options
2026-02-05 15:48:08.636 [info] [JETLS-stderr] └   init_options = InitOptions(; n_analysis_workers=1 analysis_overrides=JETLS.AnalysisOverride[])
2026-02-05 15:48:17.997 [info] [JETLS-stderr] ┌ Info: Executing analysis for:
2026-02-05 15:48:17.997 [info] [JETLS-stderr] │   entry = "script.jl [script (no env)]"
2026-02-05 15:48:17.997 [info] [JETLS-stderr] │   uri = file:///c%3A/ProgramData/DevDrives/temp/no-thing/script.jl
2026-02-05 15:48:17.997 [info] [JETLS-stderr] └   generation = 0
2026-02-05 15:48:18.941 [info] [JETLS-stderr] ┌ Info: Analysis completed in 1.06 seconds:
2026-02-05 15:48:18.941 [info] [JETLS-stderr] │   entry = "script.jl [script (no env)]"
2026-02-05 15:48:18.941 [info] [JETLS-stderr] │   uri = file:///c%3A/ProgramData/DevDrives/temp/no-thing/script.jl
2026-02-05 15:48:18.941 [info] [JETLS-stderr] └   generation = 0
```

In a project without workspaces.
Before it would always write a Manifest-v1.12.toml that, now it uses the existing Manifest.toml, or creates it if it isn't there.

```
2026-02-05 15:25:31.491 [info] [JETLS-stderr] ┌ Info: Resolving package environment
2026-02-05 15:25:31.491 [info] [JETLS-stderr] └   env_path = "c:\\ProgramData\\DevDrives\\.julia\\dev\\JuliaC\\Project.toml"
2026-02-05 15:25:35.396 [info] [JETLS-stderr] ┌ Info: Instantiating package environment
2026-02-05 15:25:35.397 [info] [JETLS-stderr] └   env_path = "c:\\ProgramData\\DevDrives\\.julia\\dev\\JuliaC\\Project.toml"
2026-02-05 15:25:39.128 [info] [JETLS-stderr] ┌ Info: Executing analysis for:
2026-02-05 15:25:39.128 [info] [JETLS-stderr] │   entry = "JuliaC.jl [package (test)]"
2026-02-05 15:25:39.128 [info] [JETLS-stderr] │   uri = file:///c%3A/ProgramData/DevDrives/.julia/dev/JuliaC/test/trimming.jl
2026-02-05 15:25:39.128 [info] [JETLS-stderr] └   generation = 0
2026-02-05 15:25:59.844 [info] [JETLS-stderr] ┌ Info: Analysis completed in 20.82 seconds:
2026-02-05 15:25:59.844 [info] [JETLS-stderr] │   entry = "JuliaC.jl [package (test)]"
2026-02-05 15:25:59.844 [info] [JETLS-stderr] │   uri = file:///c%3A/ProgramData/DevDrives/.julia/dev/JuliaC/test/trimming.jl
2026-02-05 15:25:59.844 [info] [JETLS-stderr] └   generation = 0
2026-02-05 15:26:00.090 [info] [JETLS-stderr] ┌ Info: Executing analysis for:
2026-02-05 15:26:00.090 [info] [JETLS-stderr] │   entry = "JuliaC.jl [package]"
2026-02-05 15:26:00.090 [info] [JETLS-stderr] │   uri = file:///c%3A/ProgramData/DevDrives/.julia/dev/JuliaC/src/compiling.jl
2026-02-05 15:26:00.090 [info] [JETLS-stderr] └   generation = 0
2026-02-05 15:26:10.345 [info] [JETLS-stderr] ┌ Info: Analysis completed in 10.26 seconds:
2026-02-05 15:26:10.346 [info] [JETLS-stderr] │   entry = "JuliaC.jl [package]"
2026-02-05 15:26:10.346 [info] [JETLS-stderr] │   uri = file:///c%3A/ProgramData/DevDrives/.julia/dev/JuliaC/src/compiling.jl
2026-02-05 15:26:10.346 [info] [JETLS-stderr] └   generation = 0
```

In a project with workspaces.
Before it would always write a Manifest-v1.12.toml in each subproject, now it uses the existing Manifest.toml, or creates it if it isn't there.

```
2026-02-05 15:46:40.259 [info] [JETLS-stderr] ┌ Info: Instantiating package environment
2026-02-05 15:46:40.259 [info] [JETLS-stderr] └   env_path = "c:\\ProgramData\\DevDrives\\repo\\ribasim\\Ribasim\\core\\test\\Project.toml"
2026-02-05 15:46:40.929 [info] [JETLS-stderr] ┌ Warning: File cache not found
2026-02-05 15:46:40.929 [info] [JETLS-stderr] │   uri = git:/c%3A/ProgramData/DevDrives/repo/ribasim/Ribasim/core/src/Ribasim.jl?%7B%22path%22:%22c:%5C%5CProgramData%5C%5CDevDrives%5C%5Crepo%5C%5Cribasim%5C%5CRibasim%5C%5Ccore%5C%5Csrc%5C%5CRibasim.jl%22,%22ref%22:%22%22%7D
2026-02-05 15:46:40.930 [info] [JETLS-stderr] └ @ JETLS C:\ProgramData\DevDrives\.julia\dev\JETLS\src\utils\server.jl:206
2026-02-05 15:46:40.930 [info] [JETLS-stderr] ┌ Warning: File cache not found
2026-02-05 15:46:40.930 [info] [JETLS-stderr] │   uri = git:/c%3A/ProgramData/DevDrives/repo/ribasim/Ribasim/core/src/Ribasim.jl?%7B%22path%22:%22c:%5C%5CProgramData%5C%5CDevDrives%5C%5Crepo%5C%5Cribasim%5C%5CRibasim%5C%5Ccore%5C%5Csrc%5C%5CRibasim.jl%22,%22ref%22:%22HEAD%22%7D
2026-02-05 15:46:40.930 [info] [JETLS-stderr] └ @ JETLS C:\ProgramData\DevDrives\.julia\dev\JETLS\src\utils\server.jl:206
2026-02-05 15:46:45.515 [info] [JETLS-stderr] ┌ Info: Cancelled duplicated pending analysis request:
2026-02-05 15:46:45.516 [info] [JETLS-stderr] │   entry = "Ribasim.jl [package]"
2026-02-05 15:46:45.516 [info] [JETLS-stderr] │   uri = file:///c%3A/ProgramData/DevDrives/repo/ribasim/Ribasim/core/src/config.jl
2026-02-05 15:46:45.516 [info] [JETLS-stderr] └   generation = 0
2026-02-05 15:46:45.544 [info] [JETLS-stderr] ┌ Info: Resolving package environment
2026-02-05 15:46:45.544 [info] [JETLS-stderr] └   env_path = "c:\\ProgramData\\DevDrives\\repo\\ribasim\\Ribasim\\Project.toml"
2026-02-05 15:46:48.093 [info] [JETLS-stderr] ┌ Info: Instantiating package environment
2026-02-05 15:46:48.094 [info] [JETLS-stderr] └   env_path = "c:\\ProgramData\\DevDrives\\repo\\ribasim\\Ribasim\\Project.toml"
```