### PR TITLE
schema: Inline `config-toml.schema.json` for Tombi compatibility

### DIFF
--- a/.JETLSConfig.toml
+++ b/.JETLSConfig.toml
@@ -1,3 +1,5 @@
+#:schema ./schemas/config-toml.schema.json
+
 # TODO [JETLS]
 # Need to properly set and parse line number information for `@namespace`
 [[diagnostic.patterns]]

--- a/schemas/config-toml.schema.json
+++ b/schemas/config-toml.schema.json
@@ -1,282 +1,274 @@
 {
-  "$defs": {
-    "Core.Bool": {
-      "type": "boolean"
-    },
-    "Core.Float64": {
-      "type": "number"
-    },
-    "Core.Int64": {
-      "maximum": 9223372036854775807,
-      "minimum": -9223372036854775808,
-      "type": "integer"
-    },
-    "Core.String": {
-      "type": "string"
-    },
-    "Glob.FilenameMatch{Core.String}": {
-      "type": "string"
-    },
-    "JETLS.JETLSConfig": {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "code_lens": {
       "additionalProperties": false,
+      "description": "Code lens configuration. See [Code lens configuration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/code_lens).",
       "properties": {
-        "code_lens": {
-          "additionalProperties": false,
-          "description": "Code lens configuration. See [Code lens configuration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/code_lens).",
-          "properties": {
-            "references": {
-              "$ref": "#/$defs/Core.Bool",
-              "default": false,
-              "description": "Show reference counts above top-level symbols (functions, structs, constants, etc.). Click to open references panel."
-            },
-            "testrunner": {
-              "$ref": "#/$defs/Core.Bool",
-              "default": true,
-              "description": "Show `Run`/`Debug` code lenses above `@testset` blocks. Some editors (e.g., Zed) show these as code actions, causing duplication; zed-julia defaults to false."
-            }
-          },
-          "type": "object"
-        },
-        "completion": {
-          "additionalProperties": false,
-          "description": "Completion configuration. See [Completion configuration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/completion).",
-          "properties": {
-            "latex_emoji": {
-              "additionalProperties": false,
-              "description": "LaTeX and emoji completion configuration. See [documentation](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/completion-latex_emoji-strip_prefix).",
-              "properties": {
-                "strip_prefix": {
-                  "$ref": "#/$defs/Core.Bool",
-                  "description": "Controls whether to strip `\\` or `:` prefix from LaTeX/emoji completion labels. Some editors (e.g., Zed) have sorting issues with backslash in `sortText`. Auto-detected by default; set explicitly if completions appear in wrong order."
-                }
-              },
-              "type": "object"
-            },
-            "method_signature": {
-              "additionalProperties": false,
-              "description": "Method signature completion configuration. See [documentation](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/completion-method_signature-prepend_inference_result).",
-              "properties": {
-                "prepend_inference_result": {
-                  "$ref": "#/$defs/Core.Bool",
-                  "description": "When true, prepends inferred return type to completion documentation, ensuring visibility in editors where `CompletionItem.detail` may be cut off (e.g., Zed). Auto-detected by default based on client name; set explicitly if return types are not visible."
-                }
-              },
-              "type": "object"
-            }
-          },
-          "type": "object"
-        },
-        "diagnostic": {
-          "additionalProperties": false,
-          "description": "Diagnostic configuration. See [Diagnostic configuration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/diagnostic).",
-          "properties": {
-            "all_files": {
-              "$ref": "#/$defs/Core.Bool",
-              "default": true,
-              "description": "Report diagnostics for all workspace files (true) or only open files (false). Disable to reduce noise from many warnings."
-            },
-            "allow_unused_underscore": {
-              "$ref": "#/$defs/Core.Bool",
-              "default": true,
-              "description": "Suppress unused variable diagnostics for `_`-prefixed names, following the common convention for intentionally unused variables."
-            },
-            "enabled": {
-              "$ref": "#/$defs/Core.Bool",
-              "default": true,
-              "description": "Enable or disable all JETLS diagnostics. When set to false, no diagnostic messages will be shown."
-            },
-            "patterns": {
-              "default": [],
-              "description": "Fine-grained control over diagnostics through pattern matching. See [Pattern-based diagnostic configuration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/diagnostic-patterns).",
-              "items": {
-                "additionalProperties": false,
-                "properties": {
-                  "match_by": {
-                    "description": "What to match against: `code` matches against diagnostic codes (e.g., `lowering/unused-argument`), `message` matches against diagnostic message text.",
-                    "enum": [
-                      "code",
-                      "message"
-                    ],
-                    "type": "string"
-                  },
-                  "match_type": {
-                    "description": "How to interpret the pattern: `literal` for exact string match, `regex` for regular expression match.",
-                    "enum": [
-                      "literal",
-                      "regex"
-                    ],
-                    "type": "string"
-                  },
-                  "path": {
-                    "$ref": "#/$defs/Glob.FilenameMatch{Core.String}",
-                    "description": "Optional glob pattern to restrict this configuration to specific files (e.g., `test/**/*.jl`). Patterns are matched against file paths relative to the workspace root. Supports globstar (`**`) for matching directories recursively. If omitted, the pattern applies to all files."
-                  },
-                  "pattern": {
-                    "anyOf": [
-                      {
-                        "format": "regex",
-                        "type": "string"
-                      },
-                      {
-                        "$ref": "#/$defs/Core.String"
-                      }
-                    ],
-                    "description": "The pattern to match. For code matching, use diagnostic codes like `lowering/unused-argument`. For message matching, use text patterns like `Macro name .* not found`. This value is also used as the key when merging configurations from different sources."
-                  },
-                  "severity": {
-                    "description": "Severity level to apply. String values are case-insensitive: `error`/1 for critical issues, `warning`/`warn`/2 for potential problems, `information`/`info`/3 for informational messages, `hint`/4 for suggestions, `off`/0 to disable the diagnostic.",
-                    "oneOf": [
-                      {
-                        "maximum": 4,
-                        "minimum": 0,
-                        "type": "integer"
-                      },
-                      {
-                        "enum": [
-                          "off",
-                          "error",
-                          "warning",
-                          "warn",
-                          "information",
-                          "info",
-                          "hint"
-                        ],
-                        "type": "string"
-                      }
-                    ]
-                  }
-                },
-                "required": [
-                  "pattern",
-                  "match_by",
-                  "match_type",
-                  "severity"
-                ],
-                "type": "object"
-              },
-              "type": "array"
-            }
-          },
-          "type": "object"
-        },
-        "formatter": {
-          "default": "Runic",
-          "description": "Formatter configuration. Can be a preset name (`Runic` or `JuliaFormatter`) or a custom formatter object. See [Formatter configuration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/formatter).",
-          "oneOf": [
-            {
-              "enum": [
-                "Runic",
-                "JuliaFormatter"
-              ],
-              "type": "string"
-            },
-            {
-              "additionalProperties": false,
-              "properties": {
-                "custom": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "executable": {
-                      "description": "Path to custom formatter executable for document formatting. The formatter should read Julia code from stdin and output formatted code to stdout.",
-                      "type": "string"
-                    },
-                    "executable_range": {
-                      "description": "Path to custom formatter executable for range formatting. Should accept a `--lines=START:END` argument to format only the specified line range.",
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "executable"
-                  ],
-                  "type": "object"
-                }
-              },
-              "required": [
-                "custom"
-              ],
-              "type": "object"
-            }
-          ]
-        },
-        "full_analysis": {
-          "additionalProperties": false,
-          "description": "Configuration for full JET analysis. See [Full analysis configuration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/full_analysis).",
-          "properties": {
-            "auto_instantiate": {
-              "$ref": "#/$defs/Core.Bool",
-              "default": true,
-              "description": "Automatically run `Pkg.resolve()` and `Pkg.instantiate()` for uninstantiated packages (e.g., freshly cloned repos). Creates versioned manifest if needed."
-            },
-            "debounce": {
-              "$ref": "#/$defs/Core.Float64",
-              "default": 1.0,
-              "description": "Debounce time in seconds before triggering full analysis after a file save. Higher values reduce analysis frequency but may delay diagnostic updates."
-            }
-          },
-          "type": "object"
-        },
-        "initialization_options": {
-          "additionalProperties": false,
-          "description": "Static initialization options that are set once at server startup and require a server restart to take effect. See [Initialization options](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options).",
-          "properties": {
-            "analysis_overrides": {
-              "default": [],
-              "description": "Override full analysis behavior for specific file patterns. Primarily used as a temporary workaround to disable analysis for files affected by memory leak issues. Each override specifies a glob pattern and optionally a module name. Note: This is an experimental feature that may be removed or changed in future versions.",
-              "items": {
-                "additionalProperties": false,
-                "properties": {
-                  "module_name": {
-                    "$ref": "#/$defs/Core.String",
-                    "description": "Optional module name to associate with the matched files. When specified, analysis is performed within the context of this module."
-                  },
-                  "path": {
-                    "$ref": "#/$defs/Glob.FilenameMatch{Core.String}",
-                    "description": "Glob pattern to match files for which analysis should be overridden (e.g., `src/**/*.jl`, `test/**/*.jl`). Patterns are matched against file paths relative to the workspace root. Supports globstar (`**`) for matching directories recursively."
-                  }
-                },
-                "required": [
-                  "path"
-                ],
-                "type": "object"
-              },
-              "type": "array"
-            },
-            "n_analysis_workers": {
-              "$ref": "#/$defs/Core.Int64",
-              "default": 1,
-              "description": "Number of concurrent analysis worker tasks for running full analysis (experimental). Default is 1. See [documentation](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options/n_analysis_workers) for details and current limitations."
-            }
-          },
-          "type": "object"
-        },
-        "inlay_hint": {
-          "additionalProperties": false,
-          "description": "Inlay hint configuration. See [Inlay hint configuration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/inlay_hint).",
-          "properties": {
-            "block_end_min_lines": {
-              "$ref": "#/$defs/Core.Int64",
-              "default": 25,
-              "description": "Minimum lines for a block to display an inlay hint at `end` (e.g., `end # module Foo`). Supports: `module`, `function`, `macro`, `struct`, `if`, `let`, `for`, `while`, `@testset`."
-            }
-          },
-          "type": "object"
+        "references": {
+          "default": false,
+          "description": "Show reference counts above top-level symbols (functions, structs, constants, etc.). Click to open references panel.",
+          "type": "boolean"
         },
         "testrunner": {
+          "default": true,
+          "description": "Show `Run`/`Debug` code lenses above `@testset` blocks. Some editors (e.g., Zed) show these as code actions, causing duplication; zed-julia defaults to false.",
+          "type": "boolean"
+        }
+      },
+      "required": [],
+      "type": "object"
+    },
+    "completion": {
+      "additionalProperties": false,
+      "description": "Completion configuration. See [Completion configuration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/completion).",
+      "properties": {
+        "latex_emoji": {
           "additionalProperties": false,
-          "description": "TestRunner integration configuration. See [TestRunner integration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/testrunner).",
+          "description": "LaTeX and emoji completion configuration. See [documentation](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/completion-latex_emoji-strip_prefix).",
           "properties": {
-            "executable": {
-              "$ref": "#/$defs/Core.String",
-              "default": "testrunner",
-              "description": "Path to the TestRunner.jl executable. Defaults to `testrunner` (or `testrunner.bat` on Windows)."
+            "strip_prefix": {
+              "description": "Controls whether to strip `\\` or `:` prefix from LaTeX/emoji completion labels. Some editors (e.g., Zed) have sorting issues with backslash in `sortText`. Auto-detected by default; set explicitly if completions appear in wrong order.",
+              "type": "boolean"
             }
           },
+          "required": [],
+          "type": "object"
+        },
+        "method_signature": {
+          "additionalProperties": false,
+          "description": "Method signature completion configuration. See [documentation](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/completion-method_signature-prepend_inference_result).",
+          "properties": {
+            "prepend_inference_result": {
+              "description": "When true, prepends inferred return type to completion documentation, ensuring visibility in editors where `CompletionItem.detail` may be cut off (e.g., Zed). Auto-detected by default based on client name; set explicitly if return types are not visible.",
+              "type": "boolean"
+            }
+          },
+          "required": [],
           "type": "object"
         }
       },
+      "required": [],
+      "type": "object"
+    },
+    "diagnostic": {
+      "additionalProperties": false,
+      "description": "Diagnostic configuration. See [Diagnostic configuration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/diagnostic).",
+      "properties": {
+        "all_files": {
+          "default": true,
+          "description": "Report diagnostics for all workspace files (true) or only open files (false). Disable to reduce noise from many warnings.",
+          "type": "boolean"
+        },
+        "allow_unused_underscore": {
+          "default": true,
+          "description": "Suppress unused variable diagnostics for `_`-prefixed names, following the common convention for intentionally unused variables.",
+          "type": "boolean"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Enable or disable all JETLS diagnostics. When set to false, no diagnostic messages will be shown.",
+          "type": "boolean"
+        },
+        "patterns": {
+          "default": [],
+          "description": "Fine-grained control over diagnostics through pattern matching. See [Pattern-based diagnostic configuration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/diagnostic-patterns).",
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "match_by": {
+                "description": "What to match against: `code` matches against diagnostic codes (e.g., `lowering/unused-argument`), `message` matches against diagnostic message text.",
+                "enum": [
+                  "code",
+                  "message"
+                ],
+                "type": "string"
+              },
+              "match_type": {
+                "description": "How to interpret the pattern: `literal` for exact string match, `regex` for regular expression match.",
+                "enum": [
+                  "literal",
+                  "regex"
+                ],
+                "type": "string"
+              },
+              "path": {
+                "description": "Optional glob pattern to restrict this configuration to specific files (e.g., `test/**/*.jl`). Patterns are matched against file paths relative to the workspace root. Supports globstar (`**`) for matching directories recursively. If omitted, the pattern applies to all files.",
+                "type": "string"
+              },
+              "pattern": {
+                "anyOf": [
+                  {
+                    "format": "regex",
+                    "type": "string"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "description": "The pattern to match. For code matching, use diagnostic codes like `lowering/unused-argument`. For message matching, use text patterns like `Macro name .* not found`. This value is also used as the key when merging configurations from different sources."
+              },
+              "severity": {
+                "description": "Severity level to apply. String values are case-insensitive: `error`/1 for critical issues, `warning`/`warn`/2 for potential problems, `information`/`info`/3 for informational messages, `hint`/4 for suggestions, `off`/0 to disable the diagnostic.",
+                "oneOf": [
+                  {
+                    "maximum": 4,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "enum": [
+                      "off",
+                      "error",
+                      "warning",
+                      "warn",
+                      "information",
+                      "info",
+                      "hint"
+                    ],
+                    "type": "string"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "pattern",
+              "match_by",
+              "match_type",
+              "severity"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "required": [],
+      "type": "object"
+    },
+    "formatter": {
+      "default": "Runic",
+      "description": "Formatter configuration. Can be a preset name (`Runic` or `JuliaFormatter`) or a custom formatter object. See [Formatter configuration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/formatter).",
+      "oneOf": [
+        {
+          "enum": [
+            "Runic",
+            "JuliaFormatter"
+          ],
+          "type": "string"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "custom": {
+              "additionalProperties": false,
+              "properties": {
+                "executable": {
+                  "description": "Path to custom formatter executable for document formatting. The formatter should read Julia code from stdin and output formatted code to stdout.",
+                  "type": "string"
+                },
+                "executable_range": {
+                  "description": "Path to custom formatter executable for range formatting. Should accept a `--lines=START:END` argument to format only the specified line range.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "executable"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "custom"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "full_analysis": {
+      "additionalProperties": false,
+      "description": "Configuration for full JET analysis. See [Full analysis configuration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/full_analysis).",
+      "properties": {
+        "auto_instantiate": {
+          "default": true,
+          "description": "Automatically run `Pkg.resolve()` and `Pkg.instantiate()` for uninstantiated packages (e.g., freshly cloned repos). Creates versioned manifest if needed.",
+          "type": "boolean"
+        },
+        "debounce": {
+          "default": 1.0,
+          "description": "Debounce time in seconds before triggering full analysis after a file save. Higher values reduce analysis frequency but may delay diagnostic updates.",
+          "type": "number"
+        }
+      },
+      "required": [],
+      "type": "object"
+    },
+    "initialization_options": {
+      "additionalProperties": false,
+      "description": "Static initialization options that are set once at server startup and require a server restart to take effect. See [Initialization options](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options).",
+      "properties": {
+        "analysis_overrides": {
+          "default": [],
+          "description": "Override full analysis behavior for specific file patterns. Primarily used as a temporary workaround to disable analysis for files affected by memory leak issues. Each override specifies a glob pattern and optionally a module name. Note: This is an experimental feature that may be removed or changed in future versions.",
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "module_name": {
+                "description": "Optional module name to associate with the matched files. When specified, analysis is performed within the context of this module.",
+                "type": "string"
+              },
+              "path": {
+                "description": "Glob pattern to match files for which analysis should be overridden (e.g., `src/**/*.jl`, `test/**/*.jl`). Patterns are matched against file paths relative to the workspace root. Supports globstar (`**`) for matching directories recursively.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "path"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "n_analysis_workers": {
+          "default": 1,
+          "description": "Number of concurrent analysis worker tasks for running full analysis (experimental). Default is 1. See [documentation](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options/n_analysis_workers) for details and current limitations.",
+          "maximum": 9223372036854775807,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        }
+      },
+      "required": [],
+      "type": "object"
+    },
+    "inlay_hint": {
+      "additionalProperties": false,
+      "description": "Inlay hint configuration. See [Inlay hint configuration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/inlay_hint).",
+      "properties": {
+        "block_end_min_lines": {
+          "default": 25,
+          "description": "Minimum lines for a block to display an inlay hint at `end` (e.g., `end # module Foo`). Supports: `module`, `function`, `macro`, `struct`, `if`, `let`, `for`, `while`, `@testset`.",
+          "maximum": 9223372036854775807,
+          "minimum": -9223372036854775808,
+          "type": "integer"
+        }
+      },
+      "required": [],
+      "type": "object"
+    },
+    "testrunner": {
+      "additionalProperties": false,
+      "description": "TestRunner integration configuration. See [TestRunner integration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/testrunner).",
+      "properties": {
+        "executable": {
+          "default": "testrunner",
+          "description": "Path to the TestRunner.jl executable. Defaults to `testrunner` (or `testrunner.bat` on Windows).",
+          "type": "string"
+        }
+      },
+      "required": [],
       "type": "object"
     }
   },
-  "$ref": "#/$defs/JETLS.JETLSConfig",
-  "$schema": "https://json-schema.org/draft/2020-12/schema"
+  "required": [],
+  "type": "object"
 }

--- a/scripts/schema/generate.jl
+++ b/scripts/schema/generate.jl
@@ -52,7 +52,10 @@ function generate_schema_dict(target_arg::String, ctx::SchemaContext)
     if target_arg == "--settings"
         skip!(ctx, JETLS.JETLSConfig, :initialization_options)
     end
-    schema = generate_schema(target; ctx = ctx)
+    # Inline all $defs/$ref for config-toml schema so that TOML language servers
+    # (e.g. Tombi) that don't support $ref resolution can still use it
+    inline_all_defs = target_arg == "--config-toml"
+    schema = generate_schema(target; ctx, inline_all_defs)
     return sort_keys(schema.doc)
 end
 


### PR DESCRIPTION
`config-toml.schema.json` is now generated with `inline_all_defs=true`, expanding all `\$defs`/`\$ref` references into a flat structure. This makes the schema compatible with TOML language servers such as Tombi that do not yet support `\$ref` resolution.

Also adds a `#:schema` comment directive to `.JETLSConfig.toml` to enable schema-based completion and validation via e.g. Taplo or Tombi.