### PR TITLE
cli-check: Fix `LOAD_PATH` not being set during full analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `jetls check` failing to correctly activate user package environments
+  during full analysis.
+
 - Fixed rename/document-highlight/references failing for `@kwdef` structs with
   default values (Fixed https://github.com/aviatesk/JETLS.jl/issues/540).
 

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -484,9 +484,9 @@ function handle_notification_message(server::Server, @nospecialize msg)
     nothing
 end
 
+include("app/app.jl")
 include("app/cli-check.jl")
 include("app/cli-serve.jl")
-include("app/app.jl")
 
 include("precompile.jl")
 

--- a/src/app/cli-check.jl
+++ b/src/app/cli-check.jl
@@ -331,7 +331,7 @@ function run_check(args::Vector{String})::Cint
         lookup_func = Returns(OutOfScope(Main))
     else
         # Full analysis phase (textDocument/publishDiagnostics equivalent)
-        run_full_analysis(server, root_path, paths, progress_ctx)
+        @with_cli_LOAD_PATH run_full_analysis(server, root_path, paths, progress_ctx)
         analysis_uris = collect_workspace_uris(server)
         if isempty(analysis_uris)
             @error "Full analysis failed: could not find any files to analyze"

--- a/src/app/cli-serve.jl
+++ b/src/app/cli-serve.jl
@@ -141,14 +141,7 @@ function run_serve(args::Vector{String})::Cint
 
     show_setup_info("Running JETLS with the following setup:")
 
-    old_LOAD_PATH = copy(LOAD_PATH)
-    try
-        # HACK: Set `LOAD_PATH` to the same state as during normal Julia script execution.
-        # JETLS internally uses `Pkg.activate` on user package environments and may actually load them,
-        # so this replacement is necessary.
-        empty!(LOAD_PATH)
-        push!(LOAD_PATH, "@", "@v$(VERSION.major).$(VERSION.minor)", "@stdlib")
-
+    @with_cli_LOAD_PATH begin
         if JETLS_DEV_MODE
             global currently_running
             currently_running = server = Server(endpoint) do s::Symbol, x
@@ -171,7 +164,5 @@ function run_serve(args::Vector{String})::Cint
         exit_code = fetch(runserver_task)
         @info "JETLS server stopped" exit_code
         return exit_code
-    finally
-        append!(LOAD_PATH, old_LOAD_PATH)
     end
 end


### PR DESCRIPTION
Extract the `LOAD_PATH` setup hack into a shared `@with_LOAD_PATH` macro in `app.jl` and use it in both `cli-serve.jl` and `cli-check.jl`. Previously, `jetls check` did not set `LOAD_PATH` before `run_full_analysis`, which could cause issues when loading user package environments via `Pkg.activate`.