### PR TITLE
references: Exclude function definitions when `includeDeclaration=false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Diagnostic messages are now sent as `MarkupContent` when the client advertises the [`textDocument.diagnostic.markupMessageSupport`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#diagnosticClientCapabilities) capability (added in LSP 3.18). In supporting clients (e.g. recent Sublime LSP), Markdown formatting such as inline code delimited by backticks now renders properly instead of showing the literal characters. (https://github.com/aviatesk/JETLS.jl/pull/633)
 
+### Fixed
+
+- Fixed `textDocument/references` so that `includeDeclaration=false` now correctly excludes method definitions and declarations of the target binding. As a side benefit, the [reference-count code lens](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/code_lens-references) (which queries references with `includeDeclaration=false`) now reports accurate counts, where the declaration site was previously being counted as an extra reference.
+
 ## 2026-04-14
 
 - Commit: [`d1ebbb2`](https://github.com/aviatesk/JETLS.jl/commit/d1ebbb2)

--- a/src/analysis/occurrence-analysis.jl
+++ b/src/analysis/occurrence-analysis.jl
@@ -177,9 +177,18 @@ function compute_binding_occurrences(
     return occurrences
 end
 
+"""
+`skip_recording` maps a binding to a byte range. A BindingId is skipped only if
+both its binding and its byte range match an entry. This distinguishes synthetic
+BindingIds that lowering inserts at the definition-site range (e.g., inside
+`method`, `function_type`, or `removable` nodes) from genuine uses such as
+self-recursive calls, which have distinct byte ranges.
+"""
+const SkipRecording = Dict{JL.BindingInfo,UnitRange{Int}}
+
 function record_occurrence!(occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence{Tree3}}},
         kind::Symbol, st::Tree3, ctx3::JL.VariableAnalysisContext;
-        skip_recording::Union{Nothing,Set{JL.BindingInfo}} = nothing
+        skip_recording::Union{Nothing,SkipRecording} = nothing
     ) where Tree3<:JS.SyntaxTree
     if JS.kind(st) === JS.K"BindingId"
         binfo = JL.get_binding(ctx3, st)
@@ -190,11 +199,16 @@ end
 
 function record_occurrence!(occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence{Tree3}}},
         kind::Symbol, st::Tree3, binfo::JL.BindingInfo;
-        skip_recording::Union{Nothing,Set{JL.BindingInfo}} = nothing
+        skip_recording::Union{Nothing,SkipRecording} = nothing
     ) where Tree3<:JS.SyntaxTree
-    if haskey(occurrences, binfo) && (binfo ∉ @something skip_recording ())
-        push!(occurrences[binfo], BindingOccurrence(st, kind))
+    haskey(occurrences, binfo) || return occurrences
+    if !isnothing(skip_recording)
+        skip_range = get(skip_recording, binfo, nothing)
+        if skip_range !== nothing && JS.byte_range(st) == skip_range
+            return occurrences
+        end
     end
+    push!(occurrences[binfo], BindingOccurrence(st, kind))
     return occurrences
 end
 
@@ -205,10 +219,9 @@ function compute_binding_occurrences!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence{Tree3}}},
         ctx3::JL.VariableAnalysisContext, st3::Tree3;
         ismacro::Union{Nothing,Base.RefValue{Bool}} = nothing,
-        skip_recording_uses::Union{Nothing,Set{JL.BindingInfo}} = nothing
+        skip_recording_uses::Union{Nothing,SkipRecording} = nothing
     ) where Tree3<:JS.SyntaxTree
     stack = JS.SyntaxList(st3)
-    infunc = false
     while !isempty(stack)
         st = pop!(stack)
         k = JS.kind(st)
@@ -226,7 +239,6 @@ function compute_binding_occurrences!(
 
         start_idx = 1
         if k === JS.K"function_decl"
-            infunc = true
             if nc ≥ 1
                 func = st[1]
                 if JS.kind(func) === JS.K"BindingId"
@@ -247,20 +259,42 @@ function compute_binding_occurrences!(
                     start_idx = 2
                 end
             end
-        elseif infunc && k === JS.K"block" && nc ≥ 1
-            blk1 = st[1]
-            if JS.kind(blk1) === JS.K"function_decl" && JS.numchildren(blk1) ≥ 1
-                # This is an inner function definition -- the binding of this inner function
-                # is "used" in the language constructs required to define the method,
-                # but what we're interested in is whether it's actually used in the outer scope.
-                # We add this inner function to `skip_recording_uses` and recurse.
-                innerfunc = blk1[1]
-                if JS.kind(innerfunc) === JS.K"BindingId"
-                    innerfuncinfo = JL.get_binding(ctx3, innerfunc)
-                    compute_binding_occurrences!(occurrences, ctx3, st; ismacro,
-                        skip_recording_uses = Set((innerfuncinfo,)))
-                    continue
+        elseif k === JS.K"block" && nc ≥ 1 && JS.kind(st[1]) === JS.K"function_decl"
+            # This block wraps a function definition. Each function's own binding
+            # appears as BindingId in internal lowering nodes (`method`,
+            # `function_type`, `removable`, or as the trailing "return value" of
+            # the definition) that are not user-visible uses. We collect the
+            # bindings of all leading `function_decl` children (a single block
+            # may declare multiple functions, e.g., a keyword function generates
+            # both the user-visible function and a `#kw_body#…` helper) and map
+            # each to its definition-site byte range in `skip_recording_uses`
+            # before recursing. BindingIds whose range matches are skipped, while
+            # genuine uses at different ranges (e.g., self-recursive calls) are
+            # still recorded. Bindings already present in `skip_recording_uses`
+            # are used as a termination condition to avoid infinite recursion.
+            newly_added = Pair{JL.BindingInfo,UnitRange{Int}}[]
+            for i = 1:nc
+                child = st[i]
+                JS.kind(child) === JS.K"function_decl" || continue
+                JS.numchildren(child) ≥ 1 || continue
+                funcnode = child[1]
+                JS.kind(funcnode) === JS.K"BindingId" || continue
+                funcinfo = JL.get_binding(ctx3, funcnode)
+                if isnothing(skip_recording_uses) || !haskey(skip_recording_uses, funcinfo)
+                    push!(newly_added, funcinfo => JS.byte_range(funcnode))
                 end
+            end
+            if !isempty(newly_added)
+                if isnothing(skip_recording_uses)
+                    compute_binding_occurrences!(occurrences, ctx3, st;
+                        ismacro, skip_recording_uses = SkipRecording(newly_added))
+                else
+                    for br in newly_added; push!(skip_recording_uses, br); end
+                    compute_binding_occurrences!(occurrences, ctx3, st;
+                        ismacro, skip_recording_uses)
+                    for (b, _) in newly_added; delete!(skip_recording_uses, b); end
+                end
+                continue
             end
         elseif k === JS.K"lambda"
             # All blocks except the last one define arguments and static parameters,

--- a/src/references.jl
+++ b/src/references.jl
@@ -183,8 +183,7 @@ function global_find_references_in_file!(
         include_declaration::Bool = true,
     )
     for occurrence in find_global_binding_occurrences!(state, uri, fi, st0_top, binfo)
-        is_def = occurrence.kind === :def
-        if !is_def || include_declaration
+        if include_declaration || occurrence.kind === :use
             range, adjusted_uri = unadjust_range(state, uri, jsobj_to_range(occurrence.tree, fi))
             push!(seen_locations, (adjusted_uri, range))
         end

--- a/test/test_document_highlight.jl
+++ b/test/test_document_highlight.jl
@@ -238,6 +238,41 @@ end
             end
         end
 
+        # self-recursion: recursive calls are genuine uses and should be
+        # highlighted alongside the definition
+        let code = """
+            function │fib│(n)
+                if n < 2
+                    return n
+                end
+                return │fib│(n-1) + │fib│(n-2)
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 6
+            fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
+            @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
+            for pos in positions
+                highlights = JETLS.document_highlights(fi, pos)
+                @test length(highlights) == 3
+                @test count(highlights) do highlight
+                    highlight.range.start == positions[1] &&
+                    highlight.range.var"end" == positions[2] &&
+                    highlight.kind == DocumentHighlightKind.Write
+                end == 1
+                @test count(highlights) do highlight
+                    highlight.range.start == positions[3] &&
+                    highlight.range.var"end" == positions[4] &&
+                    highlight.kind == DocumentHighlightKind.Read
+                end == 1
+                @test count(highlights) do highlight
+                    highlight.range.start == positions[5] &&
+                    highlight.range.var"end" == positions[6] &&
+                    highlight.kind == DocumentHighlightKind.Read
+                end == 1
+            end
+        end
+
         let code = """
             global │globalvar│::Int = 42
 

--- a/test/test_references.jl
+++ b/test/test_references.jl
@@ -67,8 +67,31 @@ end
             clean_code, positions = JETLS.get_text_and_positions(code)
             @test length(positions) == 8
             for pos in positions
-                refs = find_references(clean_code, pos; include_declaration=false)
+                refs = find_references(clean_code, pos; include_declaration=true)
                 @test length(refs) == 4
+            end
+            for pos in positions
+                refs = find_references(clean_code, pos; include_declaration=false)
+                @test length(refs) == 2
+            end
+        end
+
+        let code = """
+            function │kwfunc│(x; kw=nothing)
+                (x, kw)
+            end
+
+            result = │kwfunc│(1)
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 4
+            for pos in positions
+                refs = find_references(clean_code, pos; include_declaration=true)
+                @test length(refs) == 2
+            end
+            for pos in positions
+                refs = find_references(clean_code, pos; include_declaration=false)
+                @test length(refs) == 1
             end
         end
     end
@@ -153,8 +176,6 @@ end
         end
 
         # includeDeclaration=false from macrocall
-        # Note: macro definition also has :use occurrences (from JuliaLowering),
-        # so includeDeclaration=false still includes the definition location
         let code = """
             macro mymacro(ex)
                 esc(ex)
@@ -165,7 +186,7 @@ end
             clean_code, positions = JETLS.get_text_and_positions(code)
             for pos in positions
                 refs = find_references(clean_code, pos; include_declaration=false)
-                @test length(refs) == 2
+                @test length(refs) == 1
             end
         end
     end


### PR DESCRIPTION
LSP's `includeDeclaration=false` should exclude the declaration of the symbol. For global function/macro bindings, method definitions are declarations and should not be returned.

Previously, `compute_binding_occurrences!` unconditionally recorded every `K"BindingId"` node as a `:use` occurrence, including the synthesized BindingIds that JuliaLowering inserts for the function's own name in `method`, `function_type`, `removable`, and trailing "return value" nodes. These spurious `:use` occurrences caused `find_references` to still return the definition site even when `includeDeclaration=false`.

This extends the existing inner-function handling that adds the function's binding to `skip_recording_uses` so that internal BindingIds referring to it are skipped during traversal. Key changes:

- Remove the `infunc` gate so the pattern applies uniformly to both top-level and inner function definitions. Recursion termination is now achieved by checking whether the binding is already present in `skip_recording_uses`, and the set is mutated in place (push before recurse, delete after) to avoid allocating a fresh `Set` per level.
- Collect the bindings of all leading `function_decl` children in the wrapping block. A single block may declare multiple functions (e.g., a keyword function generates both the user-visible function and a `#kw_body#…` helper), and both need to be skipped to suppress the internal BindingIds scattered across the multiple `method_defs` that JuliaLowering emits.
- Change `skip_recording_uses` from `Set{BindingInfo}` to `Dict{BindingInfo,UnitRange{Int}}` that maps each binding to its definition-site byte range. A BindingId is skipped only when both its binding and its byte range match an entry. This distinguishes the synthetic BindingIds emitted at the definition-site range from genuine uses at distinct ranges, so self-recursive calls such as `fib(n-1)` inside `function fib(n) ... end` are correctly recorded as `:use` occurrences. A regression test for this case is added to `test_document_highlight.jl`.

Also fix the filter in `global_find_references_in_file!` to check `occurrence.kind === :use` instead of `!is_def`, so `:decl` occurrences recorded by `function_decl` are also excluded when `includeDeclaration=false`.