### PR TITLE
app: Remove deprecated `jetls` without-subcommand behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
 - Diff: [`ebcbd60...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/ebcbd60...HEAD)
 
+### Changes
+
+- The previously deprecated behavior of running `jetls` without a subcommand
+  to start the language server has been removed. Running `jetls` without a
+  subcommand or with unrecognized arguments now shows the help message and
+  exits. Use `jetls serve` instead
+  (Closed https://github.com/aviatesk/JETLS.jl/issues/565).
+
 ### Announcement
 
 > [!warning]
@@ -204,7 +212,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Deprecated
 
 - Running `jetls` without a subcommand (e.g., `jetls --stdio`) is deprecated.
-  Use `jetls serve` instead. This may be removed in a future release.
+  Use `jetls serve` instead. The support for `jetls` without a subcommand will
+  be removed in a future release.
 
 ### Changed
 

--- a/src/app/app.jl
+++ b/src/app/app.jl
@@ -4,7 +4,7 @@ const help_message = """
 
     VERSION: $JETLS_VERSION
 
-    Usage: jetls [COMMAND] [OPTIONS]
+    Usage: jetls <COMMAND> [OPTIONS]
 
     Commands:
       serve                       Start language server (default)
@@ -31,7 +31,7 @@ const help_message = """
 
     Examples:
       jetls serve --pipe-listen=/tmp/jetls.sock
-      jetls --socket=8080
+      jetls serve --socket=8080
       jetls check src/SomePkg.jl
       jetls check --root=/path/to/project src/
       jetls schema --settings
@@ -60,17 +60,10 @@ function (@main)(args::Vector{String})::Cint
                 return 0
             end
             return run_serve(args[2:end])
-        elseif first_arg in ("-h", "--help", "help")
-            print(stdout, help_message)
-            return 0
-        else
-            @warn "Running `jetls` without a subcommand is deprecated and may be removed in a future release. Use `jetls serve` instead."
         end
-    else
-        @warn "Running `jetls` without a subcommand is deprecated and may be removed in a future release. Use `jetls serve` instead."
     end
-
-    return run_serve(args)
+    print(stdout, help_message)
+    return 0
 end
 
 # HACK: Set `LOAD_PATH` to the same state as during normal Julia script execution.

--- a/test/app/test_jetls_serve.jl
+++ b/test/app/test_jetls_serve.jl
@@ -77,6 +77,18 @@ end
 const DEFAULT_TIMEOUT = 10
 const STARTUP_TIMEOUT = 60
 
+@testset "jetls without subcommand shows help" begin
+    for args in (``, `--stdio`, `--socket=8080`)
+        cmd = `$JULIA_CMD --project=$JETLS_DIR -m JETLS $args`
+        out = IOBuffer()
+        proc = run(pipeline(cmd; stdout=out, stderr=devnull); wait=true)
+        @test proc.exitcode == 0
+        output = String(take!(out))
+        @test occursin("Usage: jetls <COMMAND>", output)
+        @test occursin("jetls serve", output)
+    end
+end
+
 # test a very simple, normal server lifecycle
 withserverprocess() do proc
     # Send initialization request


### PR DESCRIPTION
The previously deprecated behavior of running `jetls` without a subcommand (e.g. `jetls --pipe`) to start the language server has been removed.

Running `jetls` without a recognized subcommand, or with no arguments at all, now prints the help message and exits with code 0. Users should now use `jetls serve` instead.

The example `jetls --socket=8080` in the help message has been updated to `jetls serve --socket=8080` accordingly.

A test for the new behavior has been added to
`test/app/test_jetls_serve.jl`.

Closes aviatesk/JETLS.jl#565