### PR TITLE
diagnostics: Fix false positive unused imports for included files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   For example, `jetls check --root=/path/to/Pkg src/Pkg.jl` now correctly
   resolves to `/path/to/Pkg/src/Pkg.jl`.
 
+- Fixed false positive `lowering/unused-import` diagnostics for symbols
+  in a package file but used in `include`d files
+  (Fixed https://github.com/aviatesk/JETLS.jl/issues/547).
+
 - Fixed rename/document-highlight/references failing for `@kwdef` structs with
   default values (Fixed https://github.com/aviatesk/JETLS.jl/issues/540).
 

--- a/src/analysis/Analyzer.jl
+++ b/src/analysis/Analyzer.jl
@@ -7,7 +7,7 @@ using Core.IR
 using JET.JETInterface
 using JET: CC, JET
 
-using ..JETLS: AnalysisEntry, JETLS
+using ..JETLS: AnalysisEntry
 using ..LSP
 
 # JETLS internal interface

--- a/src/analysis/Interpreter.jl
+++ b/src/analysis/Interpreter.jl
@@ -5,7 +5,7 @@ export LSInterpreter
 using JuliaSyntax: JuliaSyntax as JS
 using JET: CC, JET, JuliaInterpreter
 using ..JETLS:
-    AnalysisRequest, AnalysisResult, JETLS, JETLS_DEV_MODE, SavedFileInfo, Server,
+    AnalysisRequest, JETLS, JETLS_DEV_MODE, Server,
     is_cancelled, send_progress, yield_to_endpoint
 using ..JETLS.URIs2
 using ..JETLS.LSP

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -1169,7 +1169,7 @@ function analyze_unused_imports!(
         time_binding_occurrences += @elapsed iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
             binding_occurrences = @something get_binding_occurrences!(
                 state, search_uri, search_fi, st0; include_global_bindings = true) return
-            mod = get_context_module(state, uri, offset_to_xy(fi, JS.first_byte(st0)))
+            mod = get_context_module(state, search_uri, offset_to_xy(search_fi, JS.first_byte(st0)))
             for (binfo_key, occurrences) in binding_occurrences
                 binfo_key.kind === :global || continue
                 if any(o -> o.kind === :use, occurrences)
@@ -1184,7 +1184,7 @@ function analyze_unused_imports!(
             kind = JS.kind(st0)
             if kind === JS.K"export" || kind === JS.K"public"
                 # `using .Inner: foo; export foo` - foo is used via re-export
-                mod = get_context_module(state, uri, offset_to_xy(fi, JS.first_byte(st0)))
+                mod = get_context_module(state, search_uri, offset_to_xy(search_fi, JS.first_byte(st0)))
                 for i = 1:JS.numchildren(st0)
                     child = st0[i]
                     if JS.kind(child) === JS.K"Identifier"


### PR DESCRIPTION
Fix `analyze_unused_imports!` using incorrect file context when resolving module context for binding usages in included files.

The bug was that `get_context_module` was called with the original file's `uri`/`fi` instead of the `search_uri`/`search_fi` of the file being searched. Since `st0` comes from the search file's syntax tree, `JS.first_byte(st0)` is an offset within `search_fi`, not `fi`. This caused module context mismatches, making imports appear unused even when they were used in `include`d files.

Also removes actually unused imports in `Analyzer.jl` and `Interpreter.jl` that were revealed by the fix.

Closes #547