### PR TITLE
Remove dead `K"doc"` handling code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   with subtype declarations (e.g. `@kwdef struct A <: B`)
   (Closed https://github.com/aviatesk/JETLS.jl/issues/587).
 
+- Fixed false `unused-import` warnings for modules with docstrings
+  (Closed https://github.com/aviatesk/JETLS.jl/issues/586).
+
 ## 2026-03-08
 
 - Commit: [`d32f1cf`](https://github.com/aviatesk/JETLS.jl/commit/d32f1cf)

--- a/src/analysis/occurrence-analysis.jl
+++ b/src/analysis/occurrence-analysis.jl
@@ -53,7 +53,7 @@ end
 
 """
     compute_binding_occurrences(
-            ctx3::JL.VariableAnalysisContext, st3::Tree3;
+            ctx3::JL.VariableAnalysisContext, st3::Tree3, is_generated::Bool;
             ismacro::Union{Nothing,Base.RefValue{Bool}} = nothing
         ) where Tree3<:JS.SyntaxTree
         -> binding_occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence{Tree3}}}

--- a/src/document-symbol.jl
+++ b/src/document-symbol.jl
@@ -136,8 +136,6 @@ function extract_toplevel_symbol!(symbols::Vector{DocumentSymbol}, st0::JS.Synta
         extract_toplevel_symbols!(symbols, st0, fi, mod)
     elseif k === JS.K"macrocall"
         extract_macrocall_symbol!(symbols, st0, fi, mod)
-    elseif k === JS.K"doc"
-        extract_doc_symbol!(symbols, st0, fi, mod)
     end
     return nothing
 end
@@ -762,21 +760,6 @@ function extract_enum_value!(
         kind = SymbolKind.EnumMember,
         range = jsobj_to_range(st0, fi),
         selectionRange = jsobj_to_range(name_node, fi)))
-    return nothing
-end
-
-function extract_doc_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo, mod::Module
-    )
-    JS.numchildren(st0) ≥ 2 || return nothing
-    definition = st0[2]
-    temp_symbols = DocumentSymbol[]
-    extract_toplevel_symbol!(temp_symbols, definition, fi, mod)
-    isempty(temp_symbols) && return nothing
-    range = jsobj_to_range(st0, fi)
-    for sym in temp_symbols
-        push!(symbols, DocumentSymbol(sym; range))
-    end
     return nothing
 end
 

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -83,6 +83,15 @@ is_kwdef0(st0::JS.SyntaxTree) = is_macrocall_st0(st0, "@kwdef")
 
 is_generated0(st0::JS.SyntaxTree) = is_macrocall_st0(st0, "@generated")
 
+function is_doc0(st0::JS.SyntaxTree)
+    JS.kind(st0) === JS.K"macrocall" || return false
+    JS.numchildren(st0) >= 1 || return false
+    macro_name = st0[1]
+    JS.kind(macro_name) === JS.K"Value" || return false
+    hasproperty(macro_name, :value) || return false
+    return macro_name.value == GlobalRef(Core, Symbol("@doc"))
+end
+
 """
     foreach_inert_identifier(callback, st::JS.SyntaxTree)
 
@@ -332,17 +341,9 @@ function iterate_toplevel_tree(callback, st0_top::JS.SyntaxTree)
             for i = JS.numchildren(stblk):-1:1 # reversed since we use `pop!`
                 push!(sl, stblk[i])
             end
-        elseif JS.kind(st0) === JS.K"doc"
-            # skip docstring expressions for now
-            for i = JS.numchildren(st0):-1:1 # reversed since we use `pop!`
-                push!(sl, st0[i])
-            end
-        elseif JS.kind(st0) === JS.K"macrocall" && is_macrocall_st0(st0, "@doc")
-            # We probably can remove this after https://github.com/JuliaLang/julia/pull/60733
-            # MRE: Comment out and open app.jl and it will yield: `JETLS.check_socket_port` is not defined
-            for i = JS.numchildren(st0):-1:1 # reversed since we use `pop!`
-                push!(sl, st0[i])
-            end
+        elseif is_doc0(st0)
+            # Analyze only the code to which docstrings are attached
+            push!(sl, st0[end])
         else # st0 is lowerable tree
             ret = callback(st0)
             ret === traversal_terminator && break

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -1297,6 +1297,19 @@ end
         @test isempty(diagnostics)
     end
 
+    let diagnostics = get_unused_import_diagnostics("""
+        \"\"\"
+        Docstring for `module Issue586`
+        \"\"\"
+        module Issue586
+        using Base: sin
+        export sin
+        issue586(x) = sin(x)
+        end
+        """)
+        @test isempty(diagnostics)
+    end
+
     # Import used in nested module should not suppress warning for top-level import
     @testset "module context tracking" begin
         script = """

--- a/test/utils/test_ast.jl
+++ b/test/utils/test_ast.jl
@@ -641,4 +641,52 @@ end
     end
 end
 
+@testset "iterate_toplevel_tree" begin
+    let cnt = 0,
+        func1 = struct1 = false
+        JETLS.iterate_toplevel_tree(jlparse("""
+            module Module1
+            func1(x) = x
+            struct Struct1 end
+            end
+            """)) do st0
+            cnt += 1
+            s = JS.sourcetext(st0)
+            if s == "func1(x) = x"
+                func1 = true
+            elseif s == "struct Struct1 end"
+                struct1 = true
+            end
+        end
+        @test cnt == 2
+        @test func1 && struct1
+    end
+
+    let cnt = 0,
+        func1 = struct1 = false
+        JETLS.iterate_toplevel_tree(jlparse("""
+            \"\"\"
+            Docstring for `module Module1`
+            \"\"\"
+            module Module1
+            \"\"\"
+            Docstring for `func1`
+            \"\"\"
+            func1(x) = x
+            struct Struct1 end
+            end
+            """)) do st0
+            cnt += 1
+            s = JS.sourcetext(st0)
+            if s == "func1(x) = x"
+                func1 = true
+            elseif s == "struct Struct1 end"
+                struct1 = true
+            end
+        end
+        @test cnt == 2
+        @test func1 && struct1
+    end
+end
+
 end # module test_ast


### PR DESCRIPTION
`K"doc"` nodes are converted to `Core.@doc` macrocalls by `preprocessed_green_children` during `SyntaxTree` construction, so they never appear in the final tree. Remove the unreachable `K"doc"` branches from `iterate_toplevel_tree` and `extract_toplevel_symbol!`, along with the unused
`extract_doc_symbol!` function.

Closes aviatesk/JETLS.jl#586.