### PR TITLE
diagnostic: Fix cross-file `lowering/unused-import` staleness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   end
   ```
 
+- Fixed `lowering/unused-import` going stale in `workspace/diagnostic` when an explicit import in one file is consumed (or stops being consumed) by a sibling file in the same analysis unit. Closed files now refresh the diagnostic when a sibling edit could affect it.
+
 ## 2026-04-14
 
 - Commit: [`d1ebbb2`](https://github.com/aviatesk/JETLS.jl/commit/d1ebbb2)

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -525,6 +525,7 @@ function update_analysis_cache!(state::ServerState, analysis_result::AnalysisRes
             continue
         end
         invalidate_binding_occurrences_cache!(state, uri)
+        invalidate_lowering_diagnostics_cache!(state, uri)
     end
 end
 

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -1507,16 +1507,21 @@ function get_lowering_diagnostics!(
         cancel_flag::CancelFlag;
         lookup_func = nothing
     )
+    # For notebooks, every cell URI in a notebook resolves to the same
+    # concat-source `FileInfo`, so cache under the notebook URI to share
+    # entries across cells and to match the invalidation site
+    # (`cache_notebook_file_info!` invalidates the notebook URI).
+    cache_uri = @something get_notebook_uri_for_cell(server.state, uri) uri
     return store!(server.state.lowering_diagnostics_cache) do cache::LoweringDiagnosticsCacheData
-        if haskey(cache, uri)
-            return cache, cache[uri]
+        if haskey(cache, cache_uri)
+            return cache, cache[cache_uri]
         end
         result = compute_lowering_diagnostics(server, uri, file_info, st0_top, cancel_flag;
                                               lookup_func)
         if is_cancelled(cancel_flag)
             return cache, result
         end
-        return LoweringDiagnosticsCacheData(cache, uri => result), result
+        return LoweringDiagnosticsCacheData(cache, cache_uri => result), result
     end
 end
 

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -1299,17 +1299,52 @@ struct ImportInfo
     delete_range::Range
 end
 
+const UsedNamesByUnit = Dict{Set{URI},Dict{Module,Set{String}}}
+
+function compute_unit_used_names(
+        server::Server, search_uris::Set{URI};
+        skip_context_check::Bool = false
+    )
+    state = server.state
+    mod_used_names = Dict{Module,Set{String}}()
+    for search_uri in search_uris
+        skip_context_check || has_analyzed_context(state, search_uri) || continue
+        search_fi = @something begin
+            get_file_info(state, search_uri)
+        end begin
+            get_unsynced_file_info!(state, search_uri)
+        end continue
+        search_st0_top = build_syntax_tree(search_fi)
+
+        iterate_toplevel_tree(search_st0_top) do st0::JS.SyntaxTree
+            binding_occurrences = @something get_binding_occurrences!(
+                state, search_uri, search_fi, st0; include_global_bindings = true) return
+            mod = get_context_module(state, search_uri, offset_to_xy(search_fi, JS.first_byte(st0)))
+            for (binfo_key, occurrences) in binding_occurrences
+                binfo_key.kind === :global || continue
+                if any(o -> o.kind === :use, occurrences)
+                    push!(get!(Set{String}, mod_used_names, mod), binfo_key.name)
+                end
+            end
+        end
+    end
+    return mod_used_names
+end
+
 # Detects unused imports by scanning all workspace files for usages of imported names.
 # This analysis can be slow if implemented naively, but achieves practical performance through:
 # - Early return for files without import/using statements (~1ms depending on file size)
-# - Syntax tree caching for unsynced files (~150ms → ~25ms for ~50 files, see `FileInfo.syntax_tree0`)
+# - Syntax tree caching for unsynced files (see `FileInfo.syntax_tree0`)
 # - Binding occurrences caching (see `BindingOccurrencesCache`)
+# - Per-unit used-name memoization via `used_names_cache`, which lets a single
+#   `workspace/diagnostic` pull reuse the expensive `mod_used_names` aggregation
+#   across every import-bearing file in the same analysis unit
 # - Unchanged file skipping in workspace/diagnostic
-# With these optimizations, analyzing a workspace of ~50 files typically takes ~50-100ms.
 function analyze_unused_imports!(
         diagnostics::Vector{Diagnostic}, server::Server, uri::URI,
         fi::FileInfo, st0_top::JS.SyntaxTree;
-        skip_context_check::Bool = false
+        skip_context_check::Bool = false,
+        used_names_cache::UsedNamesByUnit = UsedNamesByUnit()
     )
     state = server.state
     mod_imported_names = Dict{Module,Dict{String,Vector{ImportInfo}}}()
@@ -1324,31 +1359,10 @@ function analyze_unused_imports!(
     end
     isempty(mod_imported_names) && return diagnostics
 
-    mod_used_names = Dict{Module,Set{String}}()
-    time_get_file_info = time_build_syntax_tree = time_binding_occurrences = 0.0
     search_uris = collect_search_uris(server, uri)
-    for search_uri in search_uris
-        skip_context_check || has_analyzed_context(state, search_uri) || continue
-        time_get_file_info += @elapsed search_fi = @something begin
-            get_file_info(state, search_uri)
-        end begin
-            get_unsynced_file_info!(state, search_uri)
-        end continue
-        time_build_syntax_tree += @elapsed st0_top = build_syntax_tree(search_fi)
-
-        time_binding_occurrences += @elapsed iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
-            binding_occurrences = @something get_binding_occurrences!(
-                state, search_uri, search_fi, st0; include_global_bindings = true) return
-            mod = get_context_module(state, search_uri, offset_to_xy(search_fi, JS.first_byte(st0)))
-            for (binfo_key, occurrences) in binding_occurrences
-                binfo_key.kind === :global || continue
-                if any(o -> o.kind === :use, occurrences)
-                    push!(get!(Set{String}, mod_used_names, mod), binfo_key.name)
-                end
-            end
-        end
+    mod_used_names = get!(used_names_cache, search_uris) do
+        compute_unit_used_names(server, search_uris; skip_context_check)
     end
-    # @info "analyze_unused_imports! timing" uri length(search_uris) time_get_file_info time_build_syntax_tree time_binding_occurrences
 
     for (mod, imported_names) in mod_imported_names
         used_names = get(mod_used_names, mod, nothing)
@@ -1460,12 +1474,16 @@ function collect_explicit_import_names(st0::JS.SyntaxTree, fi::FileInfo)
     return names
 end
 
-function toplevel_lowering_diagnostics(
-        server::Server, uri::URI, file_info::FileInfo, cancel_flag::CancelFlag=DUMMY_CANCEL_FLAG;
+# Runs `lowering_diagnostics!` over every top-level statement of `file_info`,
+# returning the per-file diagnostics that depend solely on this file's content
+# and analysis context. `analyze_unused_imports!` is not included because its
+# result depends on sibling files in the analysis unit.
+function compute_lowering_diagnostics(
+        server::Server, uri::URI, file_info::FileInfo, st0_top::JS.SyntaxTree,
+        cancel_flag::CancelFlag;
         lookup_func = nothing
     )
     diagnostics = Diagnostic[]
-    st0_top = build_syntax_tree(file_info)
     skip_analysis_requiring_context = !has_analyzed_context(server.state, uri; lookup_func)
     allow_unused_underscore = get_config(server, :diagnostic, :allow_unused_underscore)
     soft_scope = is_notebook_cell_uri(server.state, uri)
@@ -1477,11 +1495,59 @@ function toplevel_lowering_diagnostics(
             skip_analysis_requiring_context, allow_unused_underscore, soft_scope,
             analyzer, postprocessor)
     end
+    return diagnostics
+end
 
-    if !skip_analysis_requiring_context
-        analyze_unused_imports!(diagnostics, server, uri, file_info, st0_top)
+# Cached accessor for the per-file lowering diagnostics. The cached `Vector` is
+# treated as read-only; callers must copy before mutating (e.g. before appending
+# `analyze_unused_imports!` results). Cache misses and cancelled computations
+# both return without caching; only a fully computed result is stored.
+function get_lowering_diagnostics!(
+        server::Server, uri::URI, file_info::FileInfo, st0_top::JS.SyntaxTree,
+        cancel_flag::CancelFlag;
+        lookup_func = nothing
+    )
+    return store!(server.state.lowering_diagnostics_cache) do cache::LoweringDiagnosticsCacheData
+        if haskey(cache, uri)
+            return cache, cache[uri]
+        end
+        result = compute_lowering_diagnostics(server, uri, file_info, st0_top, cancel_flag;
+                                              lookup_func)
+        if is_cancelled(cancel_flag)
+            return cache, result
+        end
+        return LoweringDiagnosticsCacheData(cache, uri => result), result
     end
+end
 
+function invalidate_lowering_diagnostics_cache!(state::ServerState, uri::URI)
+    store!(state.lowering_diagnostics_cache) do cache::LoweringDiagnosticsCacheData
+        if haskey(cache, uri)
+            Base.delete(cache, uri), nothing
+        else
+            cache, nothing
+        end
+    end
+end
+
+function clear_lowering_diagnostics_cache!(state::ServerState)
+    store!(state.lowering_diagnostics_cache) do _::LoweringDiagnosticsCacheData
+        LoweringDiagnosticsCacheData(), nothing
+    end
+end
+
+function toplevel_lowering_diagnostics(
+        server::Server, uri::URI, file_info::FileInfo, cancel_flag::CancelFlag=DUMMY_CANCEL_FLAG;
+        lookup_func = nothing,
+        used_names_cache::UsedNamesByUnit = UsedNamesByUnit(),
+    )
+    st0_top = build_syntax_tree(file_info)
+    cached = get_lowering_diagnostics!(server, uri, file_info, st0_top, cancel_flag; lookup_func)
+    is_cancelled(cancel_flag) && return cached
+    diagnostics = copy(cached)
+    if has_analyzed_context(server.state, uri; lookup_func)
+        analyze_unused_imports!(diagnostics, server, uri, file_info, st0_top; used_names_cache)
+    end
     return diagnostics
 end
 
@@ -1750,6 +1816,7 @@ function send_workspace_diagnostics(
     root_path = isdefined(state, :root_path) ? state.root_path : nothing
     debuginfo = nothing
     # debuginfo = (; synced = URI[], analyzed = URI[], skipped = URI[], failed = URI[])
+    used_names_cache = UsedNamesByUnit()
     for uri in uris_to_search
         is_cancelled(cancel_flag) && return send(server,
             WorkspaceDiagnosticResponse(;
@@ -1785,7 +1852,7 @@ function send_workspace_diagnostics(
         end
 
         if isempty(fi.parsed_stream.diagnostics)
-            diagnostics = toplevel_lowering_diagnostics(server, uri, fi)
+            diagnostics = toplevel_lowering_diagnostics(server, uri, fi; used_names_cache)
         else
             diagnostics = parsed_stream_to_diagnostics(fi)
         end

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -1374,6 +1374,29 @@ end
 analyze_unused_imports(args...; kwargs...) = # used by tests
     analyze_unused_imports!(Diagnostic[], args...; kwargs...)
 
+# Returns true if `st0_top` contains an `import`/`using` with explicit names
+# (the only shape `analyze_unused_imports!` can flag). Gates whether the
+# workspace/diagnostic `result_id` must fold in the analysis unit's state.
+function file_has_explicit_imports(st0_top::JS.SyntaxTree)
+    found = traverse(st0_top) do st0::JS.SyntaxTree
+        k = JS.kind(st0)
+        if k ∈ JS.KSet"import using"
+            if JS.numchildren(st0) == 1
+                child = st0[1]
+                ck = JS.kind(child)
+                if ck === JS.K":"
+                    return TraversalReturn(true; terminate=true)
+                elseif ck === JS.K"." && k === JS.K"import" && JS.numchildren(child) >= 2
+                    return TraversalReturn(true; terminate=true)
+                end
+            end
+            return TraversalNoRecurse()
+        end
+        return nothing
+    end
+    return found === true
+end
+
 # Returns tuples of (name, name_range, delete_range).
 # For single imports like `using M: x`, delete_range covers the entire import statement.
 # For multiple imports like `using M: x, y`, delete_range covers the name plus comma/whitespace.
@@ -1692,6 +1715,27 @@ function handle_WorkspaceDiagnosticRequest(
     end
 end
 
+# Derives the `resultId` sent back for `workspace/diagnostic`. When the file has
+# explicit imports it folds every unit member's version into the key so a sibling
+# edit invalidates this file's cached diagnostics and `analyze_unused_imports!` reruns.
+# Files without explicit imports stay keyed on their own version alone.
+function compute_workspace_diagnostic_result_id(server::Server, uri::URI, fi::FileInfo)
+    state = server.state
+    if !file_has_explicit_imports(build_syntax_tree(fi))
+        return string(fi.version)
+    end
+    result_id_hash = zero(UInt)
+    for search_uri in collect_search_uris(server, uri)
+        search_fi = @something begin
+            get_file_info(state, search_uri)
+        end begin
+            get_unsynced_file_info!(state, search_uri)
+        end continue
+        result_id_hash ⊻= hash((search_uri, search_fi.version))
+    end
+    return string(result_id_hash)
+end
+
 function send_workspace_diagnostics(
         server::Server, msg::WorkspaceDiagnosticRequest, uris_to_search::Set{URI},
         cancel_flag::CancelFlag
@@ -1723,8 +1767,7 @@ function send_workspace_diagnostics(
             continue
         end
 
-        version = fi.version
-        result_id = string(version)
+        result_id = compute_workspace_diagnostic_result_id(server, uri, fi)
         prev_result_id = get(previous_result_ids, uri, nothing)
         if prev_result_id !== nothing && prev_result_id == result_id
             item = WorkspaceUnchangedDocumentDiagnosticReport(;

--- a/src/did-change-watched-files.jl
+++ b/src/did-change-watched-files.jl
@@ -61,6 +61,7 @@ function handle_config_file_change!(
     source = "[.JETLSConfig.toml] $(dirname(changed_path)) ($kind)"
     notify_config_changes(server, tracker, source)
     if tracker.diagnostic_setting_changed
+        clear_lowering_diagnostics_cache!(server.state)
         notify_diagnostics!(server; ensure_cleared = true)
         request_diagnostic_refresh!(server)
     end
@@ -150,6 +151,7 @@ function handle_jl_file_change!(server::Server, change::FileEvent)
         end
         invalidate_document_symbol_cache!(state, uri)
         invalidate_binding_occurrences_cache!(state, uri)
+        invalidate_lowering_diagnostics_cache!(state, uri)
     end
     request_diagnostic_refresh!(server)
 end

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -32,6 +32,7 @@ function cache_file_info!(
 
     invalidate_document_symbol_cache!(state, uri)
     invalidate_binding_occurrences_cache!(state, uri)
+    invalidate_lowering_diagnostics_cache!(state, uri)
 
     if !state.suppress_notifications && any_deleted
         notify_diagnostics!(server; ensure_cleared=uri)

--- a/src/notebook.jl
+++ b/src/notebook.jl
@@ -30,6 +30,7 @@ function cache_notebook_file_info!(server::Server, notebook_uri::URI, notebook_i
     end
     invalidate_document_symbol_cache!(state, notebook_uri)
     invalidate_binding_occurrences_cache!(state, notebook_uri)
+    invalidate_lowering_diagnostics_cache!(state, notebook_uri)
     return fi
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -663,6 +663,8 @@ const DocumentSymbolCacheData = Base.PersistentDict{URI,Vector{DocumentSymbol}}
 const DocumentSymbolCache = LWContainer{DocumentSymbolCacheData, LWStats}
 const BindingOccurrencesCacheData = Base.PersistentDict{URI,BindingOccurrencesCacheEntry}
 const BindingOccurrencesCache = LWContainer{BindingOccurrencesCacheData, LWStats}
+const LoweringDiagnosticsCacheData = Base.PersistentDict{URI,Vector{Diagnostic}}
+const LoweringDiagnosticsCache = LWContainer{LoweringDiagnosticsCacheData, LWStats}
 const ConfigManager = LWContainer{ConfigManagerData, LWStats}
 const UnsyncedFileCacheData = Base.PersistentDict{URI,FileInfo}
 const UnsyncedFileCache = LWContainer{UnsyncedFileCacheData, LWStats}
@@ -693,6 +695,11 @@ mutable struct ServerState
     # It should also be invalidated when full-analysis updates module context,
     # but that is not yet implemented.
     const binding_occurrences_cache::BindingOccurrencesCache
+    # Per-file cache of the diagnostics produced by `lowering_diagnostics!` over a
+    # file's top-level statements. Lets cross-file `workspace/diagnostic`
+    # invalidations (see `compute_workspace_diagnostic_result_id`) skip re-running
+    # `jl_lower_for_scope_resolution` for files whose own content is unchanged.
+    const lowering_diagnostics_cache::LoweringDiagnosticsCache
     const analysis_manager::AnalysisManager
     const extra_diagnostics::ExtraDiagnostics
     const currently_handled::CurrentlyHandled
@@ -719,6 +726,7 @@ mutable struct ServerState
             #=unsynced_file_cache=# UnsyncedFileCache(UnsyncedFileCacheData()),
             #=document_symbol_cache=# DocumentSymbolCache(DocumentSymbolCacheData()),
             #=binding_occurrences_cache=# BindingOccurrencesCache(BindingOccurrencesCacheData()),
+            #=lowering_diagnostics_cache=# LoweringDiagnosticsCache(LoweringDiagnosticsCacheData()),
             #=analysis_manager=# AnalysisManager(),
             #=extra_diagnostics=# ExtraDiagnostics(ExtraDiagnosticsData()),
             #=currently_handled=# CurrentlyHandled(),

--- a/src/workspace-configuration.jl
+++ b/src/workspace-configuration.jl
@@ -110,6 +110,7 @@ function handle_lsp_config_change!(server::Server, tracker::ConfigChangeTracker,
         notify_config_changes(server, tracker, source)
     end
     if tracker.diagnostic_setting_changed
+        clear_lowering_diagnostics_cache!(server.state)
         notify_diagnostics!(server; ensure_cleared = true)
         request_diagnostic_refresh!(server)
     end


### PR DESCRIPTION
## Summary

Fixes cross-file staleness of `lowering/unused-import` reports under `workspace/diagnostic`, and adds a per-file `lowering_diagnostics!` cache so the fix scales to keystroke-rate re-pulls.

## Problem

`send_workspace_diagnostics` derived a file's `resultId` from `fi.version` alone. `analyze_unused_imports!`, however, scans every file in the analysis unit to decide whether an `import` is consumed somewhere — so its result depends on the whole unit's state, not just this file. With a per-file `resultId`, a closed file's workspace diagnostic was never invalidated when a sibling edit changed whether one of its imports was used.

Concrete example: File A has `import XXX: yyy`; File B uses `yyy`. Removing the use of `yyy` from File B should re-flag the import in File A as unused, but didn't (and vice versa) — the client kept reporting the cached `resultId` and never re-pulled File A.

## Changes

### 1ccaef05 — Make `workspace/diagnostic` `resultId` unit-aware

Add `compute_workspace_diagnostic_result_id`. When the file contains an explicit `import`/`using` (the only shape `analyze_unused_imports!` can flag — detected by `file_has_explicit_imports`), fold every analysis-unit member's `(URI, version)` hash together so any sibling edit bumps this file's `resultId`. Files without explicit imports keep the cheap `string(fi.version)` key. Per-URI hashes are XOR-combined so the computation is order-independent without sorting `collect_search_uris`'s `Set`.

### 7f123c8b — Cache per-file lowering diagnostics

The unit-aware `resultId` means each keystroke shifts the `resultId` of every import-bearing sibling, so the client re-pulls diagnostics for tens of files per edit. Re-running `lowering_diagnostics!` on every sibling whose own content is unchanged is wasteful.

- Add `LoweringDiagnosticsCache` keyed on `URI`, populated via `get_lowering_diagnostics!` and invalidated alongside `BindingOccurrencesCache` in `cache_file_info!`, `cache_notebook_file_info!`, `handle_jl_file_change!`, and `update_analysis_cache!`. Diagnostic-affecting config changes (`.JETLSConfig.toml` or LSP config) clear the cache wholesale via `clear_lowering_diagnostics_cache!`. The cached `Vector{Diagnostic}` is treated as read-only; `toplevel_lowering_diagnostics` `copy`s before appending `analyze_unused_imports!` results, which depend on sibling state and stay outside the cache.
- Factor the unit-wide used-name aggregation out of `analyze_unused_imports!` into a standalone `compute_unit_used_names`, and add a `UsedNamesByUnit` per-pull memo. `send_workspace_diagnostics` constructs one and threads it through every sibling's `toplevel_lowering_diagnostics` call so the unit's `mod_used_names` is computed once per pull rather than once per import-bearing file.
