### PR TITLE
analysis: Add `TypeAnnotation` module for LSP type queries

### DIFF
--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -88,6 +88,9 @@ include("utils/binding.jl")
 include("utils/lsp.jl")
 include("utils/server.jl")
 
+include("analysis/TypeAnnotation.jl")
+using .TypeAnnotation
+
 include("init-options.jl")
 include("config.jl")
 include("workspace-configuration.jl")

--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -1,0 +1,744 @@
+module TypeAnnotation
+
+using Core.IR
+using JET: CC
+using ..JETLS: JETLS_DEBUG_LOWERING, JETLS_DEV_MODE, JL, JS, SyntaxTreeC,
+    jl_lower_for_scope_resolution, traverse
+
+export InferredTreeContext, get_inferrable_tree, get_type_for_range, infer_toplevel_tree
+
+# ASTTypeAnnotator
+# ================
+
+struct ASTTypeAnnotatorToken end
+
+struct ASTTypeAnnotator <: CC.AbstractInterpreter
+    toptree::SyntaxTreeC
+    topmi::MethodInstance
+    world::UInt
+    inf_params::CC.InferenceParams
+    opt_params::CC.OptimizationParams
+    inf_cache::Vector{CC.InferenceResult}
+    function ASTTypeAnnotator(
+            toptree::SyntaxTreeC,
+            topmi::MethodInstance;
+            world::UInt = Base.get_world_counter(),
+            inf_params::CC.InferenceParams = CC.InferenceParams(;
+                aggressive_constant_propagation = true
+            ),
+            opt_params::CC.OptimizationParams = CC.OptimizationParams(),
+            inf_cache::Vector{CC.InferenceResult} = CC.InferenceResult[]
+        )
+        return new(toptree, topmi, world, inf_params, opt_params, inf_cache)
+    end
+end
+CC.InferenceParams(interp::ASTTypeAnnotator) = interp.inf_params
+CC.OptimizationParams(interp::ASTTypeAnnotator) = interp.opt_params
+CC.get_inference_world(interp::ASTTypeAnnotator) = interp.world
+CC.get_inference_cache(interp::ASTTypeAnnotator) = interp.inf_cache
+CC.cache_owner(::ASTTypeAnnotator) = ASTTypeAnnotatorToken()
+
+# ASTTypeAnnotator is only used for type analysis, so it should disable optimization entirely
+CC.may_optimize(::ASTTypeAnnotator) = false
+
+# ASTTypeAnnotator doesn't need any sources to be cached, so discard them aggressively
+CC.transform_result_for_cache(::ASTTypeAnnotator, ::CC.InferenceResult, ::Core.SimpleVector) = nothing
+
+# `bail_out_toplevel_call(interp, sv::InferenceState) = sv.restrict_abstract_call_sites`
+# is `true` for thunk MIs (`def isa Module`), and `abstract_call_gf_by_type` then
+# refuses to infer any matching method whose `spec_types` isn't a `isdispatchtuple`
+# — i.e. methods with free type vars like `(::Type{NamedTuple{names}})(::Tuple)`,
+# whose result type would normally be `NamedTuple{names, Tuple{…}}`. Since we
+# always run inference on chunk thunks built from user-source method bodies, that
+# bail-out throws away precise types we'd otherwise have. Override to never bail.
+CC.bail_out_toplevel_call(::ASTTypeAnnotator, ::CC.InferenceState) = false
+
+function CC.concrete_eval_eligible(
+        interp::ASTTypeAnnotator, @nospecialize(f), result::CC.MethodCallResult,
+        arginfo::CC.ArgInfo, sv::CC.InferenceState
+    )
+    ret = @invoke CC.concrete_eval_eligible(
+        interp::CC.AbstractInterpreter, f::Any, result::CC.MethodCallResult,
+        arginfo::CC.ArgInfo, sv::CC.InferenceState)
+    if ret === :semi_concrete_eval
+        # while the base eligibility check probably won't permit semi-concrete evaluation
+        # for `ASTTypeAnnotator` (given it completely turns off optimization),
+        # this ensures we don't inadvertently enter irinterp
+        ret = :none
+    end
+    return ret
+end
+
+# Slot type at a specific use site. `argextype(SlotNumber)` returns the joined
+# post-inference `slottypes[id]`, which loses every per-use narrowing — so we instead
+# reconstruct the slot's type at `idx`:
+# - If the same basic block has a slot assignment that dominates `idx`,
+#   use the assigned RHS's type (`ssavaluetypes[pc_assign]`).
+# - Otherwise fall back to the bb's entry varstate
+#   (`bb_vartables[bb][id]`), which CC's dataflow has already populated
+#   with cross-bb branch narrowing.
+function slot_type_at(slot::SlotNumber, idx::Int, frame::CC.InferenceState)
+    pc_assign = CC.find_dominating_assignment(slot.id, idx, frame)
+    pc_assign === nothing || return frame.ssavaluetypes[pc_assign]
+    bb = CC.block_for_inst(frame.cfg, idx)
+    entry = @something frame.bb_vartables[bb] return frame.src.slottypes[slot.id]
+    return entry[slot.id].typ
+end
+
+function annotate_types!(citree::SyntaxTreeC, frame::CC.InferenceState)
+    if length(frame.src.code) != JS.numchildren(citree)
+        return @warn "ASTTypeAnnotator: Can't annotate types for " frame.linfo
+    end
+    for i = 1:length(frame.src.code)
+        stmt = frame.src.code[i]
+        stmttype = frame.src.ssavaluetypes[i]
+        stmttree = citree[i]
+        if JS.kind(stmttree) in JS.KSet"newvar goto gotoifnot"
+            # The `ssavaluetype` corresponding to these nodes is always `Any`, and since
+            # the provenance information for these nodes is very broad, it's more convenient
+            # for the implementation of `get_type_for_range` to leave them untyped
+            continue
+        end
+        JS.setattr!(stmttree, :type, stmttype)
+        if stmt isa Expr
+            stmt.head === :meta && continue
+            # TODO: properly annotate static-parameter references once CC supports
+            # `sparam_vals` for thunk MIs (currently degrades to `Any`; see the
+            # `# Limitations` section of `infer_toplevel_tree`'s docstring).
+            stmt.head === :static_parameter && continue
+            treeref = stmttree
+            if JS.numchildren(treeref) ≠ length(stmt.args)
+                @warn "ASTTypeAnnotator: Unexpected syntax tree statement conversion" treeref
+                continue
+            end
+            if stmt.head === :(=)
+                lhs = stmt.args[1]
+                if lhs isa SlotNumber
+                    JS.setattr!(treeref[1], :type, stmttype)
+                end
+                stmt = stmt.args[2]
+                stmt isa Expr || continue
+                treeref = treeref[2]
+                JS.setattr!(treeref, :type, stmttype)
+            end
+            for j = 1:length(stmt.args)
+                arg = stmt.args[j]
+                if arg isa SlotNumber
+                    argtyp = slot_type_at(arg, i, frame)
+                    JS.setattr!(treeref[j], :type, argtyp)
+                end
+            end
+        elseif stmt isa ReturnNode
+            val = stmt.val
+            if val isa SlotNumber
+                rettyp = slot_type_at(val, i, frame)
+            else
+                rettyp = CC.argextype(val, frame.src, frame.sptypes)
+            end
+            JS.setattr!(stmttree, :type, rettyp)
+        end
+    end
+end
+
+function CC.finishinfer!(frame::CC.InferenceState, interp::ASTTypeAnnotator, cycleid::Int)
+    ret = @invoke CC.finishinfer!(frame::CC.InferenceState, interp::CC.AbstractInterpreter, cycleid::Int)
+    if frame.linfo === interp.topmi
+        annotate_types!(interp.toptree[1], frame)
+    end
+    return ret
+end
+
+# Type annotation driver
+# ======================
+
+"""
+    get_inferrable_tree(
+            st0::SyntaxTreeC, mod::Module; caller::AbstractString = "get_inferrable_tree"
+        ) -> (; ctx3, st3) | nothing
+
+Lower `st0` for scope resolution against `mod` and return the `(ctx3, st3)` pair that
+[`infer_toplevel_tree`](@ref) consumes. Wraps `jl_lower_for_scope_resolution` with
+error handling: returns `nothing` if lowering throws (typically because the user's
+source contains parse errors or the macro context isn't yet ready).
+"""
+function get_inferrable_tree(
+        st0::SyntaxTreeC, mod::Module;
+        caller::AbstractString = "get_inferrable_tree"
+    )
+    (; ctx3, st3) = try
+        jl_lower_for_scope_resolution(mod, st0; trim_error_nodes=false, recover_from_macro_errors=false)
+    catch err
+        JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
+        JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
+        return nothing
+    end
+    return (; ctx3, st3)
+end
+
+"""
+    infer_toplevel_tree(
+            ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, context_module::Module;
+            world::UInt = Base.get_world_counter()
+        ) -> inferred::SyntaxTreeC
+
+Run type inference on a lowered toplevel expression and return the lowered syntax tree
+(`inferred`) annotated with a `:type` attribute on each lowered statement.
+
+`ctx3` and `st3` come from `JL.jl_lower_for_scope_resolution`, which runs JuliaLowering's
+early scope-resolution passes — typically obtained via [`get_inferrable_tree`](@ref).
+This function takes them through the remaining JuliaLowering passes, runs inference on
+the result, and writes the inferred types back into the graph.
+
+`world` (default: the current world) selects the inference world used throughout.
+
+# Reading types from the result
+
+Use [`get_type_for_range`](@ref) to look up the inferred type at a surface byte range.
+Both top-level expressions and method bodies are annotated in the same returned tree,
+so the same query handles either — no need to descend into method bodies separately.
+For traversal-based use, types live on each annotated node as a `:type` attribute.
+
+# Prerequisite: full-analysis must have run first
+
+This LSP-feature path is intentionally separate from full-analysis, but it depends on
+full-analysis having already populated `context_module`. Full analysis runs JET's concrete
+interpretation against the user's source — which goes through Julia's own lowering
+pipeline, *not* JuliaLowering — and materializes the user's bindings (functions, types,
+constants, etc.) into the appropriate module. By the time an inlay-hint / hover /
+completion request reaches this function, the caller has already chosen `context_module`
+based on full-analysis results, and we run a lightweight pass on top: parse →
+JuliaLowering → inference, just to produce the per-statement type annotations the LSP
+feature needs.
+
+The dependency is concrete, not advisory: the per-method-body argtypes resolution in the
+"Design" section below works by `getfield`-ing user names out of `context_module` (see
+step 2: evaluating `Core.Typeof(Main.f)`, `Core.apply_type(Main.Vector, Main.Int)`, …).
+If full-analysis hasn't materialized those bindings, every user-defined name falls
+through to `Any` and method bodies are inferred against `Any` argtypes. Argument type
+instantiation simply isn't possible without the bindings being present.
+
+# Design: every chunk is an "anonymous toplevel chunk"
+
+The basic inference unit is a chunk: a `Core.CodeInfo` paired with a `SyntaxTreeC` whose
+`[1]` is the block of statements to annotate, plus a list of slot argtypes. The toplevel
+itself is such a chunk (nargs=0).
+
+Method definitions are handled the same way — *not* by going through `Method` /
+`MethodInstance` dispatch, but by treating each method's body `CodeInfo` as another
+anonymous chunk:
+
+1. We walk `inferred[1]` for `:method` 3-arg statements.
+2. For each, we statically evaluate the argtypes svec referenced from `args[2]` against
+   `context_module` (`eval_to_value` follows the SSA chain in `src.code`, resolving
+   `Core.apply_type`, `Core.Typeof`, `GlobalRef`, etc.).
+3. The resolved argtypes are fed to `infer_chunk!` together with the body `CodeInfo` and
+   the corresponding `K"code_info"` subtree of `inferred`.
+
+No `Method` lookup, no dispatch, no `Base._which` — body inference needs only what's
+already in `inferred` and `src.code`, plus the caller's `context_module` for resolving
+`GlobalRef`s in type expressions.
+
+!!! note "Why we don't let `CC.typeinf` recurse into `:method` itself"
+    The straightforward alternative would be to let inference of the toplevel chunk
+    recurse into `:method` 3-arg statements via the usual dispatch path. That path
+    doesn't reach `function f(...; kw...) end`: JuliaLowering introduces synthetic
+    kwbody bindings (e.g. `var"#kw_body#f#0"`) whose names don't match the bindings
+    full analysis materialized in `context_module` via Julia's own lowering. Going
+    through dispatch would either fail or hit stale entries. Static svec evaluation
+    avoids both; the synthetic-name slot simply degrades to `Any` (see Limitations).
+
+# Limitations
+
+The static-svec approach inherits a few precision losses around lowering's synthetic
+binding constructs. None of these break correctness; they only degrade types to `Any`.
+
+- **Closures.** `JL.convert_closures` hoists every closure to a toplevel `:method` 3-arg,
+  so closure body inference itself works normally — local variables, parameter types, and
+  the closure's return type are all annotated. But the closure is callable through a
+  synthetic type (`var"#closure#N"`) that isn't `getfield`-resolvable in `context_module`.
+  So:
+  - The closure's self slot resolves to `Any`, which means **captured variables**
+    (accessed via the self field) infer as `Any`.
+  - From the **enclosing function's body**, calling the closure dispatches on this
+    synthetic type, so the call site infers as `Any` and `Any`-typedness propagates
+    outward (e.g. an accumulator that sums a closure's results becomes `Any`).
+
+- **Parametric methods.** TypeVars constructed via `Core.TypeVar(:T, ub)` in the argtypes
+  svec are flattened to their upper bound (`val.ub`) so the slot has a usable `Type`.
+  Furthermore, the chunk's `MethodInstance` is a thunk MI (`def isa Module`); CC's
+  `sptypes_from_meth_instance` forces `EMPTY_SPTYPES` for toplevel MIs, so an
+  `Expr(:static_parameter, i)` reference inside the body cannot retrieve `T` and infers
+  as `Any`.
+
+- **Synthetic kwbody self.** Same shape as the closure self issue: in the kwbody method,
+  slot 1 resolves to `Any` because the synthetic name isn't defined in `context_module`.
+  User-named slots (`init`, `xs`, etc.) still resolve correctly via the svec, so the body
+  code itself is inferred precisely.
+"""
+infer_toplevel_tree(args...; kwargs...) =
+    (@something _infer_toplevel_tree(args...; kwargs...) return nothing).toptree
+
+function _infer_toplevel_tree(
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, context_module::Module;
+        world::UInt = Base.get_world_counter()
+    )
+    inferred = try
+        ctx4, st4 = JL.convert_closures(ctx3, st3)
+        _, st5 = JL.linearize_ir(ctx4, st4)
+        st5
+    catch e
+        @error "infer_toplevel_tree: Lowering failed" e
+        return nothing
+    end |> prepare_type_attr
+    lwr = JL.to_lowered_expr(inferred)
+
+    Meta.isexpr(lwr, :thunk) || error("infer_toplevel_tree: Unexpected lowering result")
+    src = lwr.args[1]::CodeInfo
+
+    interp = @something infer_chunk!(inferred, src, context_module, nothing, world) return nothing
+    infer_method_defs!(inferred, src, context_module, world)
+    return interp
+end
+
+prepare_type_attr(st::SyntaxTreeC) = let g = JL.syntax_graph(st)
+    attrs = Dict(pairs(g.attributes))
+    attrs[:type] = Dict{Int, Any}()
+    return SyntaxTreeC(JL.SyntaxGraph(g.edge_ranges, g.edges, attrs), st._id)
+end
+
+# `argtypes === nothing` keeps the `InferenceResult`'s default argtypes (intended
+# for nargs=0 thunks); a `Vector{Any}` overrides them with one entry per slot.
+function infer_chunk!(
+        tree::SyntaxTreeC, src::CodeInfo, context_module::Module,
+        argtypes::Union{Nothing, Vector{Any}}, world::UInt
+    )
+    strip_latestworld!(src)
+    mi = construct_toplevel_mi(src, context_module)
+    interp = ASTTypeAnnotator(tree, mi; world)
+    result = CC.InferenceResult(mi)
+    if argtypes !== nothing
+        # Thunk MIs have no `specTypes`-derived argtypes, so populate them
+        # explicitly to match the chunk's slot count.
+        empty!(result.argtypes)
+        append!(result.argtypes, argtypes)
+    end
+    frame = try
+        CC.InferenceState(result, src, #=cache=#:no, interp)
+    catch err
+        JETLS_DEV_MODE && @warn "infer_chunk!: InferenceState failed" err
+        return nothing
+    end
+    CC.typeinf(interp, frame)
+    return interp
+end
+
+# `Expr(:latestworld)` syncs the current task's `world_age` to the global world counter.
+# JuliaLowering emits it after any binding-mutating op in the same chunk — `const`,
+# `import`/`using`, method add, or the `Core.declare_global` that toplevel bare assignment
+# expands to — so subsequent stmts can see those changes at runtime. CC mirrors this by
+# flipping `currsaw_latestworld`, which makes `abstract_eval_globalref` widen every global
+# (e.g. `Main.sin`) to `Any` — a guard against mid-inference binding mutation.
+#
+# In our snapshot-typing pass that guard has no subject: full-analysis has already
+# materialized any binding changes the chunk produces into `context_module` at our fixed
+# `interp.world`, so the snapshot CC reads is already the post-mutation state, and we
+# never execute or cache the inferred result. Stripping the directive is therefore not
+# just safe but a precision win — it lets `Const` propagation survive across what would
+# otherwise be a forced widening point.
+function strip_latestworld!(src::CodeInfo)
+    for i in eachindex(src.code)
+        s = src.code[i]
+        if s isa Expr && s.head === :latestworld
+            src.code[i] = nothing
+        end
+    end
+    return src
+end
+
+function construct_toplevel_mi(src::CodeInfo, context_module::Module)
+    resolve_toplevel_symbols!(src, context_module)
+    return @ccall jl_method_instance_for_thunk(src::Any, context_module::Any)::Ref{MethodInstance}
+end
+
+# Perform some post-hoc mutation on lowered code, as expected by some abstract interpretation
+# routines, especially for `:foreigncall` and `:cglobal`.
+function resolve_toplevel_symbols!(src::CodeInfo, context_module::Module)
+    @ccall jl_resolve_definition_effects_in_ir(
+        #=jl_array_t *stmts=# src.code::Any,
+        #=jl_module_t *m=# context_module::Any,
+        #=jl_svec_t *sparam_vals=# Core.svec()::Any,
+        #=jl_value_t *binding_edge=# C_NULL::Ptr{Cvoid},
+        #=int binding_effects=# 0::Int)::Cvoid
+    return src
+end
+
+function infer_method_defs!(
+        inferred::SyntaxTreeC, src::CodeInfo, context_module::Module, world::UInt
+    )
+    block = inferred[1]
+    nstmts = JS.numchildren(block)
+    nstmts == length(src.code) || return
+    for i = 1:nstmts
+        node = block[i]
+        JS.kind(node) === JS.K"method" || continue
+        JS.numchildren(node) == 3 || continue
+        body_tree = node[3]
+        JS.kind(body_tree) === JS.K"code_info" || continue
+        # Dispatcher methods synthesized for default args / kwargs have a body that just
+        # calls the user method with the defaults filled in, but the user method might not
+        # be bound in `context_module` here, so the call would infer as `Any` anyway.
+        # Skip them to save inference time and to keep the resulting tree free of
+        # meaningless `:type` annotations.
+        JS.byte_range(body_tree) == JS.byte_range(node) && continue
+        stmt = src.code[i]
+        stmt isa Expr || continue
+        stmt.head === :method || continue
+        length(stmt.args) == 3 || continue
+        sig_ref = stmt.args[2]
+        body_codeinfo = stmt.args[3]
+        body_codeinfo isa CodeInfo || continue
+
+        nargs = Int(body_codeinfo.nargs)
+        argtypes = something(
+            resolve_method_argtypes(sig_ref, src, nargs, context_module, world),
+            Any[Any for _ in 1:nargs])
+        infer_chunk!(body_tree, body_codeinfo, context_module, argtypes, world)
+    end
+    return
+end
+
+# `sig_ref` (= `stmt.args[2]` of a `:method` 3-arg Expr) points to an outer
+# `Core.svec(argtypes_svec, sparams_svec, source_loc)`; the first element is the
+# argtypes svec we evaluate. Slots whose source expression can't be resolved (e.g.
+# references to synthetic kwbody self bindings) fall back to `Any`.
+function resolve_method_argtypes(
+        @nospecialize(sig_ref), src::CodeInfo, nargs::Int,
+        context_module::Module, world::UInt
+    )
+    outer = resolve_ssa_stmt(sig_ref, src)
+    args = @something svec_call_args(outer) return nothing
+    length(args) >= 1 || return nothing
+    inner = resolve_ssa_stmt(args[1], src)
+    inner_args = @something svec_call_args(inner) return nothing
+    argtypes = Vector{Any}(undef, nargs)
+    for i = 1:nargs
+        argtypes[i] = i <= length(inner_args) ?
+            eval_to_type(inner_args[i], src, context_module, world) : Any
+    end
+    return argtypes
+end
+
+function resolve_ssa_stmt(@nospecialize(expr), src::CodeInfo)
+    while expr isa SSAValue
+        expr = src.code[expr.id]
+    end
+    return expr
+end
+
+function svec_call_args(@nospecialize(expr))
+    expr isa Expr || return nothing
+    expr.head === :call || return nothing
+    length(expr.args) >= 1 || return nothing
+    callee = expr.args[1]
+    callee isa GlobalRef || return nothing
+    (callee.mod === Core && callee.name === :svec) || return nothing
+    return @view expr.args[2:end]
+end
+
+function eval_to_type(
+        @nospecialize(expr), src::CodeInfo, context_module::Module, world::UInt
+    )
+    val = eval_to_value(expr, src, context_module, world)
+    val isa TypeVar && return val.ub
+    return val isa Type ? val : Any
+end
+
+# Returns `nothing` when any leaf reference fails to resolve (e.g. undefined
+# synthetic name); callers must treat that as "could not statically evaluate".
+function eval_to_value(
+        @nospecialize(expr), src::CodeInfo, context_module::Module, world::UInt
+    )
+    if expr isa SSAValue
+        return eval_to_value(resolve_ssa_stmt(expr, src), src, context_module, world)
+    elseif expr isa GlobalRef
+        return resolve_globalref(expr, world)
+    elseif expr isa Expr && expr.head === :call
+        f = @something eval_to_value(expr.args[1], src, context_module, world) return nothing
+        cargs = Any[]
+        for i = 2:length(expr.args)
+            v = @something eval_to_value(expr.args[i], src, context_module, world) return nothing
+            push!(cargs, v)
+        end
+        try
+            return Base.invoke_in_world(world, f, cargs...)
+        catch
+            return nothing
+        end
+    elseif expr isa QuoteNode
+        return expr.value
+    end
+    # Self-evaluating literal (Number, String, Symbol, Bool, ...).
+    return expr
+end
+
+function resolve_globalref(g::GlobalRef, world::UInt)
+    if Base.invoke_in_world(world, isdefinedglobal, g.mod, g.name)::Bool
+        return Base.invoke_in_world(world, getglobal, g.mod, g.name)
+    end
+    return nothing
+end
+
+# Queries
+# =======
+
+"""
+    InferredTreeContext(inferred_tree::SyntaxTreeC) -> ctx::InferredTreeContext
+
+Public type-query handle for a lowered, inferred syntax tree. Bundles
+`inferred_tree` (the result of [`infer_toplevel_tree`](@ref)) with a set of
+prebuilt indexes so that [`get_type_for_range`](@ref) (and friends) can answer
+each query in O(1) — or O(log N) for the branching case — without re-walking
+the tree per call.
+
+# Lifecycle
+
+The context is intended to be **built once per inferred tree** and reused
+across many queries. Constructing it does a single `O(N)` traversal that
+populates all indexes simultaneously. Typical usage:
+
+- in `JETLS` itself: cache an `InferredTreeContext` alongside (or in place
+  of) the inferred tree on the server's per-file state, rebuilding only when
+  the tree is rebuilt;
+- in tests / one-off callers: pass `inferred_tree` directly to the two-arg
+  convenience overload `get_type_for_range(inferred_tree, rng)`, which builds
+  a fresh context per call.
+
+Consumers should normally just call [`get_type_for_range`](@ref) and treat
+this type as opaque; the fields are implementation detail and may be
+reorganized as new queries demand different indexes.
+"""
+struct InferredTreeContext
+    inferred_tree::SyntaxTreeC
+    # `byte_range => kind` for the surface node each lowered node was lowered
+    # from (first element of `JS.flattened_provenance`). First-write-wins,
+    # mirroring a `traverse`-then-pick-first lookup.
+    surface_kind_index::Dict{UnitRange{UInt32}, JS.Kind}
+    # Every lowered node keyed by its own `byte_range`, in preorder. The
+    # preorder property is load-bearing for the "last `K"call"` wins"
+    # semantics in `type_for_call`.
+    by_byte_range::Dict{UnitRange{UInt32}, Vector{SyntaxTreeC}}
+    # Typed `K"call"` nodes whose first provenance is a `K"macrocall"`, keyed
+    # by the **macrocall's** `byte_range` (not the lowered call's own range —
+    # string macros lower to a `K"call"` with a smaller span than the
+    # macrocall, so we key by the surface span the user wrote).
+    macrocall_typed_calls::Dict{UnitRange{UInt32}, Vector{SyntaxTreeC}}
+    # Every `K"return"` node, in two parallel `Vector`s sorted by
+    # `JS.first_byte` (so `searchsortedfirst` is valid on `return_first_bytes`).
+    return_first_bytes::Vector{UInt32}
+    return_nodes::Vector{SyntaxTreeC}
+end
+
+function InferredTreeContext(inferred_tree::SyntaxTreeC)
+    surface_kind_index = Dict{UnitRange{UInt32}, JS.Kind}()
+    by_byte_range = Dict{UnitRange{UInt32}, Vector{SyntaxTreeC}}()
+    macrocall_typed_calls = Dict{UnitRange{UInt32}, Vector{SyntaxTreeC}}()
+    return_first_bytes = UInt32[]
+    return_nodes = SyntaxTreeC[]
+
+    traverse(inferred_tree) do st::SyntaxTreeC
+        rng = JS.byte_range(st)
+        push!(get!(Vector{SyntaxTreeC}, by_byte_range, rng), st)
+
+        provs = JS.flattened_provenance(st)
+        if !isempty(provs)
+            fprov = first(provs)
+            fprov_rng = JS.byte_range(fprov)
+            haskey(surface_kind_index, fprov_rng) ||
+                (surface_kind_index[fprov_rng] = JS.kind(fprov))
+
+            if JS.kind(st) === JS.K"call" && hasproperty(st, :type) &&
+                    length(provs) >= 2 && JS.kind(fprov) === JS.K"macrocall"
+                push!(get!(Vector{SyntaxTreeC}, macrocall_typed_calls, fprov_rng), st)
+            end
+        end
+
+        if JS.kind(st) === JS.K"return"
+            push!(return_first_bytes, JS.first_byte(st))
+            push!(return_nodes, st)
+        end
+
+        return nothing
+    end
+
+    # Sort returns by `first_byte` so `searchsortedfirst` is valid. The traverse
+    # order is roughly source order, but enforce explicitly to be safe.
+    perm = sortperm(return_first_bytes)
+    permute!(return_first_bytes, perm)
+    permute!(return_nodes, perm)
+
+    return InferredTreeContext(
+        inferred_tree, surface_kind_index, by_byte_range,
+        macrocall_typed_calls, return_first_bytes, return_nodes)
+end
+
+"""
+    get_type_for_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
+    get_type_for_range(inferred_tree::SyntaxTreeC, rng::UnitRange{<:Integer})
+
+Look up the inferred type at surface byte range `rng`.
+Returns `nothing` if no lowered node corresponding to `rng` carries a `:type` attribute.
+
+The first form is the production entry point: pass an [`InferredTreeContext`](@ref) so the
+per-tree O(N) index build is amortized across all queries against the same inferred tree.
+The second form is a convenience that constructs a fresh context per call — meant for tests
+and one-off use, **not** for batch queries against a single tree (you'd rebuild the indexes
+for every `rng`).
+
+# Dispatch
+
+Lowering routinely places multiple SSA-position nodes at the same surface byte
+range, so a naive `tmerge` of all matches would pull in synthetic helper types
+that the user never wrote. The dispatch picks a strategy based on the surface
+node's kind (recovered from `ctx.surface_kind_index`):
+
+- `K"call"` / `K"dotcall"` — returns the **last** `K"call"` lowered node at
+  `rng`. For `f(; kw=v)` kwcalls, the kwargs `NamedTuple` constructor and
+  `Core.tuple` builder sit at the same byte range as separate `K"call"`s, but
+  the user's call is emitted last, so this picks the user-visible result
+  without `Type{NamedTuple{…}}` or `Tuple{…}` chaff.
+- `K"macrocall"` — returns the **last** `K"call"` whose first provenance is
+  the macrocall at `rng`. That tail call carries the value type of the macro
+  expansion, while every internal helper inside the expansion shares the
+  macrocall's byte range but is not what the user means by the macrocall's
+  value.
+- `K"for"` / `K"while"` — always `Core.Const(nothing)`. Loop expressions
+  evaluate to `nothing`; this avoids `tmerge`-ing the iteration machinery
+  (`iterate` results, `=== nothing` checks, body return) that all share the
+  loop's byte range.
+- `K"function"` / `K"macro"` — returns the method body's `tmerge`d
+  return-statement type (i.e. the value-type of `function f(…) … end`),
+  looked up against the matching `K"method"` lowered node.
+- `K"comparison"` / `K"&&"` / `K"||"` / `K"if"` — branching expressions whose
+  value is the `tmerge` of each branch's value. Lowering emits a separate
+  branch as either a contained `K"return"` (tail position) or a merge-slot
+  `K"="` whose byte range matches `rng` (`r = a && b` etc.); both shapes get
+  merged.
+- otherwise — falls back to `tmerge` of every node at `rng`. Sufficient when
+  there is only a single typed node, or when merging is genuinely the right
+  answer (e.g. branches of a conditional).
+"""
+function get_type_for_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
+    surface_kind = surface_kind_at_range(ctx, rng)
+    if surface_kind === JS.K"macrocall"
+        return type_for_macroexpansion(ctx, rng)
+    elseif surface_kind in JS.KSet"call dotcall"
+        return type_for_call(ctx, rng)
+    elseif surface_kind in JS.KSet"for while"
+        return Core.Const(nothing)
+    elseif surface_kind in JS.KSet"function macro"
+        return type_for_funcdef(ctx, rng)
+    elseif surface_kind in JS.KSet"comparison && || if ?"
+        # Ternary `b ? x : 0` is `K"if"` in the surface tree but `K"?"` in the
+        # inferred tree's provenance (JuliaLowering retains the parser kind).
+        return type_for_branching(ctx, rng)
+    end
+    return tmerge_at_range(ctx, rng)
+end
+
+get_type_for_range(inferred_tree::SyntaxTreeC, rng::UnitRange{<:Integer}) =
+    get_type_for_range(InferredTreeContext(inferred_tree), rng)
+
+surface_kind_at_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer}) =
+    get(ctx.surface_kind_index, rng, nothing)
+
+function type_for_call(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
+    typ = nothing
+    for st in get(ctx.by_byte_range, rng, ())
+        JS.kind(st) === JS.K"call" || continue
+        hasproperty(st, :type) || continue
+        typ = st.type
+    end
+    return typ
+end
+
+function type_for_macroexpansion(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
+    typ = nothing
+    for st5 in get(ctx.macrocall_typed_calls, rng, ())
+        ntyp = st5.type
+        ntyp isa Core.Const && continue
+        typ = ntyp
+    end
+    return typ
+end
+
+# `K"comparison"` / `K"&&"` / `K"||"` / `K"if"` (ternary or block-form) all
+# lower to branching code where each branch produces a candidate value. The
+# lowered branches show up as either:
+# - merge-slot assignments (`K"="` whose byte range equals the surface `rng`)
+#   when the surface is in `K"="` RHS or any non-tail position; or
+# - tail returns (`K"return"` whose byte range is contained in `rng`) when
+#   the surface is in tail position of a function body.
+# The expression's value type is the `tmerge` over all such branch values.
+#
+# A `K"return"` that spans exactly `rng` (synthesized when the branching
+# expression is itself the function body) lives in both `by_byte_range[rng]`
+# and the K"return" containment scan, so the explicit `continue` below skips
+# it in the second scan to avoid double-counting.
+function type_for_branching(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
+    typ = nothing
+    # (1) equality match — any lowered kind, including merge-slot `K"="`.
+    for st in get(ctx.by_byte_range, rng, ())
+        hasproperty(st, :type) || continue
+        ntyp = st.type
+        typ = typ === nothing ? ntyp : CC.tmerge(ntyp, typ)
+    end
+    # (2) containment match — tail-position `K"return"` strictly inside `rng`.
+    rng_start = rng.start
+    rng_stop = rng.stop
+    lo = searchsortedfirst(ctx.return_first_bytes, rng_start)
+    for i in lo:length(ctx.return_first_bytes)
+        first_byte = ctx.return_first_bytes[i]
+        first_byte > rng_stop && break
+        st = ctx.return_nodes[i]
+        last_byte = JS.last_byte(st)
+        last_byte > rng_stop && continue
+        first_byte == rng_start && last_byte == rng_stop && continue # already counted
+        hasproperty(st, :type) || continue
+        ntyp = st.type
+        typ = typ === nothing ? ntyp : CC.tmerge(ntyp, typ)
+    end
+    return typ
+end
+
+function type_for_funcdef(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
+    typ = nothing
+    for st in get(ctx.by_byte_range, rng, ())
+        JS.kind(st) === JS.K"method" || continue
+        for i = 1:JS.numchildren(st)
+            child = st[i]
+            JS.kind(child) === JS.K"code_info" || continue
+            JS.numchildren(child) >= 1 || continue
+            block = child[1]
+            for j = 1:JS.numchildren(block)
+                stmt = block[j]
+                if JS.kind(stmt) === JS.K"return" && hasproperty(stmt, :type)
+                    ntyp = stmt.type
+                    typ = typ === nothing ? ntyp : CC.tmerge(ntyp, typ)
+                end
+            end
+        end
+    end
+    return typ
+end
+
+function tmerge_at_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
+    typ = nothing
+    for st in get(ctx.by_byte_range, rng, ())
+        hasproperty(st, :type) || continue
+        ntyp = st.type
+        typ = typ === nothing ? ntyp : CC.tmerge(ntyp, typ)
+    end
+    return typ
+end
+
+end # module TypeAnnotation

--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -160,13 +160,19 @@ Lower `st0` for scope resolution against `mod` and return the `(ctx3, st3)` pair
 [`infer_toplevel_tree`](@ref) consumes. Wraps `jl_lower_for_scope_resolution` with
 error handling: returns `nothing` if lowering throws (typically because the user's
 source contains parse errors or the macro context isn't yet ready).
+
+`K"error"` nodes are stripped from `st0` before lowering.
+JuliaSyntax doesn't bail on incomplete source — it builds a partial tree with `K"error"`
+siblings around the well-formed parts — and JuliaLowering happily lowers what remains, so
+the LSP gets meaningful types for the parts the user has finished typing (e.g. for
+`function f(x::T); x.; end` the body's `x` reference still resolves to `T`).
 """
 function get_inferrable_tree(
         st0::SyntaxTreeC, mod::Module;
         caller::AbstractString = "get_inferrable_tree"
     )
     (; ctx3, st3) = try
-        jl_lower_for_scope_resolution(mod, st0; trim_error_nodes=false, recover_from_macro_errors=false)
+        jl_lower_for_scope_resolution(mod, st0; trim_error_nodes=true, recover_from_macro_errors=false)
     catch err
         JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
         JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -1,0 +1,666 @@
+module test_type_annotation
+
+using Test
+using JETLS
+using JETLS: JL, JS
+using JETLS.TypeAnnotation
+using JETLS.JET: CC
+
+# Run the full pipeline a typical caller would: parse → lower → infer.
+# Returns `(fi, inferred)` so byte-range queries against `inferred` line up with `code`.
+function type_annotate(code::AbstractString, mod::Module = Main; expect_degrade::Bool=false)
+    fi = JETLS.FileInfo(1, code, @__FILE__)
+    st0_top = JETLS.build_syntax_tree(fi)
+    inferred = Ref{JETLS.SyntaxTreeC}()
+    JETLS.iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
+        result = @something get_inferrable_tree(st0, mod) return nothing
+        (; ctx3, st3) = result
+        inferred[] = infer_toplevel_tree(ctx3, st3, mod)
+        return nothing
+    end
+    if expect_degrade
+        @test !isassigned(inferred)
+        return nothing
+    else
+        @test isassigned(inferred)
+    end
+    return fi, inferred[]
+end
+
+# Byte range of the literal substring `s` inside `code`, in `JS.byte_range`
+# coordinates. Tests use ASCII so char and byte indices coincide.
+range_of(code::AbstractString, s::AbstractString) =
+    @something findfirst(s, code) error(lazy"`$s` is not found in $code")
+
+# Walk the surface tree of `code` and return the byte range of the first
+# encountered node of the given `kind`. Use this when you need the exact
+# `JS.byte_range` of a kind whose source includes leading trivia (e.g.
+# `K"comparison"` in tail position swallows the space between `return` and the
+# first operand) — `findfirst`-based `range_of` mismatches in those cases.
+function range_of_kind(code::AbstractString, kind::JS.Kind)
+    fi = JETLS.FileInfo(1, code, @__FILE__)
+    st0_top = JETLS.build_syntax_tree(fi)
+    return @something JETLS.traverse(st0_top) do node::JS.SyntaxTree
+        JS.kind(node) === kind || return nothing
+        return JETLS.TraversalReturn(JS.byte_range(node); terminate=true)
+    end error(lazy"no surface node of kind $kind in $code")
+end
+
+# Convenience: query helpers strip Const wrappers via `widenconst` so tests
+# don't need to special-case the constant-prop result on simple literals.
+widenconst(typ) = CC.widenconst(@something typ return nothing)
+
+# Walk the surface tree, query `get_type_for_range` at every node whose
+# source text matches `text`, and return the resulting types. Use this to
+# assert that **every** occurrence of an identifier (or expression) gets
+# an annotation, not just the first one.
+function query_all_types(
+        fi::JETLS.FileInfo, inferred::JETLS.SyntaxTreeC, text::AbstractString
+    )
+    st0_top = JETLS.build_syntax_tree(fi)
+    types = Any[]
+    JETLS.traverse(st0_top) do node::JS.SyntaxTree
+        if JS.sourcetext(node) == text
+            push!(types, get_type_for_range(inferred, JS.byte_range(node)))
+        end
+        return nothing
+    end
+    return types
+end
+
+@testset "get_inferrable_tree" begin
+    # `iterate_toplevel_tree` walks each top-level expression independently;
+    # `get_inferrable_tree` is invoked once per chunk. Verify it lowers all
+    # of them, not just the first.
+    @testset "valid input returns inferrable tree for each chunk" begin
+        let code = """
+            let x = 1
+                x
+            end
+            function add_one(y::Int)
+                y + 1
+            end
+            const C = 42
+            """
+            fi = JETLS.FileInfo(1, code, @__FILE__)
+            st0_top = JETLS.build_syntax_tree(fi)
+            results = []
+            JETLS.iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
+                r = get_inferrable_tree(st0, Main)
+                r === nothing || push!(results, r)
+                return nothing
+            end
+            @test length(results) == 3
+            for (; ctx3, st3) in results
+                @test ctx3 isa JL.VariableAnalysisContext
+                @test st3 isa JS.SyntaxTree
+                @test infer_toplevel_tree(ctx3, st3, @__MODULE__) isa JETLS.SyntaxTreeC
+            end
+        end
+    end
+
+    # Lowering errors (e.g. undefined macros) are reported as `nothing` so
+    # callers don't need to wrap every call in `try`.
+    @testset "lowering failure returns nothing" begin
+        let code = "@__undefined_macro_for_test__ xyz"
+            fi = JETLS.FileInfo(1, code, @__FILE__)
+            st0_top = JETLS.build_syntax_tree(fi)
+            JETLS.iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
+                @test isnothing(get_inferrable_tree(st0, @__MODULE__))
+                return nothing
+            end
+        end
+    end
+end
+
+@testset "Inference robustness across method shapes" begin
+    # Method bodies are inferred as their own anonymous chunks: argtypes are
+    # resolved from the lowered svec, no full-analysis-defined `Method` is
+    # required for the body's user-named slots.
+    @testset "annotates non-kwarg method body" begin
+        let code = """
+            function add_one(x::Int)
+                x + 1
+            end
+            """
+            _, inferred = type_annotate(code)
+            @test widenconst(get_type_for_range(inferred, range_of(code, "x + 1"))) === Int
+        end
+    end
+
+    # Kwarg lowering produces three `:method` 3-arg statements (kwbody,
+    # public, kwcall); the user's body lives in kwbody and we expect its
+    # user-named slots to resolve.
+    @testset "annotates kwarg method body" begin
+        let code = """
+            function sum_xs(xs::Vector{Int}; init::Int = 0)
+                s = init + xs[1]
+                s
+            end
+            """
+            _, inferred = type_annotate(code)
+            @test widenconst(get_type_for_range(inferred, range_of(code, "init + xs[1]"))) === Int
+        end
+    end
+
+    # Closures are hoisted to toplevel `:method` 3-arg statements by
+    # `JL.convert_closures`, so the closure body itself is inferred.
+    @testset "annotates closure" begin
+        let code = """
+            function with_closure(xs::Vector{Int})
+                inner(y::Int) = y * 2
+                inner(xs[1])
+            end
+            """
+            _, inferred = type_annotate(code)
+            @testset "body" begin
+                @test widenconst(get_type_for_range(inferred, range_of(code, "y * 2"))) === Int
+            end
+
+            # Limitation: from the enclosing function's body, calling a closure
+            # dispatches on a synthetic type that isn't in `context_module`, so the
+            # call site degrades to `Any`. Recorded as `@test_broken` to flip when
+            # the synthetic-name lookup gap is closed.
+            @testset "closure call from outer body" begin
+                @test_broken widenconst(get_type_for_range(inferred, range_of(code, "inner(xs[1])"))) === Int
+            end
+        end
+
+        # Limitation: a captured variable inside the closure body is accessed via
+        # the synthetic self type's field. Since the self slot resolves to `Any`,
+        # the captured variable infers as `Any` and `Any`-typedness propagates
+        # through any operation involving it. The reference inside the closure
+        # would otherwise be `Int` once the gap is closed.
+        @testset "captured variable in closure body" begin
+            let code = """
+                function with_capture(xs::Vector{Int})
+                    factor = 10
+                    inner(y::Int) = y * factor
+                    inner(xs[1])
+                end
+                """
+                _, inferred = type_annotate(code)
+                @test_broken widenconst(get_type_for_range(inferred, range_of(code, "y * factor"))) === Int
+            end
+        end
+    end
+
+    # `(::Type{NamedTuple{names}})(::Tuple{Union{T1,T2}})` and similar constructor calls
+    # have a method whose `spec_types` carries free type vars
+    # (`(NT::Type{NamedTuple{names}})(args::Tuple) where names`); for thunk-MI inference,
+    # `abstract_call_gf_by_type` refuses to infer any non-`isdispatchtuple` match,
+    # collapsing the result to `Any`. `ASTTypeAnnotator`'s explicit override of
+    # `bail_out_toplevel_call` allows the precise parameterized result.
+    @testset "type constructor with Union-typed tuple element" begin
+        let code = """
+            function f(b::Bool)
+                NamedTuple{(:a,)}((b ? "Z" : nothing,))
+            end
+            """
+            _, inferred = type_annotate(code)
+            rng = range_of(code, "NamedTuple{(:a,)}((b ? \"Z\" : nothing,))")
+            @test widenconst(get_type_for_range(inferred, rng)) <:
+                NamedTuple{(:a,), <:Tuple{Union{Nothing, String}}}
+        end
+    end
+
+    # Limitation: `Expr(:static_parameter, i)` references inside a parametric
+    # method body. The chunk's MI is a thunk MI (`def isa Module`); CC's
+    # `sptypes_from_meth_instance` forces `EMPTY_SPTYPES` for toplevel MIs,
+    # so a body expression that depends on `T` can't recover its bound and
+    # falls through to `Any`.
+    @testset "static-parameter reference in parametric method body" begin
+        let code = """
+            function make_zero(::Type{T}) where T <: Number
+                convert(T, 1)
+            end
+            """
+            _, inferred = type_annotate(code)
+            # A static-parameter-aware path would land somewhere `<: Number`.
+            @test_broken widenconst(get_type_for_range(inferred, range_of(code, "convert(T, 1)"))) <: Number
+        end
+    end
+end
+
+@testset "Surface-kind dispatch (get_type_for_range)" begin
+    # Generic fallback: a single typed node lives at the byte range, so the
+    # tmerge path collapses to that node's type.
+    @testset "generic byte-range fallback" begin
+        let code = "let x = [1.0]; x; end"
+            _, inferred = type_annotate(code)
+            @test widenconst(get_type_for_range(inferred, range_of(code, "[1.0]"))) ===
+                Vector{Float64}
+        end
+    end
+
+    # When no node matches the byte range, the result is `nothing` so the caller
+    # can distinguish "no annotation" from "annotation says `nothing`".
+    @testset "returns nothing for non-matching range" begin
+        let code = "let x = 1; x; end"
+            _, inferred = type_annotate(code)
+            @test get_type_for_range(inferred, 10_000:10_001) === nothing
+        end
+    end
+
+    @testset "regular call dispatches to the user's call result" begin
+        let code = "let v = [1.0, 2.0]; sum(v); end"
+            _, inferred = type_annotate(code)
+            @test widenconst(get_type_for_range(inferred, range_of(code, "sum(v)"))) ===
+                Float64
+        end
+    end
+
+    # Kwcall lowering plants the kwargs `NamedTuple` / `Tuple` constructors at the
+    # same byte range as the user's call. K"call" dispatch picks the last K"call",
+    # which is the user-visible result.
+    @testset "kwcall returns user's result type, not kwargs constructor" begin
+        let code = """
+            let strs = String["10", "20"]
+                s = strs[1]
+                parse(Int, s; base = 10)
+            end
+            """
+            _, inferred = type_annotate(code)
+            typ = widenconst(get_type_for_range(
+                inferred, range_of(code, "parse(Int, s; base = 10)")))
+            @test typ === Int
+            @test !occursin("NamedTuple", string(typ))
+            @test !occursin("Tuple", string(typ))
+        end
+    end
+
+    # `_str` macros expand to a single Core call.
+    @testset "string macro returns the expansion result type" begin
+        let code = "lazy\"hello\""
+            _, inferred = type_annotate(code)
+            @test widenconst(get_type_for_range(
+                inferred, range_of(code, "lazy\"hello\""))) <: Base.LazyString
+        end
+    end
+
+    # `@something x return false` expands to a let-block whose tail call yields
+    # `Int` once the `nothing` branch is ruled out — every helper inside the
+    # expansion shares the macrocall's byte range, so naive tmerge would mix in
+    # boolean checks etc.
+    @testset "general macrocall returns the expansion tail-call type" begin
+        let code = """
+            let x = Union{Int,Nothing}[1, nothing][1]
+                @something x return false
+            end
+            """
+            _, inferred = type_annotate(code)
+            @test widenconst(get_type_for_range(
+                inferred, range_of(code, "@something x return false"))) === Int
+        end
+    end
+
+    # for/while loops always evaluate to `nothing`. The iteration machinery
+    # (`iterate(xs)`, `iterate(xs, state)`, `=== nothing` checks, body return) all
+    # places typed nodes at the loop's byte range, so naive tmerge would produce a
+    # chaotic `Union{Nothing, Bool, Tuple{…}}`-ish result.
+    @testset "loops" begin
+        @testset "for loop returns Const(nothing)" begin
+            let code = """
+                let xs = [1, 2, 3]
+                    for x in xs
+                        print(x)
+                    end
+                end
+                """
+                _, inferred = type_annotate(code)
+                rng = range_of(code, "for x in xs\n        print(x)\n    end")
+                @test get_type_for_range(inferred, rng) === Core.Const(nothing)
+            end
+        end
+        @testset "while loop returns Const(nothing)" begin
+            let code = """
+                let i = 0
+                    while i < 3
+                        i += 1
+                    end
+                end
+                """
+                _, inferred = type_annotate(code)
+                rng = range_of(code, "while i < 3\n        i += 1\n    end")
+                @test get_type_for_range(inferred, rng) === Core.Const(nothing)
+            end
+        end
+    end
+
+    # `K"function"` / `K"macro"` dispatch returns the method body's `tmerge`d
+    # return-statement type. Naive lookup would either pull in unrelated nodes
+    # inside the body (slot reads, intermediate calls) or land on dispatcher
+    # methods synthesized for default args / kwargs (which share the funcdef
+    # byte range and return `Any`).
+    @testset "function and macro definitions" begin
+        @testset "single return path" begin
+            let code = """
+                function add_one(x::Int)
+                    return x + 1
+                end
+                """
+                _, inferred = type_annotate(code)
+                rng = range_of(code, rstrip(code, '\n'))
+                @test widenconst(get_type_for_range(inferred, rng)) === Int
+            end
+        end
+
+        # Multiple `return` statements `tmerge` into a Union.
+        @testset "branching returns tmerge" begin
+            let code = """
+                function maybe_int(x::Int)
+                    if x > 0
+                        return x
+                    else
+                        return nothing
+                    end
+                end
+                """
+                _, inferred = type_annotate(code)
+                rng = range_of(code, rstrip(code, '\n'))
+                typ = widenconst(get_type_for_range(inferred, rng))
+                @test typ === Union{Int, Nothing}
+            end
+        end
+
+        # Macros are also K"method" lowered, so the same dispatch applies.
+        @testset "macro definition" begin
+            let code = """
+                macro just_one()
+                    return :(1 + 1)
+                end
+                """
+                _, inferred = type_annotate(code)
+                rng = range_of(code, rstrip(code, '\n'))
+                @test widenconst(get_type_for_range(inferred, rng)) === Expr
+            end
+        end
+
+        @testset "positional default-argument function" begin
+            let code = """
+                function add_or_zero(x::Int = 0)
+                    return x + 1
+                end
+                """
+                _, inferred = type_annotate(code)
+                rng = range_of(code, rstrip(code, '\n'))
+                @test widenconst(get_type_for_range(inferred, rng)) === Int
+            end
+        end
+
+        @testset "multiple positional defaults" begin
+            let code = """
+                function f(x::Int = 0, y::Int = 1, z::Int = 2)
+                    x + y + z
+                end
+                """
+                _, inferred = type_annotate(code)
+                rng = range_of(code, rstrip(code, '\n'))
+                @test widenconst(get_type_for_range(inferred, rng)) === Int
+            end
+        end
+
+        @testset "kwarg function definition" begin
+            let code = """
+                function sum_with_init(xs::Vector{Int}; init::Int = 0)
+                    s = init
+                    for x in xs
+                        s += x
+                    end
+                    s
+                end
+                """
+                _, inferred = type_annotate(code)
+                rng = range_of(code, rstrip(code, '\n'))
+                @test widenconst(get_type_for_range(inferred, rng)) === Int
+            end
+        end
+    end
+
+    # Branching expressions: value type is the `tmerge` of all branches. Each
+    # group below pairs a `K"="` RHS case with a tail-position case (lowering
+    # of branches differs between the two contexts).
+    @testset "branching expressions" begin
+        @testset "chained comparison in `=` RHS" begin
+            let code = """
+                let x = 1
+                    r = 0 < x < 10
+                end
+                """
+                _, inferred = type_annotate(code)
+                rng = range_of(code, "0 < x < 10")
+                @test widenconst(get_type_for_range(inferred, rng)) === Bool
+            end
+        end
+        @testset "chained comparison in tail position" begin
+            let code = """
+                function f(x::Int)
+                    return 0 < x < 10
+                end
+                """
+                _, inferred = type_annotate(code)
+                rng = range_of_kind(code, JS.K"comparison")
+                @test widenconst(get_type_for_range(inferred, rng)) === Bool
+            end
+        end
+
+        @testset "&& in `=` RHS" begin
+            let code = """
+                function f(x::Int)
+                    r = x > 0 && x
+                    r
+                end
+                """
+                _, inferred = type_annotate(code)
+                rng = range_of(code, "x > 0 && x")
+                @test widenconst(get_type_for_range(inferred, rng)) === Union{Bool, Int}
+            end
+        end
+        @testset "&& in tail position" begin
+            let code = """
+                function f(x::Int)
+                    return x > 0 && x
+                end
+                """
+                _, inferred = type_annotate(code)
+                rng = range_of_kind(code, JS.K"&&")
+                @test widenconst(get_type_for_range(inferred, rng)) === Union{Bool, Int}
+            end
+        end
+        @testset "|| in tail position" begin
+            let code = """
+                function f(x::Int)
+                    return x > 0 || nothing
+                end
+                """
+                _, inferred = type_annotate(code)
+                rng = range_of_kind(code, JS.K"||")
+                @test widenconst(get_type_for_range(inferred, rng)) === Union{Bool, Nothing}
+            end
+        end
+
+        # Ternary's surface kind is `K"if"` (same as block-form), but the
+        # inferred tree's provenance keeps the parser's `K"?"` — the dispatch
+        # has to handle both kinds to cover ternary in any context.
+        @testset "ternary in `=` RHS" begin
+            let code = """
+                function f(b::Bool, x::Int)
+                    r = b ? x : nothing
+                    r
+                end
+                """
+                _, inferred = type_annotate(code)
+                rng = range_of(code, "b ? x : nothing")
+                @test widenconst(get_type_for_range(inferred, rng)) === Union{Int, Nothing}
+            end
+        end
+        @testset "ternary in tail position" begin
+            let code = """
+                function f(b::Bool, x::Int)
+                    return b ? x : nothing
+                end
+                """
+                _, inferred = type_annotate(code)
+                rng = range_of_kind(code, JS.K"if")
+                @test widenconst(get_type_for_range(inferred, rng)) === Union{Int, Nothing}
+            end
+        end
+
+        @testset "if-block in tail position" begin
+            let code = """
+                function f(b::Bool)
+                    return if b
+                        1
+                    else
+                        nothing
+                    end
+                end
+                """
+                _, inferred = type_annotate(code)
+                rng = range_of_kind(code, JS.K"if")
+                @test widenconst(get_type_for_range(inferred, rng)) === Union{Int, Nothing}
+            end
+        end
+        @testset "if-elseif-else" begin
+            let code = """
+                function f(a::Bool, b::Bool)
+                    if a
+                        1
+                    elseif b
+                        "x"
+                    else
+                        nothing
+                    end
+                end
+                """
+                _, inferred = type_annotate(code)
+                rng = range_of_kind(code, JS.K"if")
+                typ = widenconst(get_type_for_range(inferred, rng))
+                @test typ === Union{Int, String, Nothing}
+            end
+        end
+    end
+end
+
+@testset "Multi-position / composition behaviors" begin
+    # Tuple-destructuring assignment `a, b = sincos(x)` lowers to two slot
+    # assignments via `iterate(t)` / `iterate(t, state)`. The slot positions
+    # have to pick up the element type, not just `Any`, so each `a` / `b`
+    # reference resolves to `Float64` after destructuring.
+    @testset "slot types from tuple destructuring" begin
+        let code = """
+            function f(xs::Vector{Float64})
+                a, b = sincos(xs[1])
+                a + b
+            end
+            """
+            _, inferred = type_annotate(code)
+            @test widenconst(get_type_for_range(
+                inferred, range_of(code, "sincos(xs[1])"))) === Tuple{Float64, Float64}
+            @test widenconst(get_type_for_range(
+                inferred, range_of(code, "a + b"))) === Float64
+        end
+    end
+
+    # Chained dotted access on a dereferenced `Ref`: `Ref(...)[].field`
+    # exercises K"." → K"ref" → K"call" composition. Each link in the chain
+    # has to land its own `:type` for editor features (hover / inlay) to
+    # show useful information when the cursor is anywhere along the access.
+    @testset "property access via dereferenced Ref" begin
+        let code = "Ref((; scale = 2.0))[].scale"
+            _, inferred = type_annotate(code)
+            @test widenconst(get_type_for_range(
+                inferred, range_of(code, "Ref((; scale = 2.0))"))) ===
+                Base.RefValue{NamedTuple{(:scale,), Tuple{Float64}}}
+            @test widenconst(get_type_for_range(
+                inferred, range_of(code, "Ref((; scale = 2.0))[]"))) ===
+                NamedTuple{(:scale,), Tuple{Float64}}
+            @test widenconst(get_type_for_range(
+                inferred, range_of(code, "Ref((; scale = 2.0))[].scale"))) ===
+                Float64
+        end
+    end
+
+    # Multi-reference exhaustiveness: every occurrence of `cfg` / `raw` /
+    # `result` in the body should be annotated, not just the first. Catches
+    # regressions where annotation only reaches the binding site or the last
+    # assignment.
+    @testset "every reference of a local gets annotated" begin
+        let code = """
+            function f(xs::Vector{Float64})
+                cfg = (scale = 2.0, offset = 1)
+                raw = abs(sin(cos(cfg.scale)))
+                result = raw * cfg.offset
+                result
+            end
+            """
+            fi, inferred = type_annotate(code)
+            cfg_types = query_all_types(fi, inferred, "cfg")
+            @test length(cfg_types) == 3 # binding + two field accesses
+            @test all(t -> widenconst(t) ===
+                NamedTuple{(:scale, :offset), Tuple{Float64, Int}}, cfg_types)
+            raw_types = query_all_types(fi, inferred, "raw")
+            @test length(raw_types) == 2 # binding + reference in `raw * cfg.offset`
+            @test all(t -> widenconst(t) === Float64, raw_types)
+            result_types = query_all_types(fi, inferred, "result")
+            @test length(result_types) == 2 # binding + tail reference
+            @test all(t -> widenconst(t) === Float64, result_types)
+        end
+    end
+
+    # Type narrowing across control flow: each `xxx` reference within a
+    # branch should pick up its branch-narrowed type (Int / String).
+    @testset "narrowed type across control flow" begin
+        let code = """
+            function f(xxx::Union{Int, String})
+                if xxx isa Int
+                    sin(xxx)
+                else
+                    uppercase(xxx)
+                end
+            end
+            """
+            fi, inferred = type_annotate(code)
+            types = query_all_types(fi, inferred, "xxx")
+            @test any(t -> widenconst(t) === Int, types)
+            @test any(t -> widenconst(t) === String, types)
+        end
+    end
+end
+
+@testset "Pipeline-level edge cases" begin
+    # LSP requests routinely arrive on incomplete source as the user types.
+    # The pipeline (`get_inferrable_tree` → `infer_toplevel_tree`) must
+    # degrade gracefully — never throw — and the caller decides whether to
+    # show partial results or skip annotation for that chunk.
+    @testset "incomplete syntax doesn't crash the pipeline" begin
+        # lowering refuses to consume the K"error" leaf
+        @test isnothing(type_annotate("sin(", @__MODULE__; expect_degrade=true))
+        # Same property when the K"error" is buried inside a function body —
+        # the outer `function ... end` shape parses fine, but lowering still
+        # refuses the whole chunk and the pipeline degrades to `nothing`
+        # instead of throwing.
+        let code = """
+            function f(x::Some{String})
+                x.
+            end
+            """
+            @test isnothing(type_annotate(code, @__MODULE__; expect_degrade=true))
+        end
+    end
+
+    # Top-level bare assignment `x = sin(1.0)` lowers to a chunk that
+    # prepends `Core.declare_global(Main, :x, true)` + `Expr(:latestworld)`
+    # before the RHS. Without intervention the world bump would make
+    # `abstract_eval_globalref` widen `Main.sin` to `Any` and the call to
+    # infer as `Any`; `strip_latestworld!` neutralizes the directive
+    # before inference so the RHS keeps a precise `Float64`.
+    @testset "top-level bare assignment RHS" begin
+        let code = "global x = sin(1.0)"
+            _, inferred = type_annotate(code)
+            @test widenconst(get_type_for_range(inferred, range_of(code, "sin(1.0)"))) === Float64
+        end
+    end
+end
+
+end # module test_type_annotation

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -629,23 +629,42 @@ end
 end
 
 @testset "Pipeline-level edge cases" begin
-    # LSP requests routinely arrive on incomplete source as the user types.
-    # The pipeline (`get_inferrable_tree` → `infer_toplevel_tree`) must
-    # degrade gracefully — never throw — and the caller decides whether to
-    # show partial results or skip annotation for that chunk.
-    @testset "incomplete syntax doesn't crash the pipeline" begin
-        # lowering refuses to consume the K"error" leaf
-        @test isnothing(type_annotate("sin(", @__MODULE__; expect_degrade=true))
-        # Same property when the K"error" is buried inside a function body —
-        # the outer `function ... end` shape parses fine, but lowering still
-        # refuses the whole chunk and the pipeline degrades to `nothing`
-        # instead of throwing.
+    # JuliaSyntax doesn't bail on incomplete source — it produces a partial tree with
+    # `K"error"` siblings around the well-formed parts. `get_inferrable_tree` strips those
+    # error nodes, and JuliaLowering happily lowers what remains, so type queries on the
+    # well-formed portion come back accurate. This is what powers completion past `.` on
+    # a half-typed buffer.
+    @testset "partial inference on incomplete source" begin
+        # Toplevel `sin(`: the trailing `(error-t)` arg is stripped, leaving `(call sin)`.
+        # The `sin` reference itself still resolves — usable for signature help on a half-typed call.
+        let code = "sin("
+            _, inferred = type_annotate(code)
+            @test get_type_for_range(inferred, range_of(code, "sin")) === Core.Const(sin)
+        end
+        # K"error" buried inside a function body: the body parses to `(. x (inert end))`
+        # plus a sibling K"error", stripping the latter leaves a well-formed function.
+        # The body's `x` reference picks up the parameter's declared type, which is
+        # what completion on `x.|` needs.
         let code = """
             function f(x::Some{String})
                 x.
             end
             """
-            @test isnothing(type_annotate(code, @__MODULE__; expect_degrade=true))
+            fi, inferred = type_annotate(code)
+            x_types = query_all_types(fi, inferred, "x")
+            @test any(t -> widenconst(t) === Some{String}, x_types)
+        end
+        # Locally bound variable with no declared type: `s` gets `Float64` from `sum(xs)`,
+        # which the analysis must recover — AST reading alone can't.
+        let code = """
+            function f(xs::Vector{Float64})
+                s = sum(xs)
+                s.
+            end
+            """
+            fi, inferred = type_annotate(code)
+            s_types = query_all_types(fi, inferred, "s")
+            @test any(t -> widenconst(t) === Float64, s_types)
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,7 @@ end
         @testset "occurrence" include("analysis/test_occurrence_analysis.jl")
         @testset "cfg" include("analysis/test_cfg_analysis.jl")
         @testset "LSAnalyzer" include("analysis/test_Analyzer.jl")
+        @testset "TypeAnnotation" include("analysis/test_TypeAnnotation.jl")
     end
     @testset "types" include("test_types.jl")
     @testset "config" include("test_config.jl")


### PR DESCRIPTION
Introduce a new analysis layer that produces per-statement inferred
types on a lowered `SyntaxTree`, intended to back type-aware LSP
features (inlay hints, hover, completion, …). The layer is
deliberately separate from full-analysis: it depends on
full-analysis having already materialized user bindings into
`context_module` (functions, types, constants) and runs a
lightweight parse → JuliaLowering → inference pass on top.

# Core design: every chunk is an "anonymous toplevel chunk"

The basic inference unit is a chunk — a `Core.CodeInfo` paired with
a `SyntaxTreeC` whose `[1]` is the block of statements to annotate.
The toplevel itself is such a chunk (nargs=0). Method bodies — the
non-trivial case — are also handled this way, *not* by going
through `Method` / `MethodInstance` dispatch.

The motivation for this shape is that JuliaLowering generates
synthetic names for keyword methods and closure functions
(`var"#kw_body#f#0"`, `var"#closure#N"`, …) that don't match the
bindings full-analysis materialized into `context_module`. These
names are gensymed at lowering time — no choice of lowerer changes
that — so method-lookup-driven inference would fail or hit stale
entries on every keyword / closure body. Pattern-matching synthetic
names back to user bindings to bridge the gap is fundamentally a
HACK and cannot be made reliable; Revise's well-known fragility
around closures and keyword methods is empirical evidence that this
path does not scale.

The anonymous-chunk shape side-steps the whole mismatch: each
`:method` 3-arg statement's argtypes svec is statically evaluated
from the lowered code against `context_module` (`eval_to_value`
follows the SSA chain through `Core.apply_type`, `Core.Typeof`,
`GlobalRef`, …) and the body is inferred against those argtypes
directly, without any `Method` lookup. As long as a method's
argtypes are statically resolvable in the full-analysis-established
`context_module`, the body infers robustly — keyword methods,
closures, ordinary methods all the same — and that covers the bulk
of real LSP queries.

# `ASTTypeAnnotator`

A custom `CC.AbstractInterpreter` tailored to the chunk shape:

- Optimization disabled (`may_optimize = false`); only types are
  needed.
- `aggressive_constant_propagation` enabled.
- `bail_out_toplevel_call` overridden so thunk MIs can infer
  methods with free type-vars (e.g.
  `(::Type{NamedTuple{names}})(::Tuple)`), which CC otherwise
  refuses to admit at toplevel and which would otherwise collapse
  to `Any`.
- On `finishinfer!` the interpreter walks `frame.src.code` and
  writes the per-statement `:type` attribute back onto the lowered
  `SyntaxTree` — so the same returned tree carries types for both
  the toplevel chunk and every nested method body.

`infer_method_defs!` skips dispatcher methods synthesized for
default args / kwargs (their body is a forwarder to the user
method, so its annotations are noise) — the resulting tree stays
free of meaningless `Any` hints.

# Query layer

`InferredTreeContext` bundles the inferred tree with prebuilt
indexes constructed in a single traversal so `get_type_for_range`
answers each query in $O(1)$ or $O(log N)$ for the branching case
without re-walking the tree per call. Designed to be cached on
the server's per-file state alongside (or in place of) the
inferred tree.

`get_type_for_range` dispatches on the surface kind to handle
pathological lowering shapes uniformly:

- `K"call"` / `K"dotcall"`: the user's call result, not the
  kwcall `NamedTuple` / `Tuple` chaff at the same byte range.
- `K"macrocall"`: the expansion's tail call, skipping every
  internal helper that shares the macrocall's byte range.
- `K"for"` / `K"while"`: always `Const(nothing)` — avoids
  `tmerge`-ing the iteration machinery.
- `K"function"` / `K"macro"`: `tmerge` of the body's return
  statements.
- `K"comparison"` / `K"&&"` / `K"||"` / `K"if"`: branching
  `tmerge` over merge-slot `K"="` and tail `K"return"` shapes.
- otherwise: generic `tmerge` at the range.

# Public API

- `get_inferrable_tree(st0, mod)` — lower for scope resolution,
  returns `nothing` on lowering failure (so the caller can degrade
  gracefully on incomplete source).
- `infer_toplevel_tree(ctx3, st3, mod)` — full pipeline, returns
  the annotated lowered tree.
- `InferredTreeContext(inferred_tree)` — query handle, intended to
  be cached.
- `get_type_for_range(ctx, rng)` — type lookup at a surface byte
  range.

# Known limitations

The static-svec / anonymous-chunk approach is robust whenever the
argtypes are resolvable in `context_module`. Two related mechanisms
still fall through to `Any` (recorded as `@test_broken`):

- **Synthetic closure names referenced inside a method body.**
  The closure body itself is hoisted to a toplevel `:method` 3-arg
  by `JL.convert_closures` and infers normally, but:
  - Calls into the closure dispatch on a synthetic type
    (`var"#closure#N"`) that isn't `getglobal`-resolvable in
    `context_module`, so the call site degrades to `Any` and that
    `Any`-typedness propagates outward through the enclosing
    function.
  - Accordingly captured variables accessed via the closure's self
    field likewise infer as `Any`.

  This is the same kind of synthetic-name lookup gap the design
  was specifically chosen to avoid for *defining* method bodies —
  but for *references to* synthetic-named closures from a sibling
  body, the gap reappears at the call site.

- **`Expr(:static_parameter, i)` inside a parametric method body.**
  This is a separate problem from the closure synthetic-name
  issue: static parameters are a `Method` concept, so it's
  semantically correct that Compiler.jl forces `EMPTY_SPTYPES` for
  toplevel-chunk MIs (`sptypes_from_meth_instance` for thunk MIs).
  The cost simply lands on us because we deliberately repurpose
  toplevel chunks to drive method-body inference. An anonymous
  method body that depends on `T` therefore can't recover its
  bound and infers as `Any`.

# Future direction

Both remaining limitations look addressable by switching specific
cases from the anonymous-chunk shape to `OpaqueClosure`-based
inference:

- Converting a closure to an `OpaqueClosure` should let inference
  see through it, recovering precise types at call sites and for
  captured variables.
- Inferring a method body as an `OpaqueClosure` (rather than a
  bare toplevel chunk) gives us a place to thread static
  parameters through, since `OpaqueClosure` has its own MI shape
  that isn't constrained to `EMPTY_SPTYPES`.

Both are explicitly out of scope for this commit — the goal here
is a working baseline that handles the common cases robustly and
fails gracefully on the rest.
