### PR TITLE
cli-check: Resolve file paths relative to `--root`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed `jetls check` failing to correctly activate user package environments
   during full analysis.
 
+- Fixed `jetls check` resolving file path arguments relative to the current
+  working directory instead of the `--root` directory when `--root` is specified.
+  For example, `jetls check --root=/path/to/Pkg src/Pkg.jl` now correctly
+  resolves to `/path/to/Pkg/src/Pkg.jl`.
+
 - Fixed rename/document-highlight/references failing for `@kwdef` structs with
   default values (Fixed https://github.com/aviatesk/JETLS.jl/issues/540).
 

--- a/src/app/cli-check.jl
+++ b/src/app/cli-check.jl
@@ -311,6 +311,9 @@ function run_check(args::Vector{String})::Cint
     quiet && Base.CoreLogging.disable_logging(Base.CoreLogging.Warn)
 
     root_path = root_path_opt !== nothing ? abspath(root_path_opt) : pwd()
+
+    paths = String[isabspath(p) ? p : joinpath(root_path, p) for p in paths]
+
     server = start_cli_server(root_path)
     skip_analysis || start_analysis_workers!(server)
     progress_ctx = ProgressContext(progress_mode, stderr)

--- a/test/app/test_jetls_check.jl
+++ b/test/app/test_jetls_check.jl
@@ -68,6 +68,11 @@ end
         result = run_jetls_check([filepath]; root=dir)
         @test occursin("lowering/unused-local", result.stdout)
         @test occursin("test.jl", result.stdout)
+
+        # Relative path should be resolved relative to --root
+        result = run_jetls_check(["test.jl"]; root=dir)
+        @test occursin("lowering/unused-local", result.stdout)
+        @test occursin("test.jl", result.stdout)
     end
 end
 


### PR DESCRIPTION
File path arguments passed to `jetls check` are now resolved relative to the `--root` directory instead of the current working directory. For example,
`jetls check --root=/path/to/Pkg src/Pkg.jl` now correctly resolves to `/path/to/Pkg/src/Pkg.jl`.