### PR TITLE
occurrences: Replace machinery-ref heuristics with JL's `synthetic_ref`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,8 +27,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [sources]
 Compiler = {rev = "avi/JETLS-Compiler-head", subdir = "Compiler", url = "https://github.com/JuliaLang/julia"}
 JET = {rev = "8460cb66", url = "https://github.com/aviatesk/JET.jl"}
-JuliaLowering = {rev = "4421df5dda", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
-JuliaSyntax = {rev = "4421df5dda", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
+JuliaLowering = {rev = "avi/JL-synthetic-uses", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
+JuliaSyntax = {rev = "avi/JL-synthetic-uses", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
 LSP = {path = "LSP"}
 
 [compat]

--- a/src/analysis/occurrence-analysis.jl
+++ b/src/analysis/occurrence-analysis.jl
@@ -94,20 +94,25 @@ function compute_binding_occurrences(
         end
     end
 
-    # Re-key `:local (mod=nothing)` aliases introduced by type definitions
-    # (struct / abstract type / primitive type) onto the matching hidden
-    # `:global (is_internal=true)` binding in the same `ctx3`. This normalizes
-    # struct-alias occurrences so they appear under a concrete-module `:global`
-    # entry like ordinary globals, letting downstream consumers match on
-    # `(mod, name, :global)` exactly without a nothing-mod fallback.
+    # Type definitions emit two bindings at the same source token: a
+    # `:local (mod=nothing)` alias and a `:global`. The local collects
+    # user-written `:use` occurrences from inside the type body (e.g.
+    # self-recursive field types like `next::Union{Node, Nothing}`
+    # resolve to the local). Merge its bucket into the global so those
+    # uses surface under a single `(mod, name, :global)` entry.
+    #
+    # Discriminator: matching declaration `byte_range`. An unrelated
+    # `local Foo` / `let Foo = 1` that happens to share a name with a
+    # `:global Foo` has a different decl byte_range and is not merged.
     alias_remaps = Pair{JL.BindingInfo,JL.BindingInfo}[]
     for binfo in keys(occurrences)
         binfo.kind === :local || continue
         isnothing(binfo.mod) || continue
+        local_decl_range = JS.byte_range(JL.binding_ex(ctx3, binfo))
         for other in ctx3.bindings.info
             other.kind === :global || continue
-            other.is_internal || continue
             other.name == binfo.name || continue
+            JS.byte_range(JL.binding_ex(ctx3, other)) == local_decl_range || continue
             push!(alias_remaps, binfo => other)
             break
         end
@@ -133,50 +138,29 @@ function collect_inert_identifiers(st3::SyntaxTreeC)
     return result
 end
 
-"""
-`skip_recording` maps a binding to a byte range. A BindingId is skipped only if
-both its binding and its byte range match an entry. This distinguishes synthetic
-BindingIds that lowering inserts at the definition-site range (e.g., inside
-`method`, `function_type`, or `removable` nodes) from genuine uses such as
-self-recursive calls, which have distinct byte ranges.
-"""
-const SkipRecording = Dict{JL.BindingInfo,UnitRange{Int}}
-
 function may_record_occurrence!(occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
-        kind::Symbol, st::SyntaxTreeC, ctx3::JL.VariableAnalysisContext;
-        skip_recording::Union{Nothing,SkipRecording} = nothing
+        kind::Symbol, st::SyntaxTreeC, ctx3::JL.VariableAnalysisContext,
     )
     if JS.kind(st) === JS.K"BindingId"
         binfo = JL.get_binding(ctx3, st)
-        _may_record_occurrence!(occurrences, kind, st, binfo; skip_recording)
+        _may_record_occurrence!(occurrences, kind, st, binfo)
         return true
     end
     return false
 end
 
 function _may_record_occurrence!(occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
-        kind::Symbol, st::SyntaxTreeC, binfo::JL.BindingInfo;
-        skip_recording::Union{Nothing,SkipRecording} = nothing
+        kind::Symbol, st::SyntaxTreeC, binfo::JL.BindingInfo,
     )
     haskey(occurrences, binfo) || return
-    if !isnothing(skip_recording)
-        skip_range = get(skip_recording, binfo, nothing)
-        if skip_range !== nothing && JS.byte_range(st) == skip_range
-            return
-        end
-    end
     push!(occurrences[binfo], BindingOccurrence(st, kind))
     occurrences
 end
-
-is_selffunc(b::JL.BindingInfo) = b.name == "#self#"
-is_kwsorter_func(b::JL.BindingInfo) = startswith(b.name, '#') && endswith(b.name, r"#\d+$")
 
 function compute_binding_occurrences!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
         ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC;
         include_global_bindings::Bool = false,
-        skip_recording_uses::Union{Nothing,SkipRecording} = nothing
     )
     stack = JS.SyntaxList(st3)
     while !isempty(stack)
@@ -184,7 +168,13 @@ function compute_binding_occurrences!(
         k = JS.kind(st)
         nc = JS.numchildren(st)
         if k === JS.K"BindingId"
-            may_record_occurrence!(occurrences, :use, st, ctx3; skip_recording=skip_recording_uses)
+            # JL marks synthetic machinery references (e.g. function self-refs
+            # inside `K"method"`/`K"function_type"`, type self-refs inside
+            # `_typebody!`/`_equiv_typedef` calls) with `:synthetic_ref`. Those
+            # are not user-visible uses of the binding.
+            if !JL.getmeta(st, :synthetic_ref, false)::Bool
+                may_record_occurrence!(occurrences, :use, st, ctx3)
+            end
         end
 
         start_idx = 1
@@ -195,43 +185,6 @@ function compute_binding_occurrences!(
         elseif k in JS.KSet"method_defs constdecl"
             if nc ≥ 1 && may_record_occurrence!(occurrences, :def, st[1], ctx3)
                 start_idx = 2
-            end
-        elseif k === JS.K"block" && nc ≥ 1 && JS.kind(st[1]) === JS.K"function_decl"
-            # This block wraps a function definition. Each function's own binding
-            # appears as BindingId in internal lowering nodes (`method`,
-            # `function_type`, `removable`, or as the trailing "return value" of
-            # the definition) that are not user-visible uses. We collect the
-            # bindings of all leading `function_decl` children (a single block
-            # may declare multiple functions, e.g., a keyword function generates
-            # both the user-visible function and a `#kw_body#…` helper) and map
-            # each to its definition-site byte range in `skip_recording_uses`
-            # before recursing. BindingIds whose range matches are skipped, while
-            # genuine uses at different ranges (e.g., self-recursive calls) are
-            # still recorded. Bindings already present in `skip_recording_uses`
-            # are used as a termination condition to avoid infinite recursion.
-            newly_added = Pair{JL.BindingInfo,UnitRange{Int}}[]
-            for i = 1:nc
-                child = st[i]
-                JS.kind(child) === JS.K"function_decl" || continue
-                JS.numchildren(child) ≥ 1 || continue
-                funcnode = child[1]
-                JS.kind(funcnode) === JS.K"BindingId" || continue
-                funcinfo = JL.get_binding(ctx3, funcnode)
-                if isnothing(skip_recording_uses) || !haskey(skip_recording_uses, funcinfo)
-                    push!(newly_added, funcinfo => JS.byte_range(funcnode))
-                end
-            end
-            if !isempty(newly_added)
-                if isnothing(skip_recording_uses)
-                    compute_binding_occurrences!(occurrences, ctx3, st;
-                        skip_recording_uses = SkipRecording(newly_added))
-                else
-                    for br in newly_added; push!(skip_recording_uses, br); end
-                    compute_binding_occurrences!(occurrences, ctx3, st;
-                        skip_recording_uses)
-                    for (b, _) in newly_added; delete!(skip_recording_uses, b); end
-                end
-                continue
             end
         elseif k === JS.K"lambda"
             # All blocks except the last one define arguments and static parameters,
@@ -254,53 +207,6 @@ function compute_binding_occurrences!(
             start_idx = 2 # the left hand side, i.e. "definition", does not account for usage
             if nc ≥ 1
                 may_record_occurrence!(occurrences, :def, st[1], ctx3)
-                if nc ≥ 2
-                    rhs = st[2]
-                    # In struct definitions, `local struct_name` is somehow introduced,
-                    # so special case it here: https://github.com/c42f/JuliaLowering.jl/blob/4b12ab19dad40c64767558be0a8a338eb4cc9172/src/desugaring.jl#L3833
-                    # TODO investigate why this local binding introduction is necessary on the JL side
-                    if JS.kind(rhs) === JS.K"BindingId" && JL.get_binding(ctx3, rhs).name == "struct_type"
-                        start_idx = 1
-                    end
-                end
-            end
-        elseif k === JS.K"call" && nc ≥ 1
-            arg1 = st[1]
-            skip_arguments = false
-            if JS.kind(arg1) === JS.K"BindingId"
-                funcbind = JL.get_binding(ctx3, arg1)
-                if is_selffunc(funcbind)
-                    # Don't count self arguments used in self calls as "usage".
-                    # This is necessary to issue unused argument diagnostics for `x` in cases like:
-                    # ```julia
-                    # hasmatch(x::RegexMatch, y::Bool=false) = nothing
-                    # ```
-                    skip_arguments = true
-                elseif is_kwsorter_func(funcbind)
-                    # Argument uses in keyword function calls also need to be skipped for the same reason.
-                    # Without this, `:use` of `a` in `func(a; x) = x` would be counted.
-                    skip_arguments = true
-                end
-            elseif JS.kind(arg1) === JS.K"top" && get(arg1, :name_val, "") == "kwerr"
-                # Skip argument uses for `kwerr` calls as well
-                skip_arguments = true
-            end
-            if skip_arguments
-                for i = nc:-1:2 # reversed since we use `pop!`
-                    argⱼ = st[i]
-                    if JS.kind(argⱼ) === JS.K"BindingId"
-                        bkind = JL.get_binding(ctx3, argⱼ).kind
-                        # Skip both `:argument` and `:local` bindings.
-                        # `:local` bindings appear in kwsorter calls when
-                        # `scope_nest` is used for dependent keyword defaults.
-                        if bkind === :argument || bkind === :local
-                            continue
-                        end
-                    end
-                    push!(stack, st[i])
-                end
-                push!(stack, arg1)
-                continue
             end
         end
         for i = nc:-1:start_idx # reversed since we use `pop!`

--- a/test/analysis/test_occurrence_analysis.jl
+++ b/test/analysis/test_occurrence_analysis.jl
@@ -295,6 +295,48 @@ end
         end
     end
 
+    # JL-synthesized forwarding stubs (`#self#` / `#kwcall_self#` /
+    # `#ctor-self#` / `#kw_body#f#N`) pass user args as machinery. Those
+    # forwards must not be counted as `:use`, but user-written default
+    # expressions placed as args of the same stubs must still be `:use`.
+    @testset "skip args in JL-synthesized forwarding calls" begin
+        # Optional positional + keyword (no dependent default).
+        with_binding_occurrences("f(x, y=1; k=1) = x + y + k") do boccs
+            for (b, occs) in boccs
+                b.kind === :argument || continue
+                if b.name == "x"
+                    @test count(o -> o.kind === :use, occs) == 1
+                end
+            end
+        end
+        # Inner constructor with optional positional defaults.
+        with_binding_occurrences("struct B; v::Int; B(y=1, z=2) = new(y + z); end") do boccs
+            for (b, occs) in boccs
+                b.kind === :argument || continue
+                if b.name == "y"
+                    @test count(o -> o.kind === :use, occs) == 1
+                elseif b.name == "z"
+                    @test count(o -> o.kind === :use, occs) == 1
+                end
+            end
+        end
+        # Dependent defaults: `y=x` and `kw=y` are user-written refs that
+        # must be preserved alongside the machinery-forward args.
+        with_binding_occurrences("f(x, y=x; kw=y) = x + y + kw") do boccs
+            use_positions = Dict{String,Set{Int}}()
+            for (b, occs) in boccs
+                b.kind === :argument || continue
+                for o in occs
+                    o.kind === :use || continue
+                    push!(get!(Set{Int}, use_positions, b.name), JS.first_byte(o.tree))
+                end
+            end
+            @test length(get(use_positions, "x", Set{Int}())) == 2  # default + body
+            @test length(get(use_positions, "y", Set{Int}())) == 2  # default + body
+            @test length(get(use_positions, "kw", Set{Int}())) == 1 # body
+        end
+    end
+
     @testset "keyword arguments" begin
         with_binding_occurrences("func(a; kw) = kw") do binding_occurrences
             @test !any(binding_occurrences) do (binding, occurrences)
@@ -453,6 +495,137 @@ function get_full_binding_occurrences(text::AbstractString;
 end
 
 @testset "compute_full_binding_occurrences" begin
+    # Function definitions reference the function name in machinery nodes
+    # (`K"method"` / `K"function_type"` / `K"removable"` / the method-less
+    # trailing return-value shim / kwsorter body methods / optional-
+    # positional self-forwarding stubs). Those refs must be `synthetic_ref`
+    # on the JL side so the user's `foo` token surfaces as `:decl`
+    # (+ `:def` for method definitions) but never as `:use`.
+    @testset "function definitions have no spurious :use" begin
+        for (code, declonly) in (("function foo end", true),
+                                 ("foo(x) = x", false),
+                                 ("function foo(x); x; end", false),
+                                 ("foo(x, y=1) = x + y", false),
+                                 ("foo(x; k=1) = x + k", false),
+                                 ("foo(x, y=1; k=1) = x + y + k", false),
+                                 ("foo(x::T) where T = x", false),
+                                 ("foo(x)::Int = x", false),
+                                 ("foo(x, y...) = (x, y)", false),
+                                 ("@generated function foo(x); :(x + 1); end", false),
+                                 ("function foo(x::Int, y=x); y; end", false))
+            let boccs = get_full_binding_occurrences(code)
+                pairs = collect(boccs)
+                i = @something findfirst(((b, _),) -> b.name == "foo", pairs)
+                binfo, occurrences = pairs[i]
+                @test binfo.kind === :global
+                @test count(o -> o.kind === :decl, occurrences) ≥ 1
+                @test count(o -> o.kind === :def, occurrences) ≥ !declonly
+                @test count(o -> o.kind === :use, occurrences) == 0
+            end
+        end
+    end
+
+    # Macro definitions follow the same machinery pattern as functions;
+    # the macro name must not surface as `:use` from the lowering scaffolding.
+    @testset "macro definitions have no spurious :use" begin
+        for (code, declonly) in (("macro foo end", true),
+                                 ("macro foo(x); x; end", false),
+                                 ("macro foo(x, y); x; end", false),
+                                 ("macro foo(args...); args; end", false))
+            let boccs = get_full_binding_occurrences(code)
+                pairs = collect(boccs)
+                i = @something findfirst(((b, _),) -> b.name == "@foo", pairs)
+                binfo, occurrences = pairs[i]
+                @test binfo.kind === :global
+                @test count(o -> o.kind === :decl, occurrences) == 1
+                @test count(o -> o.kind === :def, occurrences) ≥ !declonly
+                @test count(o -> o.kind === :use, occurrences) == 0
+            end
+        end
+    end
+
+    # kwfunc machinery refs are skipped, but a genuine self-recursive
+    # call in the body is still recorded as `:use`.
+    @testset "self-recursive call" begin
+        let boccs = get_full_binding_occurrences("""
+                function foo(x; kw=1)
+                    return foo(x - 1; kw=kw + 1)
+                end
+                """)
+            pairs = collect(boccs)
+            i = @something findfirst(((b, _),) -> b.name == "foo", pairs)
+            binfo, occurrences = pairs[i]
+            @test binfo.kind === :global
+            # `foo` has one `:decl` (the function definition on line 1) and
+            # one `:use` (the recursive call on line 2).
+            @test count(o -> o.kind === :decl, occurrences) == 1
+            @test count(o -> o.kind === :use, occurrences) == 1
+            @test count(occurrences) do occurrence
+                occurrence.kind === :use &&
+                JS.source_line(occurrence.tree) == 2
+            end == 1
+        end
+    end
+
+    # Type definitions reference the type name in machinery calls
+    # (`_typebody!` / `_equiv_typedef` / `_defaultctors` / redef compat
+    # shim). Those refs must be `synthetic_ref` on the JL side so the
+    # user's `A` token surfaces as `:decl` + `:def` but never as `:use`.
+    @testset "type definitions have no spurious :use" begin
+        for code in ("struct A end",
+                     "mutable struct A; x::Int; end",
+                     "struct A{T}; x::T; end",
+                     "struct A; x::Int; A(x) = new(x); end",
+                     "abstract type A end",
+                     "abstract type A <: Integer end",
+                     "primitive type A 8 end")
+            let boccs = get_full_binding_occurrences(code)
+                pairs = collect(boccs)
+                i = @something findfirst(((b, _),) -> b.name == "A", pairs)
+                binfo, occurrences = pairs[i]
+                @test binfo.kind === :global
+                @test count(o -> o.kind === :decl, occurrences) ≥ 1
+                @test count(o -> o.kind === :def, occurrences) ≥ 1
+                @test count(o -> o.kind === :use, occurrences) == 0
+            end
+        end
+    end
+
+    # `compute_binding_occurrences`'s alias-remap step merges the
+    # `:local (mod=nothing)` alias that JL introduces for type definitions
+    # into the matching `:global` binding. An unrelated `local Foo = 1` /
+    # `let Foo = 1` that happens to share a name with a `:global Foo` in
+    # the same lowering unit must NOT be merged — the two have different
+    # declaration byte ranges, which the guard relies on.
+    @testset "alias-remap does not capture unrelated local of same name" begin
+        let boccs = get_full_binding_occurrences("""
+                let
+                    struct Foo end
+                    function bar()
+                        local Foo = 1
+                        return Foo
+                    end
+                end
+                """)
+            # The struct-`Foo` global should hold both its own decl and the
+            # remapped local-alias occurrences, but NOT the unrelated
+            # `local Foo` inside `bar`. After the remap, exactly two
+            # buckets named "Foo" should remain: the global (the struct)
+            # and the unrelated local inside `bar`.
+            foos = filter(((b, _),) -> b.name == "Foo", collect(boccs))
+            @test length(foos) == 2
+            @test count(((b, _),) -> b.kind === :global, foos) == 1
+            @test count(((b, _),) -> b.kind === :local, foos) == 1
+            local_foo_pair = foos[findfirst(((b, _),) -> b.kind === :local, foos)]
+            local_occs = local_foo_pair.second
+            # The unrelated local `Foo` has one `:def` (the assignment on
+            # line 4) and one `:use` (the return on line 5). If the guard
+            # were missing, these would be merged into the global instead.
+            @test count(o -> o.kind === :def, local_occs) == 1
+            @test count(o -> o.kind === :use, local_occs) == 1
+        end
+    end
+
     @testset "macro calls" begin
         let boccs = get_full_binding_occurrences("@nospecialize")
             @test length(boccs) == 1


### PR DESCRIPTION
JuliaLowering now tags machinery references (function self-refs inside `K"method"` / `K"function_type"` / `K"removable"`, kwsorter body forwards, optional-positional self-forwarding stubs, type self-refs in `_typebody!` / `_equiv_typedef` calls, etc.) with `:synthetic_ref` metadata. Replace the JETLS-side heuristic layer that approximated this with a single metadata check when recording `:use` occurrences.

Removed: the `SkipRecording` byte-range map, the
`K"block" [K"function_decl" …]` traversal that registered ranges, `is_selffunc` / `is_kwsorter_func` / `kwerr` arg-skipping, and the struct-name `:local` rhs-pattern check. Net ~130 lines out of `occurrence-analysis.jl`.

Also tighten the `:local (mod=nothing)` → `:global` alias merge for type definitions to discriminate by declaration `byte_range` rather than by `is_internal` + name, so an unrelated `local Foo` / `let Foo = 1` sharing a name is not merged.

Regression coverage in `test/analysis/test_occurrence_analysis.jl`: function / macro / type definitions produce no spurious `:use` of their own name, and user-written refs inside machinery positions (self-recursive calls, dependent defaults in optional / keyword args and inner constructors) are still counted correctly.