### PR TITLE
Improve test time

### DIFF
--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -51,17 +51,19 @@ function handle_InitializeRequest(
         # leave Refs undefined
     end
 
-    client_pid = something(init_params.processId, client_process_id, Some(nothing))
-    version = JETLS_VERSION
-    if version == "dev"
-        version *= " ($(pkgdir(JETLS)))"
+    if !JETLS_TEST_MODE
+        client_pid = something(init_params.processId, client_process_id, Some(nothing))
+        version = JETLS_VERSION
+        if version == "dev"
+            version *= " ($(pkgdir(JETLS)))"
+        end
+        workspace = isdefined(state, :root_path) ? state.root_path :
+            isempty(state.workspaceFolders) ? "(no workspace)" : "(multi-root)"
+        title = "jetls serve --$transport" *
+                (client_pid !== nothing ? " --clientProcessId=$client_pid" : "") *
+                " [version: $version, workspace: $workspace]"
+        @ccall uv_set_process_title(title::Cstring)::Cint
     end
-    workspace = isdefined(state, :root_path) ? state.root_path :
-        isempty(state.workspaceFolders) ? "(no workspace)" : "(multi-root)"
-    title = "jetls serve --$transport" *
-            (client_pid !== nothing ? " --clientProcessId=$client_pid" : "") *
-            " [version: $version, workspace: $workspace]"
-    @ccall uv_set_process_title(title::Cstring)::Cint
 
     # NOTE: Static server settings that require a server restart to take effect should be
     # accessed during server initialization via `state.init_params.initializationOptions`.

--- a/src/types.jl
+++ b/src/types.jl
@@ -518,7 +518,7 @@ end
 
 const DEFAULT_CONFIG = JETLSConfig(;
     diagnostic = DiagnosticConfig(true, true, true, DiagnosticPattern[]),
-    full_analysis = FullAnalysisConfig(1.0, true),
+    full_analysis = FullAnalysisConfig(@static(JETLS_TEST_MODE ? 0.0 : 1.0), true),
     testrunner = TestRunnerConfig(@static Sys.iswindows() ? "testrunner.bat" : "testrunner"),
     formatter = "Runic",
     completion = CompletionConfig(LaTeXEmojiConfig(missing), MethodSignatureConfig(missing)),

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -188,7 +188,11 @@ Returns:
 """
 function get_file_info(
         s::ServerState, uri::URI, cancel_flag::AbstractCancelFlag;
-        timeout::Float64 = 10., cancelled_error_data = nothing
+        # Shorten `timeout` and polling `sleep` under `JETLS_TEST_MODE` so tests
+        # that intentionally exercise the timeout path (e.g. "File cache error
+        # handling") don't block for the full production timeout.
+        timeout::Float64 = @static(JETLS_TEST_MODE ? 1.0 : 10.),
+        cancelled_error_data = nothing
     )
     start = time()
     request_id = objectid(cancel_flag) # Each request uses a unique `cancel_flag`, so this objectid can be used as a request-unique ID
@@ -207,7 +211,9 @@ function get_file_info(
             return nothing
         end
         JETLS_DEV_MODE && @info "Waiting for file cache" uri _id=request_id maxlog=1
-        sleep(0.5)
+        # Shorten the polling interval under `JETLS_TEST_MODE` (paired with the
+        # shortened `timeout` above) so the timeout-exercising tests finish fast.
+        sleep(@static JETLS_TEST_MODE ? 0.05 : 0.5)
     end
     return nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,8 +9,8 @@ end
 @testset "AtomicContainers" include("AtomicContainers/test_AtomicContainers.jl")
 @testset "FixedSizeQueues" include("FixedSizeQueues/test_FixedSizeQueues.jl")
 
-@testset "JETLS" begin
-    @testset "utils" begin
+@testset "JETLS" verbose=true begin
+    @testset "utils" verbose=true begin
         @testset "general" include("utils/test_general.jl")
         @testset "ast" include("utils/test_ast.jl")
         @testset "binding" include("utils/test_binding.jl")
@@ -20,7 +20,7 @@ end
         @testset "string" include("utils/test_string.jl")
         @testset "jl-syntax-macros" include("utils/test_jl_syntax_macros.jl")
     end
-    @testset "analysis" begin
+    @testset "analysis" verbose=true begin
         @testset "occurrence" include("analysis/test_occurrence_analysis.jl")
         @testset "def use" include("analysis/test_def_use_analysis.jl")
         @testset "LSAnalyzer" include("analysis/test_Analyzer.jl")

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -25,7 +25,7 @@ function wait_for_file_cache_version(state::JETLS.ServerState, uri::URIs2.URI,
     error("Timed out waiting for file cache version $version for $uri")
 end
 
-function take_with_timeout!(chn::Channel; interval=1, limit=60)
+function take_with_timeout!(chn::Channel; interval=0.1, limit=600)
     while limit > 0
         if isready(chn)
             return take!(chn)

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -283,24 +283,15 @@ end
 function with_completion_request(
         tester, text::AbstractString;
         context::Union{Nothing, CompletionContext} = nothing,
-        full_analysis::Bool = false,
         kwargs...
     )
     clean_code, positions = JETLS.get_text_and_positions(text; kwargs...)
-
     withscript(clean_code) do script_path
         uri = filepath2uri(script_path)
         withserver() do (; writereadmsg, id_counter, server)
-            if full_analysis
-                (; raw_res) = writereadmsg(make_DidOpenTextDocumentNotification(uri, clean_code))
-                @test raw_res isa PublishDiagnosticsNotification
-                @test raw_res.params.uri == uri
-            else
-                JETLS.cache_file_info!(server, uri, 1, clean_code)
-                JETLS.cache_saved_file_info!(server.state, uri, clean_code)
-                JETLS.request_analysis!(server, uri, #=invalidate=#false; wait=true, notify_diagnostics=false)
-            end
-
+            JETLS.cache_file_info!(server, uri, 1, clean_code)
+            JETLS.cache_saved_file_info!(server.state, uri, clean_code)
+            JETLS.request_analysis!(server, uri, #=invalidate=#false; wait=true, notify_diagnostics=false)
             for (i, pos) in enumerate(positions)
                 params = CompletionParams(;
                     textDocument = TextDocumentIdentifier(; uri),
@@ -312,6 +303,32 @@ function with_completion_request(
                 tester(i, raw_res.result, uri)
             end
         end
+    end
+end
+
+# Lightweight version of `with_completion_request` for cases where full module
+# context (populated by `request_analysis!`) isn't needed.
+# The `mod` context falls back to `Main`, so this works for tests against names defined in
+# `Main`/`Base`/`Core` and for purely local/keyword/latex/emoji completions.
+function with_completion_items(
+        tester, text::AbstractString;
+        context::Union{Nothing, CompletionContext} = nothing,
+        kwargs...
+    )
+    clean_code, positions = JETLS.get_text_and_positions(text; kwargs...)
+    uri = filepath2uri(@__FILE__)
+    state = JETLS.ServerState()
+    state.init_params = InitializeParams(;
+        processId = getpid(),
+        rootUri = nothing,
+        capabilities = ClientCapabilities())
+    fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
+    JETLS.store!(state.file_cache) do cache
+        Base.PersistentDict(cache, uri => fi), nothing
+    end
+    for (i, pos) in enumerate(positions)
+        items, isIncomplete = JETLS.get_completion_items(state, uri, fi, pos, context)
+        tester(i, (; items, isIncomplete), uri)
     end
 end
 
@@ -427,7 +444,7 @@ end
 
     context = CompletionContext(; triggerKind = CompletionTriggerKind.Invoked)
     cnt = Ref(0)
-    with_completion_request(text; context) do _, result, _
+    with_completion_items(text; context) do _, result, _
         items = result.items
         @test any(items) do item
             item.label == "yyy"
@@ -441,7 +458,7 @@ end
 @testset "empty completion" begin
     let text = "│"
         cnt = Ref(0)
-        with_completion_request(text) do _, result, _
+        with_completion_items(text) do _, result, _
             items = result.items
             # should not crash and return something
             @test length(items) > 0
@@ -452,7 +469,7 @@ end
 
     let text = "\n\n\n│"
         cnt = Ref(0)
-        with_completion_request(text) do _, result, _
+        with_completion_items(text) do _, result, _
             items = result.items
             # should not crash and return something
             @test length(items) > 0
@@ -473,7 +490,7 @@ end
             triggerKind = CompletionTriggerKind.TriggerCharacter,
             triggerCharacter = "@")
         cnt = Ref(0)
-        with_completion_request(text; context) do _, result, _
+        with_completion_items(text; context) do _, result, _
             items = result.items
             @test any(items) do item
                 item.label == "@nospecialize" &&
@@ -499,7 +516,7 @@ end
         """
         context = CompletionContext(; triggerKind = CompletionTriggerKind.Invoked)
         cnt = Ref(0)
-        with_completion_request(text; context) do _, result, _
+        with_completion_items(text; context) do _, result, _
             items = result.items
             @test any(items) do item
                 item.label == "@nospecialize" &&
@@ -521,7 +538,7 @@ end
         """
         context = CompletionContext(; triggerKind = CompletionTriggerKind.Invoked)
         cnt = Ref(0)
-        with_completion_request(text; context) do _, result, _
+        with_completion_items(text; context) do _, result, _
             items = result.items
             @test any(items) do item
                 item.label == "yyy"
@@ -539,7 +556,7 @@ end
         """
         context = CompletionContext(; triggerKind = CompletionTriggerKind.Invoked)
         cnt = Ref(0)
-        with_completion_request(text; context) do _, result, _
+        with_completion_items(text; context) do _, result, _
             items = result.items
             @test any(items) do item
                 item.label == "@nospecialize" &&
@@ -756,7 +773,7 @@ end
             triggerKind = CompletionTriggerKind.TriggerCharacter,
             triggerCharacter = "\\")
         cnt = Ref(0)
-        with_completion_request(text; context) do _, result, _
+        with_completion_items(text; context) do _, result, _
             items = result.items
             @test any(items) do item
                 item.label == "\\alpha"
@@ -783,7 +800,7 @@ end
             triggerKind = CompletionTriggerKind.TriggerCharacter,
             triggerCharacter = ":")
         cnt = Ref(0)
-        with_completion_request(text; context) do _, result, _
+        with_completion_items(text; context) do _, result, _
             items = result.items
             @test any(items) do item
                 item.label == "\\:pizza:"
@@ -891,7 +908,7 @@ end
             triggerKind = CompletionTriggerKind.TriggerCharacter,
             triggerCharacter = "(")
         cnt = Ref(0)
-        with_completion_request(text; context) do _, result, _
+        with_completion_items(text; context) do _, result, _
             items = result.items
             @test count(items) do item
                 item.labelDetails !== nothing &&
@@ -912,7 +929,7 @@ end
             triggerKind = CompletionTriggerKind.TriggerCharacter,
             triggerCharacter = ",")
         cnt = Ref(0)
-        with_completion_request(text; context) do _, result, _
+        with_completion_items(text; context) do _, result, _
             items = result.items
             @test count(items) do item
                 item.labelDetails !== nothing &&
@@ -932,7 +949,7 @@ end
             triggerKind = CompletionTriggerKind.TriggerCharacter,
             triggerCharacter = ",")
         cnt = Ref(0)
-        with_completion_request(text; context) do _, result, _
+        with_completion_items(text; context) do _, result, _
             items = result.items
             @test_broken count(items) do item
                 item.labelDetails !== nothing &&
@@ -952,7 +969,7 @@ end
             triggerKind = CompletionTriggerKind.TriggerCharacter,
             triggerCharacter = ",")
         cnt = Ref(0)
-        with_completion_request(text; context) do _, result, _
+        with_completion_items(text; context) do _, result, _
             items = result.items
             @test all(items) do item
                 newText = get_newText(item)
@@ -973,7 +990,7 @@ end
             triggerKind = CompletionTriggerKind.TriggerCharacter,
             triggerCharacter = " ")
         cnt = Ref(0)
-        with_completion_request(text; context) do _, result, _
+        with_completion_items(text; context) do _, result, _
             items = result.items
             @test all(items) do item
                 newText = get_newText(item)
@@ -996,7 +1013,7 @@ end
             triggerKind = CompletionTriggerKind.TriggerCharacter,
             triggerCharacter = " ")
         cnt = Ref(0)
-        with_completion_request(text; context) do _, result, _
+        with_completion_items(text; context) do _, result, _
             items = result.items
             method_items = filter(items) do item
                 item.labelDetails !== nothing &&
@@ -1019,7 +1036,7 @@ end
             triggerKind = CompletionTriggerKind.TriggerCharacter,
             triggerCharacter = ",")
         cnt = Ref(0)
-        with_completion_request(text; context) do _, result, _
+        with_completion_items(text; context) do _, result, _
             items = result.items
             @test all(items) do item
                 newText = get_newText(item)
@@ -1039,7 +1056,7 @@ end
             triggerKind = CompletionTriggerKind.TriggerCharacter,
             triggerCharacter = "(")
         cnt = Ref(0)
-        with_completion_request(text; context) do _, result, _
+        with_completion_items(text; context) do _, result, _
             cnt[] = 1
         end
         @test cnt[] == 1
@@ -1057,7 +1074,7 @@ end
             triggerKind = CompletionTriggerKind.TriggerCharacter,
             triggerCharacter = ";")
         cnt = Ref(0)
-        with_completion_request(text; context) do _, result, _
+        with_completion_items(text; context) do _, result, _
             items = result.items
             keyword_items = filter(items) do item
                 item.labelDetails !== nothing &&
@@ -1082,7 +1099,7 @@ end
             triggerKind = CompletionTriggerKind.TriggerCharacter,
             triggerCharacter = " ")
         cnt = Ref(0)
-        with_completion_request(text; context) do _, result, _
+        with_completion_items(text; context) do _, result, _
             items = result.items
             keyword_items = filter(items) do item
                 item.labelDetails !== nothing &&
@@ -1104,7 +1121,7 @@ end
             triggerKind = CompletionTriggerKind.TriggerCharacter,
             triggerCharacter = "=")
         cnt = Ref(0)
-        with_completion_request(text; context) do _, result, _
+        with_completion_items(text; context) do _, result, _
             items = result.items
             keyword_items = filter(items) do item
                 item.labelDetails !== nothing &&
@@ -1126,7 +1143,7 @@ end
             triggerKind = CompletionTriggerKind.TriggerCharacter,
             triggerCharacter = " ")
         cnt = Ref(0)
-        with_completion_request(text; context) do _, result, _
+        with_completion_items(text; context) do _, result, _
             items = result.items
             keyword_items = filter(items) do item
                 item.labelDetails !== nothing &&
@@ -1146,7 +1163,7 @@ end
         """
         context = CompletionContext(; triggerKind = CompletionTriggerKind.Invoked)
         cnt = Ref(0)
-        with_completion_request(text; context) do _, result, _
+        with_completion_items(text; context) do _, result, _
             items = result.items
             keyword_items = filter(items) do item
                 item.labelDetails !== nothing &&

--- a/test/test_diagnostic.jl
+++ b/test/test_diagnostic.jl
@@ -330,7 +330,10 @@ end
                     notify(event)
                 end
             end
-            sleep(5.0)
+            # Send `DidOpen` after the handler has started polling but before
+            # `get_file_info`'s `JETLS_TEST_MODE` timeout (1.0s) fires, so the
+            # test exercises the "cache arrives during polling" path.
+            sleep(0.5)
             writereadmsg(make_DidOpenTextDocumentNotification(uri, read(script_path, String)); read=0, check=false)
             wait(event)
             @test success


### PR DESCRIPTION
## Summary

Speed up the test suite. Two main changes:

### 1. Bypass LSP roundtrip in completion tests

Added `with_completion_items` that calls `JETLS.get_completion_items`
directly against a minimal `ServerState`, skipping the server loop
and LSP serialization. Migrated 22 of 23 callsites in
`test_completions.jl`; the remaining one tests `ModuleCompletion.xxx`
which needs the module context populated by `request_analysis!`.

### 2. `JETLS_TEST_MODE` knobs

Shorten production-scale waits under `JETLS_TEST_MODE`:

- `full_analysis.debounce`: `1.0 → 0.0`
- `get_file_info` `timeout`: `10s → 1s`, polling sleep: `0.5s → 0.05s`
- `take_with_timeout!` polling `interval`: `1s → 0.1s`

Also skip `uv_set_process_title` in `handle_InitializeRequest` under
test mode (clobbers the Julia test runner's process title otherwise).

## Speedups

- `test_completions.jl`: ~30s
- `test_diagnostic.jl`: ~30s