### PR TITLE
diagnostic: Detect unresolved `@goto` and unused `@label`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > This disables analysis for matched files. Basic features like completion still might work, but most LSP features will be unfunctional.
 > Note that `analysis_overrides` is provided as a temporary workaround and may be removed or changed at any time. A proper fix is being worked on.
 
+### Added
+
+- `lowering/error` now reports `@goto` references that don't resolve to any `@label` in the same function body.
+  For example:
+  ```julia
+  function f()
+      @goto nonexist  # label `nonexist` referenced but not defined (JETLS lowering/error)
+      println("foo")
+  end
+  ```
+
+- Added the `lowering/unused-label` diagnostic, reported when a `@label` is declared but never referenced by any `@goto` in the same function body. The label is marked with the `Unnecessary` tag, so editors typically display it as faded/grayed out.
+  For example:
+  ```julia
+  function f()
+      @label spare  # Unused label `spare` (JETLS lowering/unused-label)
+      return 1
+  end
+  ```
+
 ### Changed
 
 - The reference count code lens is no longer shown for inner constructors of a `struct`.

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -154,11 +154,17 @@ transforms parsed syntax into a simpler intermediate representation.
 
 General lowering errors that don't fit into more specific categories.
 
-Example:
+Examples:
 
 ```julia
-function lowering_error(x)
+macro lowering_error(x)
     $(x)  # `$` expression outside string or quote block (JETLS lowering/error)
+end
+
+function unresolved_goto()
+    @label retry
+    inner = () -> @goto retry  # label `retry` referenced but not defined (JETLS lowering/error)
+    inner()                    # (`@goto` cannot cross function boundaries)
 end
 ```
 
@@ -631,6 +637,35 @@ module.
     end
     @gencall sin(42)  # `sin` is used here
     ```
+
+#### [Unused label (`lowering/unused-label`)](@id diagnostic/reference/lowering/unused-label)
+
+**Default severity**: `Information`
+
+Reported when a `@label` is declared but never referenced by any `@goto`
+in the same function body. The label is marked with the `Unnecessary`
+tag.[^unnecessary_tag]
+
+Example:
+
+```julia
+function unused_label()
+    @label spare  # Unused label `spare` (JETLS lowering/unused-label)
+    return 1
+end
+```
+
+Because `@goto` cannot cross function boundaries, a `@label` in an outer
+function is also unused even when an inner closure references the same
+name:
+
+```julia
+function outer()
+    @label here  # Unused label `here` (JETLS lowering/unused-label)
+    inner = () -> @goto here  # also reported as `lowering/error`
+    inner()
+end
+```
 
 #### [Unreachable code (`lowering/unreachable-code`)](@id diagnostic/reference/lowering/unreachable-code)
 

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -1167,6 +1167,94 @@ function analyze_unreachable_code!(
     end
 end
 
+# `@goto`/`@label` resolution is normally validated by JuliaLowering's
+# `compile_body` (linear IR pass), which JETLS doesn't run. Mirror that
+# check against `st3` so unresolved gotos still surface as diagnostics.
+function analyze_unresolved_gotos!(
+        diagnostics::Vector{Diagnostic}, fi::FileInfo, st3::JS.SyntaxTree
+    )
+    traverse(st3) do st3′::JS.SyntaxTree
+        JS.kind(st3′) === JS.K"lambda" || return nothing
+        JS.numchildren(st3′) >= 3 || return nothing
+        check_lambda_gotos!(diagnostics, fi, st3′[3])
+        return nothing
+    end
+end
+
+function check_lambda_gotos!(
+        diagnostics::Vector{Diagnostic}, fi::FileInfo, body3::JS.SyntaxTree
+    )
+    gotos, labels = collect_gotos_labels(body3)
+    label_names = Set{String}(name for (name, _) in labels)
+    referenced = Set{String}()
+    for (name, st) in gotos
+        if name in label_names
+            push!(referenced, name)
+            continue
+        end
+        push!(diagnostics, Diagnostic(;
+            range = jsobj_to_range(st, fi),
+            severity = DiagnosticSeverity.Error,
+            message = "label `$name` referenced but not defined",
+            source = DIAGNOSTIC_SOURCE_LIVE,
+            code = LOWERING_ERROR_CODE,
+            codeDescription = diagnostic_code_description(LOWERING_ERROR_CODE)))
+    end
+    for (name, st) in labels
+        name in referenced && continue
+        # Skip macro-generated labels — only report user-written ones.
+        is_from_user_ast(JL.flattened_provenance(st)) || continue
+        push!(diagnostics, Diagnostic(;
+            range = jsobj_to_range(st, fi),
+            severity = DiagnosticSeverity.Information,
+            message = "Unused label `$name`",
+            source = DIAGNOSTIC_SOURCE_LIVE,
+            code = LOWERING_UNUSED_LABEL_CODE,
+            codeDescription = diagnostic_code_description(LOWERING_UNUSED_LABEL_CODE),
+            tags = DiagnosticTag.Ty[DiagnosticTag.Unnecessary]))
+    end
+end
+
+function collect_gotos_labels(st3::JS.SyntaxTree)
+    gotos = Tuple{String,JS.SyntaxTree}[]
+    labels = Tuple{String,JS.SyntaxTree}[]
+    collect_gotos_labels!(gotos, labels, st3)
+    return gotos, labels
+end
+function collect_gotos_labels!(
+        gotos::Vector{Tuple{String,JS.SyntaxTree}},
+        labels::Vector{Tuple{String,JS.SyntaxTree}},
+        st3::JS.SyntaxTree
+    )
+    k = JS.kind(st3)
+    if k === JS.K"lambda"
+        # Nested lambdas have their own goto/label scope; handled separately.
+        return
+    elseif (k === JS.K"symboliclabel") && hasproperty(st3, :name_val)
+        push!(labels, (st3.name_val::String, st3))
+        return
+    elseif (k === JS.K"symbolicgoto" || k === JS.K"oldsymbolicgoto") && hasproperty(st3, :name_val)
+        push!(gotos, (st3.name_val::String, st3))
+        return
+    elseif k === JS.K"symbolicblock"
+        # First child is a lowering-internal label (e.g. `loop-exit`) used by
+        # `K"break"`, not reachable via `@goto`; recurse only into the body.
+        if JS.numchildren(st3) >= 2
+            collect_gotos_labels!(gotos, labels, st3[2])
+        end
+        return
+    elseif k === JS.K"break"
+        # First child is a label name reference, not a declaration.
+        if JS.numchildren(st3) >= 2
+            collect_gotos_labels!(gotos, labels, st3[2])
+        end
+        return
+    end
+    for i in 1:JS.numchildren(st3)
+        collect_gotos_labels!(gotos, labels, st3[i])
+    end
+end
+
 function analyze_lowered_code!(
         diagnostics::Vector{Diagnostic}, uri::URI, fi::FileInfo, res::NamedTuple;
         skip_analysis_requiring_context::Bool = false,
@@ -1195,6 +1283,7 @@ function analyze_lowered_code!(
 
     analyze_captured_boxes!(diagnostics, uri, fi, ctx4, st3, reported)
     analyze_unreachable_code!(diagnostics, fi, ctx3, st3, allow_noreturn_optimization)
+    analyze_unresolved_gotos!(diagnostics, fi, st3)
 
     if !skip_analysis_requiring_context
         analyze_undefined_global_bindings!(diagnostics, fi, ctx3, binding_occurrences, reported; analyzer, postprocessor)

--- a/src/types.jl
+++ b/src/types.jl
@@ -387,6 +387,7 @@ const LOWERING_UNDEF_LOCAL_VAR_CODE = "lowering/undef-local-var"
 const LOWERING_CAPTURED_BOXED_VARIABLE_CODE = "lowering/captured-boxed-variable"
 const LOWERING_UNSORTED_IMPORT_NAMES_CODE = "lowering/unsorted-import-names"
 const LOWERING_UNUSED_IMPORT_CODE = "lowering/unused-import"
+const LOWERING_UNUSED_LABEL_CODE = "lowering/unused-label"
 const LOWERING_UNREACHABLE_CODE = "lowering/unreachable-code"
 const LOWERING_AMBIGUOUS_SOFT_SCOPE_CODE = "lowering/ambiguous-soft-scope"
 const TOPLEVEL_ERROR_CODE = "toplevel/error"
@@ -412,6 +413,7 @@ const ALL_DIAGNOSTIC_CODES = Set{String}(String[
     LOWERING_CAPTURED_BOXED_VARIABLE_CODE,
     LOWERING_UNSORTED_IMPORT_NAMES_CODE,
     LOWERING_UNUSED_IMPORT_CODE,
+    LOWERING_UNUSED_LABEL_CODE,
     LOWERING_UNREACHABLE_CODE,
     LOWERING_AMBIGUOUS_SOFT_SCOPE_CODE,
     TOPLEVEL_ERROR_CODE,

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -2083,4 +2083,131 @@ end
     end
 end
 
+@testset "unresolved goto detection" begin
+    # forward goto with matching label — no diagnostic
+    let diagnostics = get_lowered_diagnostics("""
+        begin
+            @goto here
+            println("dead")
+            @label here
+        end
+        """)
+        ds = filter(d -> d.code == JETLS.LOWERING_ERROR_CODE, diagnostics)
+        @test isempty(ds)
+    end
+
+    # backward goto with matching label — no diagnostic
+    let diagnostics = get_lowered_diagnostics("""
+        function f()
+            @label retry
+            @goto retry
+        end
+        """)
+        ds = filter(d -> d.code == JETLS.LOWERING_ERROR_CODE, diagnostics)
+        @test isempty(ds)
+    end
+
+    let diagnostics = get_lowered_diagnostics("""
+        begin
+            @goto nonexist
+            println("foo")
+        end
+        """)
+        ds = filter(d -> d.code == JETLS.LOWERING_ERROR_CODE, diagnostics)
+        @test length(ds) == 1
+        d = only(ds)
+        @test d.message == "label `nonexist` referenced but not defined"
+        @test d.severity == LSP.DiagnosticSeverity.Error
+        # range should cover the `nonexist` identifier
+        @test d.range.start.line == 1
+        @test d.range.start.character == sizeof("    @goto ")
+        @test d.range.var"end".character == sizeof("    @goto nonexist")
+    end
+
+    # `@goto` cannot cross lambda boundaries — label in outer fn,
+    # goto in inner closure should be reported as unresolved
+    let diagnostics = get_lowered_diagnostics("""
+        function f()
+            @label outer
+            g = () -> @goto outer
+            g()
+        end
+        """)
+        ds = filter(d -> d.code == JETLS.LOWERING_ERROR_CODE, diagnostics)
+        @test length(ds) == 1
+        @test only(ds).message == "label `outer` referenced but not defined"
+    end
+
+    # multiple unresolved gotos — each reported independently
+    let diagnostics = get_lowered_diagnostics("""
+        function f()
+            @goto a
+            @goto b
+        end
+        """)
+        ds = filter(d -> d.code == JETLS.LOWERING_ERROR_CODE, diagnostics)
+        @test length(ds) == 2
+        msgs = sort([d.message for d in ds])
+        @test msgs == [
+            "label `a` referenced but not defined",
+            "label `b` referenced but not defined",
+        ]
+    end
+end
+
+@testset "unused label detection" begin
+    let diagnostics = get_lowered_diagnostics("""
+        function f()
+            @label unused
+            return 1
+        end
+        """)
+        ds = filter(d -> d.code == JETLS.LOWERING_UNUSED_LABEL_CODE, diagnostics)
+        @test length(ds) == 1
+        d = only(ds)
+        @test d.message == "Unused label `unused`"
+        @test d.severity == LSP.DiagnosticSeverity.Information
+        @test !isnothing(d.tags) && LSP.DiagnosticTag.Unnecessary in d.tags
+        @test d.range.start.line == 1
+    end
+
+    # referenced label — no diagnostic
+    let diagnostics = get_lowered_diagnostics("""
+        function f()
+            @label loop
+            @goto loop
+        end
+        """)
+        ds = filter(d -> d.code == JETLS.LOWERING_UNUSED_LABEL_CODE, diagnostics)
+        @test isempty(ds)
+    end
+
+    # mix — only the unreferenced one is reported
+    let diagnostics = get_lowered_diagnostics("""
+        function f()
+            @label used
+            @goto used
+            @label spare
+        end
+        """)
+        ds = filter(d -> d.code == JETLS.LOWERING_UNUSED_LABEL_CODE, diagnostics)
+        @test length(ds) == 1
+        @test only(ds).message == "Unused label `spare`"
+    end
+
+    # `@goto` cannot cross lambda boundaries — outer label is unused even
+    # though an inner closure references the same name
+    let diagnostics = get_lowered_diagnostics("""
+        function f()
+            @label outer
+            g = () -> @goto outer
+            g()
+        end
+        """)
+        ds = filter(d -> d.code == JETLS.LOWERING_UNUSED_LABEL_CODE, diagnostics)
+        @test length(ds) == 1
+        @test only(ds).message == "Unused label `outer`"
+    end
+end
+
 end # module test_lowering_diagnostics


### PR DESCRIPTION
`@label`/`@goto` resolution is normally validated during JuliaLowering's linear IR pass, which JETLS does not run. As a result, unresolved `@goto` references previously slipped through silently. Mirror that check on `st3` so:

- `@goto` to a label that does not exist in the same function body is reported as `lowering/error` ("label `foo` referenced but not defined"). Note that `@goto` cannot cross function boundaries, so a `@label` in an enclosing function is not visible from a nested closure.
- A `@label` that is never referenced by any `@goto` in the same function body is reported as the new `lowering/unused-label` diagnostic with `Information` severity, marked with the `Unnecessary` tag.

Macro-generated labels are filtered out via `is_from_user_ast` to avoid false positives, and lowering-internal block labels (e.g. `loop-exit` from `K"symbolicblock"`) are skipped.