### PR TITLE
document-symbol: Anonymous function assignment support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   occur at runtime. For union-split calls, the diagnostic reports only the
   failing branches with their count (e.g., "1/2 union split").
 
+- Anonymous function assignments (`f = (x) -> x + 1` and
+  `clos = function (y) ... end`) are now analyzed as `Function` symbols
+  for `textDocument/documentSymbol`, with their arguments as children.
+
 ### Fixed
 
 - Fixed rename/document-highlight/references failing for `@kwdef` structs with

--- a/src/document-symbol.jl
+++ b/src/document-symbol.jl
@@ -476,7 +476,8 @@ function extract_toplevel_assignment_symbols!(
     rhs = st0[2]
     range = jsobj_to_range(st0, fi)
     detail = lstrip(JS.sourcetext(st0))
-    extract_assignment_symbols!(symbols, lhs, rhs, range, SymbolKind.Variable, detail, fi, mod)
+    kind = is_anonymous_function_rhs(rhs) ? SymbolKind.Function : SymbolKind.Variable
+    extract_assignment_symbols!(symbols, lhs, rhs, range, kind, detail, fi, mod)
     return nothing
 end
 
@@ -804,17 +805,20 @@ function extract_local_symbols_from_scopes(
     for scope_ids in values(func_to_scopes)
         union!(nested_func_scope_ids, scope_ids)
     end
-    symbols = DocumentSymbol[]
     top_scope_ids = Int[scope.id for scope in scopes
         if (scope.id ∉ nested_func_scope_ids &&
             any(((_, bid),) -> is_any_local_binding(JL.get_binding(ctx3, bid)), scope.vars))]
-    extract_local_scope_bindings!(symbols, ctx3, parent_map, top_scope_ids, func_to_scopes, fi)
-    return symbols
+    return extract_local_scope_bindings(ctx3, parent_map, top_scope_ids, func_to_scopes, fi)
 end
 
 is_any_local_binding(binfo::JL.BindingInfo) =
     binfo.kind === :local || binfo.kind === :argument || binfo.kind === :static_parameter
 
+function extract_local_scope_bindings(args...)
+    symbols = DocumentSymbol[]
+    extract_local_scope_bindings!(symbols, args...)
+    return symbols
+end
 function extract_local_scope_bindings!(symbols::Vector{DocumentSymbol},
         ctx3::JL.VariableAnalysisContext, parent_map::Dict{Tuple{Int,Int},JS.SyntaxTree},
         scope_ids::Vector{Int}, func_to_scopes::Dict{Int,Vector{Int}}, fi::FileInfo
@@ -865,6 +869,7 @@ function extract_local_scope_bindings!(symbols::Vector{DocumentSymbol},
             range = jsobj_to_range(source_node, fi)
             selectionRange = range
             detail = nothing
+            anon_scope_ids = nothing
             is_func = haskey(func_to_scopes, bid)
             if is_func
                 kind = SymbolKind.Function
@@ -898,15 +903,24 @@ function extract_local_scope_bindings!(symbols::Vector{DocumentSymbol},
                     # that this is different from :local bindings
                     kind = SymbolKind.Object
                 else
-                    detail = extract_local_variable_detail(parent_map, fb, lb)
-                    kind = SymbolKind.Variable
+                    anon_scope_ids = find_anon_func_scope_ids(parent_map, fb, lb, func_to_scopes, ctx3)
+                    if anon_scope_ids !== nothing
+                        kind = SymbolKind.Function
+                        parent = get(parent_map, (fb, lb), nothing)
+                        detail = !isnothing(parent) ? lstrip(JS.sourcetext(parent)) : nothing
+                    else
+                        kind = SymbolKind.Variable
+                        detail = extract_local_variable_detail(parent_map, fb, lb)
+                    end
                 end
             end
             children_symbols = nothing
             if is_func
-                children_symbols = DocumentSymbol[]
-                extract_local_scope_bindings!(children_symbols, ctx3, parent_map,
-                    func_to_scopes[bid], func_to_scopes, fi)
+                children_symbols = extract_local_scope_bindings(
+                    ctx3, parent_map, func_to_scopes[bid], func_to_scopes, fi)
+            elseif anon_scope_ids !== nothing
+                children_symbols = extract_local_scope_bindings(
+                    ctx3, parent_map, anon_scope_ids, func_to_scopes, fi)
             end
             push!(symbols, DocumentSymbol(;
                 name = binfo.name,
@@ -976,4 +990,33 @@ function extract_local_variable_detail(
         detail = lstrip(JS.sourcetext(parent))
     end
     return detail
+end
+
+is_anonymous_function_rhs(st::JS.SyntaxTree) = JS.kind(st) === JS.K"->" ||
+    (JS.kind(st) === JS.K"function" && JS.numchildren(st) ≥ 1 && JS.kind(st[1]) !== JS.K"call")
+
+function find_anon_func_scope_ids(
+        parent_map::Dict{Tuple{Int,Int},JS.SyntaxTree}, fb::Int, lb::Int,
+        func_to_scopes::Dict{Int,Vector{Int}}, ctx3::JL.VariableAnalysisContext
+    )
+    parent = @something get(parent_map, (fb, lb), nothing) return nothing
+    JS.kind(parent) === JS.K"=" || return nothing
+    JS.numchildren(parent) ≥ 2 || return nothing
+    rhs = parent[2]
+    is_anonymous_function_rhs(rhs) || return nothing
+    anon_body = rhs[JS.numchildren(rhs)]
+    anon_fb, anon_lb = JS.first_byte(anon_body), JS.last_byte(anon_body)
+    graph = JS.syntax_graph(ctx3)
+    for (func_bid, scope_ids) in func_to_scopes
+        binfo = JL.get_binding(ctx3, func_bid)
+        binfo.is_internal || continue
+        for scope_id in scope_ids
+            1 ≤ scope_id ≤ length(ctx3.scopes) || continue
+            scope_node = JS.SyntaxTree(graph, ctx3.scopes[scope_id].node_id)
+            if JS.first_byte(scope_node) == anon_fb && JS.last_byte(scope_node) == anon_lb
+                return scope_ids
+            end
+        end
+    end
+    return nothing
 end


### PR DESCRIPTION
Treat anonymous function assignments (`f = (x) -> x + 1` and `clos = function (y) ... end`) as `SymbolKind.Function` in both toplevel and local scopes.

Add `is_anonymous_function_rhs` to detect `->` and anonymous `function` (first child is not `call`) uniformly across all call sites.

For local scopes, `find_anon_func_scope_ids` matches the anonymous function's body position against internal closure scope positions via `ScopeInfo.node_id`, allowing extraction of the function's arguments as children in the document outline.