### PR TITLE
diagnostic: Detect non-boolean values in branch context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > This disables analysis for matched files. Basic features like completion still might work, but most LSP features will be unfunctional.
 > Note that `analysis_overrides` is provided as a temporary workaround and may be removed or changed at any time. A proper fix is being worked on.
 
+### Added
+
+- Added [`inference/non-boolean-cond`](https://aviatesk.github.io/JETLS.jl/release/diagnostic/#diagnostic/reference/inference/non-boolean-cond) diagnostic that detects non-boolean values used in boolean context (e.g. `if`, `while`, ternary `?:`, `&&`, `||`).
+  ```julia
+  function find_zero(xs::Vector{Union{Missing,Int}})
+      for i in eachindex(xs)
+          xs[i] == 0 && return i  # non-boolean `Missing` found in boolean context
+      end
+  end
+  ```
+
 ### Changed
 
 - Updated JuliaSyntax.jl and JuliaLowering.jl dependencies.

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -123,6 +123,7 @@ Here is a summary table of the diagnostics explained in this section:
 | [`inference/field-error`](@ref diagnostic/reference/inference/field-error)                       | `Warning`             | `JETLS/save`  | Access to non-existent struct fields               |
 | [`inference/bounds-error`](@ref diagnostic/reference/inference/bounds-error)                     | `Warning`             | `JETLS/save`  | Out-of-bounds field access by index                |
 | [`inference/method-error`](@ref diagnostic/reference/inference/method-error)                     | `Warning`             | `JETLS/save`  | No matching method found for function calls        |
+| [`inference/non-boolean-cond`](@ref diagnostic/reference/inference/non-boolean-cond)             | `Warning`             | `JETLS/save`  | Non-boolean value used in boolean context          |
 | [`testrunner/test-failure`](@ref diagnostic/reference/testrunner/test-failure)                   | `Error`               | `JETLS/extra` | Test failures from TestRunner integration          |
 
 ### [Syntax diagnostic (`syntax/*`)](@id diagnostic/reference/syntax)
@@ -932,6 +933,57 @@ function union_split_method_error(x::Union{Int,String})
                         # (JETLS inference/method-error)
 end
 ```
+
+#### [Non-boolean condition (`inference/non-boolean-cond`)](@id diagnostic/reference/inference/non-boolean-cond)
+
+**Default severity:** `Warning`
+
+Non-boolean values used in boolean context, such as `if` or `while` conditions.
+Julia requires conditions to be strictly `Bool`; using other types will raise a
+`TypeError` at runtime.
+
+Examples:
+
+```julia
+function non_boolean_example()
+    x = 1
+    if x  # non-boolean `Int64` found in boolean context
+          # (JETLS inference/non-boolean-cond)
+        return "truthy"
+    end
+end
+```
+
+When union-split types include non-boolean branches:
+
+```julia
+function find_zero(xs::Vector{Union{Missing,Int}})
+    for i in eachindex(xs)
+        xs[i] == 0 && return i  # non-boolean `Missing` found in boolean context (1/2 union split)
+                                # (JETLS inference/non-boolean-cond)
+    end
+end
+```
+
+!!! tip "Common case: `Any`-typed arguments and `==`"
+    When an argument is inferred as `Any`, `==` returns
+    `Union{Bool,Missing}` (because `==(::Missing, ::Any)` is a
+    candidate method):
+
+    ```julia
+    function check(x, y::AbstractString)
+        x == :flag || error("x is invalid")  # non-boolean `Missing` found in boolean context (1/2 union split)
+                                             # (JETLS inference/non-boolean-cond)
+        return println(y)
+    end
+    ```
+
+    You can resolve this by either:
+    - Restricting the argument type so that `==` no longer returns
+      `Missing` (e.g. `x::Symbol`).
+    - Adding a `::Bool` return type annotation to the comparison
+      expression if you know `x` will never be `missing`
+      (e.g. `(x == :flag)::Bool`).
 
 ### [TestRunner diagnostic (`testrunner/*`)](@id diagnostic/reference/testrunner)
 

--- a/src/analysis/Analyzer.jl
+++ b/src/analysis/Analyzer.jl
@@ -1,7 +1,8 @@
 module Analyzer
 
 export LSAnalyzer, inference_error_report_severity, inference_error_report_stack, reset_report_target_modules!
-export BoundsErrorReport, FieldErrorReport, MethodErrorReport, UndefVarErrorReport
+export BoundsErrorReport, FieldErrorReport, MethodErrorReport, NonBooleanCondErrorReport,
+    UndefVarErrorReport
 
 using Core.IR
 using JET.JETInterface
@@ -40,7 +41,7 @@ to detect [`LSErrorReport`](@ref)s, along with analyzing types and effects.
 struct LSAnalyzer <: ToplevelAbstractAnalyzer
     state::AnalyzerState
     analysis_token::AnalysisToken
-    method_table::CC.CachedMethodTable{CC.InternalMethodTable}
+    method_table::CC.CachedMethodTable{CC.OverlayMethodTable}
 
     """
         `LSAnalyzer.report_target_modules::::Union{Nothing,Set{Module}}`
@@ -65,7 +66,7 @@ struct LSAnalyzer <: ToplevelAbstractAnalyzer
             report_target_modules::Union{Nothing,Set{Module}},
             invariable_analysis_hash::UInt
         )
-        method_table = CC.CachedMethodTable(CC.InternalMethodTable(state.world))
+        method_table = CC.CachedMethodTable(CC.OverlayMethodTable(state.world, jetls_method_table))
         return new(state, analysis_token, method_table, report_target_modules, invariable_analysis_hash)
     end
 end
@@ -156,6 +157,25 @@ JETInterface.AnalysisToken(analyzer::LSAnalyzer) = analyzer.analysis_token
 
 const LS_ANALYZER_CACHE = Dict{UInt,AnalysisToken}()
 const LS_ANALYZER_CACHE_LOCK = ReentrantLock()
+
+# method overlay
+# ==============
+
+Base.Experimental.@MethodTable jetls_method_table
+
+@static if VERSION < v"1.14.0-DEV.2024"
+# Backport JuliaLang/julia#61526
+Base.Experimental.@overlay jetls_method_table Base.in(x, itr::Tuple) = _in_tuple(x, itr)
+function _in_tuple(x, @nospecialize(itr::Tuple), result = false)
+    @inline
+    isempty(itr) && return result
+    v = (itr[1] == x)
+    if v === true
+        return true
+    end
+    return _in_tuple(x, Base.tail(itr), result | v)
+end
+end
 
 # internal API
 # ============
@@ -320,6 +340,20 @@ function CC.abstract_eval_special_value(analyzer::LSAnalyzer, @nospecialize(e), 
     return @invoke CC.abstract_eval_special_value(analyzer::ToplevelAbstractAnalyzer, e::Any, sstate::CC.StatementState, sv::CC.InferenceState)
 end
 
+function CC.abstract_eval_value(analyzer::LSAnalyzer, @nospecialize(e), sstate::CC.StatementState, sv::CC.InferenceState)
+    ret = @invoke CC.abstract_eval_value(analyzer::ToplevelAbstractAnalyzer, e::Any, sstate::CC.StatementState, sv::CC.InferenceState)
+    if should_analyze(analyzer, sv)
+        stmt = JET.get_stmt((sv, JET.get_currpc(sv)))
+        if isa(stmt, GotoIfNot)
+            t = CC.widenconst(ret)
+            if t !== Union{}
+                report_non_boolean_cond!(analyzer, sv, t)
+            end
+        end
+    end
+    return ret
+end
+
 # analysis
 # ========
 
@@ -329,12 +363,11 @@ end
 Abstract type for error reports analyzed by [`LSAnalyzer`](@ref).
 
 Subtypes:
-- `UndefVarErrorReport`: Undefined variables (global, static parameters[^unimplemented])
+- `UndefVarErrorReport`: Undefined variables (global only, undefined static parameters is not analyzed currently)
 - `FieldErrorReport`: Access to non-existent struct fields
 - `BoundsErrorReport`: Out-of-bounds field access by index
-- `MethodErrorReport`: Method dispatch errors[^unimplemented]
-
-[^unimplemented]: Currently unimplemented.
+- `MethodErrorReport`: Method dispatch errors
+- `NonBooleanCondErrorReport`: Non-boolean value used in boolean context
 """
 abstract type LSErrorReport <: InferenceErrorReport end
 
@@ -577,6 +610,66 @@ function report_method_error_for_union_split!(
     end
     if empty_matches !== nothing
         add_new_report!(analyzer, sv.result, MethodErrorReport(sv, empty_matches...))
+    end
+end
+
+# NonBooleanCondErrorReport
+# -------------------------
+
+@jetreport struct NonBooleanCondErrorReport <: LSErrorReport
+    @nospecialize t # ::Union{Type, Vector{Type}}
+    union_split::Int
+    uncovered::Bool
+end
+inference_error_report_stack_impl(r::NonBooleanCondErrorReport) = length(r.vst):-1:1
+inference_error_report_severity_impl(::NonBooleanCondErrorReport) = DiagnosticSeverity.Warning
+function JETInterface.print_report_message(io::IO, report::NonBooleanCondErrorReport)
+    (; t, union_split, uncovered) = report
+    if union_split == 0
+        print(io, "non-boolean `", t, "`")
+        if uncovered
+            print(io, " may be used in boolean context")
+        else
+            print(io, " found in boolean context")
+        end
+    else
+        ts = t::Vector{Any}
+        nts = length(ts)
+        print(io, "non-boolean ")
+        for i = 1:nts
+            print(io, '`', ts[i], '`')
+            i == nts || print(io, ", ")
+        end
+        if uncovered
+            print(io, " may be used in boolean context")
+        else
+            print(io, " found in boolean context")
+        end
+        print(io, " (", nts, '/', union_split, " union split)")
+    end
+end
+
+function report_non_boolean_cond!(analyzer::LSAnalyzer, sv::CC.InferenceState, @nospecialize(t))
+    check_uncovered = false
+    ⊑ = CC.partialorder(CC.typeinf_lattice(analyzer))
+    if isa(t, Union)
+        info = nothing
+        uts = Base.uniontypes(t)
+        for ut in uts
+            if !(check_uncovered ? ut ⊑ Bool : CC.hasintersect(ut, Bool))
+                if info === nothing
+                    info = Any[], length(uts)
+                end
+                push!(info[1], ut)
+            end
+        end
+        if info !== nothing
+            add_new_report!(analyzer, sv.result, NonBooleanCondErrorReport(sv, info..., #=uncovered=#check_uncovered))
+        end
+    else
+        if !(check_uncovered ? t ⊑ Bool : CC.hasintersect(t, Bool))
+            add_new_report!(analyzer, sv.result, NonBooleanCondErrorReport(sv, t, 0, #=uncovered=#check_uncovered))
+        end
     end
 end
 

--- a/src/analysis/Interpreter.jl
+++ b/src/analysis/Interpreter.jl
@@ -239,8 +239,10 @@ function JET.virtual_process!(interp::LSInterpreter,
         end
         percentage = let prev_analysis_result = interp.request.prev_analysis_result
             n_files = isnothing(prev_analysis_result) ? 0 : length(prev_analysis_result.analyzed_file_infos)
+            analyze_from_definitions = JET.InterpretationState(interp).config.analyze_from_definitions
+            analyze_from_definitions = analyze_from_definitions isa Symbol || analyze_from_definitions
             iszero(n_files) ? 0 : compute_percentage(interp.counter[], n_files,
-                JET.InterpretationState(interp).config.analyze_from_definitions ? 50 : 100)
+                analyze_from_definitions ? 50 : 100)
         end
         send_progress(interp.server, cancellable_token.token,
             WorkDoneProgressReport(;

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -545,7 +545,7 @@ function make_insert_text(msig::AbstractString, num_existing_args::Int, use_snip
     return join(parts, ", ")
 end
 
-function cursor_equals_position(ca::CallArgs, b::Int)::Union{Nothing,Bool}
+function cursor_equals_position(ca::CallArgs, b::Int)
     for arg in ca.args
         br = JS.byte_range(arg)
         first(br) ≤ b ≤ last(br) + 1 || continue

--- a/src/config.jl
+++ b/src/config.jl
@@ -100,7 +100,7 @@ function merge_and_track(on_difference, old_val, new_val, path::Tuple{Vararg{Sym
     elseif new_val === missing
         changed = true
     else
-        changed = old_val != new_val
+        changed = (old_val != new_val)::Bool
     end
     changed && on_difference(old_val, new_val, path)
     return new_val === nothing ? old_val : new_val

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -55,7 +55,7 @@ function parse_diagnostic_pattern(x::AbstractDict{String})
     end
 
     for key in keys(x)
-        if key ∉ ("pattern", "match_by", "match_type", "severity", "path")
+        if key::String ∉ ("pattern", "match_by", "match_type", "severity", "path")
             throw(DiagnosticConfigError(
                 lazy"Unknown field \"$key\" in diagnostic pattern for pattern \"$pattern_value\". " *
                 "Valid fields are: pattern, match_by, match_type, severity, path"))

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -421,6 +421,8 @@ function inference_error_report_code(@nospecialize report::JET.InferenceErrorRep
         return INFERENCE_BOUNDS_ERROR_CODE
     elseif report isa MethodErrorReport
         return INFERENCE_METHOD_ERROR_CODE
+    elseif report isa NonBooleanCondErrorReport
+        return INFERENCE_NON_BOOLEAN_COND_CODE
     end
     error(lazy"Diagnostic code is not defined for this report: $report")
 end

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -33,14 +33,14 @@ end
 # =====
 
 """
-    flatten_args(call::JS.SyntaxTree) -> (args::JS.SyntaxList, first_kwarg_i::Int, has_semicolon::Bool) or nothing
+    flatten_args(call::SyntaxTree0) -> (args::JS.SyntaxList, first_kwarg_i::Int, has_semicolon::Bool) or nothing
 
 Return `(args::JS.SyntaxList, first_kwarg_i::Int, has_semicolon::Bool)`,
 one `SyntaxTree` per argument to call.
 Ignore function name and `K"error"` (e.g. missing closing paren).
 `has_semicolon` is true if the call contains a `K"parameters"` node (explicit semicolon).
 """
-function flatten_args(call::JS.SyntaxTree)
+function flatten_args(call::SyntaxTree0)
     while kind(call) === K"where"
         call = call[1]
     end
@@ -130,7 +130,7 @@ Keywords should be ignored if `cursor` is within the keyword's name.
 Note: the `=` form doesn't always correspond to a keyword arg after macro
 expansion, but signature help is only used on unexpanded code.
 """
-function find_kws(args::JS.SyntaxList, kw_i::Int; sig=false, cursor::Int=-1)
+function find_kws(args::SyntaxList0, kw_i::Int; sig=false, cursor::Int=-1)
     out = Dict{String, Int}()
     for i in (sig ? (kw_i:lastindex(args)) : eachindex(args))
         kind(args[i]) ∉ JS.KSet"= kw" && i < kw_i && continue
@@ -158,7 +158,7 @@ Information from a call site's arguments for filtering method signatures.
 - `kind`: Item in `CALL_KINDS`
 """
 struct CallArgs
-    args::JS.SyntaxList
+    args::SyntaxList0
     kw_i::Int
     pos_map::Dict{Int, Tuple{Int, Union{Int, Nothing}}}
     pos_args_lb::Int
@@ -166,7 +166,7 @@ struct CallArgs
     kw_map::Dict{String, Int}
     has_semicolon::Bool
     kind::JS.Kind
-    function CallArgs(st0::JS.SyntaxTree, cursor::Int=-1)
+    function CallArgs(st0::SyntaxTree0, cursor::Int=-1)
         @assert -1 ∉ JS.byte_range(st0)
         args, kw_i, has_semicolon = @something flatten_args(st0) begin
             println(stderr, JS.sourcetext(st0))

--- a/src/testrunner/testrunner.jl
+++ b/src/testrunner/testrunner.jl
@@ -278,7 +278,7 @@ function testrunner_testcase_code_actions!(
             return traversal_no_recurse
         elseif JS.kind(st0) === JS.K"macrocall" && JS.numchildren(st0) ≥ 1
             macroname = st0[1]
-            if hasproperty(macroname, :name_val) && macroname.name_val in TEST_MACROS
+            if hasproperty(macroname, :name_val) && macroname.name_val::String in TEST_MACROS
                 tcr = jsobj_to_range(st0, fi; adjust_last=1) # +1 to support cases like `@test ...│`
                 overlap(action_range, tcr) || return nothing
                 tcl = JS.source_line(st0)

--- a/src/types.jl
+++ b/src/types.jl
@@ -113,7 +113,7 @@ end
 @define_override_constructor NotebookInfo
 
 abstract type AbstractCancelFlag end
-function is_cancelled(::AbstractCancelFlag) end
+function is_cancelled end
 
 """
     CancelFlag
@@ -403,6 +403,7 @@ const INFERENCE_UNDEF_STATIC_PARAM_CODE = "inference/undef-static-param" # curre
 const INFERENCE_FIELD_ERROR_CODE = "inference/field-error"
 const INFERENCE_BOUNDS_ERROR_CODE = "inference/bounds-error"
 const INFERENCE_METHOD_ERROR_CODE = "inference/method-error"
+const INFERENCE_NON_BOOLEAN_COND_CODE = "inference/non-boolean-cond"
 const TESTRUNNER_TEST_FAILURE_CODE = "testrunner/test-failure"
 
 const ALL_DIAGNOSTIC_CODES = Set{String}(String[
@@ -427,6 +428,7 @@ const ALL_DIAGNOSTIC_CODES = Set{String}(String[
     INFERENCE_FIELD_ERROR_CODE,
     INFERENCE_BOUNDS_ERROR_CODE,
     INFERENCE_METHOD_ERROR_CODE,
+    INFERENCE_NON_BOOLEAN_COND_CODE,
     TESTRUNNER_TEST_FAILURE_CODE,
 ])
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,4 +1,6 @@
-const SyntaxTree0 = typeof(JS.build_tree(JS.SyntaxTree, JS.parse!(JS.ParseStream(""))))
+const Attrs0 = Dict{Symbol, Dict{Int64, Any}}
+const SyntaxTree0 = JS.SyntaxTree{Attrs0}
+const SyntaxList0 = JS.SyntaxList{Attrs0,Vector{Int}}
 
 abstract type ExtraDiagnosticsKey end
 to_uri(key::ExtraDiagnosticsKey) = to_uri_impl(key)::URI

--- a/src/utils/general.jl
+++ b/src/utils/general.jl
@@ -223,7 +223,7 @@ macro define_eq_overloads(Tyname)
     hash_func = :(function Base.hash(x::$Tyname, h::UInt); $hash_body; end)
     eq_body = foldr(fld2typs; init = true) do fld2typ, x
         fld, typ = fld2typ
-        if typ in _EGAL_TYPES_
+        if (typ in _EGAL_TYPES_)::Bool
             eq_ex = :(x1.$fld === x2.$fld)
         else
             eq_ex = :((x1.$fld == x2.$fld)::Bool)

--- a/test/analysis/test_Analyzer.jl
+++ b/test/analysis/test_Analyzer.jl
@@ -318,4 +318,67 @@ end
     end
 end
 
+@testset "NonBooleanCondErrorReport" begin
+    # no report for boolean condition
+    let result = analyze_call((Bool,)) do x
+            x ? 1 : 2
+        end
+        @test isempty(get_reports(result))
+    end
+    let result = analyze_call((Bool,)) do x
+            if x; 1; else; 2; end
+        end
+        @test isempty(get_reports(result))
+    end
+    let result = analyze_call((Bool,)) do x
+            x && return 1
+        end
+        @test isempty(get_reports(result))
+    end
+
+    # basic non-boolean condition
+    let result = analyze_call((Int,)) do x
+            x ? 1 : 2
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa NonBooleanCondErrorReport && r.union_split == 0
+    end
+    let result = analyze_call((Int,)) do x
+            if x; 1; else; 2; end
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa NonBooleanCondErrorReport && r.union_split == 0
+    end
+    let result = analyze_call((Int,)) do x
+            x && return 1
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa NonBooleanCondErrorReport && r.union_split == 0
+    end
+
+    # union split case: only one branch is non-boolean
+    let result = analyze_call((Union{Bool,Int},)) do x
+            x ?  1 : 2
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa NonBooleanCondErrorReport && r.union_split == 2 && length(r.t) == 1
+    end
+
+    # JuliaLang/julia#61526
+    let result = analyze_call((Vector{String},String,)) do xs, x
+            x in tuple(xs) ? 0 : 1
+        end
+        reports = get_reports(result)
+        @test isempty(reports)
+    end
+end
+
 end # module test_LSAnalyzer


### PR DESCRIPTION
Add `inference/non-boolean-cond` diagnostic that reports when
a non-boolean type is used in a condition (`if`/`while`/ternary),
which would raise a `TypeError` at runtime.

Hooks into `CC.abstract_eval_value` to check `GotoIfNot` statements,
supporting both simple types and union-split cases, following the
analysis pattern established in JET.
