### PR TITLE
code-lens: Switch to `editor.action.showReferences`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > This disables analysis for matched files. Basic features like completion still might work, but most LSP features will be unfunctional.
 > Note that `analysis_overrides` is provided as a temporary workaround and may be removed or changed at any time. A proper fix is being worked on.
 
+### Breaking
+
+- Clients that previously implemented a handler for the JETLS-defined `jetls.showReferences` command should switch to handling `editor.action.showReferences` instead. The new arguments are `[uriString, position, locations]`, where `locations` is the pre-resolved LSP `Location[]`; clients no longer need to issue a `textDocument/references` request themselves and can simply display the provided locations. See the [Neovim setup section](https://aviatesk.github.io/JETLS.jl/release/#Neovim) in the documentation for an example handler.
+
+### Changed
+
+- The reference-count code lens now emits `editor.action.showReferences` (a VSCode convention command) directly, instead of the JETLS-defined custom command `jetls.showReferences`. LSP does not standardize a way for a server to hand pre-resolved reference locations to the client, so this choice trades strict LSP spec purity for broader out-of-the-box editor support. VSCode continues to work via the `jetls-client` extension, and editors that follow the VSCode convention (e.g. Zed) now dispatch the lens out of the box. Editors that do not follow the VSCode convention (e.g. Neovim) need to register a client-side handler for `editor.action.showReferences`.
+
+- When a reference-count code lens is rendered for a file whose full analysis has not yet been run, clicking now triggers a warning notification (via `window/showMessage`) explaining why the count is unavailable, instead of opening an empty references peek.
+
 ## 2026-04-14
 
 - Commit: [`d1ebbb2`](https://github.com/aviatesk/JETLS.jl/commit/d1ebbb2)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -147,6 +147,42 @@ vim.lsp.config("jetls", {
 vim.lsp.enable("jetls")
 ```
 
+If you enable the [`code_lens.references`](@ref config/code_lens-references)
+configuration option, also register a handler for the
+`editor.action.showReferences` command, which JETLS emits on the reference-count
+code lens following the VSCode convention.[^show_references_handler]
+
+[^show_references_handler]:
+    Without this handler, Neovim reports
+    "does not support command `editor.action.showReferences`"
+    when the code lens is clicked. Register a per-client handler
+    via the `commands` field of `vim.lsp.config` so the handler is
+    scoped to the JETLS client only (rather than polluting the
+    global `vim.lsp.commands` table). The snippet below sends the
+    resolved locations to the quickfix list:
+
+    ```lua
+    vim.lsp.config("jetls", {
+        -- ... other options ...
+        commands = {
+            ["editor.action.showReferences"] = function(command, ctx)
+                local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
+                local file_uri, position, references =
+                    unpack(command.arguments)
+                local items = vim.lsp.util.locations_to_items(
+                    references, client.offset_encoding)
+                vim.fn.setqflist({}, " ", {
+                    title = command.title, items = items })
+                vim.lsp.util.show_document({
+                    uri = file_uri,
+                    range = { start = position, ["end"] = position },
+                }, client.offset_encoding)
+                vim.cmd("botright copen")
+            end,
+        },
+    })
+    ```
+
 ### Sublime
 
 Minimal [Sublime](https://www.sublimetext.com/) setup using the

--- a/jetls-client/CHANGELOG.md
+++ b/jetls-client/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
 - Diff: [`169faf25...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/169faf25...HEAD)
 
+### Removed
+
+- Removed the `jetls.showReferences` command. JETLS now emits the built-in
+  `editor.action.showReferences` directly for the reference-count code
+  lens; the new `resolveCodeLens` middleware handles the argument
+  conversion.
+
 ## v0.3.5
 
 - Commit: [`169faf25`](https://github.com/aviatesk/JETLS.jl/commit/169faf25)

--- a/jetls-client/jetls-client.ts
+++ b/jetls-client/jetls-client.ts
@@ -473,6 +473,49 @@ async function startLanguageServer() {
         vscode.workspace.createFileSystemWatcher("**/.JETLSProfile"),
       ],
     },
+    middleware: {
+      // `editor.action.showReferences` is a built-in VSCode command that
+      // requires actual `vscode.Uri`/`vscode.Position`/`vscode.Location`
+      // instances, but server-sent command arguments arrive as plain JSON.
+      // Convert them here before VSCode dispatches the command.
+      resolveCodeLens: async (codeLens, token, next) => {
+        const resolved = await next(codeLens, token);
+        if (
+          resolved?.command?.command === "editor.action.showReferences" &&
+          Array.isArray(resolved.command.arguments) &&
+          resolved.command.arguments.length === 3
+        ) {
+          const [uriString, pos, locs] = resolved.command.arguments as [
+            string,
+            { line: number; character: number },
+            {
+              uri: string;
+              range: {
+                start: { line: number; character: number };
+                end: { line: number; character: number };
+              };
+            }[],
+          ];
+          resolved.command.arguments = [
+            vscode.Uri.parse(uriString),
+            new vscode.Position(pos.line, pos.character),
+            locs.map(
+              (loc) =>
+                new vscode.Location(
+                  vscode.Uri.parse(loc.uri),
+                  new vscode.Range(
+                    loc.range.start.line,
+                    loc.range.start.character,
+                    loc.range.end.line,
+                    loc.range.end.character,
+                  ),
+                ),
+            ),
+          ];
+        }
+        return resolved;
+      },
+    },
     initializationOptions,
     outputChannel,
   };
@@ -654,53 +697,6 @@ export function activate(context: ExtensionContext) {
       "jetls-client.restartLanguageServer",
       () => {
         restartLanguageServer();
-      },
-    ),
-  );
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      "jetls.showReferences",
-      async (uriString: string, line: number, character: number) => {
-        if (!languageClient) {
-          return;
-        }
-        const uri = vscode.Uri.parse(uriString);
-        const position = new vscode.Position(line, character);
-        interface LspLocation {
-          uri: string;
-          range: {
-            start: { line: number; character: number };
-            end: { line: number; character: number };
-          };
-        }
-        const locations = await languageClient.sendRequest<LspLocation[]>(
-          "textDocument/references",
-          {
-            textDocument: { uri: uriString },
-            position: { line, character },
-            context: { includeDeclaration: false },
-          },
-        );
-        if (locations && locations.length > 0) {
-          const vsLocations = locations.map(
-            (loc) =>
-              new vscode.Location(
-                vscode.Uri.parse(loc.uri),
-                new vscode.Range(
-                  loc.range.start.line,
-                  loc.range.start.character,
-                  loc.range.end.line,
-                  loc.range.end.character,
-                ),
-              ),
-          );
-          vscode.commands.executeCommand(
-            "editor.action.showReferences",
-            uri,
-            position,
-            vsLocations,
-          );
-        }
       },
     ),
   );

--- a/jetls-client/package.json
+++ b/jetls-client/package.json
@@ -43,10 +43,6 @@
       {
         "command": "jetls-client.restartLanguageServer",
         "title": "JETLS Client: Restart JETLS Language Server"
-      },
-      {
-        "command": "jetls.showReferences",
-        "title": "JETLS: Show References"
       }
     ],
     "configuration": {

--- a/src/code-lens.jl
+++ b/src/code-lens.jl
@@ -1,6 +1,6 @@
 const CODE_LENS_REGISTRATION_ID = "jetls-code-lens"
 const CODE_LENS_REGISTRATION_METHOD = "textDocument/codeLens"
-const COMMAND_SHOW_REFERENCES = "jetls.showReferences"
+const COMMAND_SHOW_REFERENCES = "editor.action.showReferences"
 
 function code_lens_options()
     return CodeLensOptions(;
@@ -90,14 +90,15 @@ function handle_CodeLensResolveRequest(
         return send(server, CodeLensResolveResponse(; id = msg.id, result = code_lens))
 
     pos = Position(; line = data.line, character = data.character)
-    arguments = Any[string(data.uri), pos.line, pos.character]
 
     if !has_analyzed_context(server.state, data.uri)
         command = Command(;
             title = "? references",
-            command = COMMAND_SHOW_REFERENCES,
-            arguments)
-        resolved = CodeLens(; range = code_lens.range, command, data = code_lens.data)
+            command = COMMAND_SHOW_MESSAGE,
+            arguments = Any[
+                "Reference count is unavailable: full analysis has not been run for this file yet.",
+                MessageType.Warning])
+        resolved = CodeLens(; range = code_lens.range, command)
         return send(server, CodeLensResolveResponse(; id = msg.id, result = resolved))
     end
 
@@ -110,10 +111,11 @@ function handle_CodeLensResolveRequest(
     locations = find_references(server, data.uri, fi, pos;
         include_declaration = false, cancel_flag)
     count = locations isa Vector ? length(locations) : 0
-
-    title = count == 1 ? "1 reference" : "$count references"
-    command = Command(; title, command = COMMAND_SHOW_REFERENCES, arguments)
-    resolved = CodeLens(; range = code_lens.range, command, data = code_lens.data)
+    command = Command(;
+        title = count == 1 ? "1 reference" : "$count references",
+        command = COMMAND_SHOW_REFERENCES,
+        arguments = Any[string(data.uri), pos, locations isa Vector ? locations : Location[]])
+    resolved = CodeLens(; range = code_lens.range, command)
     return send(server,
         CodeLensResolveResponse(; id = msg.id, result = resolved))
 end


### PR DESCRIPTION
Previously the reference-count code lens emitted `jetls.showReferences`, a custom command defined by the JETLS server and implemented on the client side (e.g. in `jetls-client`). LSP permits server-defined custom commands, but every client that wants to support the lens then has to ship its own implementation -- which is why Zed (and any editor without such wiring) could not dispatch the code lens.

Strictly speaking, `editor.action.showReferences` is not part of the LSP spec either; it is a VSCode convention. In exchange for giving up LSP spec purity, emitting it directly lets VSCode and Zed (which also follows the convention) dispatch the lens out of the box, without each client shipping a JETLS-specific wrapper. VSCode additionally needs a conversion shim because `editor.action.showReferences` expects actual `vscode.Uri`/`vscode.Position`/`vscode.Location` instances while LSP delivers `Command.arguments` as plain JSON; this is handled inside `jetls-client` via a `resolveCodeLens` middleware.

For the "not yet analyzed" case, the code lens now emits the new `jetls.showMessage` command instead of a degraded
`editor.action.showReferences` call with an empty location list. Clicking shows a warning describing why the reference count is unavailable.