### PR TITLE
ci: Add GitHub Actions composite action for `jetls check`

### DIFF
--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -1,0 +1,73 @@
+name: "JETLS Check"
+description: "Run JETLS diagnostics on Julia source files"
+
+inputs:
+  files:
+    description: "Space-separated list of Julia files to check"
+    required: true
+  version:
+    description: "JETLS revision to install (branch, tag, or commit SHA)"
+    required: false
+    default: "release"
+  julia-version:
+    description: "Julia version to use"
+    required: false
+    default: "1.12"
+  quiet:
+    description: "Suppress info and warning log messages"
+    required: false
+    default: "true"
+  root:
+    description: "Root directory for configuration and relative paths"
+    required: false
+    default: "."
+  context-lines:
+    description: "Number of source context lines to show around diagnostics"
+    required: false
+    default: ""
+  exit-severity:
+    description: "Minimum severity to trigger non-zero exit (error, warn, info, hint)"
+    required: false
+    default: "warn"
+  show-severity:
+    description: "Minimum severity to display in output (error, warn, info, hint)"
+    required: false
+    default: ""
+  progress:
+    description: "Progress display mode (auto, full, simple, none)"
+    required: false
+    default: "none"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: julia-actions/setup-julia@v2
+      with:
+        version: ${{ inputs.julia-version }}
+    - uses: julia-actions/cache@v2
+    - name: Install jetls
+      shell: bash
+      run: |
+        julia --startup-file=no -e '
+          using Pkg
+          Pkg.Apps.add(; url="https://github.com/aviatesk/JETLS.jl",
+                         rev="${{ inputs.version }}")'
+        echo "$HOME/.julia/bin" >> "$GITHUB_PATH"
+    - name: Run jetls check
+      shell: bash
+      run: |
+        args=()
+        if [[ "${{ inputs.quiet }}" == "true" ]]; then
+          args+=(--quiet)
+        fi
+        args+=(--root="${{ inputs.root }}")
+        if [[ -n "${{ inputs.context-lines }}" ]]; then
+          args+=(--context-lines="${{ inputs.context-lines }}")
+        fi
+        args+=(--exit-severity="${{ inputs.exit-severity }}")
+        if [[ -n "${{ inputs.show-severity }}" ]]; then
+          args+=(--show-severity="${{ inputs.show-severity }}")
+        fi
+        args+=(--progress="${{ inputs.progress }}")
+        args+=(${{ inputs.files }})
+        jetls check "${args[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > Note that `analysis_overrides` is provided as a temporary workaround and may
 > be removed or changed at any time. A proper fix is being worked on.
 
+### Added
+
+- Added a GitHub composite action (`.github/actions/check/`) for running
+  `jetls check` in CI pipelines. External packages can use it as:
+  ```yaml
+  - uses: aviatesk/JETLS.jl/.github/actions/check@release
+    with:
+      files: src/SomePkg.jl
+  ```
+  All `jetls check` command-line options are available as action inputs.
+
 ### Changes
 
 - The previously deprecated behavior of running `jetls` without a subcommand

--- a/docs/src/cli-check.md
+++ b/docs/src/cli-check.md
@@ -23,6 +23,7 @@ jetls --threads=4,2 -- check src/SomePkg.jl test/runtests.jl
 ## [Command reference](@id cli-check/reference)
 
 > `jetls check --help`
+
 ```@eval
 using JETLS
 using Markdown
@@ -64,6 +65,7 @@ Sets the root path for configuration file lookup and relative path display.
 By default, the current working directory is used.
 
 When specified, JETLS will:
+
 - Look for `.JETLSConfig.toml` in the specified root directory
 - Display file paths relative to this root in diagnostic output
 
@@ -94,6 +96,7 @@ Sets the minimum severity level that causes a non-zero exit code. This is useful
 for CI pipelines where you want to fail only on certain severity levels.
 
 Available levels (from most to least severe):
+
 - `error` - Only errors cause exit code 1
 - `warn` (default) - Warnings and errors cause exit code 1
 - `info` - Information, warnings, and errors cause exit code 1
@@ -114,6 +117,7 @@ level are hidden from the output but may still affect the exit code (depending
 on `--exit-severity`).
 
 Available levels (from most to least severe):
+
 - `error` - Only show errors
 - `warn` - Show warnings and errors
 - `info` - Show information, warnings, and errors
@@ -132,6 +136,7 @@ jetls check --show-severity=hint --exit-severity=error src/SomePkg.jl
 Controls how progress is displayed during analysis.
 
 Available modes:
+
 - `auto` (default) - Uses spinner for interactive terminals, simple output
   otherwise
 - `full` - Always show animated spinner with detailed progress
@@ -185,3 +190,49 @@ path = "test/**/*.jl"
 ```
 
 For complete configuration options, see the [JETLS configuration](@ref config/schema) page.
+
+## [GitHub Actions](@id cli-check/github-actions)
+
+A composite action is available for running `jetls check` in CI pipelines.
+This handles Julia setup, caching, and JETLS installation automatically.
+
+### Basic usage
+
+```yaml
+steps:
+  - uses: actions/checkout@v6
+  - uses: aviatesk/JETLS.jl/.github/actions/check@release
+    with:
+      files: src/SomePkg.jl
+```
+
+### With options
+
+```yaml
+steps:
+  - uses: actions/checkout@v6
+  - uses: aviatesk/JETLS.jl/.github/actions/check@release
+    with:
+      files: src/SomePkg.jl test/runtests.jl
+      exit-severity: error
+      show-severity: warn
+```
+
+### Action inputs
+
+All `jetls check` command-line options are available as action inputs:
+
+| Input              | Default   | Description                                         |
+| :----------------- | :-------- | :-------------------------------------------------- |
+| `files` (required) |           | Space-separated list of files to check              |
+| `version`          | `release` | JETLS revision to install                           |
+| `julia-version`    | `1.12`    | Julia version to use                                |
+| `quiet`            | `true`    | Suppress info and warning log messages              |
+| `root`             | `.`       | Root directory for configuration and relative paths |
+| `context-lines`    | `2`       | Number of source context lines                      |
+| `exit-severity`    | `warn`    | Minimum severity to trigger non-zero exit           |
+| `show-severity`    | `hint`    | Minimum severity to display                         |
+| `progress`         | `none`    | Progress display mode                               |
+
+See [`.github/actions/check/action.yml`](https://github.com/aviatesk/JETLS.jl/blob/release/.github/actions/check/action.yml)
+for the full action definition.


### PR DESCRIPTION
Add `.github/actions/check/action.yml` so that external packages can run `jetls check` in their CI pipelines with:

```yaml
  - uses: aviatesk/JETLS.jl/.github/actions/check@release
    with:
      files: src/SomePkg.jl
```

The action handles Julia setup, caching, and `jetls` installation via `Pkg.Apps.add`. All `jetls check` CLI options are exposed as action inputs.

Also add a GitHub Actions section to `docs/src/cli-check.md` with usage examples and an input reference table.