### PR TITLE
full-analysis: Enable signature analysis for all modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `clos = function (y) ... end`) are now analyzed as `Function` symbols
   for `textDocument/documentSymbol`, with their arguments as children.
 
+### Changed
+
+- Enabled signature analysis for all analysis modes. Previously, signature
+  analysis was only active in the package source analysis, meaning some
+  potential errors within standalone scripts can be missed.
+  This change ensures that diagnostics like `inference/field-error`
+  can be detected from methods within standalone scripts.
+  (Fixed https://github.com/aviatesk/JETLS.jl/issues/479).
+
 ### Fixed
 
 - Fixed rename/document-highlight/references failing for `@kwdef` structs with

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -902,6 +902,7 @@ getjetconfigs(entry::AnalysisEntry) = getjetconfigs_impl(entry)::Dict{Symbol,Any
 
 let default_jetconfigs = Dict{Symbol,Any}(
         :toplevel_logger => nothing,
+        :analyze_from_definitions => true,
         # force concretization of documentation
         :concretization_patterns => [:($(Base.Docs.doc!)(xs__))])
     global getjetconfigs_impl(::AnalysisEntry) = default_jetconfigs

--- a/test/test_diagnostic.jl
+++ b/test/test_diagnostic.jl
@@ -79,13 +79,13 @@ end
 end
 
 @testset "inference diagnostic (script analysis)" begin
-    # Test with code that has syntax errors
     scriptcode = """
-    struct Hello
-        who::String
+    struct MyStruct
+        property::Int
     end
-    function hello(x::Hello)
-        return "Hello, \$(x.who)!"
+    function field_error()
+        x = MyStruct(42)
+        return x.propert  # FieldError: type MyStruct has no field `propert`, available fields: `property` (JETLS inference/field-error)
     end
     """
 
@@ -100,13 +100,14 @@ end
 
             found_diagnostic = false
             for diag in raw_res.params.diagnostics
-                if diag.source == JETLS.DIAGNOSTIC_SOURCE_SAVE
+                if (diag.source == JETLS.DIAGNOSTIC_SOURCE_SAVE &&
+                    diag.code == JETLS.INFERENCE_FIELD_ERROR_CODE &&
+                    occursin("type MyStruct has no field `propert`, available fields: `property`", diag.message))
                     found_diagnostic = true
                     break
                 end
             end
-            # NOTE Currently the script analysis doesn't set `analyze_from_definitions=true`
-            @test_broken found_diagnostic
+            @test found_diagnostic
         end
     end
 end


### PR DESCRIPTION
Enable `analyze_from_definitions` in the default JET configs so that signature analysis runs for all analysis modes, not just package source analysis. This ensures diagnostics like `inference/field-error` can detect issues in methods within standalone scripts.

Update the test in `test/test_diagnostic.jl` to verify that `inference/field-error` is now reported for script analysis, replacing the previous `@test_broken`.

- Fixes aviatesk/JETLS.jl#479