### PR TITLE
ci: Extract app test jobs into a reusable workflow

### DIFF
--- a/.github/workflows/JETLS.jl.yml
+++ b/.github/workflows/JETLS.jl.yml
@@ -10,6 +10,7 @@ on:
       - "LSP/**"
       - "Project.toml"
       - ".github/workflows/JETLS.jl.yml"
+      - ".github/workflows/test-app.yml"
   pull_request:
     branches-ignore:
       - release
@@ -19,6 +20,7 @@ on:
       - "LSP/**"
       - "Project.toml"
       - ".github/workflows/JETLS.jl.yml"
+      - ".github/workflows/test-app.yml"
 
 jobs:
   test:
@@ -141,35 +143,8 @@ jobs:
         env:
           JULIA_NUM_THREADS: "4,2"
 
-  test_jetls_serve:
-    name: Test jetls serve
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: "1.12" # most stable version
-          arch: x64
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@latest
-      - name: run test
-        run: |
-          julia --startup-file=no --project=./test ./test/app/test_jetls_serve.jl
-
-  test_jetls_check:
-    name: Test jetls check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: "1.12" # most stable version
-          arch: x64
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@latest
-      - name: run test
-        run: |
-          julia --startup-file=no --project=./test ./test/app/test_jetls_check.jl
+  test_app:
+    uses: ./.github/workflows/test-app.yml
 
   jetls_self_check:
     name: Self diagnostics

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,35 +29,9 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
 
-  test_jetls_serve:
-    name: Test jetls serve with release environment
+  test_app:
     if: github.event_name == 'pull_request' && github.event.action != 'closed'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: "1.12"
-          arch: x64
-      - uses: julia-actions/julia-buildpkg@latest
-      - name: run test
-        run: |
-          julia --startup-file=no --project=./test ./test/app/test_jetls_serve.jl
-
-  test_jetls_check:
-    name: Test jetls check with release environment
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: "1.12"
-          arch: x64
-      - uses: julia-actions/julia-buildpkg@latest
-      - name: run test
-        run: |
-          julia --startup-file=no --project=./test ./test/app/test_jetls_check.jl
+    uses: ./.github/workflows/test-app.yml
 
   docs:
     name: Documentation

--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -1,0 +1,35 @@
+name: Test app commands
+
+on:
+  workflow_call:
+
+jobs:
+  test_jetls_serve:
+    name: Test jetls serve
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: "1.12" # most stable version
+          arch: x64
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: run test
+        run: |
+          julia --startup-file=no --project=./test ./test/app/test_jetls_serve.jl
+
+  test_jetls_check:
+    name: Test jetls check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: "1.12" # most stable version
+          arch: x64
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: run test
+        run: |
+          julia --startup-file=no --project=./test ./test/app/test_jetls_check.jl


### PR DESCRIPTION
Move `test_jetls_serve` and `test_jetls_check` jobs, which were duplicated in `JETLS.jl.yml` and `release.yml`, into a new reusable workflow `.github/workflows/test-app.yml`. Both callers now reference it via `workflow_call`.

Also add `.github/workflows/test-app.yml` to the `paths` trigger of `JETLS.jl.yml` so that changes to the reusable workflow correctly trigger CI.

Written by Claude