### PR TITLE
full-analysis: Invalidate binding occurrences cache on module change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- The reference-count code lens now emits `editor.action.showReferences` (a VSCode convention command) directly, instead of the JETLS-defined `jetls.showReferences`. Editors that follow the VSCode convention (e.g. Zed) now dispatch the lens out of the box; editors that do not (e.g. Neovim) need to register a client-side handler.
+- The [reference-count code lens](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/code_lens-references) now emits `editor.action.showReferences` (a VSCode convention command) directly, instead of the JETLS-defined `jetls.showReferences`. Editors that follow the VSCode convention (e.g. Zed) now dispatch the lens out of the box; editors that do not (e.g. Neovim) need to register a client-side handler.
 
 - When a reference-count code lens is clicked on a file whose full analysis has not yet run, a warning notification (via `window/showMessage`) is now shown instead of an empty references peek.
 
@@ -63,6 +63,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fixed `textDocument/references` so that `includeDeclaration=false` now correctly excludes method definitions and declarations of the target binding. As a side benefit, the [reference-count code lens](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/code_lens-references) now reports accurate counts.
+
+- Fixed the reference-count code lens, `textDocument/references`, `textDocument/documentHighlight`, and `textDocument/rename` silently dropping results after a full analysis completes.
 
 - Names listed in `export` and `public` statements are now treated as references to the surrounding module's global bindings, so `textDocument/documentHighlight`, `textDocument/references`, `textDocument/definition`, and `textDocument/rename` all work when the cursor is placed on an exported/public name.
 

--- a/src/analysis/Interpreter.jl
+++ b/src/analysis/Interpreter.jl
@@ -104,7 +104,7 @@ end
 function cache_intermediate_analysis_result!(interp::LSInterpreter)
     result = JET.JETToplevelResult(interp.analyzer, interp.state.res, "LSInterpreter (intermediate result)", ())
     intermediate_result, _ = JETLS.new_analysis_result(interp, interp.request, result)
-    JETLS.update_analysis_cache!(interp.server.state.analysis_manager, intermediate_result)
+    JETLS.update_analysis_cache!(interp.server.state, intermediate_result)
 end
 
 function JET.analyze_from_definitions!(interp::LSInterpreter, config::JET.ToplevelConfig)

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -412,7 +412,7 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
     tm = round(time() - s, digits=2)
     JETLS_DEV_MODE && @info "Analysis completed in $tm seconds:" entry=progress_title(request.entry) uri=request.uri generation=get_generation(manager,request.entry)
 
-    update_analysis_cache!(manager, analysis_result)
+    update_analysis_cache!(server.state, analysis_result)
     mark_analyzed_generation!(manager, request)
     request.notify_diagnostics && notify_diagnostics!(server)
 
@@ -502,8 +502,10 @@ function cleanup_prev_methods(prev_result::AnalysisResult)
     end
 end
 
-function update_analysis_cache!(manager::AnalysisManager, analysis_result::AnalysisResult)
+function update_analysis_cache!(state::ServerState, analysis_result::AnalysisResult)
+    manager = state.analysis_manager
     analyzed_uris = analyzed_file_uris(analysis_result)
+    prev_cache = load(manager.cache)
     store!(manager.cache) do cache
         new_cache = copy(cache)
         for uri in analyzed_uris
@@ -511,6 +513,29 @@ function update_analysis_cache!(manager::AnalysisManager, analysis_result::Analy
         end
         return new_cache, nothing
     end
+    # Cached occurrences embed `binfo.mod` from the module context that was in effect when
+    # they were computed. Analysis modes that use virtualized contexts
+    # (scripts, old package mode) mint a fresh gensym'd virtual module on every successful
+    # run, so the module identity changes between consecutive reanalyses.
+    # Invalidate so lowering-based LSP handlers recompute under then current module context.
+    # Revise-based analysis keeps module identity stable across runs, so we
+    # skip invalidation when `module_range_infos` is unchanged.
+    for uri in analyzed_uris
+        if module_range_infos_unchanged(prev_cache, analysis_result, uri)
+            continue
+        end
+        invalidate_binding_occurrences_cache!(state, uri)
+    end
+end
+
+function module_range_infos_unchanged(
+        prev_cache::Dict{URI,AnalysisInfo}, new_result::AnalysisResult, uri::URI,
+    )
+    prev_result = get(prev_cache, uri, nothing)
+    prev_result isa AnalysisResult || return false
+    prev_safi = @something analyzed_file_info(prev_result, uri) return false
+    new_safi = @something analyzed_file_info(new_result, uri) return false
+    return prev_safi.module_range_infos == new_safi.module_range_infos
 end
 
 function mark_analyzed_generation!(manager::AnalysisManager, request::AnalysisRequest)

--- a/test/test_full_lifecycle.jl
+++ b/test/test_full_lifecycle.jl
@@ -2,6 +2,8 @@ module test_full_lifecycle
 
 include("setup.jl")
 
+@testset "full completion cycle" begin
+
 let (pkgcode, positions) = JETLS.get_text_and_positions("""
     module TestFullLifecycle
 
@@ -150,6 +152,101 @@ let (pkgcode, positions) = JETLS.get_text_and_positions("""
 
         # also test cases when external script is open
         withserver(test_full_cycle)
+    end
+end
+
+end # @testset "full completion cycle" begin
+
+# Regression test: `textDocument/references` previously returned stale
+# results after script-mode reanalysis because the cached occurrences kept
+# `binfo.mod` from the previous virtual module while the new target binding
+# resolved in the freshly gensym'd virtual module of the new analysis run.
+@testset "occurrence cache invalidation across script-mode reanalysis" begin
+    script_code = """
+    func│(x) = sin(x)
+
+    function main(args::Vector{String})::Cint
+        println(func(@something tryparse(Int, first(args)) return 1))
+        return 0
+    end
+    """
+    clean_code, positions = JETLS.get_text_and_positions(script_code)
+    @test length(positions) == 1
+    refpos = only(positions)
+
+    withscript(clean_code) do script_path
+        uri = filepath2uri(script_path)
+        withserver() do (; writereadmsg, id_counter)
+            # Open the file; the response publishes diagnostics only once the
+            # initial full analysis completes.
+            let (; raw_res) = writereadmsg(
+                    make_DidOpenTextDocumentNotification(uri, clean_code))
+                @test raw_res isa PublishDiagnosticsNotification
+                @test raw_res.params.uri == uri
+            end
+
+            refparams = ReferenceParams(;
+                textDocument = TextDocumentIdentifier(; uri),
+                position = refpos,
+                context = ReferenceContext(; includeDeclaration = true))
+
+            # First request populates `binding_occurrences_cache` with
+            # entries keyed against the first analysis run's virtual module.
+            refs_first = let id = id_counter[] += 1
+                (; raw_res) = writereadmsg(
+                    ReferencesRequest(; id, params = refparams))
+                @test raw_res isa ReferencesResponse && raw_res.id == id
+                raw_res.result
+            end
+            @test refs_first isa Vector{Location}
+            @test length(refs_first) == 2
+
+            # Trigger reanalysis: script mode mints a new gensym'd virtual
+            # module, so the cached occurrences become stale unless
+            # `update_analysis_cache!` invalidates them.
+            let (; raw_res) = writereadmsg(
+                    DidSaveTextDocumentNotification(;
+                        params = DidSaveTextDocumentParams(;
+                            textDocument = TextDocumentIdentifier(; uri),
+                            text = clean_code)))
+                @test raw_res isa PublishDiagnosticsNotification
+                @test raw_res.params.uri == uri
+            end
+
+            # Without the invalidation, the stale cache would fail to match
+            # the target binding's new virtual module and references would
+            # drop to 0 or 1 here.
+            refs_second = let id = id_counter[] += 1
+                (; raw_res) = writereadmsg(
+                    ReferencesRequest(; id, params = refparams))
+                @test raw_res isa ReferencesResponse && raw_res.id == id
+                raw_res.result
+            end
+            @test refs_second isa Vector{Location}
+            @test length(refs_second) == 2
+
+            # Reanalyze once more to exercise the virtual-module -> virtual-module
+            # transition: the previous reanalysis populated the cache with
+            # entries keyed against its virtual module, and this run produces yet
+            # another gensym'd virtual module.
+            let (; raw_res) = writereadmsg(
+                    DidSaveTextDocumentNotification(;
+                        params = DidSaveTextDocumentParams(;
+                            textDocument = TextDocumentIdentifier(; uri),
+                            text = clean_code)))
+                @test raw_res isa PublishDiagnosticsNotification
+                @test raw_res.params.uri == uri
+            end
+
+            refs_third = let id = id_counter[] += 1
+                (; raw_res) = writereadmsg(
+                    ReferencesRequest(; id, params = refparams))
+                @test raw_res isa ReferencesResponse && raw_res.id == id
+                raw_res.result
+            end
+            @test refs_third isa Vector{Location}
+            @test length(refs_third) == 2
+        end
     end
 end
 


### PR DESCRIPTION
Cached entries in `state.binding_occurrences_cache` embed `binfo.mod` from the module context that was in effect when they were computed. Analysis modes that use virtualized contexts (script mode, old package mode) mint a fresh gensym'd virtual module on every successful run, so the module identity changes both on the initial `Main` -> virtual transition and between consecutive reanalyses.

Without invalidation, stale cached occurrences kept matching against the previous module while `find_references` resolved the target binding under the newly installed one, causing
`is_matching_global_binding`
to fail and the affected references to silently disappear from results of `textDocument/references`, `textDocument/documentHighlight`, `textDocument/rename`, and related lowering-based diagnostics.

`update_analysis_cache!` now takes the full `ServerState` and invalidates the cache for each newly analyzed URI. Revise-based analysis keeps module identity stable across runs, so the helper `module_range_infos_unchanged` lets us skip invalidation when the previous `AnalysisResult` for the URI has identical `module_range_infos`, avoiding unnecessary flushes on package reanalysis.