### PR TITLE
kwdef: Add new-style `@kwdef` macro for provenance preservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed rename/document-highlight/references failing for `@kwdef` structs with
+  default values (Fixed https://github.com/aviatesk/JETLS.jl/issues/540).
 - Fixed various type instabilities across the codebase caught by the new
   `inference/method-error` diagnostic running on JETLS itself.
 

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -65,6 +65,8 @@ is_nospecialize_or_specialize_macrocall0(st0::JS.SyntaxTree) =
 
 is_mainfunc0(st0::JS.SyntaxTree) = is_macrocall_st0(st0, "@main")
 
+is_kwdef0(st0::JS.SyntaxTree) = is_macrocall_st0(st0, "@kwdef")
+
 function is_nospecialize_or_specialize_macrocall3(st3::JS.SyntaxTree)
     JS.kind(st3) === JS.K"macrocall" || return false
     JS.numchildren(st3) >= 1 || return false
@@ -91,6 +93,10 @@ function _remove_macrocalls(st::JS.SyntaxTree)
         elseif is_mainfunc0(st)
             # `@main` functions are always lowered to `main` functions without issues,
             # so there's no need to remove them
+            return st, false
+        elseif is_kwdef0(st)
+            # `@kwdef` has a new-style macro definition (in jl-syntax-macros.jl) that
+            # preserves provenance, so there's no need to remove it here.
             return st, false
         end
         new_children = JS.SyntaxList(JS.syntax_graph(st))

--- a/src/utils/jl-syntax-macros.jl
+++ b/src/utils/jl-syntax-macros.jl
@@ -35,3 +35,139 @@ function Base.var"@specialize"(__context__::JL.MacroContext)
             __context__.macrocall::JS.SyntaxTree,
             [JS.K"meta" "specialize"::JS.K"Symbol"])
 end
+
+# New-style `@kwdef` macro that preserves provenance information.
+# This strips default values from struct fields and generates keyword constructors,
+# matching the semantics of Base.@kwdef.
+function Base.var"@kwdef"(__context__::JL.MacroContext, ex::JS.SyntaxTree)
+    JS.kind(ex) === JS.K"struct" ||
+        throw(JL.MacroExpansionError(ex, "Invalid usage of @kwdef"))
+
+    type_sig = ex[1]
+    type_body = ex[2]
+
+    field_names = JS.SyntaxTree[]
+    field_defaults = Union{Nothing,JS.SyntaxTree}[]
+    stripped = JS.SyntaxTree[]
+    _kwdef_collect_fields!(__context__, type_body, field_names, field_defaults, stripped)
+
+    stripped_body = JL.@ast(__context__, type_body::JS.SyntaxTree,
+                           [JS.K"block" stripped...])
+    new_struct = JS.mapchildren(_ -> stripped_body, __context__, ex, [2])
+
+    if isempty(field_names)
+        return new_struct
+    end
+
+    constructors = _kwdef_make_constructors(
+        __context__, type_sig, field_names, field_defaults)
+
+    return JL.@ast(__context__, __context__.macrocall::JS.SyntaxTree,
+                   [JS.K"block" new_struct constructors...])
+end
+
+function _kwdef_collect_fields!(
+        ctx::JL.MacroContext, body::JS.SyntaxTree,
+        field_names::Vector{JS.SyntaxTree},
+        field_defaults::Vector{Union{Nothing,JS.SyntaxTree}},
+        stripped::Vector{JS.SyntaxTree})
+    for field::JS.SyntaxTree in JS.children(body)
+        k = JS.kind(field)
+        if k === JS.K"="
+            _kwdef_push_field!(field[1], field[2], field_names, field_defaults)
+            push!(stripped, field[1])
+        elseif k === JS.K"const" && JS.numchildren(field) >= 1 &&
+               JS.kind(field[1]) === JS.K"="
+            inner = field[1]
+            _kwdef_push_field!(inner[1], inner[2], field_names, field_defaults)
+            push!(stripped, JS.mapchildren(_ -> inner[1], ctx, field, [1]))
+        elseif k === JS.K"block"
+            _kwdef_collect_fields!(ctx, field, field_names, field_defaults, stripped)
+        else
+            name = _kwdef_extract_name(field)
+            if name !== nothing
+                push!(field_names, name)
+                push!(field_defaults, nothing)
+            end
+            push!(stripped, field)
+        end
+    end
+end
+
+function _kwdef_push_field!(
+        decl::JS.SyntaxTree, default::JS.SyntaxTree,
+        field_names::Vector{JS.SyntaxTree},
+        field_defaults::Vector{Union{Nothing,JS.SyntaxTree}})
+    name = _kwdef_extract_name(decl)
+    if name !== nothing
+        push!(field_names, name)
+        push!(field_defaults, default)
+    end
+end
+
+function _kwdef_extract_name(st::JS.SyntaxTree)
+    k = JS.kind(st)
+    if k === JS.K"Identifier"
+        return st
+    elseif k === JS.K"::" && JS.numchildren(st) >= 1
+        return _kwdef_extract_name(st[1])
+    elseif k === JS.K"const" && JS.numchildren(st) >= 1
+        return _kwdef_extract_name(st[1])
+    elseif k === JS.K"atomic" && JS.numchildren(st) >= 1
+        return _kwdef_extract_name(st[1])
+    else
+        return nothing
+    end
+end
+
+function _kwdef_make_constructors(
+        ctx::JL.MacroContext, type_sig::JS.SyntaxTree,
+        field_names::Vector{JS.SyntaxTree},
+        field_defaults::Vector{Union{Nothing,JS.SyntaxTree}})
+    mc = __source__ = ctx.macrocall::JS.SyntaxTree
+
+    params = JS.SyntaxTree[]
+    for (name::JS.SyntaxTree, default) in zip(field_names, field_defaults)
+        if default !== nothing
+            push!(params, JL.@ast(ctx, name, [JS.K"kw" name default]))
+        else
+            push!(params, name)
+        end
+    end
+    parameters = JL.@ast(ctx, mc, [JS.K"parameters" params...])
+
+    if JS.kind(type_sig) === JS.K"Identifier"
+        sig = JL.@ast(ctx, mc, [JS.K"call" type_sig parameters])
+        body = JL.@ast(ctx, mc, [JS.K"block"
+            [JS.K"call" type_sig field_names...]
+        ])
+        return JS.SyntaxTree[JL.@ast(ctx, mc, [JS.K"function" sig body])]
+    elseif JS.kind(type_sig) === JS.K"curly"
+        S = type_sig[1]
+        P = JS.SyntaxTree[type_sig[i] for i::Int in 2:JS.numchildren(type_sig)]
+        Q = JS.SyntaxTree[
+            JS.kind(p) === JS.K"<:" ? p[1] : p for p::JS.SyntaxTree in P]
+        SQ = JL.@ast(ctx, type_sig, [JS.K"curly" S Q...])
+
+        # def1: S(; a=default, b) = S(a, b)
+        sig1 = JL.@ast(ctx, mc, [JS.K"call" S parameters])
+        body1 = JL.@ast(ctx, mc, [JS.K"block"
+            [JS.K"call" S field_names...]
+        ])
+        def1 = JL.@ast(ctx, mc, [JS.K"function" sig1 body1])
+
+        # def2: S{T}(; a=default, b) where {T<:Real} = S{T}(a, b)
+        sig2_call = JL.@ast(ctx, mc, [JS.K"call" SQ parameters])
+        braces = JL.@ast(ctx, mc, [JS.K"braces" P...])
+        sig2 = JL.@ast(ctx, mc, [JS.K"where" sig2_call braces])
+        body2 = JL.@ast(ctx, mc, [JS.K"block"
+            [JS.K"call" SQ field_names...]
+        ])
+        def2 = JL.@ast(ctx, mc, [JS.K"function" sig2 body2])
+
+        return JS.SyntaxTree[def1, def2]
+    else
+        throw(JL.MacroExpansionError(
+            type_sig, "Invalid type signature for @kwdef"))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ end
         @testset "path" include("utils/test_path.jl")
         @testset "markdown" include("utils/test_markdown.jl")
         @testset "string" include("utils/test_string.jl")
+        @testset "jl-syntax-macros" include("utils/test_jl_syntax_macros.jl")
     end
     @testset "analysis" begin
         @testset "occurrence" include("analysis/test_occurrence_analysis.jl")

--- a/test/utils/test_jl_syntax_macros.jl
+++ b/test/utils/test_jl_syntax_macros.jl
@@ -1,0 +1,127 @@
+module test_jl_syntax_macros
+
+using Test
+using JETLS: JETLS, JL, JS
+
+include(normpath(pkgdir(JETLS), "test", "jsjl-utils.jl"))
+
+global lowering_module::Module = Module()
+
+function kwdef_expand(code::AbstractString)
+    st0 = jlparse(code; rule=:statement)
+    world = Base.get_world_counter()
+    _, st1 = JL.expand_forms_1(lowering_module, st0, true, world)
+    return st1
+end
+
+children_kinds(st::JS.SyntaxTree) = JS.Kind[JS.kind(c) for c in JS.children(st)]
+
+@testset "@kwdef" begin
+    @testset "macro expansion" begin
+        # parametric with defaults
+        let st1 = kwdef_expand("""
+                @kwdef struct A{T <: Real}
+                    a::T = 1.0
+                    b::Int
+                end
+                """)
+            @test JS.kind(st1) === JS.K"block"
+            ks = children_kinds(st1)
+            @test count(==(JS.K"struct"), ks) == 1
+            # parametric: 2 constructors (S(...) and S{T}(...) where {T})
+            @test count(==(JS.K"function"), ks) == 2
+
+            # struct fields should have defaults stripped
+            st_struct = st1[findfirst(==(JS.K"struct"), ks)]
+            body = st_struct[2]
+            for field in JS.children(body)
+                @test JS.kind(field) !== JS.K"="
+            end
+        end
+
+        # non-parametric with defaults
+        let st1 = kwdef_expand("""
+                @kwdef struct A
+                    a::Float64 = 1.0
+                end
+                """)
+            @test JS.kind(st1) === JS.K"block"
+            ks = children_kinds(st1)
+            @test count(==(JS.K"struct"), ks) == 1
+            # non-parametric: only 1 constructor
+            @test count(==(JS.K"function"), ks) == 1
+        end
+
+        # no defaults: keyword constructor is still generated
+        let st1 = kwdef_expand("""
+                @kwdef struct A
+                    a::Int
+                end
+                """)
+            @test JS.kind(st1) === JS.K"block"
+            ks = children_kinds(st1)
+            @test count(==(JS.K"struct"), ks) == 1
+            @test count(==(JS.K"function"), ks) == 1
+        end
+
+        # mutable struct with const field default
+        let st1 = kwdef_expand("""
+                @kwdef mutable struct A{T <: Real}
+                    const a::T = 1.0
+                    b::Int
+                end
+                """)
+            @test JS.kind(st1) === JS.K"block"
+            ks = children_kinds(st1)
+            @test count(==(JS.K"struct"), ks) == 1
+            @test count(==(JS.K"function"), ks) == 2
+
+            st_struct = st1[findfirst(==(JS.K"struct"), ks)]
+            body = st_struct[2]
+            # `const a::T` should remain, but no `=`
+            has_const = false
+            for field in JS.children(body)
+                @test JS.kind(field) !== JS.K"="
+                if JS.kind(field) === JS.K"const"
+                    has_const = true
+                end
+            end
+            @test has_const
+        end
+    end
+
+    @testset "full lowering succeeds" begin
+        for code in [
+            "@kwdef struct A{T <: Real}\n    a::T = 1.0\nend\n",
+            "@kwdef struct A\n    a::Float64 = 1.0\nend\n",
+            "@kwdef mutable struct A{T}\n    const a::T = 1.0\n    b::Int\nend\n",
+            "@kwdef struct A\n    a::Int\nend\n",
+        ]
+            st0 = jlparse(code)
+            world = Base.get_world_counter()
+            result = JETLS.jl_lower_for_scope_resolution(
+                lowering_module, st0, world)
+            @test result isa NamedTuple
+        end
+    end
+
+    @testset "binding resolution" begin
+        for code in [
+            "@kwdef struct MyStruct{T <: Real}\n    a::T = 1.0\nend\n",
+            "@kwdef struct MyStruct\n    a::Float64 = 1.0\nend\n",
+            "@kwdef mutable struct MyStruct{T}\n    const a::T = 1.0\n    b::Int\nend\n",
+            "@kwdef struct MyStruct\n    a::Int\nend\n",
+        ]
+            st0 = jlparse(code)
+            offset = findfirst("MyStruct", code).start
+            result = JETLS._select_target_binding(
+                st0, offset, lowering_module)
+            @test result !== nothing
+            binfo = JL.get_binding(result.ctx3, result.binding)
+            @test binfo.name == "MyStruct"
+            @test binfo.kind === :global
+        end
+    end
+end
+
+end # module test_jl_syntax_macros


### PR DESCRIPTION
Add a new-style `@kwdef` macro definition in `jl-syntax-macros.jl` that operates on `SyntaxTree` via `MacroContext`, preserving fine-grained provenance information (byte-level source locations). This fixes rename/document-highlight/references for fields in `@kwdef` structs with default values (aviatesk/JETLS.jl#540).

Previously, `remove_macrocalls` would strip `@kwdef` and leave `a::T = 1.0` in the struct body, which caused JuliaLowering's `expand_forms_2` to throw "assignment syntax in structure fields is reserved". The new-style macro properly strips defaults and generates keyword constructors before desugaring runs.

Changes:
- `src/utils/jl-syntax-macros.jl`: Implement `Base.var"@kwdef"` with `MacroContext` signature, plus helpers for field collection and constructor generation
- `src/utils/ast.jl`: Add `is_kwdef0` and skip `@kwdef` removal in `_remove_macrocalls` since the new-style macro handles it
- `test/utils/test_jl_syntax_macros.jl`: Test macro expansion, full lowering, and binding resolution for `@kwdef` structs

Closes aviatesk/JETLS.jl#540