### PR TITLE
rename: Preserve source-module names via `as` aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Locally-introduced names from `import`/`using` statements are now treated as local declarations. This includes every form that actually binds a name: `using A` / `import A`, `using A, B`, dotted paths like `using A.B` (trailing `B`), relative paths like `using .Inner`, and explicit names in `using A: x, y` / `using A: x as y`. `textDocument/documentHighlight`, `textDocument/references`, and `textDocument/rename` all now work when the cursor is placed on an imported name, and the import site participates in their results just like any other declaration site (e.g. `local x`).
 
+- `textDocument/rename` on imported names now preserves the source-module name by introducing or updating an `as` alias instead of rewriting the original name. For example, renaming `sin` in `using Base: sin` produces `using Base: sin as newsin` plus `newsin` at every use site — avoiding the previous result of `using Base: newsin` which would not resolve. `using M: name as alias` simply renames the alias; `import M.name` and `import M` extend to `import M.name as newname` / `import M as newname`. Conversely, renaming an alias back to its source name (e.g. renaming `randcycle2` back to `randcycle` in `using Random: randcycle as randcycle2`) drops the ` as …` suffix so the import simplifies to `using Random: randcycle`. In the few forms where Julia does not accept `as` at all (`using M`, `using M, N`, `using M.Sub`), rename falls back to a bare replacement.
+
 ## 2026-04-14
 
 - Commit: [`d1ebbb2`](https://github.com/aviatesk/JETLS.jl/commit/d1ebbb2)

--- a/src/rename.jl
+++ b/src/rename.jl
@@ -328,7 +328,7 @@ function collect_global_rename_edits!(
     )
     state = server.state
     n_files = length(uris_to_search)
-    seen_locations = Set{Tuple{URI,Range}}()
+    seen_edits = Set{Tuple{URI,Range,String}}()
     for (i, uri) in enumerate(uris_to_search)
         if is_cancelled(cancel_flag)
             return false
@@ -350,15 +350,15 @@ function collect_global_rename_edits!(
             version = fi.version
         end
         search_st0_top = build_syntax_tree(fi)
-        empty!(seen_locations)
-        collect_global_rename_ranges_in_file!(
-            seen_locations, state, uri, fi, search_st0_top, binfo)
-        isempty(seen_locations) && continue
+        empty!(seen_edits)
+        collect_global_rename_edits_in_file!(
+            seen_edits, state, uri, fi, search_st0_top, binfo, newName)
+        isempty(seen_edits) && continue
 
         # Group edits by URI (for notebooks, occurrences may map to different cell URIs)
         edits_by_uri = Dict{URI,Vector{TextEdit}}()
-        for (loc_uri, range) in seen_locations
-            edit = TextEdit(; range, newText = newName)
+        for (loc_uri, range, newText) in seen_edits
+            edit = TextEdit(; range, newText)
             push!(get!(Vector{TextEdit}, edits_by_uri, loc_uri), edit)
         end
         if changes isa Vector{TextDocumentEdit}
@@ -376,17 +376,95 @@ function collect_global_rename_edits!(
     return true
 end
 
-function collect_global_rename_ranges_in_file!(
-        seen_locations::Set{Tuple{URI,Range}}, state::ServerState, uri::URI, fi::FileInfo,
-        st0_top::JS.SyntaxTree, binfo::JL.BindingInfo
+function collect_global_rename_edits_in_file!(
+        seen_edits::Set{Tuple{URI,Range,String}}, state::ServerState, uri::URI, fi::FileInfo,
+        st0_top::JS.SyntaxTree, binfo::JL.BindingInfo, newName::String
     )
     ismacro = startswith(binfo.name, '@')
     for occurrence in find_global_binding_occurrences!(state, uri, fi, st0_top, binfo)
-        adjust_first = ismacro && is_macrocall_use_site(fi, occurrence.tree) ? 1 : 0
-        range, adjusted_uri = unadjust_range(state, uri, jsobj_to_range(occurrence.tree, fi; adjust_first))
-        push!(seen_locations, (adjusted_uri, range))
+        id_byte_range = JS.byte_range(occurrence.tree)
+        classification = classify_import_rename(st0_top, id_byte_range, occurrence.kind)
+        if classification === :needs_as
+            # Insert ` as <newname>` right after the full identifier (including any
+            # leading `@`), keeping the source name intact.
+            full_range = jsobj_to_range(occurrence.tree, fi)
+            insert_range, adjusted_uri =
+                unadjust_range(state, uri, Range(; start=full_range.var"end", var"end"=full_range.var"end"))
+            newText = ismacro ? " as @$newName" : " as $newName"
+            push!(seen_edits, (adjusted_uri, insert_range, newText))
+        elseif classification === :alias && begin
+                collapse = collapse_alias_to_source(st0_top, id_byte_range, fi, newName, ismacro)
+                collapse !== nothing
+            end
+            # Renaming an alias back to its source name — drop the ` as <alias>` suffix
+            # so the import simplifies to `using M: <source>` instead of `<source> as <source>`.
+            collapse_range, adjusted_uri = unadjust_range(state, uri, collapse)
+            push!(seen_edits, (adjusted_uri, collapse_range, ""))
+        else
+            adjust_first = ismacro && is_macrocall_use_site(fi, occurrence.tree) ? 1 : 0
+            range, adjusted_uri = unadjust_range(state, uri, jsobj_to_range(occurrence.tree, fi; adjust_first))
+            push!(seen_edits, (adjusted_uri, range, newName))
+        end
     end
-    return seen_locations
+    return seen_edits
+end
+
+# Classify a `:decl` occurrence sitting inside an `import`/`using` statement.
+# Returns one of:
+# - `:regular`        — not in an `import`/`using`; treat as a normal rename.
+# - `:alias`          — the identifier is the alias of a `K"as"` node (`using M: foo as bar`);
+#                       a standard replace renames only the alias.
+# - `:needs_as`       — the identifier is a bare source name in an `import`/`using` form that
+#                       accepts `as` (any `import` form, or `using M: name` inside a colon list);
+#                       we rewrite `name` → `name as newname` and rename local uses as usual.
+# - `:implicit_bare`  — bare source name in `using M`, `using M, N`, or `using M.N` where
+#                       `using ... as ...` is not legal syntax; fall back to a standard replace
+#                       (breaks code, but matches the rename policy for implicit imports).
+function classify_import_rename(st0_top::JS.SyntaxTree, id_byte_range::UnitRange{Int}, kind::Symbol)
+    kind === :decl || return :regular
+    bas = byte_ancestors(st0_top, id_byte_range)
+    import_stmt_idx = findfirst(b::JS.SyntaxTree -> JS.kind(b) in JS.KSet"import using", bas)
+    isnothing(import_stmt_idx) && return :regular
+    has_colon = false
+    for i = 1:import_stmt_idx-1
+        k = JS.kind(bas[i])
+        if k === JS.K"as"
+            as_node = bas[i]
+            if JS.numchildren(as_node) >= 2 && JS.byte_range(as_node[2]) == id_byte_range
+                return :alias
+            end
+            return :regular
+        elseif k === JS.K":"
+            has_colon = true
+        end
+    end
+    import_kind = JS.kind(bas[import_stmt_idx])
+    if import_kind === JS.K"import" || has_colon
+        return :needs_as
+    end
+    return :implicit_bare
+end
+
+# If the alias occurrence is being renamed back to the source name of its
+# surrounding `K"as"` node, return the LSP range covering ` as <alias>` so a
+# single empty-text edit can delete it. Otherwise return `nothing`.
+function collapse_alias_to_source(
+        st0_top::JS.SyntaxTree, id_byte_range::UnitRange{Int}, fi::FileInfo,
+        newName::String, ismacro::Bool
+    )
+    bas = byte_ancestors(st0_top, id_byte_range)
+    as_idx = @something findfirst(b::JS.SyntaxTree -> JS.kind(b) === JS.K"as", bas) return nothing
+    as_node = bas[as_idx]
+    JS.numchildren(as_node) >= 2 || return nothing
+    source_path = as_node[1]
+    source_id = @something get_local_import_identifier(source_path) return nothing
+    source_name = get(source_id, :name_val, nothing)
+    source_name isa AbstractString || return nothing
+    effective_new = ismacro ? "@" * newName : newName
+    source_name == effective_new || return nothing
+    source_range = jsobj_to_range(source_path, fi)
+    alias_range = jsobj_to_range(as_node[2], fi)
+    return Range(; start=source_range.var"end", var"end"=alias_range.var"end")
 end
 
 function file_rename(

--- a/src/types.jl
+++ b/src/types.jl
@@ -626,6 +626,7 @@ struct CachedSyntaxTree
 end
 JS.first_byte(cst::CachedSyntaxTree) = cst.fb
 JS.last_byte(cst::CachedSyntaxTree) = cst.lb
+JS.byte_range(cst::CachedSyntaxTree) = cst.fb:cst.lb
 JS.source_location(cst::CachedSyntaxTree) = (cst.line, cst.column)
 
 struct CachedBindingOccurrence

--- a/test/test_rename.jl
+++ b/test/test_rename.jl
@@ -9,15 +9,41 @@ include(normpath(pkgdir(JETLS), "test", "jsjl-utils.jl"))
 
 function rename_testcase(
         code::AbstractString, n::Int;
-        filename::AbstractString = joinpath(@__DIR__, "testfile.jl"),
+        # Use a unique filename per call so that the various server caches
+        # (file cache, binding-occurrences cache, analysis info) keyed by URI
+        # stay isolated between tests — otherwise successive tests sharing a
+        # URI can hit stale cache entries when byte ranges of top-level
+        # statements happen to coincide.
+        filename::AbstractString = joinpath(@__DIR__, "testfile_$(gensym(:rename_testcase)).jl"),
+        server::Union{JETLS.Server,Nothing} = nothing,
+        context_module::Union{Module,Nothing} = nothing,
     )
     clean_code, positions = JETLS.get_text_and_positions(code)
     @test length(positions) == n
     fi = JETLS.FileInfo(#=version=#0, clean_code, filename)
     @test issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
     furi = filename2uri(filename)
+    # Register the file with the provided server so that
+    # `get_file_info`/`collect_global_rename_edits!` can actually find it —
+    # otherwise global rename silently returns an empty `changes` dict.
+    if server !== nothing
+        JETLS.store!(server.state.file_cache) do cache
+            Base.PersistentDict(cache, furi => fi), nothing
+        end
+        # Tie the file URI to a dedicated module so that `get_context_info`
+        # (and downstream occurrence resolution) agrees with whatever module
+        # the caller passes to `global_binding_rename`. Without this the file
+        # falls back to `Main`, causing a module mismatch that makes
+        # `find_global_binding_occurrences!` miss every occurrence.
+        if context_module !== nothing
+            JETLS.cache_out_of_scope!(
+                server.state.analysis_manager, furi, JETLS.OutOfScope(context_module))
+        end
+    end
     return fi, positions, furi
 end
+
+module test_import_rename_context end
 
 @testset "local_binding_rename_preparation" begin
     state = JETLS.ServerState()
@@ -439,22 +465,96 @@ end
     end
 
     @testset "import/using rename" begin
-        # Renaming from a cursor on an imported name should rewrite every
-        # occurrence, including the import site itself.
+        # Renaming a bare imported name inserts ` as newname` at the import
+        # site (preserving the source name) and replaces local uses.
         let code = """
             using Base: │foo│
             │foo│(1)
             bar() = │foo│()
             """
-            fi, positions, furi = rename_testcase(code, 6)
+            fi, positions, furi = rename_testcase(code, 6; server, context_module=test_import_rename_context)
             for pos in positions
                 (; result, error) = JETLS.global_binding_rename(
-                    server, furi, fi, pos, @__MODULE__, "qux")
+                    server, furi, fi, pos, test_import_rename_context, "qux")
                 @test result isa WorkspaceEdit && isnothing(error)
-                for (_, edits) in result.changes
-                    @test length(edits) == 3
-                    @test all(edit -> edit.newText == "qux", edits)
-                end
+                edits = only(result.changes).second
+                @test length(edits) == 3
+                @test count(e -> e.newText == "qux", edits) == 2
+                @test count(e -> e.newText == " as qux", edits) == 1
+                # The as-insertion is zero-width, right after the import identifier
+                as_edit = only(filter(e -> e.newText == " as qux", edits))
+                @test as_edit.range.start == as_edit.range.var"end"
+                @test as_edit.range.start == positions[2]
+            end
+        end
+
+        # Renaming an existing `as`-alias just renames the alias.
+        let code = """
+            using Base: foo as │myfoo│
+            │myfoo│(1)
+            """
+            fi, positions, furi = rename_testcase(code, 4; server, context_module=test_import_rename_context)
+            for pos in positions
+                (; result, error) = JETLS.global_binding_rename(
+                    server, furi, fi, pos, test_import_rename_context, "qux")
+                @test result isa WorkspaceEdit && isnothing(error)
+                edits = only(result.changes).second
+                @test length(edits) == 2
+                @test all(e -> e.newText == "qux", edits)
+            end
+        end
+
+        # Renaming an alias back to its source name drops the ` as <alias>`.
+        let code = """
+            using Random: randcycle as │randcycle2│
+            │randcycle2│(5)
+            """
+            fi, positions, furi = rename_testcase(code, 4; server, context_module=test_import_rename_context)
+            for pos in positions
+                (; result, error) = JETLS.global_binding_rename(
+                    server, furi, fi, pos, test_import_rename_context, "randcycle")
+                @test result isa WorkspaceEdit && isnothing(error)
+                edits = only(result.changes).second
+                @test length(edits) == 2
+                @test count(e -> e.newText == "randcycle", edits) == 1
+                @test count(e -> e.newText == "", edits) == 1
+                # The deletion is at the end of `randcycle` inside the import,
+                # spanning through the end of `randcycle2` (i.e. ` as randcycle2`)
+                delete_edit = only(filter(e -> e.newText == "", edits))
+                @test delete_edit.range.var"end" == positions[2]
+            end
+        end
+
+        # `import M.name` supports `as`, so the same as-insertion is used.
+        let code = """
+            import Base.│sin│
+            │sin│(1.0)
+            """
+            fi, positions, furi = rename_testcase(code, 4; server, context_module=test_import_rename_context)
+            for pos in positions
+                (; result, error) = JETLS.global_binding_rename(
+                    server, furi, fi, pos, test_import_rename_context, "mysin")
+                @test result isa WorkspaceEdit && isnothing(error)
+                edits = only(result.changes).second
+                @test length(edits) == 2
+                @test count(e -> e.newText == "mysin", edits) == 1
+                @test count(e -> e.newText == " as mysin", edits) == 1
+            end
+        end
+
+        # `using M.name` cannot use `as` (invalid Julia syntax), so fall back
+        # to a bare replacement of the module name.
+        let code = """
+            using Base.│Iterators│
+            """
+            fi, positions, furi = rename_testcase(code, 2; server, context_module=test_import_rename_context)
+            for pos in positions
+                (; result, error) = JETLS.global_binding_rename(
+                    server, furi, fi, pos, test_import_rename_context, "MyIter")
+                @test result isa WorkspaceEdit && isnothing(error)
+                edits = only(result.changes).second
+                @test length(edits) == 1
+                @test only(edits).newText == "MyIter"
             end
         end
     end


### PR DESCRIPTION
`textDocument/rename` on an imported name used to rewrite the original name at the import site too, producing code like
`using Base: newsin` that no longer resolves. Rename now preserves the source-module name and adjusts only the local alias:

- `using M: name` / `import M: name` — inserts ` as newname` after the identifier, keeping the original import intact.
- `using M: name as alias` — renames only the alias (unchanged behavior).
- `import M.name` / `import M` — inserts ` as newname` after the trailing identifier (valid Julia syntax for these `import` forms).
- `using M`, `using M, N`, `using M.Sub` — Julia does not accept `as` here, so rename falls back to a bare replacement.

Renaming an alias back to its source name now also removes the `as` clause itself (e.g. `using Random: randcycle as randcycle2` renamed `randcycle2` → `randcycle` becomes
`using Random: randcycle`), so the import simplifies instead of leaving redundant `name as name`.

Implementation hooks into the existing occurrence loop in `collect_global_rename_edits_in_file!`: a new
`classify_import_rename` inspects the occurrence's ancestors to decide between a plain rename, an as-insertion, an alias rename, or an alias collapse. A `byte_range` method is added for `CachedBindingOccurrence`'s tree so the classifier can compare the cached occurrence against live AST nodes.

The `test/test_rename.jl` harness grows a few conveniences so that global rename tests can actually exercise the cross-file search: a per-call unique filename (so the binding-occurrences cache does not leak across tests), an optional `server` keyword that wires the file into `server.state.file_cache`, and a `context_module` keyword that pins the URI to a dedicated module via `cache_out_of_scope!`. A top-level `test_import_rename_context` module is used as the rename context for the new `import/using rename` testset.