### PR TITLE
declaration: Implement `textDocument/declaration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Clients that previously implemented a handler for the JETLS-defined `jetls.showReferences` command should switch to handling `editor.action.showReferences` instead. The new arguments are `[uriString, position, locations]`, where `locations` is the pre-resolved LSP `Location[]`; clients no longer need to issue a `textDocument/references` request themselves and can simply display the provided locations. See the [Neovim setup section](https://aviatesk.github.io/JETLS.jl/release/#Neovim) in the documentation for an example handler.
 
+### Added
+
+- Added `textDocument/declaration` ("go to declaration"). Invoking it on an imported name jumps to the import site (e.g. `using Base: sin` or `using Base: foo as bar`), and on a `local` declaration jumps to the `local` line.
+  When the symbol at the cursor has no dedicated declaration site (e.g. a bare global assignment `x = 1`, a `Base` function, a module reference), the request transparently falls back to the same logic as `textDocument/definition` — including the reflection-based lookup for modules and methods — so `textDocument/declaration` never dead-ends on a resolvable symbol. This mirrors the convention used by rust-analyzer, gopls, and pyright for languages without a C/C++-style declaration/definition split.
+
 ### Changed
 
 - The reference-count code lens now emits `editor.action.showReferences` (a VSCode convention command) directly, instead of the JETLS-defined custom command `jetls.showReferences`. LSP does not standardize a way for a server to hand pre-resolved reference locations to the client, so this choice trades strict LSP spec purity for broader out-of-the-box editor support. VSCode continues to work via the `jetls-client` extension, and editors that follow the VSCode convention (e.g. Zed) now dispatch the lens out of the box. Editors that do not follow the VSCode convention (e.g. Neovim) need to register a client-side handler for `editor.action.showReferences`.

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -101,6 +101,7 @@ include("apply-edit.jl")
 include("execute-command.jl")
 include("signature-help.jl")
 include("completions.jl")
+include("declaration.jl")
 include("definition.jl")
 include("references.jl")
 include("hover.jl")
@@ -424,6 +425,8 @@ function handle_request_message(server::Server, @nospecialize(msg), cancel_flag:
         handle_CompletionResolveRequest(server, msg)
     elseif msg isa SignatureHelpRequest
         handle_SignatureHelpRequest(server, msg, cancel_flag)
+    elseif msg isa DeclarationRequest
+        handle_DeclarationRequest(server, msg, cancel_flag)
     elseif msg isa DefinitionRequest
         handle_DefinitionRequest(server, msg, cancel_flag)
     elseif msg isa ReferencesRequest

--- a/src/declaration.jl
+++ b/src/declaration.jl
@@ -1,0 +1,140 @@
+const DECLARATION_REGISTRATION_ID = "jetls-declaration"
+const DECLARATION_REGISTRATION_METHOD = "textDocument/declaration"
+
+function declaration_options()
+    return DeclarationOptions()
+end
+
+function declaration_registration()
+    return Registration(;
+        id = DECLARATION_REGISTRATION_ID,
+        method = DECLARATION_REGISTRATION_METHOD,
+        registerOptions = DeclarationRegistrationOptions(;
+            documentSelector = DEFAULT_DOCUMENT_SELECTOR,
+        )
+    )
+end
+
+# For dynamic registrations during development
+# unregister(currently_running, Unregistration(;
+#     id = DECLARATION_REGISTRATION_ID,
+#     method = DECLARATION_REGISTRATION_METHOD))
+# register(currently_running, declaration_registration())
+
+function handle_DeclarationRequest(
+        server::Server, msg::DeclarationRequest, cancel_flag::CancelFlag)
+    state = server.state
+    uri = msg.params.textDocument.uri
+    origin_position = adjust_position(state, uri, msg.params.position)
+
+    result = get_file_info(state, uri, cancel_flag)
+    if isnothing(result)
+        return send(server, DeclarationResponse(; id = msg.id, result = null))
+    elseif result isa ResponseError
+        return send(server, DeclarationResponse(; id = msg.id, result = nothing, error = result))
+    end
+    fi = result
+
+    locations, origin_node =
+        find_declaration(server, uri, fi, origin_position; fallback_to_definition=true)
+    if origin_node === nothing || isempty(locations)
+        return send(server, DeclarationResponse(; id = msg.id, result = null))
+    end
+    if supports(server, :textDocument, :declaration, :linkSupport)
+        originSelectionRange, _ = unadjust_range(state, uri, jsobj_to_range(origin_node, fi))
+        result = LocationLink[LocationLink(loc, originSelectionRange) for loc in locations]
+    else
+        result = locations
+    end
+    return send(server, DeclarationResponse(; id = msg.id, result))
+end
+
+"""
+    find_declaration(server, uri, fi, pos; soft_scope, fallback_to_definition=false) ->
+        (locations::Vector{Location}, origin_node::Union{JS.SyntaxTree,Nothing})
+
+Core routine behind `textDocument/declaration`. Returns the declaration
+locations for the symbol at `pos` (source-level `:decl` occurrences —
+`import`/`using` sites, `local x`, empty `function foo end`) together
+with the syntax-tree node representing the cursor's origin.
+
+With `fallback_to_definition=true`, an empty result falls through to
+[`find_definition`](@ref) so the caller never returns an empty
+response for a resolvable symbol. This mirrors rust-analyzer's
+behavior where "go to declaration" defers to "go to definition" for
+languages that don't have a distinct declaration concept for every
+binding.
+"""
+function find_declaration(
+        server::Server, uri::URI, fi::FileInfo, pos::Position;
+        soft_scope::Bool = is_notebook_cell_uri(server.state, uri),
+        fallback_to_definition::Bool = false,
+    )
+    state = server.state
+    st0 = build_syntax_tree(fi)
+    offset = xy_to_offset(fi, pos)
+    (; mod) = get_context_info(state, uri, pos)
+
+    binding_result = select_target_binding(st0, offset, mod; caller="find_declaration", soft_scope)
+    if !isnothing(binding_result)
+        (; ctx3, st3, st0, binding) = binding_result
+        binfo = JL.get_binding(ctx3, binding)
+        if binfo.kind === :global
+            locations = find_global_binding_declarations(server, uri, binfo)
+        else
+            locations = find_local_binding_declarations(
+                state, uri, fi, ctx3, st3, binfo; is_generated=is_generated0(st0))
+        end
+        isempty(locations) || return locations, binding
+    end
+    fallback_to_definition || return Location[], nothing
+    return find_definition(server, uri, fi, pos; soft_scope)
+end
+
+function find_global_binding_declarations(
+        server::Server, uri::URI, binfo::JL.BindingInfo
+    )
+    state = server.state
+    uris_to_search = collect_search_uris(server, uri)
+    seen_locations = Set{Tuple{URI,Range}}()
+    for search_uri in uris_to_search
+        fi = @something begin
+            get_file_info(state, search_uri)
+        end begin
+            get_unsynced_file_info!(state, search_uri)
+        end continue
+        search_st0_top = build_syntax_tree(fi)
+        for occurrence in find_global_binding_occurrences!(state, search_uri, fi, search_st0_top, binfo)
+            occurrence.kind === :decl || continue
+            range, adjusted_uri =
+                unadjust_range(state, search_uri, jsobj_to_range(occurrence.tree, fi))
+            push!(seen_locations, (adjusted_uri, range))
+        end
+    end
+    locations = Location[]
+    for (loc_uri, range) in seen_locations
+        push!(locations, Location(; uri = loc_uri, range))
+    end
+    return locations
+end
+
+function find_local_binding_declarations(
+        state::ServerState, uri::URI, fi::FileInfo,
+        ctx3, st3, binfo::JL.BindingInfo;
+        is_generated::Bool = false,
+    )
+    locations = Location[]
+    binding_occurrences = compute_binding_occurrences(ctx3, st3, is_generated)
+    haskey(binding_occurrences, binfo) || return locations
+    seen_locations = Set{Tuple{URI,Range}}()
+    for occurrence in binding_occurrences[binfo]
+        occurrence.kind === :decl || continue
+        range, adjusted_uri =
+            unadjust_range(state, uri, jsobj_to_range(occurrence.tree, fi))
+        push!(seen_locations, (adjusted_uri, range))
+    end
+    for (loc_uri, range) in seen_locations
+        push!(locations, Location(; uri = loc_uri, range))
+    end
+    return locations
+end

--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -94,6 +94,15 @@ function handle_InitializeRequest(
         end
     end
 
+    if supports(server, :textDocument, :declaration, :dynamicRegistration)
+        declarationProvider = nothing # will be registered dynamically
+    else
+        declarationProvider = declaration_options()
+        if JETLS_DEV_MODE
+            @info "Registering 'textDocument/declaration' with `InitializeResponse`"
+        end
+    end
+
     if supports(server, :textDocument, :definition, :dynamicRegistration)
         definitionProvider = nothing # will be registered dynamically
     else
@@ -252,6 +261,7 @@ function handle_InitializeRequest(
                 save = true),
             completionProvider,
             signatureHelpProvider,
+            declarationProvider,
             definitionProvider,
             referencesProvider,
             documentHighlightProvider,
@@ -352,6 +362,13 @@ function handle_InitializedNotification(server::Server)
         # NOTE If completion's `dynamicRegistration` is not supported,
         # it needs to be registered along with initialization in the `InitializeResponse`,
         # since `SignatureHelpRegistrationOptions` does not extend `StaticRegistrationOptions`.
+    end
+
+    if supports(server, :textDocument, :declaration, :dynamicRegistration)
+        push!(registrations, declaration_registration())
+        if JETLS_DEV_MODE
+            @info "Dynamically registering 'textDocument/declaration' upon `InitializedNotification`"
+        end
     end
 
     if supports(server, :textDocument, :definition, :dynamicRegistration)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ end
     @testset "resolver" include("test_resolver.jl")
     @testset "completions" include("test_completions.jl")
     @testset "signature help" include("test_signature_help.jl")
+    @testset "declaration" include("test_declaration.jl")
     @testset "definition" include("test_definition.jl")
     @testset "document highlight" include("test_document_highlight.jl")
     @testset "document symbol" include("test_document_symbol.jl")

--- a/test/test_declaration.jl
+++ b/test/test_declaration.jl
@@ -1,0 +1,127 @@
+module test_declaration
+
+using Test
+using JETLS
+using JETLS.LSP
+
+include(normpath(pkgdir(JETLS), "test", "setup.jl"))
+
+function declaration_testcase(
+        code::AbstractString, n::Int;
+        filename::AbstractString = joinpath(@__DIR__, "testfile_$(gensym(:declaration)).jl")
+    )
+    clean_code, positions = JETLS.get_text_and_positions(code)
+    @assert length(positions) == n
+    fi = JETLS.FileInfo(#=version=#0, clean_code, filename)
+    @assert issorted(positions; by = x -> JETLS.xy_to_offset(fi, x))
+    furi = filename2uri(filename)
+    server = JETLS.Server()
+    JETLS.store!(server.state.file_cache) do cache
+        Base.PersistentDict(cache, furi => fi), nothing
+    end
+    return server, fi, positions, furi
+end
+find_declaration_locations(server, furi, fi, pos) =
+    first(JETLS.find_declaration(server, furi, fi, pos))
+
+@testset "declaration for imported names" begin
+    let code = """
+        using Base: │sin│
+        │si│n(1.0)
+        """
+        server, fi, positions, furi = declaration_testcase(code, 4)
+        for pos in positions
+            locations = find_declaration_locations(server, furi, fi, pos)
+            @test length(locations) == 1
+            loc = only(locations)
+            @test loc.uri == furi
+            @test loc.range.start.line == 0
+        end
+    end
+
+    # `using M: foo as bar` — cursor anywhere on the alias or its uses
+    # should jump to the alias identifier in the import statement.
+    let code = """
+        using Base: sin as │mysin│
+        │mysin│(1.0)
+        """
+        server, fi, positions, furi = declaration_testcase(code, 4)
+        for pos in positions
+            locations = find_declaration_locations(server, furi, fi, pos)
+            @test length(locations) == 1
+            loc = only(locations)
+            @test loc.uri == furi
+            @test loc.range.start.line == 0
+        end
+    end
+end
+
+@testset "declaration for `local` declarations" begin
+    let code = """
+        function f()
+            local │x│
+            │x│ = 1
+            return │x│
+        end
+        """
+        server, fi, positions, furi = declaration_testcase(code, 6)
+        for pos in positions
+            locations = find_declaration_locations(server, furi, fi, pos)
+            @test length(locations) == 1
+            loc = only(locations)
+            @test loc.uri == furi
+            @test loc.range.start.line == 1
+        end
+    end
+end
+
+@testset "declaration returns empty when no `:decl` exists" begin
+    # A bare global assignment records only `:def`, so declaration finds
+    # no location.
+    let code = """
+        │x│ = 1
+        println(│x│)
+        """
+        server, fi, positions, furi = declaration_testcase(code, 4)
+        for pos in positions
+            locations = find_declaration_locations(server, furi, fi, pos)
+            @test isempty(locations)
+        end
+    end
+end
+
+@testset "declaration falls back to definition when enabled" begin
+    # With fallback enabled, a symbol that has only a `:def` (no `:decl`)
+    # resolves through `find_definition` rather than returning empty.
+    let code = """
+        │x│ = 1
+        println(│x│)
+        """
+        server, fi, positions, furi = declaration_testcase(code, 4)
+        for pos in positions
+            locations, _ = JETLS.find_declaration(
+                server, furi, fi, pos; fallback_to_definition=true)
+            @test length(locations) == 1
+            @test only(locations).uri == furi
+            @test only(locations).range.start.line == 0
+        end
+    end
+
+    # When a `:decl` is available, fallback is not triggered — the import
+    # site is preferred over the reflection-based source.
+    let code = """
+        using Base: │sin│
+        │sin│(1.0)
+        """
+        server, fi, positions, furi = declaration_testcase(code, 4)
+        for pos in positions
+            locations, _ = JETLS.find_declaration(
+                server, furi, fi, pos; fallback_to_definition=true)
+            @test length(locations) == 1
+            @test only(locations).uri == furi
+            @test only(locations).range.start.line == 0
+        end
+    end
+end
+
+end # module test_declaration


### PR DESCRIPTION
Add server support for the "Go To Declaration" request that landed as type definitions in a previous commit. The new `src/declaration.jl` follows the structure of `src/definition.jl`:

- `declaration_options` / `declaration_registration` advertise the `DeclarationOptions` / `DeclarationRegistrationOptions` capability, wired into `initialize.jl` alongside dynamic registration.
- `handle_DeclarationRequest` converts the request into a `DeclarationResponse`, attaching `LocationLink.originSelectionRange` only when the client supports `declaration.linkSupport`.
- `find_declaration` is the reusable core (mirroring `find_definition`): it collects source-level `:decl` occurrences via `find_global_binding_occurrences!` for globals and `compute_binding_occurrences` for locals, then returns `(locations, origin_node)` so callers can build the response.

Semantics map to the two places where Julia's `:decl` kind is meaningful: import sites introduced by our occurrence analysis (`using M: x`, `using M: x as y`, `import M.x`, …) and explicit `local x` / `function f end` declarations. Cursors on those jump straight to the declaration site.

When the target has no `:decl` (bare global assignment, `Base` function, qualified module reference, …), the handler passes `fallback_to_definition=true` so `find_declaration` transparently defers to `find_definition`. This mirrors rust-analyzer, gopls, and pyright — languages without a clean C/C++-style header/source split — so `textDocument/declaration` never dead-ends on a resolvable symbol.

The new `test/test_declaration.jl` exercises the main paths (imported names, `local` declarations, empty-result for symbols without `:decl`, and the definition fallback) by calling `find_declaration` directly.