### PR TITLE
occurrences: Track `import`/`using` local names as references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Names listed in `export` and `public` statements are now treated as references to the surrounding module's global bindings. `textDocument/documentHighlight`, `textDocument/references`, `textDocument/definition`, and `textDocument/rename` all now work when the cursor is placed on an exported/public name, and the export/public site is included in highlight and reference results (and rewritten by rename) for the corresponding binding.
 
+- Locally-introduced names from `import`/`using` statements are now treated as local declarations. This includes every form that actually binds a name: `using A` / `import A`, `using A, B`, dotted paths like `using A.B` (trailing `B`), relative paths like `using .Inner`, and explicit names in `using A: x, y` / `using A: x as y`. `textDocument/documentHighlight`, `textDocument/references`, and `textDocument/rename` all now work when the cursor is placed on an imported name, and the import site participates in their results just like any other declaration site (e.g. `local x`).
+
 ## 2026-04-14
 
 - Commit: [`d1ebbb2`](https://github.com/aviatesk/JETLS.jl/commit/d1ebbb2)

--- a/src/analysis/occurrence-analysis.jl
+++ b/src/analysis/occurrence-analysis.jl
@@ -451,14 +451,24 @@ function compute_binding_occurrences_st0(
         is_notebook_uri(state, uri)
     (; mod) = get_context_info(state, uri, offset_to_xy(fi, JS.first_byte(st0)); lookup_func)
 
-    # Lowering `export`/`public` statements collapses their listed identifiers into opaque
-    # `K"Value"` nodes and records no `BindingInfo` for them, so the usual traversal finds nothing.
-    # Handle them directly: each child identifier is recorded as a `:use` of the
-    # corresponding global binding in the surrounding module.
-    if include_global_bindings && JS.kind(st0) in JS.KSet"export public"
-        binding_occurrences = Dict{JL.BindingInfo,Set{BindingOccurrence{typeof(st0)}}}()
-        collect_export_public_occurrences!(binding_occurrences, st0, mod)
-        return binding_occurrences
+    # Lowering `export`/`public`/`import`/`using` statements collapses their listed
+    # identifiers into opaque `K"Value"` nodes and records no `BindingInfo` for them,
+    # so the usual traversal finds nothing. Handle them directly:
+    # - `export foo`/`public foo`: record `foo` as a `:use` of the corresponding global
+    #   binding in the surrounding module.
+    # - `using M: foo`/`import M: foo`/`import M.foo`: record the local alias identifier
+    #   (`foo`, or `bar` in `foo as bar`) as a `:def` of the local global binding.
+    if include_global_bindings
+        k0 = JS.kind(st0)
+        if k0 in JS.KSet"export public"
+            binding_occurrences = Dict{JL.BindingInfo,Set{BindingOccurrence{typeof(st0)}}}()
+            collect_export_public_occurrences!(binding_occurrences, st0, mod)
+            return binding_occurrences
+        elseif k0 in JS.KSet"import using"
+            binding_occurrences = Dict{JL.BindingInfo,Set{BindingOccurrence{typeof(st0)}}}()
+            collect_import_using_occurrences!(binding_occurrences, st0, mod)
+            return binding_occurrences
+        end
     end
 
     (; ctx3, st3) = try
@@ -498,6 +508,21 @@ function collect_export_public_occurrences!(
         binfo = JL.BindingInfo(0, name, :global, 0; mod)
         target_set = get!(Set{BindingOccurrence{Tree3}}, occurrences, binfo)
         push!(target_set, BindingOccurrence{Tree3}(child, :use))
+    end
+    return occurrences
+end
+
+function collect_import_using_occurrences!(
+        occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence{Tree3}}},
+        st0::Tree3, mod::Module
+    ) where Tree3<:JS.SyntaxTree
+    foreach_local_import_identifier(st0) do id_st::Tree3
+        name = get(id_st, :name_val, nothing)
+        name isa AbstractString || return
+        binfo = JL.BindingInfo(0, name, :global, 0; mod)
+        target_set = get!(Set{BindingOccurrence{Tree3}}, occurrences, binfo)
+        push!(target_set, BindingOccurrence{Tree3}(id_st, :decl))
+        return
     end
     return occurrences
 end

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -164,14 +164,54 @@ function collect_import_names(st0::SyntaxTree0)
 end
 
 """
+    foreach_local_import_identifier(f, st0::JS.SyntaxTree)
+
+Invoke `f(id_st)` once for each locally-introduced identifier of an
+`import`/`using` statement `st0`. Covers every form that actually binds
+a name in the current scope:
+
+- `using A` / `import A` — `A`
+- `using A, B` / `import A, B` — `A`, `B`
+- `using A.B` / `import A.B` / `using .A.B` — the trailing component
+- `using A: x, y` / `import A: x, y` — each listed name
+- `using A: x as y` — the alias `y`
+- `import A: x as y` — likewise
+"""
+function foreach_local_import_identifier(f, st0::JS.SyntaxTree)
+    kind = JS.kind(st0)
+    kind in JS.KSet"import using" || return
+    nchildren = JS.numchildren(st0)
+    if nchildren == 1 && JS.kind(st0[1]) === JS.K":"
+        child = st0[1]
+        for i = 2:JS.numchildren(child)
+            id_st = get_local_import_identifier(child[i])
+            id_st === nothing || f(id_st)
+        end
+    else
+        # Direct children are `K"."` paths (one per comma-separated module),
+        # e.g. `using A` → `[K"."(A)]`, `using A, B` → `[K"."(A), K"."(B)]`,
+        # `using .A.B` → `[K"."(., A, B)]`. The locally-introduced name is the
+        # last component of each path.
+        for i = 1:nchildren
+            id_st = get_local_import_identifier(st0[i])
+            id_st === nothing || f(id_st)
+        end
+    end
+    return
+end
+
+"""
     get_local_import_identifier(st0::JS.SyntaxTree) -> Union{JS.SyntaxTree, Nothing}
 
 Return the `K"Identifier"` node that represents the local binding introduced
-by a single element of an `import`/`using` statement, or `nothing` if `st0`
-does not introduce a local binding:
-- `using M: a` / `using M: a, b` — `a`/`b` directly
-- `using M: a as b` — the alias `b`
-- `import M.a` — the trailing component `a`
+by a single element of an `import`/`using` statement, or `nothing` if the
+element is not a well-formed name path. Accepts both the top-level module
+path children (`using A.B` → path `A.B`) and the names listed after `:`
+(`using A: foo` → path `foo`):
+- path with a bare `Identifier` — the identifier itself
+- dotted path `K"."` — the trailing component (skipping the relative `.`
+  or `..` prefixes of forms like `.A` / `..A.B`)
+- `K"as"` (inside a colon list) — the alias
 """
 function get_local_import_identifier(st0::JS.SyntaxTree)
     kind = JS.kind(st0)
@@ -181,7 +221,6 @@ function get_local_import_identifier(st0::JS.SyntaxTree)
     elseif kind === JS.K"Identifier"
         return st0
     elseif kind === JS.K"."
-        # `import M.a` style within a colon list
         npath = JS.numchildren(st0)
         if npath >= 1
             last_st = st0[npath]

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -242,6 +242,9 @@ function select_target_binding(
     export_public_result = select_export_public_binding(st0, offset, mod, caller; soft_scope)
     export_public_result !== nothing && return export_public_result
 
+    import_using_result = select_import_using_binding(st0, offset, mod, caller; soft_scope)
+    import_using_result !== nothing && return import_using_result
+
     (; ctx3, st3) = try
         # Remove macros to preserve precise source locations
         jl_lower_for_scope_resolution(mod, remove_macrocalls(st0); soft_scope)
@@ -346,6 +349,50 @@ function select_export_public_binding(
         j::Int -> JS.kind(parent[j]) === JS.K"Identifier" && offset in JS.byte_range(parent[j]),
             1:JS.numchildren(parent)) return nothing; end
     name_node = parent[i]
+    (; ctx3, st3) = try
+        jl_lower_for_scope_resolution(mod, name_node; soft_scope)
+    catch err
+        JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
+        JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
+        return nothing
+    end
+    for binfo in ctx3.bindings.info
+        binding = JL.binding_ex(ctx3, binfo)
+        if offset in JS.byte_range(binding)
+            return (; ctx3, st3, st0=name_node, binding)
+        end
+    end
+    return nothing
+end
+
+# Mirror `select_export_public_binding` for `import`/`using`. The listed
+# identifiers also collapse into opaque `K"Value"` nodes during lowering, so we
+# detect the cursor against `foreach_local_import_identifier` and lower the
+# single matching identifier to synthesize a normal binding tuple.
+function select_import_using_binding(
+        st0::JS.SyntaxTree, offset::Int, mod::Module, caller::AbstractString;
+        soft_scope::Bool = false
+    )
+    find_name_node_at = function (offset::Int, st0′::JS.SyntaxTree)
+        hit = Ref{Union{Nothing,JS.SyntaxTree}}(nothing)
+        foreach_local_import_identifier(st0′) do id_st::JS.SyntaxTree
+            offset in JS.byte_range(id_st) || return
+            hit[] = id_st
+            return
+        end
+        return hit[]
+    end
+    find_container = (offset::Int) -> (st0′::JS.SyntaxTree) ->
+        JS.kind(st0′) in JS.KSet"import using" &&
+            find_name_node_at(offset, st0′) !== nothing
+    bas = byte_ancestors(find_container(offset), st0, offset)
+    if isempty(bas)
+        # Support cases like `foo│` at the end of an imported name
+        offset -= 1
+        bas = byte_ancestors(find_container(offset), st0, offset)
+    end
+    isempty(bas) && return nothing
+    name_node = @something find_name_node_at(offset, bas[1]) return nothing
     (; ctx3, st3) = try
         jl_lower_for_scope_resolution(mod, name_node; soft_scope)
     catch err

--- a/test/analysis/test_occurrence_analysis.jl
+++ b/test/analysis/test_occurrence_analysis.jl
@@ -386,6 +386,77 @@ end
             @test boccs !== nothing && isempty(boccs)
         end
     end
+
+    @testset "import/using" begin
+        # `using M: a, b` / `import M: a, b` — each name as `:decl`
+        for keyword in ("using", "import")
+            let boccs = get_binding_occurrences_st0("$keyword Base: foo, bar";
+                                                    include_global_bindings=true)
+                @test length(boccs) == 2
+                for name in ("foo", "bar")
+                    i = @something findfirst(((b, _),) -> b.name == name, collect(boccs))
+                    binfo, occs = collect(boccs)[i]
+                    @test binfo.kind === :global
+                    @test length(occs) == 1
+                    @test only(occs).kind === :decl
+                end
+            end
+        end
+        # `using M: a as b` — the alias is the local binding
+        let boccs = get_binding_occurrences_st0("using Base: foo as bar";
+                                                include_global_bindings=true)
+            @test length(boccs) == 1
+            binfo, occs = only(boccs)
+            @test binfo.name == "bar"
+            @test only(occs).kind === :decl
+        end
+        # `import M.a` — last component is the local binding
+        let boccs = get_binding_occurrences_st0("import Base.foo";
+                                                include_global_bindings=true)
+            @test length(boccs) == 1
+            binfo, occs = only(boccs)
+            @test binfo.name == "foo"
+            @test only(occs).kind === :decl
+        end
+        # `using M` / `import M` — the module name is the local binding
+        for keyword in ("using", "import")
+            let boccs = get_binding_occurrences_st0("$keyword Base";
+                                                    include_global_bindings=true)
+                @test length(boccs) == 1
+                binfo, occs = only(boccs)
+                @test binfo.name == "Base"
+                @test only(occs).kind === :decl
+            end
+        end
+        # `using A, B` — each module name
+        let boccs = get_binding_occurrences_st0("using Base, LinearAlgebra";
+                                                include_global_bindings=true)
+            @test length(boccs) == 2
+            for name in ("Base", "LinearAlgebra")
+                i = @something findfirst(((b, _),) -> b.name == name, collect(boccs))
+                binfo, occs = collect(boccs)[i]
+                @test only(occs).kind === :decl
+            end
+        end
+        # `using M.a` / `import M.a` — trailing component is the local binding
+        for keyword in ("using", "import")
+            let boccs = get_binding_occurrences_st0("$keyword Base.Iterators";
+                                                    include_global_bindings=true)
+                @test length(boccs) == 1
+                binfo, occs = only(boccs)
+                @test binfo.name == "Iterators"
+                @test only(occs).kind === :decl
+            end
+        end
+        # Relative: `using .A` / `import ..A.B` — trailing component
+        let boccs = get_binding_occurrences_st0("using .Inner";
+                                                include_global_bindings=true)
+            @test length(boccs) == 1
+            binfo, occs = only(boccs)
+            @test binfo.name == "Inner"
+            @test only(occs).kind === :decl
+        end
+    end
 end
 
 function with_global_binding_occurrences(
@@ -553,6 +624,36 @@ macro noop(ex) esc(ex) end
             """, "@m") do ranges, positions
             @test length(positions) == 10
             @test length(ranges) == 5
+        end
+    end
+
+    @testset "import/using" begin
+        with_global_binding_occurrences("""
+            using Base: │foo│
+            │foo│(1)
+            """, "foo") do ranges, positions
+            @test length(positions) == 4
+            @test length(ranges) == 2
+            @test Range(; start=positions[1], var"end"=positions[2]) in ranges
+            @test Range(; start=positions[3], var"end"=positions[4]) in ranges
+        end
+        with_global_binding_occurrences("""
+            using Base: foo as │bar│
+            │bar│(1)
+            """, "bar") do ranges, positions
+            @test length(positions) == 4
+            @test length(ranges) == 2
+            @test Range(; start=positions[1], var"end"=positions[2]) in ranges
+            @test Range(; start=positions[3], var"end"=positions[4]) in ranges
+        end
+        with_global_binding_occurrences("""
+            import Base.│foo│
+            │foo│(1)
+            """, "foo") do ranges, positions
+            @test length(positions) == 4
+            @test length(ranges) == 2
+            @test Range(; start=positions[1], var"end"=positions[2]) in ranges
+            @test Range(; start=positions[3], var"end"=positions[4]) in ranges
         end
     end
 

--- a/test/test_definition.jl
+++ b/test/test_definition.jl
@@ -282,6 +282,31 @@ end
     end
 end
 
+@testset "'Definition' for imported names" begin
+    # Cursor on an imported name should NOT stop at the import site.
+    # The import site is a declaration (`:decl`), so `textDocument/definition`
+    # falls through to reflection-based lookup and jumps to the source
+    # (e.g. `sin` in Base).
+    sin_cand_file, sin_cand_line = functionloc(first(methods(sin, (Float64,))))
+    sin_cand_file = JETLS.to_full_path(sin_cand_file)
+    cnt = 0
+    with_definition_request("""
+        using Base: sin
+        si│n(1.0)
+    """) do i, results, uri
+        @test results isa Vector{Location}
+        @test length(results) >= 1
+        # Jump must go outside the current file (to Base's source).
+        @test all(r -> JETLS.uri2filepath(r.uri) != JETLS.uri2filepath(uri), results)
+        @test any(results) do r
+            JETLS.uri2filepath(r.uri) == sin_cand_file &&
+            r.range.start.line == (sin_cand_line - 1)
+        end
+        cnt += 1
+    end
+    @test cnt == 1
+end
+
 @testset "'Definition' for global bindings" begin
     cnt = 0
     with_definition_request("""

--- a/test/test_document_highlight.jl
+++ b/test/test_document_highlight.jl
@@ -510,6 +510,54 @@ end
                 end
             end
         end
+
+        @testset "import/using highlights" begin
+            # Import sites are `:decl` occurrences (like `local x`), so they
+            # highlight as `Text` rather than `Write`.
+            let code = """
+                using Base: │myfunc│
+                │myfunc│(1)
+                """
+                fi, positions = highlight_testcase(code, 4)
+                for pos in positions
+                    highlights = JETLS.document_highlights(fi, pos)
+                    @test length(highlights) == 2
+                    @test count(highlights) do highlight
+                        highlight.range.start == positions[1] &&
+                        highlight.range.var"end" == positions[2] &&
+                        highlight.kind == DocumentHighlightKind.Text
+                    end == 1
+                    @test count(highlights) do highlight
+                        highlight.range.start == positions[3] &&
+                        highlight.range.var"end" == positions[4] &&
+                        highlight.kind == DocumentHighlightKind.Read
+                    end == 1
+                end
+            end
+
+            # Alias: clicking on the alias name highlights it + uses
+            let code = """
+                using Base: foo as │myfunc│
+                │myfunc│(1)
+                """
+                fi, positions = highlight_testcase(code, 4)
+                for pos in positions
+                    highlights = JETLS.document_highlights(fi, pos)
+                    @test length(highlights) == 2
+                end
+            end
+
+            let code = """
+                import Base.│myfunc│
+                │myfunc│(1)
+                """
+                fi, positions = highlight_testcase(code, 4)
+                for pos in positions
+                    highlights = JETLS.document_highlights(fi, pos)
+                    @test length(highlights) == 2
+                end
+            end
+        end
     end
 end
 

--- a/test/test_references.jl
+++ b/test/test_references.jl
@@ -191,6 +191,27 @@ end
         end
     end
 
+    @testset "import/using references" begin
+        # Cursor on an imported name should find the import site + uses.
+        let code = """
+            using Base: │myfunc│
+            │myfunc│(1)
+            │myfunc│()
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 6
+            for pos in positions
+                refs = find_references(clean_code, pos; include_declaration=true)
+                @test length(refs) == 3
+            end
+            # includeDeclaration=false excludes the import site (`:def`).
+            for pos in positions
+                refs = find_references(clean_code, pos; include_declaration=false)
+                @test length(refs) == 2
+            end
+        end
+    end
+
     @testset "export/public references" begin
         # Cursor on an exported name should find all references, including
         # the export statement itself.

--- a/test/test_rename.jl
+++ b/test/test_rename.jl
@@ -438,6 +438,27 @@ end
         end
     end
 
+    @testset "import/using rename" begin
+        # Renaming from a cursor on an imported name should rewrite every
+        # occurrence, including the import site itself.
+        let code = """
+            using Base: │foo│
+            │foo│(1)
+            bar() = │foo│()
+            """
+            fi, positions, furi = rename_testcase(code, 6)
+            for pos in positions
+                (; result, error) = JETLS.global_binding_rename(
+                    server, furi, fi, pos, @__MODULE__, "qux")
+                @test result isa WorkspaceEdit && isnothing(error)
+                for (_, edits) in result.changes
+                    @test length(edits) == 3
+                    @test all(edit -> edit.newText == "qux", edits)
+                end
+            end
+        end
+    end
+
     @testset "export/public rename" begin
         # Renaming from a cursor inside `export`/`public` should rewrite every
         # occurrence, including the export statement itself.


### PR DESCRIPTION
Names locally introduced by `import`/`using` statements are now recorded as `:decl` occurrences of the corresponding global binding in the surrounding module. `textDocument/documentHighlight`, `textDocument/references`, and `textDocument/rename` now all work when the cursor is placed on an imported name, and the import site participates in highlight, reference, and rename results just like any other declaration site (e.g. `local x`). `textDocument/definition` continues to fall through to reflection-based lookup, since `:decl` occurrences are intentionally excluded from its `:def`-only filter.

Every form that actually binds a name in the current scope is covered:

- `using A` / `import A` — `A` itself
- `using A, B` / `import A, B` — each module name
- `using A.B` / `import A.B` / `using .A.B` — the trailing component
- `using A: x, y` / `import A: x, y` — each listed name
- `using A: x as y` — the alias `y`

Implementation mirrors the earlier `export`/`public` support: lowering collapses these identifiers into opaque `K"Value"` nodes, so the occurrence collector walks the source-level statement directly. `compute_binding_occurrences_st0` short-circuits to the new `collect_import_using_occurrences!`, and `select_target_binding` picks up cursors on import names via a new `select_import_using_binding` helper that follows the same pattern as `select_export_public_binding`.

A shared `foreach_local_import_identifier` iterator lives alongside `get_local_import_identifier` in `src/utils/ast.jl` so both the occurrence collector and the cursor selector agree on which identifiers an import statement introduces.

`analyze_unused_imports!` is unaffected: it continues to use `collect_explicit_import_names`, which intentionally skips whole-module forms like `using Random`, so no new unused-import diagnostics are produced.