### PR TITLE
ast/binding: Move `@eval` to new-style macrocall handling

### DIFF
--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -127,17 +127,12 @@ is_macro0(st0::SyntaxTree0) = JS.kind(st0) === JS.K"macro"
 # macros — whose expansion collapses source positions to line granularity and
 # is why `_remove_macrocalls` exists — these don't need to be rewritten to a
 # `block` to keep accurate locations for scope resolution.
-#
-# `@eval` is kept off: preserving it surfaces its inert `[K"quote" ex]`
-# template to `collect_inert_global_occurrences!`, which resolves inert
-# content without threading the enclosing `ctx3` and would therefore
-# record `$x` interpolations of enclosing locals as spurious `:global`
-# occurrences. Stripping via `_remove_macrocalls` avoids this.
 const NEW_STYLE_MACROCALL_NAMES = (
     # JuliaLowering/src/syntax_macros.jl
     "@__FUNCTION__",
     "@ccall",
     "@cfunction",
+    "@eval",
     "@generated",
     "@goto",
     "@isdefined",
@@ -353,8 +348,7 @@ function _remove_macrocalls(st0::SyntaxTree0)
             # Macros with new-style JuliaLowering implementations preserve
             # fine-grained provenance during expansion, so we don't need to
             # rewrite them to a `block` to keep source locations accurate.
-            # See `NEW_STYLE_MACROCALL_NAMES` for the list and the rationale
-            # for why certain candidates (notably `@eval`) are excluded.
+            # See `NEW_STYLE_MACROCALL_NAMES` for the list.
             return st0, false
         elseif is_mainfunc0(st0)
             # `@main` functions are desugared by `desugar_main_macrocall` below,

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -186,6 +186,12 @@ function find_target_binding(ctx3::JL.VariableAnalysisContext, st3::JS.SyntaxTre
         if binfo.is_internal || startswith(binfo.name, "#") || binfo.name in _IMPLICIT_BINDING_NAMES
             return nothing
         end
+        # Skip bindings constructed inside a macro body — e.g. `@eval`'s
+        # synthetic `eval_result` local, whose `srcref` covers the whole
+        # macrocall and would otherwise shadow the user identifier inside.
+        # `$`-escaped user bindings stay at layer 1, so this only filters out
+        # macro-local bindings.
+        binding_scope_layer(ctx3, binfo) === 1 || return nothing
         return TraversalReturn(st)
     end
 end
@@ -253,11 +259,17 @@ function select_target_binding(
         JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
         return nothing
     end
-    binding = @something(
-        _select_target_binding(ctx3, st3, offset; is_generated=is_generated0(st0)),
-        return nothing)
-    binding = normalize_local_alias_to_global(ctx3, binding)
-    return (; ctx3, st3, st0, binding)
+    primary = _select_target_binding(ctx3, st3, offset; is_generated=is_generated0(st0))
+    if primary !== nothing
+        binding = normalize_local_alias_to_global(ctx3, primary)
+        return (; ctx3, st3, st0, binding)
+    end
+    # Fall back to resolving an identifier inside a preserved macrocall's
+    # inert template (e.g. `LSAnalyzer` in `@eval ::LSAnalyzer = ...`).
+    # Inert contents aren't scope-resolved, so no `BindingId` exists for
+    # `find_target_binding` to pick up — we run a fresh resolution on just
+    # the inert subtree.
+    return find_inert_global_target_binding(st0, st3, offset, mod; soft_scope)
 end
 
 function find_inert_target_binding(
@@ -269,6 +281,55 @@ function find_inert_target_binding(
         return JL.binding_ex(ctx3, binfo.id)
     end
     return nothing
+end
+
+find_inert_global_target_binding(
+    st0::JS.SyntaxTree, st3::JS.SyntaxTree, offset::Int, mod::Module;
+    soft_scope::Bool = false
+) = @something(
+    _find_inert_global_target_binding(st0, st3, offset, mod; soft_scope),
+    # Handle `var│` at end-of-token (same retry as `_select_target_binding`).
+    _find_inert_global_target_binding(st0, st3, offset-1, mod; soft_scope),
+    return nothing)
+
+function _find_inert_global_target_binding(
+        st0::JS.SyntaxTree, st3::JS.SyntaxTree, offset::Int, mod::Module;
+        soft_scope::Bool = false
+    )
+    name = @something find_inert_identifier_name(st3, offset) return nothing
+    inert_tree = @something enclosing_inert_tree(st3, offset) return nothing
+    JS.numchildren(inert_tree) ≥ 1 || return nothing
+    ires = try
+        jl_lower_for_scope_resolution(mod, unwrap_interpolations(inert_tree[1]); soft_scope)
+    catch
+        return nothing
+    end
+    for binfo in ires.ctx3.bindings.info
+        binfo.kind === :global || continue
+        binfo.is_internal && continue
+        binfo.name == name || continue
+        binding = JL.binding_ex(ires.ctx3, binfo.id)
+        return (; ctx3 = ires.ctx3, st3 = ires.st3, st0, binding)
+    end
+    return nothing
+end
+
+# Find the innermost `K"inert"` node in `st3` whose byte range contains
+# `offset`. Used to run fresh scope resolution on just that inert subtree.
+function enclosing_inert_tree(st3::JS.SyntaxTree, offset::Int)
+    best = Ref{Union{Nothing,JS.SyntaxTree}}(nothing)
+    best_len = Ref(typemax(Int))
+    traverse(st3) do st::JS.SyntaxTree
+        JS.kind(st) === JS.K"inert" || return nothing
+        offset in JS.byte_range(st) || return nothing
+        len = length(JS.byte_range(st))
+        if len < best_len[]
+            best[] = st
+            best_len[] = len
+        end
+        return nothing
+    end
+    return best[]
 end
 
 # Struct/type definitions generate a local binding with `mod=nothing` for

--- a/test/test_references.jl
+++ b/test/test_references.jl
@@ -357,6 +357,24 @@ end
             @test length(refs_at_let) == 1
         end
     end
+
+    # Cursor on a non-`\$` identifier inside a preserved macrocall's inert
+    # template must resolve to the matching module-level global.
+    @testset "cursor on inert global inside preserved macrocall" begin
+        let code = """
+            struct │LSAnalyzer│ end
+            let x = 1
+                @eval some_func(::│LSAnalyzer│) = \$x
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 4
+            for pos in positions
+                refs = find_references(clean_code, pos)
+                @test length(refs) == 2
+            end
+        end
+    end
 end
 
 end # module test_references

--- a/test/utils/test_binding.jl
+++ b/test/utils/test_binding.jl
@@ -152,6 +152,41 @@ end
         end
         @test cnt == 1
     end
+
+    # User-written identifiers escaped into a macro's generated code
+    # (here via `\$` inside `@eval`) should resolve to the enclosing
+    # user binding, not to any binding synthesized by the macro itself.
+    let cnt = 0
+        with_target_binding("""
+            let │valid_keys│ = 42
+                @eval some_func() = \$│valid_keys│
+            end
+            """) do _, (; ctx3, binding)
+            binfo = JL.get_binding(ctx3, binding)
+            @test binfo.name == "valid_keys"
+            @test binfo.kind === :local
+            cnt += 1
+        end
+        @test cnt == 4
+    end
+
+    # User-written identifiers sitting in a macro's inert/quoted template
+    # (here the type name inside `@eval`) should resolve to the matching
+    # module-level global.
+    let cnt = 0
+        with_target_binding("""
+            struct │LSAnalyzer│ end
+            let x = 1
+                @eval some_func(::│LSAnalyzer│) = \$x
+            end
+            """) do _, (; ctx3, binding)
+            binfo = JL.get_binding(ctx3, binding)
+            @test binfo.name == "LSAnalyzer"
+            @test binfo.kind === :global
+            cnt += 1
+        end
+        @test cnt == 4
+    end
 end
 
 function with_target_binding_definitions(f, text::AbstractString; kwargs...)


### PR DESCRIPTION
`@eval` is now added to `NEW_STYLE_MACROCALL_NAMES` so that its expansion goes through JuliaLowering's fine-grained provenance path rather than being collapsed by `remove_macrocalls`.

Preserving `@eval` surfaces two new concerns handled here:

- `@eval` expansion introduces a synthetic `eval_result` local built via `@ast ctx srcref ...`, whose source ref covers the entire macrocall. Without filtering, this binding shadows any user-written identifier inside the macrocall. `find_target_binding` now skips bindings whose `scope_layer != 1`, matching the hygiene semantics already used in `is_relevant`: `\$`-escaped user bindings stay at layer 1, while macro-local bindings introduced via `@ast` sit on the macro's own layer.

- Identifiers inside a preserved macrocall's inert template (e.g. `LSAnalyzer` in `@eval ::LSAnalyzer = ...`) are not scope-resolved by the enclosing lowering and never get a `BindingId`. A new `find_inert_global_target_binding` runs a fresh scope resolution on the innermost enclosing `K"inert"` subtree and reports the matching `:global` binding, serving as a fallback after the regular `_select_target_binding` path.