### PR TITLE
occurrences: Track `export`/`public` as references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed `textDocument/references` so that `includeDeclaration=false` now correctly excludes method definitions and declarations of the target binding. As a side benefit, the [reference-count code lens](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/code_lens-references) (which queries references with `includeDeclaration=false`) now reports accurate counts, where the declaration site was previously being counted as an extra reference.
 
+- Names listed in `export` and `public` statements are now treated as references to the surrounding module's global bindings. `textDocument/documentHighlight`, `textDocument/references`, `textDocument/definition`, and `textDocument/rename` all now work when the cursor is placed on an exported/public name, and the export/public site is included in highlight and reference results (and rewritten by rename) for the corresponding binding.
+
 ## 2026-04-14
 
 - Commit: [`d1ebbb2`](https://github.com/aviatesk/JETLS.jl/commit/d1ebbb2)

--- a/src/analysis/occurrence-analysis.jl
+++ b/src/analysis/occurrence-analysis.jl
@@ -450,6 +450,17 @@ function compute_binding_occurrences_st0(
         # lowering requires `soft_scope`.
         is_notebook_uri(state, uri)
     (; mod) = get_context_info(state, uri, offset_to_xy(fi, JS.first_byte(st0)); lookup_func)
+
+    # Lowering `export`/`public` statements collapses their listed identifiers into opaque
+    # `K"Value"` nodes and records no `BindingInfo` for them, so the usual traversal finds nothing.
+    # Handle them directly: each child identifier is recorded as a `:use` of the
+    # corresponding global binding in the surrounding module.
+    if include_global_bindings && JS.kind(st0) in JS.KSet"export public"
+        binding_occurrences = Dict{JL.BindingInfo,Set{BindingOccurrence{typeof(st0)}}}()
+        collect_export_public_occurrences!(binding_occurrences, st0, mod)
+        return binding_occurrences
+    end
+
     (; ctx3, st3) = try
         # Remove macros to preserve precise source locations.
         # TODO: This won't be necessary once JuliaLowering can preserve precise
@@ -472,6 +483,23 @@ function compute_binding_occurrences_st0(
     end
 
     return binding_occurrences
+end
+
+function collect_export_public_occurrences!(
+        occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence{Tree3}}},
+        st0::Tree3, mod::Module
+    ) where Tree3<:JS.SyntaxTree
+    JS.kind(st0) in JS.KSet"export public" || return occurrences
+    for i = 1:JS.numchildren(st0)
+        child = st0[i]
+        JS.kind(child) === JS.K"Identifier" || continue
+        name = get(child, :name_val, nothing)
+        name isa AbstractString || continue
+        binfo = JL.BindingInfo(0, name, :global, 0; mod)
+        target_set = get!(Set{BindingOccurrence{Tree3}}, occurrences, binfo)
+        push!(target_set, BindingOccurrence{Tree3}(child, :use))
+    end
+    return occurrences
 end
 
 function collect_macrocall_occurrences!(

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -239,6 +239,9 @@ function select_target_binding(
     macrocall_result = select_macrocall_binding(st0, offset, mod, caller; soft_scope)
     macrocall_result !== nothing && return macrocall_result
 
+    export_public_result = select_export_public_binding(st0, offset, mod, caller; soft_scope)
+    export_public_result !== nothing && return export_public_result
+
     (; ctx3, st3) = try
         # Remove macros to preserve precise source locations
         jl_lower_for_scope_resolution(mod, remove_macrocalls(st0); soft_scope)
@@ -309,6 +312,51 @@ function select_macrocall_binding(
         binding = JL.binding_ex(ctx3, binfo)
         if offset in JS.byte_range(binding)
             return (; ctx3, st3, st0=macrocall_name, binding)
+        end
+    end
+    return nothing
+end
+
+# Lowering an `export`/`public` statement collapses the listed identifiers into
+# opaque `K"Value"` nodes, leaving no `BindingId` for the cursor to resolve to.
+# Detect that case directly and lower just the single identifier under the
+# cursor so callers receive a normal `(ctx3, st3, st0, binding)` tuple.
+function select_export_public_binding(
+        st0::JS.SyntaxTree, offset::Int, mod::Module, caller::AbstractString;
+        soft_scope::Bool = false
+    )
+    find_name_node = (offset::Int) -> (st0′::JS.SyntaxTree) -> begin
+        JS.kind(st0′) in JS.KSet"export public" || return false
+        for i = 1:JS.numchildren(st0′)
+            c = st0′[i]
+            JS.kind(c) === JS.K"Identifier" || continue
+            offset in JS.byte_range(c) && return true
+        end
+        return false
+    end
+    bas = byte_ancestors(find_name_node(offset), st0, offset)
+    if isempty(bas)
+        # Support cases like `foo│` at the end of an exported name
+        offset -= 1
+        bas = byte_ancestors(find_name_node(offset), st0, offset)
+    end
+    isempty(bas) && return nothing
+    parent = bas[1]
+    i = let offset=offset; @something findfirst(
+        j::Int -> JS.kind(parent[j]) === JS.K"Identifier" && offset in JS.byte_range(parent[j]),
+            1:JS.numchildren(parent)) return nothing; end
+    name_node = parent[i]
+    (; ctx3, st3) = try
+        jl_lower_for_scope_resolution(mod, name_node; soft_scope)
+    catch err
+        JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
+        JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
+        return nothing
+    end
+    for binfo in ctx3.bindings.info
+        binding = JL.binding_ex(ctx3, binfo)
+        if offset in JS.byte_range(binding)
+            return (; ctx3, st3, st0=name_node, binding)
         end
     end
     return nothing

--- a/test/analysis/test_occurrence_analysis.jl
+++ b/test/analysis/test_occurrence_analysis.jl
@@ -359,6 +359,33 @@ end
             @test length(occs) == 1
         end
     end
+
+    @testset "export/public" begin
+        let boccs = get_binding_occurrences_st0("export foo, @bar, baz";
+                                                include_global_bindings=true)
+            @test length(boccs) == 3
+            for name in ("foo", "@bar", "baz")
+                i = @something findfirst(((b, _),) -> b.name == name, collect(boccs))
+                binfo, occs = collect(boccs)[i]
+                @test binfo.kind === :global
+                @test length(occs) == 1
+                @test only(occs).kind === :use
+            end
+        end
+        let boccs = get_binding_occurrences_st0("public qux";
+                                                include_global_bindings=true)
+            @test length(boccs) == 1
+            binfo, occs = only(boccs)
+            @test binfo.name == "qux"
+            @test binfo.kind === :global
+            @test only(occs).kind === :use
+        end
+        # Without `include_global_bindings`, export/public yields no occurrences
+        # (no local/argument bindings to track).
+        let boccs = get_binding_occurrences_st0("export foo")
+            @test boccs !== nothing && isempty(boccs)
+        end
+    end
 end
 
 function with_global_binding_occurrences(
@@ -526,6 +553,45 @@ macro noop(ex) esc(ex) end
             """, "@m") do ranges, positions
             @test length(positions) == 10
             @test length(ranges) == 5
+        end
+    end
+
+    @testset "export/public" begin
+        with_global_binding_occurrences("""
+            │foo│() = 42
+            export │foo│
+            bar() = │foo│()
+            """, "foo") do ranges, positions
+            @test length(positions) == 6
+            @test length(ranges) == 3
+            @test Range(; start=positions[1], var"end"=positions[2]) in ranges
+            @test Range(; start=positions[3], var"end"=positions[4]) in ranges
+            @test Range(; start=positions[5], var"end"=positions[6]) in ranges
+        end
+        with_global_binding_occurrences("""
+            const │MY_CONST│ = 100
+            public │MY_CONST│
+            use_const() = │MY_CONST│ * 2
+            """, "MY_CONST") do ranges, positions
+            @test length(positions) == 6
+            @test length(ranges) == 3
+            @test Range(; start=positions[1], var"end"=positions[2]) in ranges
+            @test Range(; start=positions[3], var"end"=positions[4]) in ranges
+            @test Range(; start=positions[5], var"end"=positions[6]) in ranges
+        end
+        # Macro identifiers in export
+        with_global_binding_occurrences("""
+            macro │mymacro│(ex)
+                esc(ex)
+            end
+            export │@mymacro│
+            result = │@mymacro│ 42
+            """, "@mymacro") do ranges, positions
+            @test length(positions) == 6
+            @test length(ranges) == 3
+            @test Range(; start=positions[1], var"end"=positions[2]) in ranges
+            @test Range(; start=positions[3], var"end"=positions[4]) in ranges
+            @test Range(; start=positions[5], var"end"=positions[6]) in ranges
         end
     end
 end

--- a/test/test_document_highlight.jl
+++ b/test/test_document_highlight.jl
@@ -467,6 +467,49 @@ end
                 end
             end
         end
+
+        @testset "export/public highlights" begin
+            let code = """
+                function │myfunc│(x)
+                    x + 1
+                end
+                export │myfunc│
+                │myfunc│(1)
+                """
+                fi, positions = highlight_testcase(code, 6)
+                for pos in positions
+                    highlights = JETLS.document_highlights(fi, pos)
+                    @test length(highlights) == 3
+                    @test count(highlights) do highlight
+                        highlight.range.start == positions[1] &&
+                        highlight.range.var"end" == positions[2] &&
+                        highlight.kind == DocumentHighlightKind.Write
+                    end == 1
+                    @test count(highlights) do highlight
+                        highlight.range.start == positions[3] &&
+                        highlight.range.var"end" == positions[4] &&
+                        highlight.kind == DocumentHighlightKind.Read
+                    end == 1
+                    @test count(highlights) do highlight
+                        highlight.range.start == positions[5] &&
+                        highlight.range.var"end" == positions[6] &&
+                        highlight.kind == DocumentHighlightKind.Read
+                    end == 1
+                end
+            end
+
+            let code = """
+                const │MYCONST│ = "constant"
+                public │MYCONST│
+                get_const() = │MYCONST│ + 1
+                """
+                fi, positions = highlight_testcase(code, 6)
+                for pos in positions
+                    highlights = JETLS.document_highlights(fi, pos)
+                    @test length(highlights) == 3
+                end
+            end
+        end
     end
 end
 

--- a/test/test_references.jl
+++ b/test/test_references.jl
@@ -190,6 +190,31 @@ end
             end
         end
     end
+
+    @testset "export/public references" begin
+        # Cursor on an exported name should find all references, including
+        # the export statement itself.
+        let code = """
+            function │myfunc│(x)
+                x + 1
+            end
+            export │myfunc│
+            │myfunc│(1)
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 6
+            for pos in positions
+                refs = find_references(clean_code, pos; include_declaration=true)
+                @test length(refs) == 3
+            end
+            # With includeDeclaration=false, the definition in `function myfunc`
+            # is excluded, but the `:use` inside `export` is kept.
+            for pos in positions
+                refs = find_references(clean_code, pos; include_declaration=false)
+                @test length(refs) == 2
+            end
+        end
+    end
 end
 
 end # module test_references

--- a/test/test_rename.jl
+++ b/test/test_rename.jl
@@ -518,6 +518,31 @@ end
             end
         end
     end
+
+    @testset "export/public rename" begin
+        # Renaming from a cursor inside `export`/`public` should rewrite every
+        # occurrence, including the export statement itself.
+        let code = """
+            │foo│() = 42
+            export │foo│
+            bar() = │foo│()
+            """
+            filename = joinpath(@__DIR__, "testfile.jl")
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 6
+            fi = JETLS.FileInfo(#=version=#0, clean_code, filename)
+            furi = filename2uri("Untitled-" * filename)
+            for pos in positions
+                (; result, error) = JETLS.global_binding_rename(
+                    server, furi, fi, pos, @__MODULE__, "qux")
+                @test result isa WorkspaceEdit && isnothing(error)
+                for (_, edits) in result.changes
+                    @test length(edits) == 3
+                    @test all(edit -> edit.newText == "qux", edits)
+                end
+            end
+        end
+    end
 end
 
 @testset "file_rename_preparation" begin


### PR DESCRIPTION
Names listed in `export` and `public` statements are now treated as `:use` occurrences of the corresponding global bindings in the surrounding module. As a result, `textDocument/documentHighlight`, `textDocument/references`, `textDocument/definition`, and `textDocument/rename` all work when the cursor is placed on an exported/public name, and the export/public site is included in highlight and reference results (and rewritten by rename).

Lowering succeeds on `export`/`public` statements but collapses the listed identifiers into opaque `K"Value"` nodes and records no `BindingInfo` for them, so the existing occurrence traversal found nothing. Two pieces handle this directly at the source level:

- `collect_export_public_occurrences!` in `src/analysis/occurrence-analysis.jl` walks the statement's child identifiers and records a synthetic `(mod, name, :global)` `BindingInfo` keyed occurrence for each. `compute_binding_occurrences_st0` short-circuits to this collector when given an `export`/`public` top-level statement.
- `select_export_public_binding` in `src/utils/binding.jl` mirrors `select_macrocall_binding`: it detects cursors inside an `export`/`public` identifier, lowers just that single identifier to produce a `(ctx3, st3, st0, binding)` tuple, and is invoked from `select_target_binding` right after the macrocall case. This keeps the contract of `select_target_binding` stable so all downstream features light up without further adjustment.