### PR TITLE
Use MarkupContent in diagnostic message if supported by client

### DIFF
--- a/LSP/src/basic-json-structures.jl
+++ b/LSP/src/basic-json-structures.jl
@@ -442,6 +442,93 @@ Represents a link between a source and a target location.
     targetSelectionRange::Range
 end
 
+# MarkupContent
+# =============
+
+"""
+Describes the content type that a client supports in various
+result literals like `Hover`, `ParameterInfo` or `CompletionItem`.
+Please note that `MarkupKinds` must not start with a `\$`. This kinds
+are reserved for internal usage.
+"""
+@namespace MarkupKind::String begin
+    "Plain text is supported as a content format"
+    PlainText = "plaintext"
+    "Markdown is supported as a content format"
+    Markdown = "markdown"
+end
+
+"""
+A `MarkupContent` literal represents a string value which content is
+interpreted base on its kind flag. Currently the protocol supports
+`plaintext` and `markdown` as markup kinds.
+
+If the kind is `markdown` then the value can contain fenced code blocks like
+in GitHub issues.
+
+Here is an example how such a string can be constructed using
+JavaScript / TypeScript:
+```typescript
+let markdown: MarkdownContent = {
+    kind: MarkupKind.Markdown,
+    value: [
+        '# Header',
+        'Some text',
+        '```typescript',
+        'someCode();',
+        '```',
+    ].join('\n')
+};
+```
+
+*Please Note* that clients might sanitize the return markdown. A client could
+decide to remove HTML from the markdown to avoid script execution.
+"""
+@interface MarkupContent begin
+    "The type of the Markup"
+    kind::MarkupKind.Ty
+
+    "The content itself"
+    value::String
+end
+
+"""
+Client capabilities specific to the used markdown parser.
+
+In addition clients should signal the markdown parser they are using via the client
+capability general.markdown introduced in version 3.16.0 defined as follows.
+
+Known markdown parsers used by clients right now are:
+
+| Parser | Version | Documentation |
+| --- | --- | --- |
+| marked | 1.1.0 | [Marked Documentation](https://marked.js.org/) |
+| Python-Markdown | 3.2.2 | [Python-Markdown Documentation](https://python-markdown.github.io/) |
+
+# Tags
+- since – 3.16.0
+"""
+@interface MarkdownClientCapabilities begin
+    """
+    The name of the parser.
+    """
+    parser::String
+
+    """
+    The version of the parser.
+    """
+    version::Union{String, Nothing} = nothing
+
+    """
+    A list of HTML tags that the client allows / supports in
+    Markdown.
+
+    # Tags
+    - since – 3.17.0
+    """
+    allowedTags::Union{Vector{String}, Nothing} = nothing
+end
+
 # Diagnostic
 # ==========
 
@@ -570,8 +657,14 @@ Diagnostic objects are only valid in the scope of a resource.
     """
     source::Union{String, Nothing} = nothing
 
-    "The diagnostic's message."
-    message::String
+    """
+    The diagnostic's message.
+
+    # Tags
+    - since – 3.18.0 - support for MarkupContent. This is guarded by the client capability
+    `textDocument.diagnostic.markupMessageSupport`.
+    """
+    message::Union{String, MarkupContent}
 
     """
     Additional metadata about the diagnostic.
@@ -615,93 +708,6 @@ command. The protocol currently doesn’t specify a set of well-known commands.
     command::String
     "Arguments that the command handler should be invoked with"
     arguments::Union{Vector{Any}, Nothing} = nothing
-end
-
-# MarkupContent
-# =============
-
-"""
-Describes the content type that a client supports in various
-result literals like `Hover`, `ParameterInfo` or `CompletionItem`.
-Please note that `MarkupKinds` must not start with a `\$`. This kinds
-are reserved for internal usage.
-"""
-@namespace MarkupKind::String begin
-    "Plain text is supported as a content format"
-    PlainText = "plaintext"
-    "Markdown is supported as a content format"
-    Markdown = "markdown"
-end
-
-"""
-A `MarkupContent` literal represents a string value which content is
-interpreted base on its kind flag. Currently the protocol supports
-`plaintext` and `markdown` as markup kinds.
-
-If the kind is `markdown` then the value can contain fenced code blocks like
-in GitHub issues.
-
-Here is an example how such a string can be constructed using
-JavaScript / TypeScript:
-```typescript
-let markdown: MarkdownContent = {
-    kind: MarkupKind.Markdown,
-    value: [
-        '# Header',
-        'Some text',
-        '```typescript',
-        'someCode();',
-        '```',
-    ].join('\n')
-};
-```
-
-*Please Note* that clients might sanitize the return markdown. A client could
-decide to remove HTML from the markdown to avoid script execution.
-"""
-@interface MarkupContent begin
-    "The type of the Markup"
-    kind::MarkupKind.Ty
-
-    "The content itself"
-    value::String
-end
-
-"""
-Client capabilities specific to the used markdown parser.
-
-In addition clients should signal the markdown parser they are using via the client
-capability general.markdown introduced in version 3.16.0 defined as follows.
-
-Known markdown parsers used by clients right now are:
-
-| Parser | Version | Documentation |
-| --- | --- | --- |
-| marked | 1.1.0 | [Marked Documentation](https://marked.js.org/) |
-| Python-Markdown | 3.2.2 | [Python-Markdown Documentation](https://python-markdown.github.io/) |
-
-# Tags
-- since – 3.16.0
-"""
-@interface MarkdownClientCapabilities begin
-    """
-    The name of the parser.
-    """
-    parser::String
-
-    """
-    The version of the parser.
-    """
-    version::Union{String, Nothing} = nothing
-
-    """
-    A list of HTML tags that the client allows / supports in
-    Markdown.
-
-    # Tags
-    - since – 3.17.0
-    """
-    allowedTags::Union{Vector{String}, Nothing} = nothing
 end
 
 # File Resource changes

--- a/LSP/src/language-features/diagnostic.jl
+++ b/LSP/src/language-features/diagnostic.jl
@@ -1,3 +1,10 @@
+@interface ClientDiagnosticsTagOptions begin
+    """
+    The tags supported by the client.
+    """
+    valueSet::Vector{DiagnosticTag.Ty}
+end
+
 # Publish diagnostics
 # ===================
 
@@ -39,12 +46,7 @@ See also the [Diagnostic](@ref diagnostic) section.
     # Tags
     - since - 3.15.0
     """
-    tagSupport::Union{Nothing, @interface begin
-        """
-        The tags supported by the client.
-        """
-        valueSet::Vector{DiagnosticTag.Ty}
-    end} = nothing
+    tagSupport::Union{Nothing, ClientDiagnosticsTagOptions} = nothing
 
     """
     Whether the client interprets the version property of the
@@ -142,6 +144,37 @@ Client capabilities specific to diagnostic pull requests.
     pulls.
     """
     relatedDocumentSupport::Union{Nothing, Bool} = nothing
+
+    """
+    Whether the clients accepts diagnostics with related information.
+    """
+    relatedInformation::Union{Nothing, Bool} = nothing
+
+    """
+    Client supports the tag property to provide meta data about a diagnostic.
+    Clients supporting tags have to handle unknown tags gracefully.
+    """
+    tagSupport::Union{Nothing, ClientDiagnosticsTagOptions} = nothing
+
+    """
+    Client supports a codeDescription property
+    """
+    codeDescriptionSupport::Union{Nothing, Bool} = nothing
+
+    """
+    Whether the client supports `MarkupContent` in diagnostic messages.
+
+    # Tags
+    - since - 3.18.0
+    """
+    markupMessageSupport::Union{Nothing, Bool} = nothing
+
+    """
+    Whether code action supports the `data` property which is
+    preserved between a `textDocument/publishDiagnostics` and
+    `textDocument/codeAction` request.
+    """
+    dataSupport::Union{Nothing, Bool} = nothing
 end
 
 """

--- a/src/app/cli-check.jl
+++ b/src/app/cli-check.jl
@@ -551,7 +551,7 @@ function print_diagnostics(
             textbuf = Vector{UInt8}(text)
             start_byte = _xy_to_offset(textbuf, diagnostic.range.start, PositionEncodingKind.UTF16)
             end_byte = _xy_to_offset(textbuf, diagnostic.range.var"end", PositionEncodingKind.UTF16)
-            note = diagnostic.message
+            note = get_raw_message(diagnostic)
             if diagnostic.code !== nothing
                 note *= " [$severity_str:$(diagnostic.code)]"
             else

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -256,6 +256,17 @@ function diagnostic_code_description(code::AbstractString)
         href = URI("https://aviatesk.github.io/JETLS.jl/release/diagnostic/#diagnostic/reference/$code"))
 end
 
+function apply_markdown_message!(diagnostics::Vector{Diagnostic})
+    i = 1
+    while i <= length(diagnostics)
+        diagnostic = diagnostics[i]
+        if diagnostic.message isa String && occursin('`', diagnostic.message)
+            diagnostics[i] = Diagnostic(diagnostic; message = MarkupContent(; kind = MarkupKind.Markdown, value = diagnostic.message))
+        end
+        i += 1
+    end
+end
+
 # utilities
 # =========
 
@@ -1626,6 +1637,9 @@ function notify_diagnostics!(server::Server, uri2diagnostics::URI2Diagnostics; e
             continue
         end
         apply_diagnostic_config!(diagnostics, state.config_manager, uri, root_path)
+        if supports(server, :textDocument, :diagnostic, :markupMessageSupport)
+            apply_markdown_message!(diagnostics)
+        end
         send(server, PublishDiagnosticsNotification(;
             params = PublishDiagnosticsParams(;
                 uri,
@@ -1746,6 +1760,9 @@ function handle_DocumentDiagnosticRequest(
     if notebook_uri !== nothing
         diagnostics = localize_notebook_diagnostics(server.state, notebook_uri, uri, diagnostics)
     end
+    if supports(server, :textDocument, :diagnostic, :markupMessageSupport)
+        apply_markdown_message!(diagnostics)
+    end
     return send(server,
         DocumentDiagnosticResponse(;
             id = msg.id,
@@ -1826,6 +1843,10 @@ function send_workspace_diagnostics(
         notebook_uri = get_notebook_uri_for_cell(state, uri)
         if notebook_uri !== nothing
             diagnostics = localize_notebook_diagnostics(state, notebook_uri, uri, diagnostics)
+        end
+
+        if supports(server, :textDocument, :diagnostic, :markupMessageSupport)
+            apply_markdown_message!(diagnostics)
         end
 
         item = WorkspaceFullDocumentDiagnosticReport(;

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -258,7 +258,7 @@ end
 function apply_markdown_message!(diagnostics::Vector{Diagnostic})
     for i = 1:length(diagnostics)
         diagnostic = diagnostics[i]
-        if diagnostic.message isa String && occursin('`', diagnostic.message)
+        if diagnostic.message isa String
             diagnostics[i] = Diagnostic(diagnostic; message = MarkupContent(; kind = MarkupKind.Markdown, value = diagnostic.message))
         end
     end

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -202,7 +202,6 @@ function _apply_diagnostic_config(
     else
         path_for_glob = filepath
     end
-    message = diagnostic.message
     severity = nothing
     best_specificity = 0
     for pattern_config in patterns
@@ -210,7 +209,7 @@ function _apply_diagnostic_config(
         if globpath !== nothing && !occursin(globpath, path_for_glob)
             continue
         end
-        target = pattern_config.match_by == "message" ? message : code
+        target = pattern_config.match_by == "message" ? get_raw_message(diagnostic) : code
         is_message_match = pattern_config.match_by == "message"
         specificity = calculate_match_specificity(
             pattern_config.pattern, target, is_message_match)
@@ -308,6 +307,8 @@ function lines_range((start_line, end_line)::Pair{Int,Int})
     var"end" = Position(; line=end_line, character=Int(typemax(Int32)))
     return Range(; start, var"end")
 end
+
+get_raw_message(diagnostic::Diagnostic) = diagnostic.message isa String ? diagnostic.message : diagnostic.message.value
 
 # syntax diagnostics
 # ==================

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -257,13 +257,11 @@ function diagnostic_code_description(code::AbstractString)
 end
 
 function apply_markdown_message!(diagnostics::Vector{Diagnostic})
-    i = 1
-    while i <= length(diagnostics)
+    for i = 1:length(diagnostics)
         diagnostic = diagnostics[i]
         if diagnostic.message isa String && occursin('`', diagnostic.message)
             diagnostics[i] = Diagnostic(diagnostic; message = MarkupContent(; kind = MarkupKind.Markdown, value = diagnostic.message))
         end
-        i += 1
     end
 end
 


### PR DESCRIPTION
I noticed that most diagnostic messages from JETLS use inline code in standard Markdown format (delimited by backticks).

The upcoming 3.18 version of the LSP specs allows to send [diagnostic](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#diagnostic) messages with MarkupContent if the client has support for that:
```ts
	/**
	 * The diagnostic's message.
	 *
	 * @since 3.18.0 - support for MarkupContent. This is guarded by the client
	 * capability `textDocument.diagnostic.markupMessageSupport`.
	 */
	message: string | MarkupContent;
```

This PR proposes to use MarkupContent in diagnostic messages if applicable for the message and if supported by the client. This allows the client to render the message in a nicer way.

The following screenshots are from Sublime Text and with a currently unreleased version of the LSP client, which has recently added support for that (it will be available with the next release of the LSP package for Sublime Text).

Before:

<img width="768" height="96" alt="before" src="https://github.com/user-attachments/assets/772a5314-e1b0-4d33-b877-4a831ac58625" />

---

After:

<img width="768" height="96" alt="after" src="https://github.com/user-attachments/assets/8c2f0056-5535-4143-aaca-b3d7ef1ebc06" />

---

I want to mention that technically the client capability for `markupMessageSupport` is only part of the [DiagnosticClientCapabilities](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#diagnosticClientCapabilities) (`textDocument.diagnostic.markupMessageSupport`), and not part of the [PublishDiagnosticsClientCapabilities](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#publishDiagnosticsClientCapabilities) (`textDocument.publishDiagnostics`). However, I believe this is just a small inconsistency in the LSP specs, and it wouldn't really make sense for the client to limit this to only pull diagnostics, so I also applied the MarkupContent to diagnostics from `publishDiagnostics` notifications. The docstring for the `Diagnostic` type that I quoted above also refers only to that single capability path, so I assume that it should be fine.