### PR TITLE
code-action: Add "Remove unused label" quick fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   end
   ```
 
-- Added the `lowering/unused-label` diagnostic, reported when a `@label` is declared but never referenced by any `@goto` in the same function body. The label is marked with the `Unnecessary` tag, so editors typically display it as faded/grayed out.
+- Added the `lowering/unused-label` diagnostic, reported when a `@label` is declared but never referenced by any `@goto` in the same function body. The label is marked with the `Unnecessary` tag, so editors typically display it as faded/grayed out. A "Remove unused label" code action is also offered to drop the entire `@label` statement.
   For example:
   ```julia
   function f()

--- a/LSP/src/basic-json-structures.jl
+++ b/LSP/src/basic-json-structures.jl
@@ -597,10 +597,17 @@ struct AmbiguousSoftScopeData
 end
 export AmbiguousSoftScopeData
 
-struct UnreachableCodeData
+"""
+Diagnostic data attached to lowering diagnostics whose only quick fix is
+"delete this range." `kind` lets the code action handler pick a label
+appropriate to the diagnostic (e.g. "Remove unused import" vs. "Delete
+unreachable code") without splitting into one struct per diagnostic.
+"""
+struct DeleteRangeData
+    kind::Symbol
     delete_range::Range
 end
-export UnreachableCodeData
+export DeleteRangeData
 
 struct UnsortedImportData
     new_text::String
@@ -611,11 +618,6 @@ struct UnusedArgumentData
     is_kwarg::Bool
 end
 export UnusedArgumentData
-
-struct UnusedImportData
-    delete_range::Range
-end
-export UnusedImportData
 
 struct UnusedVariableData
     is_tuple_unpacking::Bool
@@ -687,7 +689,7 @@ Diagnostic objects are only valid in the scope of a resource.
     # Tags
     - since – 3.16.0
     """
-    data::Union{AmbiguousSoftScopeData, UnsortedImportData, UnreachableCodeData, UnusedArgumentData, UnusedImportData, UnusedVariableData, Nothing} = nothing
+    data::Union{AmbiguousSoftScopeData, DeleteRangeData, UnsortedImportData, UnusedArgumentData, UnusedVariableData, Nothing} = nothing
 end
 
 # Command

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -667,6 +667,9 @@ function outer()
 end
 ```
 
+!!! tip "Code action available"
+    Use the "Remove unused label" code action to delete the `@label` statement.
+
 #### [Unreachable code (`lowering/unreachable-code`)](@id diagnostic/reference/lowering/unreachable-code)
 
 **Default severity**: `Information`

--- a/src/code-action.jl
+++ b/src/code-action.jl
@@ -38,8 +38,7 @@ function handle_CodeActionRequest(
     diagnostics = msg.params.context.diagnostics
     unused_variable_code_actions!(code_actions, uri, diagnostics;
         allow_unused_underscore = get_config(server, :diagnostic, :allow_unused_underscore))
-    unused_import_code_actions!(code_actions, uri, diagnostics)
-    unreachable_code_actions!(code_actions, uri, diagnostics)
+    delete_range_code_actions!(code_actions, uri, diagnostics)
     sort_imports_code_actions!(code_actions, uri, diagnostics)
     ambiguous_soft_scope_code_actions!(code_actions, uri, diagnostics)
     return send(server,
@@ -74,17 +73,23 @@ function unused_variable_code_actions!(
     return code_actions
 end
 
-function unused_import_code_actions!(
+const DELETE_RANGE_TITLES = Dict{Symbol,String}(
+    :unreachable_code => "Delete unreachable code",
+    :unused_import    => "Remove unused import",
+    :unused_label     => "Remove unused label",
+)
+
+function delete_range_code_actions!(
         code_actions::Vector{Union{CodeAction,Command}},
         uri::URI,
         diagnostics::Vector{Diagnostic}
     )
     for diagnostic in diagnostics
-        diagnostic.code == LOWERING_UNUSED_IMPORT_CODE || continue
         data = diagnostic.data
-        data isa UnusedImportData || continue
+        data isa DeleteRangeData || continue
+        title = @something get(DELETE_RANGE_TITLES, data.kind, nothing) continue
         push!(code_actions, CodeAction(;
-            title = "Remove unused import",
+            title,
             kind = CodeActionKind.QuickFix,
             diagnostics = Diagnostic[diagnostic],
             isPreferred = true,
@@ -154,28 +159,6 @@ function add_delete_unused_var_code_actions!(
                             newText = "")]))))
         end
     end
-end
-
-function unreachable_code_actions!(
-        code_actions::Vector{Union{CodeAction,Command}},
-        uri::URI, diagnostics::Vector{Diagnostic}
-    )
-    for diagnostic in diagnostics
-        diagnostic.code == LOWERING_UNREACHABLE_CODE || continue
-        data = diagnostic.data
-        data isa UnreachableCodeData || continue
-        push!(code_actions, CodeAction(;
-            title = "Delete unreachable code",
-            kind = CodeActionKind.QuickFix,
-            diagnostics = Diagnostic[diagnostic],
-            isPreferred = true,
-            edit = WorkspaceEdit(;
-                changes = Dict{URI,Vector{TextEdit}}(
-                    uri => TextEdit[TextEdit(;
-                        range = data.delete_range,
-                        newText = "")]))))
-    end
-    return code_actions
 end
 
 function sort_imports_code_actions!(

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -1159,7 +1159,7 @@ function analyze_unreachable_code!(
                     code = LOWERING_UNREACHABLE_CODE,
                     codeDescription = diagnostic_code_description(LOWERING_UNREACHABLE_CODE),
                     tags = DiagnosticTag.Ty[DiagnosticTag.Unnecessary],
-                    data = UnreachableCodeData(delete_range)))
+                    data = DeleteRangeData(:unreachable_code, delete_range)))
             end
             break
         end
@@ -1203,7 +1203,10 @@ function check_lambda_gotos!(
     for (name, st) in labels
         name in referenced && continue
         # Skip macro-generated labels — only report user-written ones.
-        is_from_user_ast(JL.flattened_provenance(st)) || continue
+        provs = JL.flattened_provenance(st)
+        is_from_user_ast(provs) || continue
+        # `first(provs)` is the user-written `@label name` macrocall.
+        delete_range = line_absorbing_delete_range(first(provs), fi)
         push!(diagnostics, Diagnostic(;
             range = jsobj_to_range(st, fi),
             severity = DiagnosticSeverity.Information,
@@ -1211,7 +1214,8 @@ function check_lambda_gotos!(
             source = DIAGNOSTIC_SOURCE_LIVE,
             code = LOWERING_UNUSED_LABEL_CODE,
             codeDescription = diagnostic_code_description(LOWERING_UNUSED_LABEL_CODE),
-            tags = DiagnosticTag.Ty[DiagnosticTag.Unnecessary]))
+            tags = DiagnosticTag.Ty[DiagnosticTag.Unnecessary],
+            data = DeleteRangeData(:unused_label, delete_range)))
     end
 end
 
@@ -1466,7 +1470,7 @@ function analyze_unused_imports!(
                     code = LOWERING_UNUSED_IMPORT_CODE,
                     codeDescription = diagnostic_code_description(LOWERING_UNUSED_IMPORT_CODE),
                     tags = DiagnosticTag.Ty[DiagnosticTag.Unnecessary],
-                    data = UnusedImportData(info.delete_range)))
+                    data = DeleteRangeData(:unused_import, info.delete_range)))
             end
         end
     end
@@ -1520,7 +1524,7 @@ function collect_explicit_import_names(st0::JS.SyntaxTree, fi::FileInfo)
                 name_range = jsobj_to_range(id_st, fi)
                 if nnames == 1
                     # Single import: delete entire statement
-                    delete_range = jsobj_to_range(st0, fi)
+                    delete_range = line_absorbing_delete_range(st0, fi)
                 else
                     # Multiple imports: delete name with comma
                     idx = i - 1  # 1-based index among names
@@ -1553,7 +1557,7 @@ function collect_explicit_import_names(st0::JS.SyntaxTree, fi::FileInfo)
                 if JS.kind(last_st) === JS.K"Identifier"
                     # Single import: delete entire statement
                     name_range = jsobj_to_range(last_st, fi)
-                    delete_range = jsobj_to_range(st0, fi)
+                    delete_range = line_absorbing_delete_range(st0, fi)
                     push!(names, (JS.sourcetext(last_st), name_range, delete_range))
                 end
             end

--- a/src/notebook.jl
+++ b/src/notebook.jl
@@ -296,10 +296,8 @@ function localize_range(range::Range, concat::ConcatenatedNotebook)
 end
 
 function localize_diagnostic_data(@nospecialize(data), concat::ConcatenatedNotebook)
-    if data isa UnreachableCodeData
-        return UnreachableCodeData(localize_range(data.delete_range, concat))
-    elseif data isa UnusedImportData
-        return UnusedImportData(localize_range(data.delete_range, concat))
+    if data isa DeleteRangeData
+        return DeleteRangeData(data.kind, localize_range(data.delete_range, concat))
     elseif data isa UnusedVariableData
         assignment_range = data.assignment_range
         if assignment_range !== nothing

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -1149,6 +1149,46 @@ function jsobj_to_range(
     end
 end
 
+"""
+    line_absorbing_delete_range(obj, fi::FileInfo) -> Range
+
+Build a delete range covering the bytes of `obj`. When `obj` is the only
+non-whitespace content on its line, the range is extended to absorb the
+surrounding indentation and the trailing newline so that deletion does not
+leave a stray blank line behind. Otherwise, the result equals
+[`jsobj_to_range(obj, fi)`](@ref jsobj_to_range).
+
+Intended for `data.delete_range` of a `DeleteRangeData` quick-fix that
+removes a whole statement (e.g. `using M: x`, `@label foo`).
+"""
+function line_absorbing_delete_range(obj, fi::FileInfo)
+    fb = JS.first_byte(obj)
+    lb = JS.last_byte(obj)
+    textbuf = fi.parsed_stream.textbuf
+    line_start = fb
+    while line_start > 1 && textbuf[line_start - 1] != UInt8('\n')
+        c = textbuf[line_start - 1]
+        if c != UInt8(' ') && c != UInt8('\t')
+            return jsobj_to_range(obj, fi)
+        end
+        line_start -= 1
+    end
+    after_end = lb + 1
+    while after_end ≤ length(textbuf) && textbuf[after_end] != UInt8('\n')
+        c = textbuf[after_end]
+        if c != UInt8(' ') && c != UInt8('\t')
+            return jsobj_to_range(obj, fi)
+        end
+        after_end += 1
+    end
+    if after_end ≤ length(textbuf) && textbuf[after_end] == UInt8('\n')
+        after_end += 1
+    end
+    return Range(;
+        start = offset_to_xy(fi, line_start),
+        var"end" = offset_to_xy(fi, after_end))
+end
+
 function try_extract_field_line(node::JS.SyntaxNode, structname::Symbol, fname::Symbol)
     if JS.kind(node) === JS.K"struct" && JS.numchildren(node) ≥ 2
         structnm = node[1]

--- a/test/test_code_action.jl
+++ b/test/test_code_action.jl
@@ -213,7 +213,7 @@ function get_unused_import_code_actions(marked_text::AbstractString)
     diagnostics = JETLS.analyze_unused_imports(server, uri, fi, st0_top;
         skip_context_check=true)
     code_actions = Union{CodeAction,Command}[]
-    JETLS.unused_import_code_actions!(code_actions, uri, diagnostics)
+    JETLS.delete_range_code_actions!(code_actions, uri, diagnostics)
     return code_actions, uri, positions
 end
 
@@ -260,13 +260,33 @@ end
         @test edit.range.start == positions[1]
         @test edit.range.var"end" == positions[2]
     end
+
+    # Single import on its own line: delete also absorbs the trailing newline
+    let (code_actions, uri, positions) = get_unused_import_code_actions(
+            "│using Base: cos\n│sin(1.0)")
+        @test length(code_actions) == 1
+        edit = only(code_actions[1].edit.changes[uri])
+        @test edit.newText == ""
+        @test edit.range.start == positions[1]
+        @test edit.range.var"end" == positions[2]
+    end
+
+    # Single import indented: also absorbs the leading indentation
+    let (code_actions, uri, positions) = get_unused_import_code_actions(
+            "module M\n│    using Base: cos\n│end")
+        @test length(code_actions) == 1
+        edit = only(code_actions[1].edit.changes[uri])
+        @test edit.newText == ""
+        @test edit.range.start == positions[1]
+        @test edit.range.var"end" == positions[2]
+    end
 end
 
 function get_unreachable_code_actions(marked_text::AbstractString)
     text, positions = JETLS.get_text_and_positions(marked_text)
     diagnostics, uri = get_lowering_diagnostics(text, JETLS.LOWERING_UNREACHABLE_CODE)
     code_actions = Union{CodeAction,Command}[]
-    JETLS.unreachable_code_actions!(code_actions, uri, diagnostics)
+    JETLS.delete_range_code_actions!(code_actions, uri, diagnostics)
     return code_actions, uri, positions
 end
 
@@ -311,6 +331,45 @@ end
         end
         """)
         @test isempty(code_actions)
+    end
+end
+
+function get_unused_label_code_actions(marked_text::AbstractString)
+    text, positions = JETLS.get_text_and_positions(marked_text)
+    diagnostics, uri = get_lowering_diagnostics(text, JETLS.LOWERING_UNUSED_LABEL_CODE)
+    code_actions = Union{CodeAction,Command}[]
+    JETLS.delete_range_code_actions!(code_actions, uri, diagnostics)
+    return code_actions, uri, positions
+end
+
+@testset "unused label code actions" begin
+    # Label on its own line: delete the whole line including indent and trailing newline
+    let (code_actions, uri, positions) = get_unused_label_code_actions("""
+        function f()
+        │    @label unused
+        │    return 1
+        end
+        """)
+        @test length(code_actions) == 1
+        action = only(code_actions)
+        @test action.title == "Remove unused label"
+        @test action.isPreferred == true
+        @test length(action.diagnostics) == 1
+        @test action.diagnostics[1].code == JETLS.LOWERING_UNUSED_LABEL_CODE
+        edit = only(action.edit.changes[uri])
+        @test edit.newText == ""
+        @test edit.range.start == positions[1]
+        @test edit.range.var"end" == positions[2]
+    end
+
+    # Label sharing a line with other statements: delete only the macrocall bytes
+    let (code_actions, uri, positions) = get_unused_label_code_actions(
+            "function f(); │@label unused│; return 1; end")
+        @test length(code_actions) == 1
+        edit = only(code_actions[1].edit.changes[uri])
+        @test edit.newText == ""
+        @test edit.range.start == positions[1]
+        @test edit.range.var"end" == positions[2]
     end
 end
 


### PR DESCRIPTION
Offer a quick fix for the `lowering/unused-label` diagnostic that deletes the entire `@label name` macrocall. When the macrocall is the only content of its line, the trailing newline and surrounding indentation are absorbed too, so applying the fix doesn't leave a stray blank line behind.

The line-absorbing range computation is factored out as `line_absorbing_delete_range` in `src/utils/ast.jl` and reused for the single-name "Remove unused import" code action, which previously left a blank line behind for `using M: x` (or `import M.a`) on its own line.

The three diagnostics whose only quick fix is "delete this range" (`lowering/unreachable-code`, `lowering/unused-import`, `lowering/unused-label`) now share a single `DeleteRangeData` data struct carrying a `kind::Symbol` plus the `delete_range`. The code action handler picks the user-visible title from `DELETE_RANGE_TITLES` keyed on `kind`, replacing the three near-identical handler functions with one `delete_range_code_actions!`.