### PR TITLE
document-symbol: Include descendant scopes in children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   symbol details. (e.g., a symbol named `foo` with detail `foo = func(args...)`
   now shows ` = func(args...)` as the detail.
 
+### Fixed
+
+- Fixed bindings in `let`/`for`/`while` blocks inside nested functions
+  not appearing as children of those functions in the document outline.
+
 ## 2026-02-16
 
 - Commit: [`e141508`](https://github.com/aviatesk/JETLS.jl/commit/e141508)


### PR DESCRIPTION
Previously, bindings in `let`/`for`/`while` blocks inside nested functions were not shown as children of those functions in the document outline. This happened because only the lambda scope IDs were passed to `extract_local_scope_bindings!`, missing descendant non-function scopes.

Add `collect_descendant_scope_ids!` to walk `parent_id` chains and include all descendant scopes that are not themselves function scopes. This is used both for children extraction and for computing `func_scope_ids` (to prevent inner function scopes from leaking to the outer level).