### PR TITLE
fix signature help fail with invalid arg

### DIFF
--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -357,9 +357,15 @@ function make_siginfo(
             # splat after semicolon
             maybe_var_kwp
         elseif kind(ca.args[active_arg]) in JS.KSet"= kw" || active_arg >= ca.kw_i
-            n = extract_kwarg_name(ca.args[active_arg]).name_val # we don't have a backwards mapping
-            out = get(kwp_map, n, nothing)
-            isnothing(out) ? maybe_var_kwp : out
+            kwname = extract_kwarg_name(ca.args[active_arg])
+            # `extract_kwarg_name` returns `nothing` for unrecognized forms like `a.b=`
+            if isnothing(kwname)
+                maybe_var_kwp
+            else
+                # we don't have a backwards mapping
+                out = get(kwp_map, kwname.name_val, nothing)
+                isnothing(out) ? maybe_var_kwp : out
+            end
         else
             JETLS_DEBUG_LOWERING && @info "No active arg" active_arg ca.args[active_arg]
             nothing

--- a/test/test_signature_help.jl
+++ b/test/test_signature_help.jl
@@ -267,6 +267,9 @@ end
     @test 6 == active_parameter(M_highlight, "f(kwfake=1│, 0, 1, 2, 3)")
     # # splat after semicolon
     @test 6 == active_parameter(M_highlight, "f(0, 1, 2, 3; kwfake...│)")
+
+    # unrecognized kwarg forms should not crash and return something
+    @test siginfos(M_highlight, "f(0, 1, 2; a.b=1│)") isa Vector
 end
 
 module M_nested


### PR DESCRIPTION
I noticed that the language server throws an exception when the following typo occurs:

```julia
f(x; y = 1) = x + y
f(0; y.y=1│)
```

This appears to be syntactically valid (it fails during lowering), but signature-help seems to attempt to analyze it and fails. I added an additional check to handle this case.
