### PR TITLE
binding: Filter implicit binding names from cursor selection

### DIFF
--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -637,7 +637,7 @@ end
 function analyze_unused_bindings!(
         diagnostics::Vector{Diagnostic}, fi::FileInfo, st0::JS.SyntaxTree, ctx3::JL.VariableAnalysisContext,
         binding_occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence{Tree3}}},
-        ismacro::Base.RefValue{Bool}, reported::Set{LoweringDiagnosticKey},
+        has_implicit_args::Bool, reported::Set{LoweringDiagnosticKey},
         kwarg_type_names::Dict{Tuple{Int,Int},Set{String}};
         allow_unused_underscore::Bool
     ) where Tree3<:JS.SyntaxTree
@@ -648,7 +648,7 @@ function analyze_unused_bindings!(
             continue
         end
         bn = binfo.name
-        if ismacro[] && (bn == "__module__" || bn == "__source__")
+        if has_implicit_args && bn in _IMPLICIT_BINDING_NAMES
             continue
         end
         if allow_unused_underscore && startswith(bn, '_')
@@ -1037,8 +1037,10 @@ function analyze_lowered_code!(
     reported = Set{LoweringDiagnosticKey}() # to prevent duplicate reports for unused default or keyword arguments
     kwarg_type_names = compute_kwarg_type_annotation_names(st0)
 
+    has_implicit_args = ismacro[] || is_generated0(st0)
+
     analyze_unused_bindings!(
-        diagnostics, fi, st0, ctx3, binding_occurrences, ismacro, reported, kwarg_type_names;
+        diagnostics, fi, st0, ctx3, binding_occurrences, has_implicit_args, reported, kwarg_type_names;
         allow_unused_underscore)
 
     skip_analysis_requiring_context ||

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -155,6 +155,11 @@ function cursor_bindings(st0_top::JS.SyntaxTree, offset::Int, mod::Module)
     end
 end
 
+# Implicit binding names introduced by JuliaLowering for macros (`__module__`,
+# `__source__`) and `@generated` functions (`__context__`).
+# These span the full signature byte range and should not be selected by cursor.
+const _IMPLICIT_BINDING_NAMES = ("__context__", "__module__", "__source__")
+
 function find_target_binding(ctx3::JL.VariableAnalysisContext, st3::JS.SyntaxTree, offset::Int)
     return traverse(st3) do st::JS.SyntaxTree
         k = JS.kind(st)
@@ -166,7 +171,7 @@ function find_target_binding(ctx3::JL.VariableAnalysisContext, st3::JS.SyntaxTre
         offset in JS.byte_range(st) || return nothing
         k === JS.K"BindingId" || return nothing
         binfo = JL.get_binding(ctx3, st)
-        if binfo.is_internal || startswith(binfo.name, "#")
+        if binfo.is_internal || startswith(binfo.name, "#") || binfo.name in _IMPLICIT_BINDING_NAMES
             return nothing
         end
         return TraversalReturn(st)

--- a/test/test_document_highlight.jl
+++ b/test/test_document_highlight.jl
@@ -374,8 +374,7 @@ end
                 @test length(positions) == 6
                 fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
                 @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
-                for (i, pos) in enumerate(positions)
-                    i == 2 && continue # end position selects `__context__` (implicit @generated arg)
+                for pos in positions
                     highlights = JETLS.document_highlights(fi, pos)
                     @test length(highlights) == 3
                     @test count(highlights) do highlight
@@ -404,8 +403,7 @@ end
                 @test length(positions) == 6
                 fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
                 @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
-                for (i, pos) in enumerate(positions)
-                    i == 2 && continue # end position selects `__context__` (implicit @generated arg)
+                for pos in positions
                     highlights = JETLS.document_highlights(fi, pos)
                     @test length(highlights) == 3
                 end
@@ -425,8 +423,7 @@ end
                 @test length(positions) == 7
                 fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
                 @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
-                for (i, pos) in enumerate(positions)
-                    i == 3 && continue # Only test start position; end position selects `__module__` (implicit macro arg)
+                for pos in positions
                     highlights = JETLS.document_highlights(fi, pos)
                     @test length(highlights) == 3
                     @test count(highlights) do highlight

--- a/test/test_references.jl
+++ b/test/test_references.jl
@@ -81,8 +81,7 @@ end
             """
             clean_code, positions = JETLS.get_text_and_positions(code)
             @test length(positions) == 9
-            for (i, pos) in enumerate(positions)
-                i == 3 && continue # end position selects `__context__` (implicit @generated arg)
+            for pos in positions
                 refs = find_references(clean_code, pos)
                 @test length(refs) == 3
             end
@@ -96,8 +95,7 @@ end
             """
             clean_code, positions = JETLS.get_text_and_positions(code)
             @test length(positions) == 6
-            for (i, pos) in enumerate(positions)
-                i == 2 && continue # end position selects `__context__` (implicit @generated arg)
+            for pos in positions
                 refs = find_references(clean_code, pos)
                 @test length(refs) == 3
             end
@@ -115,9 +113,10 @@ end
             @mymacro println("world")
             """
             clean_code, positions = JETLS.get_text_and_positions(code)
-            # Only test start position; end position selects `__module__` (implicit macro arg)
-            refs = find_references(clean_code, positions[1])
-            @test length(refs) == 3
+            for pos in positions
+                refs = find_references(clean_code, pos)
+                @test length(refs) == 3
+            end
         end
 
         # Test from macrocall

--- a/test/test_rename.jl
+++ b/test/test_rename.jl
@@ -238,8 +238,7 @@ end
             fi = JETLS.FileInfo(#=version=#0, clean_code, filename)
             @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
             furi = filename2uri("Untitled" * filename)
-            for (i, pos) in enumerate(positions)
-                i == 2 && continue # end position selects `__context__` (implicit @generated arg)
+            for pos in positions
                 (; result, error) = JETLS.local_binding_rename(
                     server, furi, fi, pos, @__MODULE__, "y")
                 @test result isa WorkspaceEdit && isnothing(error)
@@ -263,8 +262,7 @@ end
             fi = JETLS.FileInfo(#=version=#0, clean_code, filename)
             @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
             furi = filename2uri("Untitled" * filename)
-            for (i, pos) in enumerate(positions)
-                i == 2 && continue # end position selects `__context__` (implicit @generated arg)
+            for pos in positions
                 (; result, error) = JETLS.local_binding_rename(
                     server, furi, fi, pos, @__MODULE__, "S")
                 @test result isa WorkspaceEdit && isnothing(error)


### PR DESCRIPTION
Add `_IMPLICIT_BINDING_NAMES` constant listing JuliaLowering's implicit bindings (`__context__`, `__module__`, `__source__`) and filter them in `find_target_binding` so they don't interfere with cursor-based binding selection in highlights, references, and rename.

Also use the same constant in `analyze_unused_bindings!`, replacing the previous inline string checks. The guard is generalized from `ismacro` to `has_implicit_args` (macro or `@generated` function) for consistency, since both introduce implicit argument bindings.

Test workarounds that skipped certain cursor positions due to these implicit bindings are now removed.