### PR TITLE
jl-syntax-macros: Add new-style stub for `Base.@something`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `lowering/unreachable-code` now uses control-flow reachability instead of syntactic block-walking, fixing several false positives and missed cases:
   - Code reachable via `@goto` nested inside an expression (e.g. `return cnd ? @goto(fallback) : println("Return"); @label fallback; ...`) is no longer reported as unreachable.
-  - Code after `try ... finally ... end` whose `try` body always terminates is now correctly flagged as unreachable.ro call.
+  - Code after `try ... finally ... end` whose `try` body always terminates is now correctly flagged as unreachable.
 
 ## 2026-04-28
 

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -141,6 +141,7 @@ const NEW_STYLE_MACROCALL_NAMES = (
     # src/utils/jl-syntax-macros.jl
     "@kwdef",
     "@label",
+    "@something",
     "@spawn",
     "@specialize",
     "@test",

--- a/src/utils/jl-syntax-macros.jl
+++ b/src/utils/jl-syntax-macros.jl
@@ -126,6 +126,43 @@ function Base.var"@label"(__context__::JL.MacroContext, ::JS.SyntaxTree...)
         "@label currently only supports the `@label name` form")
 end
 
+# New-style stub for `Base.@something`. Mirrors `Base.@something`'s nested
+# `let val_i = arg_i; if !isnothing(val_i) something(val_i) else <next> end end`
+# expansion so that:
+#   - each `arg_i` is evaluated at most once (binding occurrences and other
+#     identifier-level semantics inside `arg_i` are preserved exactly);
+#   - downstream def-use analysis sees the same conditional evaluation
+#     structure as the real macro — assignments inside `arg_{i+1}` are
+#     statically reachable only on paths where every preceding `arg_j` was
+#     `nothing`.
+#
+# `val_i` identifiers are introduced in the macro's scope layer (via
+# `JL.@ast`), so they cannot clash with user code, and `let`-binding scopes
+# them so they do not leak into the enclosing block.
+#
+# The zero-argument form mirrors `Base.@something()`: it expands to
+# `something(nothing)`, which throws at runtime.
+function Base.var"@something"(__context__::JL.MacroContext, args::JS.SyntaxTree...)
+    mc = __context__.macrocall::JS.SyntaxTree
+    expr = JL.@ast(__context__, mc,
+        [JS.K"call" "something"::JS.K"Identifier" nothing::JS.K"Value"])
+    for i in length(args):-1:1
+        arg = args[i]
+        val_name = "val_$i"
+        expr = JL.@ast(__context__, mc, [JS.K"let"
+            [JS.K"block"
+                [JS.K"=" val_name::JS.K"Identifier" arg]]
+            [JS.K"block"
+                [JS.K"if"
+                    [JS.K"call" "isnothing"::JS.K"Identifier"
+                        val_name::JS.K"Identifier"]
+                    expr
+                    [JS.K"call" "something"::JS.K"Identifier"
+                        val_name::JS.K"Identifier"]]]])
+    end
+    return expr
+end
+
 # New-style `@kwdef` macro that preserves provenance information.
 # This strips default values from struct fields and generates keyword constructors,
 # matching the semantics of Base.@kwdef.

--- a/test/analysis/test_cfg_analysis.jl
+++ b/test/analysis/test_cfg_analysis.jl
@@ -1058,6 +1058,35 @@ end
     end
 end
 
+@testset "@something short-circuit control flow" begin
+    # `@something(a, b)` only evaluates `b` when `a` is `nothing`. An
+    # assignment that lives inside a later argument is therefore conditional,
+    # so `v` may be undefined at the trailing `return`. If the macro stub
+    # collapsed to a flat `something(a, b)` call, both args would be
+    # evaluated unconditionally and `v` would be definitely defined.
+    let status = get_undef_status("""
+        function f(x)
+            local v
+            @something(x, (v = 1; nothing))
+            return v
+        end
+        """)
+        @test status["v"] === nothing
+    end
+
+    # Dual case: `v` is assigned in the first argument (always evaluated),
+    # so it is definitely defined regardless of what later args do.
+    let status = get_undef_status("""
+        function f()
+            local v
+            @something((v = 1; nothing), other)
+            return v
+        end
+        """)
+        @test status["v"] === false
+    end
+end
+
 end # @testset "undef analysis" begin
 
 # --- Dead store (unused assignment) analysis ---

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -2051,6 +2051,39 @@ end
         unreachable = filter(d -> d.code == JETLS.LOWERING_UNREACHABLE_CODE, diagnostics)
         @test isempty(unreachable)
     end
+
+    # Same shape but via `@something(rand(), @goto fallback)`: the goto
+    # lives in the second macro argument, only evaluated when the first
+    # produced `nothing`. The label is reachable via that goto edge even
+    # though the surrounding `return` would otherwise terminate.
+    let diagnostics = get_lowered_diagnostics("""
+        function foo()
+            return @something rand((rand(), nothing)) @goto fallback
+            @label fallback
+            println("Hit")
+        end
+        """)
+        unreachable = filter(d -> d.code == JETLS.LOWERING_UNREACHABLE_CODE, diagnostics)
+        @test isempty(unreachable)
+    end
+
+    # `@something(x, return default)` is a common early-return idiom. The
+    # macro expands to nested `let val_i = arg_i; if isnothing(val_i) ...`,
+    # whose macro-introduced wrapper contains the user-written `return`.
+    # The wrapper's lowered form puts the `K"if"` AFTER the `K"="` whose
+    # rhs is `return`, but the wrapper's byte range encompasses the
+    # `return`, so reporting it would surface a confusing
+    # "macro-everything-is-unreachable" warning. The
+    # `byte_range(child).start > terminator_end` filter in
+    # `analyze_unreachable_code!` suppresses it.
+    let diagnostics = get_lowered_diagnostics("""
+        function find_thing(env)
+            return @something parse_thing(env) return nothing
+        end
+        """)
+        unreachable = filter(d -> d.code == JETLS.LOWERING_UNREACHABLE_CODE, diagnostics)
+        @test isempty(unreachable)
+    end
 end
 
 module soft_scope_module

--- a/test/utils/test_jl_syntax_macros.jl
+++ b/test/utils/test_jl_syntax_macros.jl
@@ -299,6 +299,107 @@ end
         """) isa NamedTuple
 end
 
+@testset "@something" begin
+    @testset "macro expansion" begin
+        # Single argument: produces `let val_1 = arg; if isnothing(val_1)
+        # something(nothing) else something(val_1) end end`.
+        let st1 = jlexpand("@something xxx")
+            @test JS.kind(st1) === JS.K"let"
+            bindings, body = st1[1], st1[2]
+            @test JS.kind(bindings) === JS.K"block"
+            @test JS.kind(bindings[1]) === JS.K"="
+            @test bindings[1][1].name_val == "val_1"
+            @test JS.sourcetext(bindings[1][2]) == "xxx"
+            @test JS.kind(body) === JS.K"block"
+            ifnode = body[1]
+            @test JS.kind(ifnode) === JS.K"if"
+            cond = ifnode[1]
+            @test JS.kind(cond) === JS.K"call"
+            @test cond[1].name_val == "isnothing"
+            @test cond[2].name_val == "val_1"
+            then_branch = ifnode[2]
+            @test JS.kind(then_branch) === JS.K"call"
+            @test then_branch[1].name_val == "something"
+            @test JS.kind(then_branch[2]) === JS.K"Value"
+            @test then_branch[2].value === nothing
+            else_branch = ifnode[3]
+            @test JS.kind(else_branch) === JS.K"call"
+            @test else_branch[1].name_val == "something"
+            @test else_branch[2].name_val == "val_1"
+        end
+
+        # Multiple arguments: nests `let`/`if` per arg, with
+        # `something(nothing)` at the innermost then-branch.
+        let st1 = jlexpand("@something a b c")
+            count_let = Ref(0)
+            count_if = Ref(0)
+            innermost = Ref{Any}(nothing)
+            walk(st) = begin
+                k = JS.kind(st)
+                k === JS.K"let" && (count_let[] += 1)
+                k === JS.K"if" && (count_if[] += 1)
+                if k === JS.K"call" && JS.numchildren(st) == 2 &&
+                        st[1].name_val == "something" &&
+                        JS.kind(st[2]) === JS.K"Value" &&
+                        st[2].value === nothing
+                    innermost[] = st
+                end
+                for c in JS.children(st)
+                    var"#self#"(c)
+                end
+            end
+            walk(st1)
+            @test count_let[] == 3
+            @test count_if[] == 3
+            @test innermost[] !== nothing
+        end
+
+        # Zero arguments: matches `Base.@something()` — expands to
+        # `something(nothing)`.
+        let st1 = jlexpand("@something")
+            @test JS.kind(st1) === JS.K"call"
+            @test st1[1].name_val == "something"
+            @test JS.kind(st1[2]) === JS.K"Value"
+            @test st1[2].value === nothing
+        end
+    end
+
+    @testset "full lowering succeeds" begin
+        for code in [
+            "@something x",
+            "@something a b c",
+            "@something",
+            "function f(x)\n    @something(x, 1)\nend",
+        ]
+            @test jlresolve(code) isa NamedTuple
+        end
+    end
+
+    @testset "binding resolution preserves provenance" begin
+        # User identifiers inside `@something` keep accurate byte ranges so
+        # downstream LSP analyses can recognize them as user-written via
+        # `is_from_user_ast`.
+        let res = jlresolve("somefunc() = @something(xxx, yyy)")
+            binding_occurrences = JETLS.compute_binding_occurrences(
+                res.ctx3, res.st3, false; include_global_bindings=true)
+            xxx_binfo = yyy_binfo = nothing
+            for (binfo, _) in binding_occurrences
+                if binfo.kind === :global && binfo.name == "xxx"
+                    xxx_binfo = binfo
+                elseif binfo.kind === :global && binfo.name == "yyy"
+                    yyy_binfo = binfo
+                end
+            end
+            @test xxx_binfo !== nothing
+            @test yyy_binfo !== nothing
+            xxx_provs = JS.flattened_provenance(JL.binding_ex(res.ctx3, xxx_binfo.id))
+            @test JS.sourcetext(last(xxx_provs)) == "xxx"
+            yyy_provs = JS.flattened_provenance(JL.binding_ex(res.ctx3, yyy_binfo.id))
+            @test JS.sourcetext(last(yyy_provs)) == "yyy"
+        end
+    end
+end
+
 module test_lowering_module; using Test; end
 test_macro_expand(code::AbstractString) = jlexpand(test_lowering_module, code)
 test_macro_lower(code::AbstractString) = jlresolve(test_lowering_module, code)


### PR DESCRIPTION
Mirror `Base.@something`'s nested
`let val_i = arg_i; if !isnothing(val_i) something(val_i) else <next> end end`
expansion as a JuliaLowering new-style macro so that:

- each `arg_i` is evaluated at most once (binding occurrences and identifier-level semantics inside `arg_i` are preserved exactly);
- downstream def-use analysis sees the same conditional evaluation structure as the real macro — assignments inside `arg_{i+1}` are statically reachable only on paths where every preceding `arg_j` was `nothing`;
- LSP features (`textDocument/references`, `textDocument/rename`, etc.) and lowering-based diagnostics (`lowering/undef-global-var`, `lowering/unused-assignment`, `lowering/unreachable-code`) all see identifiers inside `@something` arguments with their original byte ranges intact.

The zero-argument form mirrors `Base.@something()`: it expands to `something(nothing)`, which throws at runtime.

`@something` is added to `NEW_STYLE_MACROCALL_NAMES` so that the old-style `_remove_macrocalls` rewriter does not run on it.