### PR TITLE
docs: fix default value of `allow_unused_underschore`

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -21,7 +21,7 @@ executable_range = ""              # string (path), optional
 [diagnostic]
 enabled = true                     # boolean, default: true
 all_files = true                   # boolean, default: true
-allow_unused_underscore = false    # boolean, default: false
+allow_unused_underscore = true     # boolean, default: true
 
 [[diagnostic.patterns]]
 pattern = ""                       # string, required


### PR DESCRIPTION
It looks that default value of  `allow_unused_underschore` should be `true`. Other descriptions about this look correct.
https://github.com/aviatesk/JETLS.jl/blob/bb035de4195b6f93d7ae7d43da707003600e91b5/src/types.jl#L518