### PR TITLE
Introduce concrete `SyntaxTreeC` type alias

### DIFF
--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -57,6 +57,10 @@ const SWStats  = Nothing
 const LWStats  = Nothing
 const CASStats = Nothing
 
+const AttrsC = Dict{Symbol, Dict{Int64, Any}}
+const SyntaxTreeC = JS.SyntaxTree{AttrsC}
+const SyntaxListC = JS.SyntaxList{AttrsC,Vector{Int}}
+
 include("analysis/Analyzer.jl")
 using .Analyzer
 

--- a/src/analysis/cfg-analysis.jl
+++ b/src/analysis/cfg-analysis.jl
@@ -38,7 +38,7 @@
 struct BlockEvent
     kind::Symbol
     var_id::JL.IdTag
-    st::JS.SyntaxTree
+    st::SyntaxTreeC
 end
 
 # Per-variable, per-block event entry stored in `LambdaCFG.var_events`.
@@ -47,7 +47,7 @@ end
 struct VarEvent
     kind::Symbol
     block_id::Int
-    st::JS.SyntaxTree
+    st::SyntaxTreeC
 end
 
 # A `K"block"` child statement together with the CFG blocks execution
@@ -56,7 +56,7 @@ end
 struct StatementRecord
     before_block::Int
     after_block::Int
-    st::JS.SyntaxTree
+    st::SyntaxTreeC
 end
 
 mutable struct EventBlock
@@ -136,7 +136,7 @@ function cfg_add_edge!(lin::EventLinearizer, from::Int, to::Int)
     end
 end
 
-function cfg_emit_event!(lin::EventLinearizer, event_kind::Symbol, var_id::JL.IdTag, st::JS.SyntaxTree)
+function cfg_emit_event!(lin::EventLinearizer, event_kind::Symbol, var_id::JL.IdTag, st::SyntaxTreeC)
     lin.blocks[lin.current_block].event = BlockEvent(event_kind, var_id, st)
     # Create a new block to ensure proper ordering.
     # This allows the path-based analysis to track intra-block event order:
@@ -241,7 +241,7 @@ end
 # Walk the top-level operands of a condition expression, unwrapping
 # EST `K"block"` wrappers and recursing through `&&` chains (all
 # operands must be true in the true branch).
-function for_each_cond_operand(callback, cond::JS.SyntaxTree)
+function for_each_cond_operand(callback, cond::SyntaxTreeC)
     k = JS.kind(cond)
     if k == JS.K"block" && JS.numchildren(cond) == 1
         return for_each_cond_operand(callback, cond[1])
@@ -257,9 +257,9 @@ end
 
 # Emit `:isdefined` hints for `@isdefined(var)` in condition expressions.
 function undef_emit_isdefined_hints!(
-        lin::EventLinearizer, cond::JS.SyntaxTree, candidates::Set{JL.IdTag}
+        lin::EventLinearizer, cond::SyntaxTreeC, candidates::Set{JL.IdTag}
     )
-    for_each_cond_operand(cond) do operand::JS.SyntaxTree
+    for_each_cond_operand(cond) do operand::SyntaxTreeC
         JS.kind(operand) == JS.K"isdefined" || return
         JS.numchildren(operand) >= 1 || return
         arg = operand[1]
@@ -275,9 +275,9 @@ end
 # Collect all BindingId var_ids asserted true by a condition.
 # Returns `true` if every operand is a BindingId (for recording),
 # `false` otherwise (lookup still uses the collected ids).
-function undef_cond_binding_ids!(result::Vector{JL.IdTag}, cond::JS.SyntaxTree)
+function undef_cond_binding_ids!(result::Vector{JL.IdTag}, cond::SyntaxTreeC)
     all_bindings = Ref(true)
-    for_each_cond_operand(cond) do operand::JS.SyntaxTree
+    for_each_cond_operand(cond) do operand::SyntaxTreeC
         if JS.kind(operand) == JS.K"BindingId"
             push!(result, operand.var_id::JL.IdTag)
         else
@@ -291,7 +291,7 @@ end
 # Returns `nothing` when the node is not a definition or the LHS is not a BindingId.
 # This is the single source of truth for "what counts as a local variable definition"
 # used by both event linearization and correlated condition recording.
-function undef_direct_assign_var_id(node::JS.SyntaxTree)
+function undef_direct_assign_var_id(node::SyntaxTreeC)
     k = JS.kind(node)
     if (k == JS.K"=" || k == JS.K"function_decl") && JS.numchildren(node) >= 1
         lhs = node[1]
@@ -306,7 +306,7 @@ end
 # in a branch. Only considers assignments at the top level of `K"block"` nodes,
 # not those nested inside conditionals/loops.
 function undef_collect_branch_direct_assigns(
-        branch::JS.SyntaxTree, candidates::Set{JL.IdTag}
+        branch::SyntaxTreeC, candidates::Set{JL.IdTag}
     )
     result = Set{JL.IdTag}()
     undef_scan_direct_assigns!(result, branch, candidates)
@@ -314,7 +314,7 @@ function undef_collect_branch_direct_assigns(
 end
 
 function undef_scan_direct_assigns!(
-        result::Set{JL.IdTag}, node::JS.SyntaxTree, candidates::Set{JL.IdTag}
+        result::Set{JL.IdTag}, node::SyntaxTreeC, candidates::Set{JL.IdTag}
     )
     var_id = undef_direct_assign_var_id(node)
     if !isnothing(var_id)
@@ -343,7 +343,7 @@ end
 # Extracts all BindingId operands asserted true by the condition and checks
 # if any recorded implication key is a subset.
 function undef_emit_cond_implied_hints!(
-        lin::EventLinearizer, cond::JS.SyntaxTree, candidates::Set{JL.IdTag}
+        lin::EventLinearizer, cond::SyntaxTreeC, candidates::Set{JL.IdTag}
     )
     isempty(lin.cond_implies_defined) && return
     cond_vars = JL.IdTag[]
@@ -379,7 +379,7 @@ function undef_record_cond_implies!(
 end
 
 function linearize_cfg_events!(
-        lin::EventLinearizer, ctx3::JL.VariableAnalysisContext, ex3::JS.SyntaxTree,
+        lin::EventLinearizer, ctx3::JL.VariableAnalysisContext, ex3::SyntaxTreeC,
         candidates::Set{JL.IdTag}, allow_noreturn_optimization::Vector{Symbol}
     )
     k = JS.kind(ex3)
@@ -739,9 +739,9 @@ end
 # closure does not correctly block assignments that come after the closure
 # definition, leading to false-positive dead store reports.  Variables
 # identified here are excluded from dead store analysis.
-function collect_closure_captured_vars(body::JS.SyntaxTree, candidates::Set{JL.IdTag})
+function collect_closure_captured_vars(body::SyntaxTreeC, candidates::Set{JL.IdTag})
     result = Set{JL.IdTag}()
-    traverse(body) do st::JS.SyntaxTree
+    traverse(body) do st::SyntaxTreeC
         JS.kind(st) == JS.K"lambda" || return nothing
         nested_lb = st.lambda_bindings::JL.LambdaBindings
         for (id, is_capt) in nested_lb.locals_capt
@@ -806,7 +806,7 @@ end
 # Construct the `LambdaCFG` for `lambda_st3`.
 # The returned CFG is shared between `analyze_local_def_use!` and `analyze_unreachable!`.
 function build_lambda_cfg(
-        ctx3::JL.VariableAnalysisContext, lambda_st3::JS.SyntaxTree;
+        ctx3::JL.VariableAnalysisContext, lambda_st3::SyntaxTreeC;
         allow_noreturn_optimization::Vector{Symbol} = Symbol[]
     )
     JS.kind(lambda_st3) == JS.K"lambda" || return nothing
@@ -858,7 +858,7 @@ end
 # `unreachable_statements` every recorded statement whose entry and exit CFG blocks are
 # both unreachable from the lambda entry.
 function analyze_unreachable!(
-        unreachable_statements::Set{JS.SyntaxTree}, cfg::LambdaCFG
+        unreachable_statements::Set{SyntaxTreeC}, cfg::LambdaCFG
     )
     reachable = compute_reachable_blocks(cfg.lin.blocks)
     for rec in cfg.lin.statement_blocks
@@ -874,18 +874,18 @@ end
 Information about a local variable's definition/use sites and undef status.
 
 Fields:
-- `defs::Vector{JS.SyntaxTree}`: Definition sites (assignments, function declarations)
-- `undef_uses::Vector{Pair{Bool,JS.SyntaxTree}}`: Use sites on undef paths.
+- `defs::Vector{SyntaxTreeC}`: Definition sites (assignments, function declarations)
+- `undef_uses::Vector{Pair{Bool,SyntaxTreeC}}`: Use sites on undef paths.
   Each entry is `is_strict => use_tree`:
   - `true => tree`: Variable is definitely undefined at `tree`
   - `false => tree`: Variable may be undefined at `tree`
 """
 struct UndefInfo
-    defs::Vector{JS.SyntaxTree}
-    undef_uses::Vector{Pair{Bool,JS.SyntaxTree}}
+    defs::Vector{SyntaxTreeC}
+    undef_uses::Vector{Pair{Bool,SyntaxTreeC}}
 end
 
-UndefInfo() = UndefInfo(JS.SyntaxTree[], Pair{Bool,JS.SyntaxTree}[])
+UndefInfo() = UndefInfo(SyntaxTreeC[], Pair{Bool,SyntaxTreeC}[])
 
 """
     DeadStoreInfo
@@ -893,11 +893,11 @@ UndefInfo() = UndefInfo(JS.SyntaxTree[], Pair{Bool,JS.SyntaxTree}[])
 Information about dead store assignments for a local variable.
 
 Fields:
-- `dead_defs::Vector{JS.SyntaxTree}`: Assignment sites whose values are
+- `dead_defs::Vector{SyntaxTreeC}`: Assignment sites whose values are
   never read on any CFG path (dead stores).
 """
 struct DeadStoreInfo
-    dead_defs::Vector{JS.SyntaxTree}
+    dead_defs::Vector{SyntaxTreeC}
 end
 
 # Run undef-analysis and dead-store analysis for every local binding tracked by
@@ -919,11 +919,11 @@ function analyze_local_def_use!(
             continue
         end
 
-        defs = JS.SyntaxTree[]
+        defs = SyntaxTreeC[]
         assign_blocks = BitSet()       # for undef (includes :isdefined)
         real_assign_blocks = BitSet()  # for dead store (only :assign)
         use_blocks = BitSet()
-        event_trees = Dict{Int,JS.SyntaxTree}()
+        event_trees = Dict{Int,SyntaxTreeC}()
         for evt in evts
             event_trees[evt.block_id] = evt.st
             if evt.kind === :assign
@@ -939,15 +939,15 @@ function analyze_local_def_use!(
 
         # --- Undef analysis ---
         if isempty(use_blocks)
-            undef_info[binfo] = UndefInfo(defs, Pair{Bool,JS.SyntaxTree}[])
+            undef_info[binfo] = UndefInfo(defs, Pair{Bool,SyntaxTreeC}[])
         elseif isempty(assign_blocks)
-            undef_uses = Pair{Bool,JS.SyntaxTree}[true => event_trees[ub] for ub in use_blocks]
+            undef_uses = Pair{Bool,SyntaxTreeC}[true => event_trees[ub] for ub in use_blocks]
             undef_info[binfo] = UndefInfo(defs, undef_uses)
         else
             reached = cfg_reachable_targets(cfg.lin.blocks, 1, use_blocks, assign_blocks, visited)
             if !isempty(reached)
                 min_assign_block = minimum(assign_blocks)
-                undef_uses = Pair{Bool,JS.SyntaxTree}[]
+                undef_uses = Pair{Bool,SyntaxTreeC}[]
                 for ub in reached
                     is_strict = ub < min_assign_block &&
                                 cfg_is_must_execute(cfg.lin.blocks, ub, cfg.exit_blocks, visited)
@@ -955,7 +955,7 @@ function analyze_local_def_use!(
                 end
                 undef_info[binfo] = UndefInfo(defs, undef_uses)
             else
-                undef_info[binfo] = UndefInfo(defs, Pair{Bool,JS.SyntaxTree}[])
+                undef_info[binfo] = UndefInfo(defs, Pair{Bool,SyntaxTreeC}[])
             end
         end
 
@@ -964,7 +964,7 @@ function analyze_local_def_use!(
            isempty(use_blocks) || isempty(real_assign_blocks)
             continue
         end
-        dead_defs = JS.SyntaxTree[]
+        dead_defs = SyntaxTreeC[]
         other_assigns = BitSet()
         for def_block_id in real_assign_blocks
             empty!(other_assigns)
@@ -991,8 +991,8 @@ end
 function analyze_lambda!(
         undef_info::Dict{JL.BindingInfo, UndefInfo},
         dead_store_info::Dict{JL.BindingInfo, DeadStoreInfo},
-        unreachable_statements::Set{JS.SyntaxTree},
-        ctx3::JL.VariableAnalysisContext, lambda_st3::JS.SyntaxTree,
+        unreachable_statements::Set{SyntaxTreeC},
+        ctx3::JL.VariableAnalysisContext, lambda_st3::SyntaxTreeC,
         allow_noreturn_optimization::Vector{Symbol}
     )
     cfg = @something build_lambda_cfg(ctx3, lambda_st3; allow_noreturn_optimization) return
@@ -1023,7 +1023,7 @@ all three CFG-aware analyses on it:
 
 - **Unreachable-code analysis** — collects `K"block"` children whose
   CFG block is not reachable from the lambda entry. Returned as
-  `Set{JS.SyntaxTree}`. Because the CFG accurately models
+  `Set{SyntaxTreeC}`. Because the CFG accurately models
   expression-nested control transfers, patterns like
   `return cnd ? @goto(fallback) : println("Return"); @label fallback; <code>`
   correctly keep `<code>` reachable via the goto edge.
@@ -1035,7 +1035,7 @@ per-lambda intermediate dicts/sets are allocated and merged.
 # Arguments
 - `ctx3::JL.VariableAnalysisContext`: the variable-analysis context
   produced by JuliaLowering's scope-resolution pass.
-- `st3::JS.SyntaxTree`: scope-resolved syntax tree to analyze. Top-
+- `st3::SyntaxTreeC`: scope-resolved syntax tree to analyze. Top-
   level (non-lambda) constructs are skipped.
 - `allow_noreturn_optimization::Vector{Symbol}`: globals (typically
   function names) whose calls should be treated as guaranteed
@@ -1048,13 +1048,13 @@ Macro-expanded code is best fed in after `_remove_macrocalls` for old-style macr
 expression positions that this analysis is not designed to handle correctly.
 """
 function analyze_all_lambdas(
-        ctx3::JL.VariableAnalysisContext, st3::JS.SyntaxTree;
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC;
         allow_noreturn_optimization::Vector{Symbol} = Symbol[]
     )
     undef_info = Dict{JL.BindingInfo, UndefInfo}()
     dead_store_info = Dict{JL.BindingInfo, DeadStoreInfo}()
-    unreachable_statements = Set{JS.SyntaxTree}()
-    traverse(st3) do st3′::JS.SyntaxTree
+    unreachable_statements = Set{SyntaxTreeC}()
+    traverse(st3) do st3′::SyntaxTreeC
         if JS.kind(st3′) == JS.K"lambda"
             analyze_lambda!(
                 undef_info, dead_store_info, unreachable_statements,

--- a/src/analysis/occurrence-analysis.jl
+++ b/src/analysis/occurrence-analysis.jl
@@ -1,16 +1,15 @@
 """
     compute_binding_occurrences(
-            ctx3::JL.VariableAnalysisContext, st3::Tree3, is_generated::Bool;
+            ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, is_generated::Bool;
             include_global_bindings::Bool = false
-        ) where Tree3<:JS.SyntaxTree
-        -> binding_occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence{Tree3}}}
+        ) -> binding_occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}}
 
 Analyze a lowered syntax tree to find all occurrences of local and argument bindings.
 
 This function traverses the syntax tree `st3` and records `occurrence::BindingOccurrence`s
 for each local and argument binding within `st3`, where `occurrence` have the following
 information:
-- `occurrence.tree::JS.SyntaxTree`: Syntax tree for this occurrence of the binding
+- `occurrence.tree::SyntaxTreeC`: Syntax tree for this occurrence of the binding
 - `occurrence.kind::Symbol`
   - `:decl` - explicit declarations like `local x`
   - `:def` - assignments or function arguments
@@ -32,10 +31,10 @@ a set of `BindingOccurrence` objects that record where and how the binding appea
     variable diagnostics or comprehensive binding analysis.
 """
 function compute_binding_occurrences(
-        ctx3::JL.VariableAnalysisContext, st3::Tree3, is_generated::Bool;
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, is_generated::Bool;
         include_global_bindings::Bool = false
-    ) where Tree3<:JS.SyntaxTree
-    occurrences = Dict{JL.BindingInfo,Set{BindingOccurrence{Tree3}}}()
+    )
+    occurrences = Dict{JL.BindingInfo,Set{BindingOccurrence}}()
 
     same_arg_bindings = Dict{Symbol,Vector{Int}}() # group together argument bindings with the same name
     same_location_bindings = Dict{Tuple{Symbol,Int,Int},Vector{Int}}() # group together local bindings with the same location and name
@@ -58,7 +57,7 @@ function compute_binding_occurrences(
             lockey = (Symbol(binfo.name), JS.source_location(JL.binding_ex(ctx3, binfo.id))...)
             push!(get!(Vector{Int}, same_location_bindings, lockey), i)
         end
-        occurrences[binfo] = Set{BindingOccurrence{Tree3}}()
+        occurrences[binfo] = Set{BindingOccurrence}()
     end
 
     isempty(occurrences) && return occurrences
@@ -116,7 +115,7 @@ function compute_binding_occurrences(
     end
     for (local_binfo, global_binfo) in alias_remaps
         local_occs = pop!(occurrences, local_binfo)
-        existing = get!(Set{BindingOccurrence{Tree3}}, occurrences, global_binfo)
+        existing = get!(Set{BindingOccurrence}, occurrences, global_binfo)
         union!(existing, local_occs)
     end
 
@@ -141,13 +140,13 @@ function compute_binding_occurrences(
     return occurrences
 end
 
-function collect_inert_identifiers(st3::JS.SyntaxTree)
-    result = Dict{String,Vector{JS.SyntaxTree}}()
-    foreach_inert_identifier(st3) do id_node::JS.SyntaxTree
+function collect_inert_identifiers(st3::SyntaxTreeC)
+    result = Dict{String,Vector{SyntaxTreeC}}()
+    foreach_inert_identifier(st3) do id_node::SyntaxTreeC
         JS.hasattr(id_node, :name_val) || return true
         name_val = id_node.name_val
         name_val isa AbstractString || return true
-        push!(get!(Vector{JS.SyntaxTree}, result, name_val), id_node)
+        push!(get!(Vector{SyntaxTreeC}, result, name_val), id_node)
         return true
     end
     return result
@@ -162,10 +161,10 @@ self-recursive calls, which have distinct byte ranges.
 """
 const SkipRecording = Dict{JL.BindingInfo,UnitRange{Int}}
 
-function may_record_occurrence!(occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence{Tree3}}},
-        kind::Symbol, st::Tree3, ctx3::JL.VariableAnalysisContext;
+function may_record_occurrence!(occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
+        kind::Symbol, st::SyntaxTreeC, ctx3::JL.VariableAnalysisContext;
         skip_recording::Union{Nothing,SkipRecording} = nothing
-    ) where Tree3<:JS.SyntaxTree
+    )
     if JS.kind(st) === JS.K"BindingId"
         binfo = JL.get_binding(ctx3, st)
         _may_record_occurrence!(occurrences, kind, st, binfo; skip_recording)
@@ -174,10 +173,10 @@ function may_record_occurrence!(occurrences::Dict{JL.BindingInfo,Set{BindingOccu
     return false
 end
 
-function _may_record_occurrence!(occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence{Tree3}}},
-        kind::Symbol, st::Tree3, binfo::JL.BindingInfo;
+function _may_record_occurrence!(occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
+        kind::Symbol, st::SyntaxTreeC, binfo::JL.BindingInfo;
         skip_recording::Union{Nothing,SkipRecording} = nothing
-    ) where Tree3<:JS.SyntaxTree
+    )
     haskey(occurrences, binfo) || return
     if !isnothing(skip_recording)
         skip_range = get(skip_recording, binfo, nothing)
@@ -193,11 +192,11 @@ is_selffunc(b::JL.BindingInfo) = b.name == "#self#"
 is_kwsorter_func(b::JL.BindingInfo) = startswith(b.name, '#') && endswith(b.name, r"#\d+$")
 
 function compute_binding_occurrences!(
-        occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence{Tree3}}},
-        ctx3::JL.VariableAnalysisContext, st3::Tree3;
+        occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC;
         include_global_bindings::Bool = false,
         skip_recording_uses::Union{Nothing,SkipRecording} = nothing
-    ) where Tree3<:JS.SyntaxTree
+    )
     stack = JS.SyntaxList(st3)
     while !isempty(stack)
         st = pop!(stack)
@@ -339,12 +338,12 @@ function is_matching_global_binding(
 end
 
 function find_global_binding_occurrences!(
-        state::ServerState, uri::URI, fi::FileInfo, st0_top::JS.SyntaxTree,
+        state::ServerState, uri::URI, fi::FileInfo, st0_top::SyntaxTreeC,
         binfo::JL.BindingInfo;
         kwargs...
     )
     ret = Set{CachedBindingOccurrence}()
-    iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
+    iterate_toplevel_tree(st0_top) do st0::SyntaxTreeC
         binding_occurrences = @something get_binding_occurrences!(
             state, uri, fi, st0; include_global_bindings = true, kwargs...) return
         for (binfo′, occurrences) in binding_occurrences
@@ -359,7 +358,7 @@ function find_global_binding_occurrences!(
 end
 
 function get_binding_occurrences!(
-        state::ServerState, uri::URI, fi::FileInfo, st0::JS.SyntaxTree; kwargs...
+        state::ServerState, uri::URI, fi::FileInfo, st0::SyntaxTreeC; kwargs...
     )
     cache_uri = canonical_cache_uri(state, uri)
     range_key = JS.byte_range(st0)
@@ -389,7 +388,7 @@ function get_binding_occurrences!(
 end
 
 function compute_binding_occurrences_st0(
-        state::ServerState, uri::URI, fi::FileInfo, st0::JS.SyntaxTree;
+        state::ServerState, uri::URI, fi::FileInfo, st0::SyntaxTreeC;
         lookup_func = gen_lookup_out_of_scope!(state, uri),
         include_global_bindings::Bool = false
     )
@@ -411,11 +410,11 @@ function compute_binding_occurrences_st0(
     if include_global_bindings
         k0 = JS.kind(st0)
         if k0 in JS.KSet"export public"
-            binding_occurrences = Dict{JL.BindingInfo,Set{BindingOccurrence{typeof(st0)}}}()
+            binding_occurrences = Dict{JL.BindingInfo,Set{BindingOccurrence}}()
             collect_export_public_occurrences!(binding_occurrences, st0, mod)
             return binding_occurrences
         elseif k0 in JS.KSet"import using"
-            binding_occurrences = Dict{JL.BindingInfo,Set{BindingOccurrence{typeof(st0)}}}()
+            binding_occurrences = Dict{JL.BindingInfo,Set{BindingOccurrence}}()
             collect_import_using_occurrences!(binding_occurrences, st0, mod)
             return binding_occurrences
         end
@@ -446,9 +445,9 @@ function compute_binding_occurrences_st0(
 end
 
 function collect_export_public_occurrences!(
-        occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence{Tree3}}},
-        st0::Tree3, mod::Module
-    ) where Tree3<:JS.SyntaxTree
+        occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
+        st0::SyntaxTreeC, mod::Module
+    )
     JS.kind(st0) in JS.KSet"export public" || return occurrences
     for i = 1:JS.numchildren(st0)
         child = st0[i]
@@ -456,33 +455,33 @@ function collect_export_public_occurrences!(
         name = get(child, :name_val, nothing)
         name isa AbstractString || continue
         binfo = JL.BindingInfo(0, name, :global, 0; mod)
-        target_set = get!(Set{BindingOccurrence{Tree3}}, occurrences, binfo)
-        push!(target_set, BindingOccurrence{Tree3}(child, :use))
+        target_set = get!(Set{BindingOccurrence}, occurrences, binfo)
+        push!(target_set, BindingOccurrence(child, :use))
     end
     return occurrences
 end
 
 function collect_import_using_occurrences!(
-        occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence{Tree3}}},
-        st0::Tree3, mod::Module
-    ) where Tree3<:JS.SyntaxTree
-    foreach_local_import_identifier(st0) do id_st::Tree3
+        occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
+        st0::SyntaxTreeC, mod::Module
+    )
+    foreach_local_import_identifier(st0) do id_st::SyntaxTreeC
         name = get(id_st, :name_val, nothing)
         name isa AbstractString || return
         binfo = JL.BindingInfo(0, name, :global, 0; mod)
-        target_set = get!(Set{BindingOccurrence{Tree3}}, occurrences, binfo)
-        push!(target_set, BindingOccurrence{Tree3}(id_st, :decl))
+        target_set = get!(Set{BindingOccurrence}, occurrences, binfo)
+        push!(target_set, BindingOccurrence(id_st, :decl))
         return
     end
     return occurrences
 end
 
 function collect_macrocall_occurrences!(
-        occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence{Tree3}}},
-        mod::Module, st0::JS.SyntaxTree;
+        occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
+        mod::Module, st0::SyntaxTreeC;
         soft_scope::Bool = false
-    ) where Tree3<:JS.SyntaxTree
-    traverse(st0) do st::JS.SyntaxTree
+    )
+    traverse(st0) do st::SyntaxTreeC
         JS.kind(st) === JS.K"macrocall" || return nothing
         JS.numchildren(st) ≥ 1 || return nothing
         macrocall_name = st[1]
@@ -493,8 +492,8 @@ function collect_macrocall_occurrences!(
         end
         for binfo in ctx3.bindings.info
             if binfo.kind === :global
-                target_set = get!(Set{BindingOccurrence{Tree3}}, occurrences, binfo)
-                push!(target_set, BindingOccurrence{Tree3}(JL.binding_ex(ctx3, binfo), :use))
+                target_set = get!(Set{BindingOccurrence}, occurrences, binfo)
+                push!(target_set, BindingOccurrence(JL.binding_ex(ctx3, binfo), :use))
             end
         end
         return nothing # Don't TraversalNoRecurse since macro calls can be nested
@@ -564,10 +563,10 @@ function/macro argument name are filtered out to avoid false
   compensates for this unwrap artifact.
 """
 function collect_inert_global_occurrences!(
-        occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence{Tree3}}},
-        ctx3::JL.VariableAnalysisContext, st3::JS.SyntaxTree, mod::Module;
+        occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, mod::Module;
         soft_scope::Bool = false
-    ) where Tree3<:JS.SyntaxTree
+    )
     arg_names = Set{String}()
     for binfo in ctx3.bindings.info
         if binfo.kind === :argument && !binfo.is_internal
@@ -575,7 +574,7 @@ function collect_inert_global_occurrences!(
         end
     end
     st3_range = JS.byte_range(st3)
-    traverse(st3) do st3′::JS.SyntaxTree
+    traverse(st3) do st3′::SyntaxTreeC
         JS.kind(st3′) === JS.K"inert" || return nothing
         JS.numchildren(st3′) >= 1 || return nothing
         # Skip the outer inert that wraps the entire generator template
@@ -593,7 +592,7 @@ function collect_inert_global_occurrences!(
             if binfo.kind === :global && !binfo.is_internal && !(binfo.name in arg_names)
                 # Use the inert ctx's BindingInfo as key; when cached via
                 # BindingInfoKey(mod, name, :global) it matches the import.
-                occ_set = get!(Set{BindingOccurrence{Tree3}}, occurrences, binfo)
+                occ_set = get!(Set{BindingOccurrence}, occurrences, binfo)
                 push!(occ_set, BindingOccurrence(
                     JL.binding_ex(ires.ctx3, binfo.id), :use))
             end

--- a/src/analysis/resolver.jl
+++ b/src/analysis/resolver.jl
@@ -1,5 +1,5 @@
 """
-    resolve_type(analyzer::LSAnalyzer, context_module::Module, s0::Union{JS.SyntaxNode,JS.SyntaxTree})
+    resolve_type(analyzer::LSAnalyzer, context_module::Module, s0::Union{JS.SyntaxNode,SyntaxTreeC})
     resolve_type(analyzer::LSAnalyzer, context_module::Module, ex::Expr)
 
 Resolves the type of `s0` in the `context_module` that has been analyzed by the `analyzer`.
@@ -32,7 +32,7 @@ function resolve_type(analyzer::LSAnalyzer, context_module::Module, node::JS.Syn
     end
     return resolve_type(analyzer, context_module, ex)
 end
-function resolve_type(analyzer::LSAnalyzer, context_module::Module, st::JS.SyntaxTree)
+function resolve_type(analyzer::LSAnalyzer, context_module::Module, st::SyntaxTreeC)
     ex = try
         JL.est_to_expr(st)
     catch

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -95,7 +95,7 @@ Sending (4) and (5) to the client can happen eagerly in response to <TAB>
 in later versions.
 """
 function to_completion(
-        binding::JL.BindingInfo, st::JS.SyntaxTree, sort_offset::Int,
+        binding::JL.BindingInfo, st::SyntaxTreeC, sort_offset::Int,
         uri::URI, fi::FileInfo
     )
     label_kind = CompletionItemKind.Variable
@@ -115,7 +115,7 @@ function to_completion(
 
     typeid = binding.type
     if !isnothing(typeid)
-        label_detail = "::" * JS.sourcetext(JS.SyntaxTree(JS.syntax_graph(st), typeid))
+        label_detail = "::" * JS.sourcetext(SyntaxTreeC(JS.syntax_graph(st), typeid))
     end
 
     io = IOBuffer()
@@ -483,7 +483,7 @@ end
 # call completions (method signatures and keyword arguments)
 # ==========================================================
 
-function extract_param_text(p::JS.SyntaxTree)
+function extract_param_text(p::SyntaxTreeC)
      k = JS.kind(p)
     if k === JS.K"Identifier"
         return extract_name_val(p)
@@ -563,7 +563,7 @@ function cursor_equals_position(ca::CallArgs, b::Int)
     return nothing
 end
 
-function extract_kwarg_name_str(p::JS.SyntaxTree)
+function extract_kwarg_name_str(p::SyntaxTreeC)
     node = @something extract_kwarg_name(p; sig=true) return nothing
     return extract_name_val(node)
 end

--- a/src/declaration.jl
+++ b/src/declaration.jl
@@ -51,7 +51,7 @@ end
 
 """
     find_declaration(server, uri, fi, pos; soft_scope, fallback_to_definition=false) ->
-        (locations::Vector{Location}, origin_node::Union{JS.SyntaxTree,Nothing})
+        (locations::Vector{Location}, origin_node::Union{SyntaxTreeC,Nothing})
 
 Core routine behind `textDocument/declaration`. Returns the declaration
 locations for the symbol at `pos` (source-level `:decl` occurrences —

--- a/src/definition.jl
+++ b/src/definition.jl
@@ -105,7 +105,7 @@ end
 
 """
     find_definition(server, uri, fi, pos; soft_scope) ->
-        (locations::Vector{Location}, origin_node::Union{JS.SyntaxTree,Nothing})
+        (locations::Vector{Location}, origin_node::Union{SyntaxTreeC,Nothing})
 
 Core routine behind `textDocument/definition`. Returns the definition locations for
 the symbol at `pos` together with the syntax-tree node that represents the cursor's

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -531,7 +531,7 @@ end
 # lowering diagnostic
 # ===================
 
-const JL_MACRO_FILE = only(methods(JL.expand_macro, (JL.MacroExpansionContext,JS.SyntaxTree))).file
+const JL_MACRO_FILE = only(methods(JL.expand_macro, (JL.MacroExpansionContext,SyntaxTreeC))).file
 function scrub_expand_macro_stacktrace(stacktrace::Vector{Base.StackTraces.StackFrame})
     idx = @something findfirst(stacktrace) do stackframe::Base.StackTraces.StackFrame
         stackframe.func === :expand_macro && stackframe.file === JL_MACRO_FILE
@@ -594,7 +594,7 @@ end
 
 # Compute a mapping from source locations to the set of identifier names found in keyword
 # argument type annotations.
-function compute_kwarg_type_annotation_names(st0::JS.SyntaxTree)
+function compute_kwarg_type_annotation_names(st0::SyntaxTreeC)
     type_names = Dict{Tuple{Int,Int},Set{String}}()
     locations = Set{Tuple{Int,Int}}()
     traverse(st0) do node
@@ -614,7 +614,7 @@ function compute_kwarg_type_annotation_names(st0::JS.SyntaxTree)
     return type_names, locations
 end
 
-function collect_identifier_names!(names::Set{String}, st::JS.SyntaxTree)
+function collect_identifier_names!(names::Set{String}, st::SyntaxTreeC)
     if JS.kind(st) === JS.K"Identifier"
         name = get(st, :name_val, nothing)
         if name !== nothing
@@ -648,10 +648,9 @@ function is_kwarg_constraining_used_sparam(
 end
 
 function has_matching_argument_binding(
-        binding_occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence{Tree3}}},
-        name::String, range::Range,
-        fi::FileInfo, ctx3::JL.VariableAnalysisContext
-    ) where Tree3<:JS.SyntaxTree
+        binding_occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
+        name::String, range::Range, fi::FileInfo, ctx3::JL.VariableAnalysisContext
+    )
     for (binfo2, _) in binding_occurrences
         binfo2.kind === :argument || continue
         binfo2.name == name || continue
@@ -663,13 +662,13 @@ function has_matching_argument_binding(
 end
 
 function analyze_unused_bindings!(
-        diagnostics::Vector{Diagnostic}, fi::FileInfo, st0::JS.SyntaxTree, ctx3::JL.VariableAnalysisContext,
-        binding_occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence{Tree3}}},
+        diagnostics::Vector{Diagnostic}, fi::FileInfo, st0::SyntaxTreeC, ctx3::JL.VariableAnalysisContext,
+        binding_occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
         has_implicit_args::Bool, reported::Set{LoweringDiagnosticKey},
         kwarg_type_names::Dict{Tuple{Int,Int},Set{String}},
         kwarg_locations::Set{Tuple{Int,Int}};
         allow_unused_underscore::Bool
-    ) where Tree3<:JS.SyntaxTree
+    )
     for (binfo, occurrences) in binding_occurrences
         bk = binfo.kind
         bk === :global && continue
@@ -724,7 +723,7 @@ function analyze_unused_bindings!(
 end
 
 function analyze_unused_assignments!(
-        diagnostics::Vector{Diagnostic}, fi::FileInfo, st0::JS.SyntaxTree,
+        diagnostics::Vector{Diagnostic}, fi::FileInfo, st0::SyntaxTreeC,
         dead_store_info::Dict{JL.BindingInfo, DeadStoreInfo},
         reported::Set{LoweringDiagnosticKey};
         allow_unused_underscore::Bool
@@ -770,11 +769,11 @@ end
 #   full-analysis reports.
 function analyze_undefined_global_bindings!(
         diagnostics::Vector{Diagnostic}, fi::FileInfo, ctx3::JL.VariableAnalysisContext,
-        binding_occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence{Tree3}}},
+        binding_occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
         reported::Set{LoweringDiagnosticKey};
         analyzer::Union{Nothing,LSAnalyzer} = nothing,
         postprocessor::LSPostProcessor = LSPostProcessor()
-    ) where Tree3<:JS.SyntaxTree
+    )
     world = Base.get_world_counter()
     for (binfo, occurrences) in binding_occurrences
         bk = binfo.kind
@@ -860,12 +859,12 @@ function analyze_undefined_local_bindings!(
 end
 
 function compute_unused_variable_data(
-        st0::JS.SyntaxTree,
-        prov::JS.SyntaxTree,
+        st0::SyntaxTreeC,
+        prov::SyntaxTreeC,
         fi::FileInfo
     )
     # Find parent K"=" node using byte_ancestors
-    ancestors = byte_ancestors(st::JS.SyntaxTree->JS.kind(st)===JS.K"=", st0, JS.byte_range(prov))
+    ancestors = byte_ancestors(st::SyntaxTreeC->JS.kind(st)===JS.K"=", st0, JS.byte_range(prov))
     isempty(ancestors) && return nothing
 
     assignment = first(ancestors)
@@ -899,7 +898,7 @@ end
 
 function analyze_captured_boxes!(
         diagnostics::Vector{Diagnostic}, uri::URI, fi::FileInfo,
-        ctx4::JL.ClosureConversionCtx, st3::JL.SyntaxTree,
+        ctx4::JL.ClosureConversionCtx, st3::SyntaxTreeC,
         reported::Set{LoweringDiagnosticKey}
     )
     for binfo in ctx4.bindings.info
@@ -941,7 +940,7 @@ function is_captured_binding(binfo::JL.BindingInfo, ctx4::JL.ClosureConversionCt
 end
 
 function find_capture_sites(
-        st3::JL.SyntaxTree, binfo::JL.BindingInfo, ctx4::JL.ClosureConversionCtx,
+        st3::SyntaxTreeC, binfo::JL.BindingInfo, ctx4::JL.ClosureConversionCtx,
         uri::URI, fi::FileInfo
     )
     relatedInformation = DiagnosticRelatedInformation[]
@@ -950,13 +949,13 @@ function find_capture_sites(
             haskey(lambda.locals_capt, binfo.id) || continue
             lambda.locals_capt[binfo.id] || continue
             # Find the lambda in st3 that has matching lambda_bindings.self
-            traverse(st3) do node::JL.SyntaxTree
-                JS.kind(node) === JS.K"lambda" || return nothing
-                hasproperty(node, :lambda_bindings) || return nothing
-                lambda_bindings = node.lambda_bindings::JL.LambdaBindings
+            traverse(st3) do node3::SyntaxTreeC
+                JS.kind(node3) === JS.K"lambda" || return nothing
+                hasproperty(node3, :lambda_bindings) || return nothing
+                lambda_bindings = node3.lambda_bindings::JL.LambdaBindings
                 lambda_bindings.self == lambda.self || return nothing
                 # Find references to binfo.id inside this lambda
-                traverse(node) do inner::JL.SyntaxTree
+                traverse(node3) do inner::SyntaxTreeC
                     if JS.kind(inner) === JS.K"BindingId" && JL._binding_id(inner) == binfo.id
                         varprov = last(JL.flattened_provenance(inner))
                         push!(relatedInformation, DiagnosticRelatedInformation(;
@@ -1007,9 +1006,9 @@ const SORT_IMPORTS_MAX_LINE_LENGTH = 92
 const SORT_IMPORTS_INDENT = "    "
 
 function analyze_unsorted_imports!(
-        diagnostics::Vector{Diagnostic}, fi::FileInfo, st0::JS.SyntaxTree
+        diagnostics::Vector{Diagnostic}, fi::FileInfo, st0::SyntaxTreeC
     )
-    traverse(st0) do st0′::JS.SyntaxTree
+    traverse(st0) do st0′::SyntaxTreeC
         kind = JS.kind(st0′)
         if kind ∉ JS.KSet"import using export public"
             return nothing
@@ -1035,7 +1034,7 @@ function analyze_unsorted_imports!(
 end
 
 function generate_sorted_import_text(
-        node::JS.SyntaxTree, sorted_name_keys::Vector{Pair{SyntaxTree0,String}},
+        node::SyntaxTreeC, sorted_name_keys::Vector{Pair{SyntaxTreeC,String}},
         base_indent::String
     )
     kind = JS.kind(node)
@@ -1088,11 +1087,11 @@ end
 # `return f(@goto label); @label label; ...` are correctly recognized as
 # reachable via the goto edge.
 function analyze_unreachable_code!(
-        diagnostics::Vector{Diagnostic}, fi::FileInfo, st3::JS.SyntaxTree,
-        unreachable_statements::Set{JS.SyntaxTree}
+        diagnostics::Vector{Diagnostic}, fi::FileInfo, st3::SyntaxTreeC,
+        unreachable_statements::Set{SyntaxTreeC}
     )
     isempty(unreachable_statements) && return
-    traverse(st3) do st3′::JS.SyntaxTree
+    traverse(st3) do st3′::SyntaxTreeC
         JS.kind(st3′) === JS.K"block" || return nothing
         nchildren = JS.numchildren(st3′)
         first_unreach_idx = 0
@@ -1158,9 +1157,9 @@ end
 # `compile_body` (linear IR pass), which JETLS doesn't run. Mirror that
 # check against `st3` so unresolved gotos still surface as diagnostics.
 function analyze_unresolved_gotos!(
-        diagnostics::Vector{Diagnostic}, fi::FileInfo, st3::JS.SyntaxTree
+        diagnostics::Vector{Diagnostic}, fi::FileInfo, st3::SyntaxTreeC
     )
-    traverse(st3) do st3′::JS.SyntaxTree
+    traverse(st3) do st3′::SyntaxTreeC
         JS.kind(st3′) === JS.K"lambda" || return nothing
         JS.numchildren(st3′) >= 3 || return nothing
         check_lambda_gotos!(diagnostics, fi, st3′[3])
@@ -1169,7 +1168,7 @@ function analyze_unresolved_gotos!(
 end
 
 function check_lambda_gotos!(
-        diagnostics::Vector{Diagnostic}, fi::FileInfo, body3::JS.SyntaxTree
+        diagnostics::Vector{Diagnostic}, fi::FileInfo, body3::SyntaxTreeC
     )
     gotos, labels = collect_gotos_labels(body3)
     label_names = Set{String}(name for (name, _) in labels)
@@ -1213,16 +1212,15 @@ function check_lambda_gotos!(
     end
 end
 
-function collect_gotos_labels(st3::JS.SyntaxTree)
-    gotos = Tuple{String,JS.SyntaxTree}[]
-    labels = Tuple{String,JS.SyntaxTree}[]
+function collect_gotos_labels(st3::SyntaxTreeC)
+    gotos = Tuple{String,SyntaxTreeC}[]
+    labels = Tuple{String,SyntaxTreeC}[]
     collect_gotos_labels!(gotos, labels, st3)
     return gotos, labels
 end
 function collect_gotos_labels!(
-        gotos::Vector{Tuple{String,JS.SyntaxTree}},
-        labels::Vector{Tuple{String,JS.SyntaxTree}},
-        st3::JS.SyntaxTree
+        gotos::Vector{Tuple{String,SyntaxTreeC}}, labels::Vector{Tuple{String,SyntaxTreeC}},
+        st3::SyntaxTreeC
     )
     k = JS.kind(st3)
     if k === JS.K"lambda"
@@ -1292,7 +1290,7 @@ function analyze_lowered_code!(
 end
 
 function lowering_diagnostics!(
-        diagnostics::Vector{Diagnostic}, uri::URI, fi::FileInfo, mod::Module, st0::JS.SyntaxTree;
+        diagnostics::Vector{Diagnostic}, uri::URI, fi::FileInfo, mod::Module, st0::SyntaxTreeC;
         skip_analysis_requiring_context::Bool = false,
         soft_scope::Bool = false,
         kwargs...
@@ -1403,7 +1401,7 @@ function compute_unit_used_names(
         end continue
         search_st0_top = build_syntax_tree(search_fi)
 
-        iterate_toplevel_tree(search_st0_top) do st0::JS.SyntaxTree
+        iterate_toplevel_tree(search_st0_top) do st0::SyntaxTreeC
             binding_occurrences = @something get_binding_occurrences!(
                 state, search_uri, search_fi, st0; include_global_bindings = true) return
             mod = get_context_module(state, search_uri, offset_to_xy(search_fi, JS.first_byte(st0)))
@@ -1429,13 +1427,13 @@ end
 # - Unchanged file skipping in workspace/diagnostic
 function analyze_unused_imports!(
         diagnostics::Vector{Diagnostic}, server::Server, uri::URI,
-        fi::FileInfo, st0_top::JS.SyntaxTree;
+        fi::FileInfo, st0_top::SyntaxTreeC;
         skip_context_check::Bool = false,
         used_names_cache::UsedNamesByUnit = UsedNamesByUnit()
     )
     state = server.state
     mod_imported_names = Dict{Module,Dict{String,Vector{ImportInfo}}}()
-    traverse(st0_top) do st0::JS.SyntaxTree
+    traverse(st0_top) do st0::SyntaxTreeC
         JS.kind(st0) ∈ JS.KSet"import using" || return nothing
         mod = get_context_module(state, uri, offset_to_xy(fi, JS.first_byte(st0)))
         for (name, name_range, delete_range) in collect_explicit_import_names(st0, fi)
@@ -1478,8 +1476,8 @@ analyze_unused_imports(args...; kwargs...) = # used by tests
 # Returns true if `st0_top` contains an `import`/`using` with explicit names
 # (the only shape `analyze_unused_imports!` can flag). Gates whether the
 # workspace/diagnostic `result_id` must fold in the analysis unit's state.
-function file_has_explicit_imports(st0_top::JS.SyntaxTree)
-    found = traverse(st0_top) do st0::JS.SyntaxTree
+function file_has_explicit_imports(st0_top::SyntaxTreeC)
+    found = traverse(st0_top) do st0::SyntaxTreeC
         k = JS.kind(st0)
         if k ∈ JS.KSet"import using"
             if JS.numchildren(st0) == 1
@@ -1501,7 +1499,7 @@ end
 # Returns tuples of (name, name_range, delete_range).
 # For single imports like `using M: x`, delete_range covers the entire import statement.
 # For multiple imports like `using M: x, y`, delete_range covers the name plus comma/whitespace.
-function collect_explicit_import_names(st0::JS.SyntaxTree, fi::FileInfo)
+function collect_explicit_import_names(st0::SyntaxTreeC, fi::FileInfo)
     kind = JS.kind(st0)
     names = Tuple{String,Range,Range}[]
     kind ∈ JS.KSet"import using" || return names
@@ -1566,7 +1564,7 @@ end
 # and analysis context. `analyze_unused_imports!` is not included because its
 # result depends on sibling files in the analysis unit.
 function compute_lowering_diagnostics(
-        server::Server, uri::URI, file_info::FileInfo, st0_top::JS.SyntaxTree,
+        server::Server, uri::URI, file_info::FileInfo, st0_top::SyntaxTreeC,
         cancel_flag::CancelFlag;
         lookup_func = nothing
     )
@@ -1574,7 +1572,7 @@ function compute_lowering_diagnostics(
     skip_analysis_requiring_context = !has_analyzed_context(server.state, uri; lookup_func)
     allow_unused_underscore = get_config(server, :diagnostic, :allow_unused_underscore)
     soft_scope = is_notebook_cell_uri(server.state, uri)
-    iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
+    iterate_toplevel_tree(st0_top) do st0::SyntaxTreeC
         is_cancelled(cancel_flag) && return traversal_terminator
         pos = offset_to_xy(file_info, JS.first_byte(st0))
         (; mod, analyzer, postprocessor) = get_context_info(server.state, uri, pos; lookup_func)
@@ -1590,7 +1588,7 @@ end
 # `analyze_unused_imports!` results). Cache misses and cancelled computations
 # both return without caching; only a fully computed result is stored.
 function get_lowering_diagnostics!(
-        server::Server, uri::URI, file_info::FileInfo, st0_top::JS.SyntaxTree,
+        server::Server, uri::URI, file_info::FileInfo, st0_top::SyntaxTreeC,
         cancel_flag::CancelFlag;
         lookup_func = nothing
     )

--- a/src/document-highlight.jl
+++ b/src/document-highlight.jl
@@ -91,7 +91,7 @@ document_highlight_kind(occurrence::AnyBindingOccurrence) =
 
 function global_document_highlights!(
         highlights′::Dict{Range,DocumentHighlightKind.Ty},
-        state::ServerState, uri::URI, fi::FileInfo, st0_top::JS.SyntaxTree,
+        state::ServerState, uri::URI, fi::FileInfo, st0_top::SyntaxTreeC,
         binfo::JL.BindingInfo,
     )
     for occurrence in find_global_binding_occurrences!(state, uri, fi, st0_top, binfo)

--- a/src/document-link.jl
+++ b/src/document-link.jl
@@ -46,7 +46,7 @@ function collect_include_document_links!(
     )
     basedir = dirname(uri2filename(uri))
     st0_top = build_syntax_tree(fi)
-    traverse(st0_top) do node::JS.SyntaxTree
+    traverse(st0_top) do node::SyntaxTreeC
         string_node = @something include_path_string_node(node) return
         resolved = @something resolve_path_string_literal(string_node, basedir) return
         range, _ = unadjust_range(state, uri, jsobj_to_range(string_node, fi))
@@ -59,7 +59,7 @@ end
 # If `node` is an `include("path")` call with a single non-interpolated string
 # argument, return that `K"String"` node. Otherwise return `nothing`.
 # Interpolated strings (e.g. `"$x.jl"`) parse into `K"string"` and are skipped.
-function include_path_string_node(node::JS.SyntaxTree)
+function include_path_string_node(node::SyntaxTreeC)
     JS.kind(node) === JS.K"call" || return nothing
     JS.numchildren(node) == 2 || return nothing
     callee = node[1]

--- a/src/document-symbol.jl
+++ b/src/document-symbol.jl
@@ -91,7 +91,7 @@ function invalidate_document_symbol_cache!(state::ServerState, uri::URI)
     end
 end
 
-function extract_document_symbols(st0_top::JS.SyntaxTree, fi::FileInfo, mod::Module=Main)
+function extract_document_symbols(st0_top::SyntaxTreeC, fi::FileInfo, mod::Module=Main)
     @assert JS.kind(st0_top) === JS.K"toplevel"
     symbols = DocumentSymbol[]
     extract_toplevel_symbols!(symbols, st0_top, fi, mod)
@@ -100,14 +100,14 @@ function extract_document_symbols(st0_top::JS.SyntaxTree, fi::FileInfo, mod::Mod
 end
 
 function extract_toplevel_symbols!(
-        symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
     )
     for i = 1:JS.numchildren(st0)
         extract_toplevel_symbol!(symbols, st0[i], fi, mod)
     end
 end
 
-function extract_toplevel_symbol!(symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo, mod::Module)
+function extract_toplevel_symbol!(symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module)
     k = JS.kind(st0)
     if k === JS.K"module"
         extract_module_symbol!(symbols, st0, fi, mod)
@@ -144,7 +144,7 @@ function extract_toplevel_symbol!(symbols::Vector{DocumentSymbol}, st0::JS.Synta
 end
 
 function extract_module_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo, parent_mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, parent_mod::Module
     )
     JS.numchildren(st0) ≥ 3 || return nothing
     name_node = st0[2]
@@ -174,7 +174,7 @@ function extract_module_symbol!(
 end
 
 function extract_function_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
     )
     JS.numchildren(st0) ≥ 1 || return nothing
     sig = st0[1]
@@ -192,12 +192,12 @@ function extract_function_symbol!(
     return nothing
 end
 
-function extract_function_name(sig::JS.SyntaxTree)
+function extract_function_name(sig::SyntaxTreeC)
     sig = unwrap_where(sig)
     k = JS.kind(sig)
     if k === JS.K"::"
         JS.numchildren(sig) ≥ 1 || return nothing
-        return extract_function_name(sig[1])::Union{Nothing,Tuple{String,JS.SyntaxTree}}
+        return extract_function_name(sig[1])::Union{Nothing,Tuple{String,SyntaxTreeC}}
     end
     if k === JS.K"call"
         JS.numchildren(sig) ≥ 1 || return nothing
@@ -226,7 +226,7 @@ function extract_function_name(sig::JS.SyntaxTree)
     return nothing
 end
 
-function extract_dotted_name(node::JS.SyntaxTree)
+function extract_dotted_name(node::SyntaxTreeC)
     k = JS.kind(node)
     if JS.is_identifier(k)
         return extract_name_val(node)
@@ -248,7 +248,7 @@ function extract_dotted_name(node::JS.SyntaxTree)
 end
 
 function extract_macro_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
     )
     JS.numchildren(st0) ≥ 1 || return nothing
     sig_orig = st0[1]
@@ -278,7 +278,7 @@ function extract_macro_symbol!(
 end
 
 function extract_struct_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
     )
     JS.numchildren(st0) ≥ 2 || return nothing
     sig_node = st0[2]
@@ -320,7 +320,7 @@ function extract_struct_symbol!(
 end
 
 function extract_struct_field!(
-        symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo
     )
     field_node = st0
     k = JS.kind(st0)
@@ -344,7 +344,7 @@ function extract_struct_field!(
 end
 
 function extract_abstract_type_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo
     )
     JS.numchildren(st0) ≥ 1 || return nothing
     name_node = def_node = st0[1]
@@ -368,7 +368,7 @@ function extract_abstract_type_symbol!(
 end
 
 function extract_primitive_type_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo
     )
     JS.numchildren(st0) ≥ 2 || return nothing
     def_node = st0[1]
@@ -390,7 +390,7 @@ function extract_primitive_type_symbol!(
 end
 
 function extract_const_symbols!(
-        symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
     )
     JS.numchildren(st0) ≥ 1 || return nothing
     assign = st0[1]
@@ -405,7 +405,7 @@ function extract_const_symbols!(
 end
 
 function extract_global_symbols!(
-        symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
     )
     JS.numchildren(st0) ≥ 1 || return nothing
     inner = st0[1]
@@ -423,7 +423,7 @@ function extract_global_symbols!(
 end
 
 function extract_assignment_symbols!(
-        symbols::Vector{DocumentSymbol}, lhs::JS.SyntaxTree, rhs::Union{JS.SyntaxTree,Nothing},
+        symbols::Vector{DocumentSymbol}, lhs::SyntaxTreeC, rhs::Union{SyntaxTreeC,Nothing},
         range::Range, kind::SymbolKind.Ty, detail::AbstractString, fi::FileInfo, mod::Module
     )
     children = if rhs !== nothing && JS.kind(rhs) === JS.K"let"
@@ -489,7 +489,7 @@ function extract_assignment_symbols!(
 end
 
 function extract_toplevel_assignment_symbols!(
-        symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
     )
     JS.numchildren(st0) ≥ 2 || return nothing
     lhs = st0[1]
@@ -513,7 +513,7 @@ end
 
 # Short-form function definition: `f(x) = x` or `f(x) where T = x`
 function extract_short_function_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
     )
     JS.numchildren(st0) ≥ 2 || return nothing
     sig = st0[1]
@@ -537,7 +537,7 @@ extract_while_symbol!(args...) = extract_namespace_symbol!(args..., "while ")
 extract_for_symbol!(args...) = extract_namespace_symbol!(args..., "for ")
 
 function extract_namespace_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo, mod::Module,
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module,
         prefix::AbstractString
     )
     JS.numchildren(st0) ≥ 2 || return nothing
@@ -557,9 +557,9 @@ function extract_namespace_symbol!(
 end
 
 function extract_if_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo, mod::Module;
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module;
         prefix::AbstractString="if ",
-        range_node::JS.SyntaxTree=st0
+        range_node::SyntaxTreeC=st0
     )
     JS.numchildren(st0) ≥ 2 || return nothing
     children = DocumentSymbol[]
@@ -576,7 +576,7 @@ function extract_if_symbol!(
 end
 
 function extract_if_children!(
-        children::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo, mod::Module
+        children::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
     )
     for i in 2:JS.numchildren(st0)
         child = st0[i]
@@ -591,7 +591,7 @@ function extract_if_children!(
 end
 
 function extract_macrocalls_from_block!(
-        symbols::Vector{DocumentSymbol}, st::JS.SyntaxTree, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st::SyntaxTreeC, fi::FileInfo, mod::Module
     )
     for i = 1:JS.numchildren(st)
         child = st[i]
@@ -603,7 +603,7 @@ function extract_macrocalls_from_block!(
 end
 
 function extract_macrocall_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
     )
     macro_name = get_macrocall_name(st0)
     if macro_name == "@enum"
@@ -621,7 +621,7 @@ function extract_macrocall_symbol!(
 end
 
 function extract_static_if_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
     )
     JS.numchildren(st0) ≥ 3 || return nothing
     if_node = st0[3]
@@ -630,7 +630,7 @@ function extract_static_if_symbol!(
     return nothing
 end
 
-function get_macrocall_name(st0::JS.SyntaxTree)
+function get_macrocall_name(st0::SyntaxTreeC)
     JS.numchildren(st0) ≥ 1 || return nothing
     macro_node = st0[1]
     if JS.kind(macro_node) === JS.K"."
@@ -647,7 +647,7 @@ function get_macrocall_name(st0::JS.SyntaxTree)
 end
 
 function extract_testset_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
     )
     JS.numchildren(st0) ≥ 3 || return nothing
 
@@ -701,7 +701,7 @@ function extract_testset_symbol!(
     return nothing
 end
 
-function extract_string_content(st0::JS.SyntaxTree)
+function extract_string_content(st0::SyntaxTreeC)
     JS.kind(st0) === JS.K"string" || return nothing
     JS.numchildren(st0) ≥ 1 || return nothing
     first_child = st0[1]
@@ -715,7 +715,7 @@ function extract_string_content(st0::JS.SyntaxTree)
     end
 end
 
-function extract_test_symbol!(symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo)
+function extract_test_symbol!(symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo)
     JS.numchildren(st0) ≥ 3 || return nothing
     expr_node = st0[3]
     expr_text = lstrip(JS.sourcetext(expr_node))
@@ -728,7 +728,7 @@ function extract_test_symbol!(symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTre
     return nothing
 end
 
-function extract_enum_symbol!(symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, fi::FileInfo)
+function extract_enum_symbol!(symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo)
     JS.numchildren(st0) ≥ 3 || return nothing
     type_node = st0[3]
     name_node = type_node
@@ -752,7 +752,7 @@ function extract_enum_symbol!(symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTre
 end
 
 function extract_enum_value!(
-        symbols::Vector{DocumentSymbol}, st0::JS.SyntaxTree, enum_name::String, fi::FileInfo
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, enum_name::String, fi::FileInfo
     )
     if JS.kind(st0) === JS.K"block"
         for i = 1:JS.numchildren(st0)
@@ -777,7 +777,7 @@ end
 
 # Binding-based extraction for scoped children (function body, let block, etc.)
 function extract_scoped_children(
-        st0::JS.SyntaxTree, fi::FileInfo, mod::Module;
+        st0::SyntaxTreeC, fi::FileInfo, mod::Module;
         soft_scope::Bool = false
     )
     (; ctx3) = try
@@ -792,14 +792,14 @@ function extract_scoped_children(
     return @somereal extract_local_symbols_from_scopes(ctx3, parent_map, node_map, fi, root_range) Some(nothing)
 end
 
-build_node_maps(st0::JS.SyntaxTree) =
-    build_node_maps!(Dict{Tuple{Int,Int},JS.SyntaxTree}(),
-                     Dict{Tuple{Int,Int},JS.SyntaxTree}(), st0, nothing)
+build_node_maps(st0::SyntaxTreeC) =
+    build_node_maps!(Dict{Tuple{Int,Int},SyntaxTreeC}(),
+                     Dict{Tuple{Int,Int},SyntaxTreeC}(), st0, nothing)
 function build_node_maps!(
-        parent_map::Dict{Tuple{Int,Int},JS.SyntaxTree},
-        node_map::Dict{Tuple{Int,Int},JS.SyntaxTree},
-        st0::JS.SyntaxTree,
-        parent::Union{Nothing,JS.SyntaxTree}
+        parent_map::Dict{Tuple{Int,Int},SyntaxTreeC},
+        node_map::Dict{Tuple{Int,Int},SyntaxTreeC},
+        st0::SyntaxTreeC,
+        parent::Union{Nothing,SyntaxTreeC}
     )
     fb, lb = JS.first_byte(st0), JS.last_byte(st0)
     if !(iszero(fb) && iszero(lb))
@@ -847,8 +847,8 @@ end
 
 struct LocalScopeContext
     ctx3::JL.VariableAnalysisContext
-    parent_map::Dict{Tuple{Int,Int},JS.SyntaxTree}
-    node_map::Dict{Tuple{Int,Int},JS.SyntaxTree}
+    parent_map::Dict{Tuple{Int,Int},SyntaxTreeC}
+    node_map::Dict{Tuple{Int,Int},SyntaxTreeC}
     scope_children::Dict{Int,Vector{Int}}
     func_scope_ids::Set{Int}
     func_to_scopes::Dict{Int,Vector{Int}}
@@ -860,8 +860,8 @@ end
 function LocalScopeContext(
         lctx::LocalScopeContext;
         ctx3::JL.VariableAnalysisContext = lctx.ctx3,
-        parent_map::Dict{Tuple{Int, Int}, JS.SyntaxTree} = lctx.parent_map,
-        node_map::Dict{Tuple{Int, Int}, JS.SyntaxTree} = lctx.node_map,
+        parent_map::Dict{Tuple{Int, Int}, SyntaxTreeC} = lctx.parent_map,
+        node_map::Dict{Tuple{Int, Int}, SyntaxTreeC} = lctx.node_map,
         scope_children::Dict{Int, Vector{Int}} = lctx.scope_children,
         func_scope_ids::Set{Int} = lctx.func_scope_ids,
         func_to_scopes::Dict{Int, Vector{Int}} = lctx.func_to_scopes,
@@ -877,8 +877,8 @@ function LocalScopeContext(
 end
 
 function extract_local_symbols_from_scopes(
-        ctx3::JL.VariableAnalysisContext, parent_map::Dict{Tuple{Int,Int},JS.SyntaxTree},
-        node_map::Dict{Tuple{Int,Int},JS.SyntaxTree},
+        ctx3::JL.VariableAnalysisContext, parent_map::Dict{Tuple{Int,Int},SyntaxTreeC},
+        node_map::Dict{Tuple{Int,Int},SyntaxTreeC},
         fi::FileInfo, root_range::Tuple{Int,Int}=(0,0)
     )
     scopes = ctx3.scopes
@@ -1062,7 +1062,7 @@ function extract_child_scope_symbols!(
     # (e.g. a for loop creates scope_blocks for both iteration vars and body).
     # Scopes without a construct (or whose construct is already processed)
     # are collected as "transparent" and their bindings are inlined.
-    construct_groups = Dict{Tuple{Int,Int},Tuple{JS.SyntaxTree,Vector{Int}}}()
+    construct_groups = Dict{Tuple{Int,Int},Tuple{SyntaxTreeC,Vector{Int}}}()
     transparent_ids = Int[]
     for child_id in child_ids
         child_id in lctx.func_scope_ids && continue
@@ -1098,7 +1098,7 @@ function extract_child_scope_symbols!(
 end
 
 function push_namespace_symbol!(
-        symbols::Vector{DocumentSymbol}, construct::JS.SyntaxTree,
+        symbols::Vector{DocumentSymbol}, construct::SyntaxTreeC,
         children::Vector{DocumentSymbol}, fi::FileInfo
     )
     JS.numchildren(construct) ≥ 1 || return nothing
@@ -1124,7 +1124,7 @@ const TRY_CLAUSE_POSITIONS =
     (("try", 1), ("catch", 3), ("else", 5), ("finally", 4))
 
 function push_try_namespace_symbol!(
-        symbols::Vector{DocumentSymbol}, try_node::JS.SyntaxTree,
+        symbols::Vector{DocumentSymbol}, try_node::SyntaxTreeC,
         lctx::LocalScopeContext, group_ids::Vector{Int}
     )
     (; ctx3, fi) = lctx
@@ -1164,11 +1164,11 @@ end
 
 function _classify_try_clause(
         ctx3::JL.VariableAnalysisContext, scope_id::Int,
-        try_node::JS.SyntaxTree
+        try_node::SyntaxTreeC
     )
     1 ≤ scope_id ≤ length(ctx3.scopes) || return "try"
     scope = ctx3.scopes[scope_id]
-    scope_st = JS.SyntaxTree(JS.syntax_graph(ctx3), scope.node_id)
+    scope_st = SyntaxTreeC(JS.syntax_graph(ctx3), scope.node_id)
     prov = JS.flattened_provenance(scope_st)
     isempty(prov) && return "try"
     source_node = first(prov)
@@ -1187,10 +1187,10 @@ end
 
 function find_scope_construct(
         ctx3::JL.VariableAnalysisContext, scope::JL.ScopeInfo,
-        parent_map::Dict{Tuple{Int,Int},JS.SyntaxTree},
-        node_map::Dict{Tuple{Int,Int},JS.SyntaxTree}
+        parent_map::Dict{Tuple{Int,Int},SyntaxTreeC},
+        node_map::Dict{Tuple{Int,Int},SyntaxTreeC}
     )
-    scope_st = JS.SyntaxTree(JS.syntax_graph(ctx3), scope.node_id)
+    scope_st = SyntaxTreeC(JS.syntax_graph(ctx3), scope.node_id)
     prov = JS.flattened_provenance(scope_st)
     isempty(prov) && return nothing
     source_node = first(prov)
@@ -1214,7 +1214,7 @@ function find_scope_construct(
 end
 
 function extract_argument_detail(
-        parent_map::Dict{Tuple{Int,Int},JS.SyntaxTree}, fb::Int, lb::Int
+        parent_map::Dict{Tuple{Int,Int},SyntaxTreeC}, fb::Int, lb::Int
     )
     parent = get(parent_map, (fb, lb), nothing)
     detail = nothing
@@ -1232,7 +1232,7 @@ function extract_argument_detail(
 end
 
 function extract_local_variable_detail(
-        parent_map::Dict{Tuple{Int,Int},JS.SyntaxTree}, fb::Int, lb::Int
+        parent_map::Dict{Tuple{Int,Int},SyntaxTreeC}, fb::Int, lb::Int
     )
     parent = get(parent_map, (fb, lb), nothing)
     detail = nothing
@@ -1270,11 +1270,11 @@ function extract_local_variable_detail(
     return detail
 end
 
-is_anonymous_function_rhs(st::JS.SyntaxTree) = JS.kind(st) === JS.K"->" ||
+is_anonymous_function_rhs(st::SyntaxTreeC) = JS.kind(st) === JS.K"->" ||
     (JS.kind(st) === JS.K"function" && JS.numchildren(st) ≥ 1 && JS.kind(st[1]) !== JS.K"call")
 
 function find_anon_func_scope_ids(
-        parent_map::Dict{Tuple{Int,Int},JS.SyntaxTree}, fb::Int, lb::Int,
+        parent_map::Dict{Tuple{Int,Int},SyntaxTreeC}, fb::Int, lb::Int,
         func_to_scopes::Dict{Int,Vector{Int}}, ctx3::JL.VariableAnalysisContext
     )
     parent = @something get(parent_map, (fb, lb), nothing) return nothing
@@ -1290,7 +1290,7 @@ function find_anon_func_scope_ids(
         binfo.is_internal || continue
         for scope_id in scope_ids
             1 ≤ scope_id ≤ length(ctx3.scopes) || continue
-            scope_node = JS.SyntaxTree(graph, ctx3.scopes[scope_id].node_id)
+            scope_node = SyntaxTreeC(graph, ctx3.scopes[scope_id].node_id)
             if JS.first_byte(scope_node) == anon_fb && JS.last_byte(scope_node) == anon_lb
                 return scope_ids
             end

--- a/src/hover.jl
+++ b/src/hover.jl
@@ -22,7 +22,7 @@ end
 # register(currently_running, hover_registration())
 
 function local_binding_hover(
-        state::ServerState, fi::FileInfo, uri::URI, st0_top::JS.SyntaxTree, offset::Int, mod::Module;
+        state::ServerState, fi::FileInfo, uri::URI, st0_top::SyntaxTreeC, offset::Int, mod::Module;
         soft_scope::Bool = false
     )
     target_binding, definitions = @something begin
@@ -35,7 +35,7 @@ function local_binding_hover(
     return Hover(; contents, range)
 end
 
-function local_binding_hover_info(fi::FileInfo, uri::URI, definitions::JS.SyntaxList)
+function local_binding_hover_info(fi::FileInfo, uri::URI, definitions::SyntaxListC)
     io = IOBuffer()
     n = length(definitions)
     for (i, definition) in enumerate(definitions)

--- a/src/references.jl
+++ b/src/references.jl
@@ -179,7 +179,7 @@ end
 
 function global_find_references_in_file!(
         seen_locations::Set{Tuple{URI,Range}}, state::ServerState, uri::URI, fi::FileInfo,
-        st0_top::JS.SyntaxTree, binfo::JL.BindingInfo;
+        st0_top::SyntaxTreeC, binfo::JL.BindingInfo;
         include_declaration::Bool = true,
     )
     for occurrence in find_global_binding_occurrences!(state, uri, fi, st0_top, binfo)

--- a/src/rename.jl
+++ b/src/rename.jl
@@ -378,7 +378,7 @@ end
 
 function collect_global_rename_edits_in_file!(
         seen_edits::Set{Tuple{URI,Range,String}}, state::ServerState, uri::URI, fi::FileInfo,
-        st0_top::JS.SyntaxTree, binfo::JL.BindingInfo, newName::String
+        st0_top::SyntaxTreeC, binfo::JL.BindingInfo, newName::String
     )
     ismacro = startswith(binfo.name, '@')
     for occurrence in find_global_binding_occurrences!(state, uri, fi, st0_top, binfo)
@@ -420,10 +420,10 @@ end
 # - `:implicit_bare`  — bare source name in `using M`, `using M, N`, or `using M.N` where
 #                       `using ... as ...` is not legal syntax; fall back to a standard replace
 #                       (breaks code, but matches the rename policy for implicit imports).
-function classify_import_rename(st0_top::JS.SyntaxTree, id_byte_range::UnitRange{Int}, kind::Symbol)
+function classify_import_rename(st0_top::SyntaxTreeC, id_byte_range::UnitRange{Int}, kind::Symbol)
     kind === :decl || return :regular
     bas = byte_ancestors(st0_top, id_byte_range)
-    import_stmt_idx = findfirst(b::JS.SyntaxTree -> JS.kind(b) in JS.KSet"import using", bas)
+    import_stmt_idx = findfirst(b::SyntaxTreeC -> JS.kind(b) in JS.KSet"import using", bas)
     isnothing(import_stmt_idx) && return :regular
     has_colon = false
     for i = 1:import_stmt_idx-1
@@ -449,11 +449,11 @@ end
 # surrounding `K"as"` node, return the LSP range covering ` as <alias>` so a
 # single empty-text edit can delete it. Otherwise return `nothing`.
 function collapse_alias_to_source(
-        st0_top::JS.SyntaxTree, id_byte_range::UnitRange{Int}, fi::FileInfo,
+        st0_top::SyntaxTreeC, id_byte_range::UnitRange{Int}, fi::FileInfo,
         newName::String, ismacro::Bool
     )
     bas = byte_ancestors(st0_top, id_byte_range)
-    as_idx = @something findfirst(b::JS.SyntaxTree -> JS.kind(b) === JS.K"as", bas) return nothing
+    as_idx = @something findfirst(b::SyntaxTreeC -> JS.kind(b) === JS.K"as", bas) return nothing
     as_node = bas[as_idx]
     JS.numchildren(as_node) >= 2 || return nothing
     source_path = as_node[1]

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -33,14 +33,14 @@ end
 # =====
 
 """
-    flatten_args(call::SyntaxTree0) -> (args::JS.SyntaxList, first_kwarg_i::Int, has_semicolon::Bool) or nothing
+    flatten_args(call::SyntaxTreeC) -> (args::SyntaxListC, first_kwarg_i::Int, has_semicolon::Bool) or nothing
 
-Return `(args::JS.SyntaxList, first_kwarg_i::Int, has_semicolon::Bool)`,
+Return `(args::SyntaxListC, first_kwarg_i::Int, has_semicolon::Bool)`,
 one `SyntaxTree` per argument to call.
 Ignore function name and `K"error"` (e.g. missing closing paren).
 `has_semicolon` is true if the call contains a `K"parameters"` node (explicit semicolon).
 """
-function flatten_args(call::SyntaxTree0)
+function flatten_args(call::SyntaxTreeC)
     while kind(call) === K"where"
         call = call[1]
     end
@@ -49,7 +49,7 @@ function flatten_args(call::SyntaxTree0)
         # than `K"call"`, skip them for now
         return nothing
     end
-    usable = (arg::JS.SyntaxTree) -> kind(arg) ∉ JS.KSet"error Value"
+    usable = (arg::SyntaxTreeC) -> kind(arg) ∉ JS.KSet"error Value"
     # In new EST, dotcall `f.(args)` is represented as `K"."` with children
     # `[func, tuple(args...)]`, so we unwrap the tuple to get the actual args.
     if kind(call) === K"." && JS.numchildren(call) ≥ 2 && kind(call[2]) === K"tuple"
@@ -87,7 +87,7 @@ Get K"Identifier" tree from a kwarg tree (child of K"call" or K"parameters").
   (= (:: a T) 1) => a  # only when sig=true
  (kw (:: a T) 1) => a  # only when sig=true
 """
-function extract_kwarg_name(a::JS.SyntaxTree; sig::Bool=false)
+function extract_kwarg_name(a::SyntaxTreeC; sig::Bool=false)
     ret = identitifier_like(a)
     isnothing(ret) || return ret
     if kind(a) === K"=" || kind(a) === K"kw"
@@ -105,7 +105,7 @@ function extract_kwarg_name(a::JS.SyntaxTree; sig::Bool=false)
     return nothing
 end
 
-function identitifier_like(st::JS.SyntaxTree)
+function identitifier_like(st::SyntaxTreeC)
     if kind(st) === K"Identifier"
         return st
     elseif kind(st) === K"var"
@@ -130,7 +130,7 @@ Keywords should be ignored if `cursor` is within the keyword's name.
 Note: the `=` form doesn't always correspond to a keyword arg after macro
 expansion, but signature help is only used on unexpanded code.
 """
-function find_kws(args::SyntaxList0, kw_i::Int; sig=false, cursor::Int=-1)
+function find_kws(args::SyntaxListC, kw_i::Int; sig=false, cursor::Int=-1)
     out = Dict{String, Int}()
     for i in (sig ? (kw_i:lastindex(args)) : eachindex(args))
         kind(args[i]) ∉ JS.KSet"= kw" && i < kw_i && continue
@@ -158,7 +158,7 @@ Information from a call site's arguments for filtering method signatures.
 - `kind`: Item in `CALL_KINDS`
 """
 struct CallArgs
-    args::SyntaxList0
+    args::SyntaxListC
     kw_i::Int
     pos_map::Dict{Int, Tuple{Int, Union{Int, Nothing}}}
     pos_args_lb::Int
@@ -166,7 +166,7 @@ struct CallArgs
     kw_map::Dict{String, Int}
     has_semicolon::Bool
     kind::JS.Kind
-    function CallArgs(st0::SyntaxTree0, cursor::Int=-1)
+    function CallArgs(st0::SyntaxTreeC, cursor::Int=-1)
         @assert -1 ∉ JS.byte_range(st0)
         args, kw_i, has_semicolon = @something flatten_args(st0) begin
             println(stderr, JS.sourcetext(st0))
@@ -267,7 +267,7 @@ end
 # =======================
 
 function make_paraminfo(
-        param::JS.SyntaxTree, active_argtree::Union{Nothing,JS.SyntaxTree},
+        param::SyntaxTreeC, active_argtree::Union{Nothing,SyntaxTreeC},
         @nospecialize(active_argtype), postprocessor::LSPostProcessor
     )
     label = let r = JS.byte_range(param)
@@ -391,7 +391,7 @@ end
 
 const empty_siginfos = SignatureInformation[]
 
-function is_relevant_call(call::JS.SyntaxTree)
+function is_relevant_call(call::SyntaxTreeC)
     kind(call) in CALL_KINDS &&
         # don't show help for a+b, M', etc., where call[1] isn't the function
         !(JS.is_infix_op_call(call) || JS.is_postfix_op_call(call)) &&
@@ -402,7 +402,7 @@ end
 
 # If parents of our call are like (macro/function (where (where... (call |) ...))),
 # we're actually in a declaration, and shouldn't show signature help.
-function call_is_decl(_bas::JS.SyntaxList, i::Int, _basᵢ::JS.SyntaxTree = _bas[i])
+function call_is_decl(_bas::SyntaxListC, i::Int, _basᵢ::SyntaxTreeC = _bas[i])
     kind(_basᵢ) != JS.K"call" && return false
     j = i + 1
     while j <= lastindex(_bas) && kind(_bas[j]) === JS.K"where"
@@ -416,7 +416,7 @@ end
 
 # Find cases where a macro call is not surrounded by parentheses
 # and the current cursor position is on a different line from the `@` macro call
-function is_crossline_noparen_macrocall(call::JS.SyntaxTree, cursor_byte::Int)
+function is_crossline_noparen_macrocall(call::SyntaxTreeC, cursor_byte::Int)
     return noparen_macrocall(call) && let source_file = JS.sourcefile(call)
         # Check if cursor is on a different line from the @ symbol
         source_file isa JS.SourceFile && JS.numchildren(call) ≥ 1 &&
@@ -432,7 +432,7 @@ call expression, e.g. `foo(#=hi=# |`, `@bar |`.  A more accurate description
 would be: return the nearest call in `st0` such that stuff inserted at the
 cursor would be descendents of it.
 """
-function cursor_call(ps::JS.ParseStream, st0::JS.SyntaxTree, b::Int)
+function cursor_call(ps::JS.ParseStream, st0::SyntaxTreeC, b::Int)
     # disable signature help if invoked within comment scope
     tc = token_before_offset(ps, b)
     if !isnothing(tc) && JS.kind(tc) === K"Comment"
@@ -465,7 +465,7 @@ function cursor_call(ps::JS.ParseStream, st0::JS.SyntaxTree, b::Int)
         bas = byte_ancestors(st0, pnb)
         # If the previous nontrivia byte is part of a call or macrocall, and it is
         # missing a closing paren, use that.
-        i = findfirst(st::JS.SyntaxTree -> is_relevant_call(st) && !noparen_macrocall(st), bas)
+        i = findfirst(st::SyntaxTreeC -> is_relevant_call(st) && !noparen_macrocall(st), bas)
         if !isnothing(i)
             basᵢ = bas[i]
             if JS.is_error(JS.children(basᵢ)[end])
@@ -497,8 +497,8 @@ Note that neither `ca` nor `argtypes` include the type of the function object it
 Also note that this function resolves the type of each argument in `ca` in the global scope,
 completely ignoring information arising from the local scope in which it is contained.
 
-In the future, with the integration of `JS.SyntaxTree` and the full-analysis,
-this method should be replaced with a query to a cached typed-`JS.SyntaxTree`.
+In the future, with the integration of `SyntaxTreeC` and the full-analysis,
+this method should be replaced with a query to a cached typed-`SyntaxTreeC`.
 """
 function collect_call_argtypes(analyzer::LSAnalyzer, mod::Module, ca::CallArgs)
     argtypes = Any[]
@@ -558,7 +558,7 @@ function cursor_siginfos(mod::Module, fi::FileInfo, b::Int, analyzer::LSAnalyzer
     call = cursor_call(fi.parsed_stream, st0, b)
     isnothing(call) && return empty_siginfos
     after_semicolon = let
-        params_i = findfirst(st::JS.SyntaxTree -> kind(st) === K"parameters", JS.children(call))
+        params_i = findfirst(st::SyntaxTreeC -> kind(st) === K"parameters", JS.children(call))
         !isnothing(params_i) && b > JS.first_byte(call[params_i])
     end
 
@@ -588,7 +588,7 @@ function cursor_siginfos(mod::Module, fi::FileInfo, b::Int, analyzer::LSAnalyzer
     if past_pos_args && !after_semicolon
         active_arg = false # before semicolon, highlight next positional arg
     else
-        active_arg = findfirst(a::JS.SyntaxTree -> JS.first_byte(a) <= b <= JS.last_byte(a) + 1, ca.args)
+        active_arg = findfirst(a::SyntaxTreeC -> JS.first_byte(a) <= b <= JS.last_byte(a) + 1, ca.args)
         if active_arg === nothing && after_semicolon
             active_arg = true # after semicolon, highlight next keyword arg
         end

--- a/src/testrunner/testrunner.jl
+++ b/src/testrunner/testrunner.jl
@@ -30,7 +30,7 @@ function summary_testrunner_result(result::TestRunnerResult)
 end
 
 testset_name(testsetinfo::TestsetInfo) = testset_name(testsetinfo.st0)
-function testset_name(testset::JS.SyntaxTree)
+function testset_name(testset::SyntaxTreeC)
     desc = testset_description_node(testset)
     isnothing(desc) && return ""
     if JS.kind(desc) === JS.K"String"
@@ -40,7 +40,7 @@ function testset_name(testset::JS.SyntaxTree)
     end
 end
 testset_line(testsetinfo::TestsetInfo) = testset_line(testsetinfo.st0)
-function testset_line(testset::JS.SyntaxTree)
+function testset_line(testset::SyntaxTreeC)
     desc = testset_description_node(testset)
     return isnothing(desc) ? JS.source_line(testset) : JS.source_line(desc)
 end
@@ -48,7 +48,7 @@ end
 # Find the description string node of a `@testset` macrocall.
 # Returns `K"String"` for simple literals (sourcetext has no quotes)
 # or `K"string"` for interpolated strings (sourcetext includes quotes).
-function testset_description_node(testset::JS.SyntaxTree)
+function testset_description_node(testset::SyntaxTreeC)
     for i = 2:JS.numchildren(testset)
         child = testset[i]
         if JS.kind(child) in JS.KSet"string String"
@@ -59,7 +59,7 @@ function testset_description_node(testset::JS.SyntaxTree)
 end
 
 """
-    compute_testsetinfos!(server::Server, st0::SyntaxTree0, prev_testsetinfos::Vector{TestsetInfo})
+    compute_testsetinfos!(server::Server, st0::SyntaxTreeC, prev_testsetinfos::Vector{TestsetInfo})
 
 Compute new testsetinfos from the syntax tree, preserving test results from
 previous testsetinfos where testset names match. Clears extra diagnostics for
@@ -69,7 +69,7 @@ Returns `(testsetinfos, any_deleted)` where `any_deleted` indicates whether any
 diagnostics were cleared.
 """
 function compute_testsetinfos!(
-        server::Server, st0::SyntaxTree0, prev_testsetinfos::Vector{TestsetInfo}
+        server::Server, st0::SyntaxTreeC, prev_testsetinfos::Vector{TestsetInfo}
     )
     new_testsets = find_executable_testsets(st0)
     m = length(new_testsets)
@@ -122,9 +122,9 @@ function compute_testsetinfos!(
     return testsetinfos, any_deleted
 end
 
-function find_executable_testsets(st0_top::SyntaxTree0)
+function find_executable_testsets(st0_top::SyntaxTreeC)
     testsets = JS.SyntaxList(JS.syntax_graph(st0_top))
-    traverse(st0_top) do st0::SyntaxTree0
+    traverse(st0_top) do st0::SyntaxTreeC
         if JS.kind(st0) in JS.KSet"function macro"
             # avoid visit inside function scope
             return traversal_no_recurse
@@ -272,7 +272,7 @@ function testrunner_testcase_code_actions!(
         code_actions::Vector{Union{CodeAction,Command}}, uri::URI, fi::FileInfo, action_range::Range
     )
     st0_top = build_syntax_tree(fi)
-    traverse(st0_top) do st0::SyntaxTree0
+    traverse(st0_top) do st0::SyntaxTreeC
         if JS.kind(st0) in JS.KSet"function macro"
             # avoid visit inside function scope
             return traversal_no_recurse

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,7 +1,3 @@
-const Attrs0 = Dict{Symbol, Dict{Int64, Any}}
-const SyntaxTree0 = JS.SyntaxTree{Attrs0}
-const SyntaxList0 = JS.SyntaxList{Attrs0,Vector{Int}}
-
 abstract type ExtraDiagnosticsKey end
 to_uri(key::ExtraDiagnosticsKey) = to_uri_impl(key)::URI
 @eval to_key(key::ExtraDiagnosticsKey) = hash(key, $(rand(UInt)))
@@ -19,10 +15,10 @@ struct TestsetResult
 end
 
 struct TestsetInfo
-    st0::SyntaxTree0
+    st0::SyntaxTreeC
     result::TestsetResult
-    TestsetInfo(st0::SyntaxTree0) = new(st0)
-    TestsetInfo(st0::SyntaxTree0, result::TestsetResult) = new(st0, result)
+    TestsetInfo(st0::SyntaxTreeC) = new(st0)
+    TestsetInfo(st0::SyntaxTreeC, result::TestsetResult) = new(st0, result)
 end
 
 const EMPTY_TESTSETINFOS = TestsetInfo[]
@@ -36,7 +32,7 @@ struct FileInfo
     filename::String
     encoding::LSP.PositionEncodingKind.Ty
     testsetinfos::Vector{TestsetInfo}
-    syntax_tree0::Union{Nothing,SyntaxTree0}
+    syntax_tree0::Union{Nothing,SyntaxTreeC}
 
     function FileInfo(
             version::Int, parsed_stream::JS.ParseStream, filename::AbstractString,
@@ -583,13 +579,13 @@ function ConfigManagerData(
     return ConfigManagerData(file_config, lsp_config, file_config_path, initialized)
 end
 
-struct BindingOccurrence{Tree3<:JS.SyntaxTree}
-    tree::Tree3
+struct BindingOccurrence
+    tree::SyntaxTreeC
     kind::Symbol
 end
 
 # Types for binding occurrences cache.
-# IMPORTANT: We must not cache full `JS.SyntaxTree` or `JL.BindingInfo` objects
+# IMPORTANT: We must not cache full `SyntaxTreeC` or `JL.BindingInfo` objects
 # as they hold references to large internal structures (syntax graphs, lowering
 # contexts). Instead, we extract only the essential information needed for
 # LSP features, i.e. mainly binding kind and location information.
@@ -606,7 +602,7 @@ end
 
 A lightweight representation of syntax tree location information.
 This struct stores only the byte range and source location, implementing the
-minimum `JS.SyntaxTree` API (`first_byte`, `last_byte`, `source_location`)
+minimum `SyntaxTreeC` API (`first_byte`, `last_byte`, `source_location`)
 required by [`jsobj_to_range`](@ref) that convert syntax tree to LSP `Range` objects.
 """
 struct CachedSyntaxTree
@@ -614,7 +610,7 @@ struct CachedSyntaxTree
     lb::Int
     line::Int
     column::Int
-    function CachedSyntaxTree(st::JS.SyntaxTree)
+    function CachedSyntaxTree(st::SyntaxTreeC)
         return new(JS.first_byte(st), JS.last_byte(st), JS.source_location(st)...)
     end
 end

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -1,14 +1,14 @@
 # Lightweight copy function for SyntaxTree
 # This copies the SyntaxGraph's mutable structures (edge_ranges, edges, attributes)
 # but shares the immutable data within attribute dictionaries
-function copy_syntax_tree(st::JS.SyntaxTree)
+function copy_syntax_tree(st::SyntaxTreeC)
     g = JS.syntax_graph(st)
     new_attrs = Dict{Symbol,Dict{JL.IdTag,Any}}()
     for (k, v) in pairs(g.attributes)
         new_attrs[k] = copy(v)
     end
     new_graph = JS.SyntaxGraph(copy(g.edge_ranges), copy(g.edges), new_attrs)
-    return JS.SyntaxTree(new_graph, st._id)
+    return SyntaxTreeC(new_graph, st._id)
 end
 
 function build_syntax_tree(fi::FileInfo)
@@ -37,7 +37,7 @@ end
 Return a tree where all nodes of `kinds` are removed.  Should not modify any
 nodes, and should not create new nodes unnecessarily.
 """
-function _without_kinds(st::JS.SyntaxTree, kinds::Tuple{Vararg{JS.Kind}})
+function _without_kinds(st::SyntaxTreeC, kinds::Tuple{Vararg{JS.Kind}})
     if JS.kind(st) in kinds
         return (nothing, true)
     elseif JS.is_leaf(st)
@@ -56,11 +56,11 @@ function _without_kinds(st::JS.SyntaxTree, kinds::Tuple{Vararg{JS.Kind}})
     return (new_node, changed)
 end
 
-function without_kinds(st::JS.SyntaxTree, kinds::Tuple{Vararg{JS.Kind}})
+function without_kinds(st::SyntaxTreeC, kinds::Tuple{Vararg{JS.Kind}})
     ensure_jl_source_attr!(JS.syntax_graph(st))
     return (JS.kind(st) in kinds ?
         JL.@ast(JS.syntax_graph(st), st, [JS.K"TOMBSTONE"]) :
-        _without_kinds(st, kinds)[1])::JS.SyntaxTree
+        _without_kinds(st, kinds)[1])::SyntaxTreeC
 end
 
 """
@@ -68,7 +68,7 @@ Return a tree where `K"\$"` interpolation nodes are replaced by their content.
 Unlike `without_kinds` which removes nodes entirely, this preserves the child
 so that parent nodes (e.g. dot expressions like `x.\$name`) remain well-formed.
 """
-function _unwrap_interpolations(st::JS.SyntaxTree)
+function _unwrap_interpolations(st::SyntaxTreeC)
     if JS.kind(st) === JS.K"$"
         if JS.numchildren(st) >= 1
             nc, _ = _unwrap_interpolations(st[1])
@@ -99,12 +99,12 @@ function _unwrap_interpolations(st::JS.SyntaxTree)
     return (new_node, changed)
 end
 
-function unwrap_interpolations(st::JS.SyntaxTree)
+function unwrap_interpolations(st::SyntaxTreeC)
     ensure_jl_source_attr!(JS.syntax_graph(st))
     return _unwrap_interpolations(st)[1]
 end
 
-function is_macrocall_st0(st0::SyntaxTree0, names::AbstractString...; from::Union{Nothing,Module}=nothing)
+function is_macrocall_st0(st0::SyntaxTreeC, names::AbstractString...; from::Union{Nothing,Module}=nothing)
     JS.kind(st0) === JS.K"macrocall" || return false
     JS.numchildren(st0) >= 1 || return false
     macro_name = st0[1]
@@ -115,11 +115,11 @@ function is_macrocall_st0(st0::SyntaxTree0, names::AbstractString...; from::Unio
     return name_val in names && (isnothing(from) || (JS.hasattr(macro_name, :mod) && macro_name.mod === from))
 end
 
-is_mainfunc0(st0::SyntaxTree0) = is_macrocall_st0(st0, "@main")
+is_mainfunc0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@main")
 
-is_generated0(st0::SyntaxTree0) = is_macrocall_st0(st0, "@generated")
+is_generated0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@generated")
 
-is_macro0(st0::SyntaxTree0) = JS.kind(st0) === JS.K"macro"
+is_macro0(st0::SyntaxTreeC) = JS.kind(st0) === JS.K"macro"
 
 # Simple (non-qualified) macro names whose new-style implementations in
 # `JuliaLowering/src/syntax_macros.jl` and `src/utils/jl-syntax-macros.jl`
@@ -148,15 +148,15 @@ const NEW_STYLE_MACROCALL_NAMES = (
     "@testset",
 )
 
-is_new_style_macrocall0(st0::SyntaxTree0) =
+is_new_style_macrocall0(st0::SyntaxTreeC) =
     is_macrocall_st0(st0, NEW_STYLE_MACROCALL_NAMES...)
 
-is_doc0(st0::SyntaxTree0) = is_macrocall_st0(st0, "@doc"; from=Core)
+is_doc0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@doc"; from=Core)
 
-is_cmd0(st0::SyntaxTree0) = is_macrocall_st0(st0, "@cmd"; from=Core)
+is_cmd0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@cmd"; from=Core)
 
 """
-    collect_import_names(st0::SyntaxTree0) -> Vector{Pair{SyntaxTree0, String}}
+    collect_import_names(st0::SyntaxTreeC) -> Vector{Pair{SyntaxTreeC, String}}
 
 Return pairs of `(node, sort_key)` for the named items of an
 `import`/`using`/`export`/`public` statement: the child node representing
@@ -164,9 +164,9 @@ each item alongside its sort key (see [`get_import_sort_key`](@ref)).
 For `using M: a, b` returns entries for `a` and `b`; for `using M.A` (no
 `:`) returns entries for the imported path nodes.
 """
-function collect_import_names(st0::SyntaxTree0)
+function collect_import_names(st0::SyntaxTreeC)
     kind = JS.kind(st0)
-    names = Pair{SyntaxTree0, String}[]
+    names = Pair{SyntaxTreeC, String}[]
     if kind in JS.KSet"import using"
         nchildren = JS.numchildren(st0)
         if nchildren == 1
@@ -193,7 +193,7 @@ function collect_import_names(st0::SyntaxTree0)
 end
 
 """
-    foreach_local_import_identifier(f, st0::JS.SyntaxTree)
+    foreach_local_import_identifier(f, st0::SyntaxTreeC)
 
 Invoke `f(id_st)` once for each locally-introduced identifier of an
 `import`/`using` statement `st0`. Covers every form that actually binds
@@ -206,7 +206,7 @@ a name in the current scope:
 - `using A: x as y` — the alias `y`
 - `import A: x as y` — likewise
 """
-function foreach_local_import_identifier(f, st0::JS.SyntaxTree)
+function foreach_local_import_identifier(f, st0::SyntaxTreeC)
     kind = JS.kind(st0)
     kind in JS.KSet"import using" || return
     nchildren = JS.numchildren(st0)
@@ -230,7 +230,7 @@ function foreach_local_import_identifier(f, st0::JS.SyntaxTree)
 end
 
 """
-    get_local_import_identifier(st0::JS.SyntaxTree) -> Union{JS.SyntaxTree, Nothing}
+    get_local_import_identifier(st0::SyntaxTreeC) -> Union{SyntaxTreeC, Nothing}
 
 Return the `K"Identifier"` node that represents the local binding introduced
 by a single element of an `import`/`using` statement, or `nothing` if the
@@ -242,7 +242,7 @@ path children (`using A.B` → path `A.B`) and the names listed after `:`
   or `..` prefixes of forms like `.A` / `..A.B`)
 - `K"as"` (inside a colon list) — the alias
 """
-function get_local_import_identifier(st0::JS.SyntaxTree)
+function get_local_import_identifier(st0::SyntaxTreeC)
     kind = JS.kind(st0)
     if kind === JS.K"as"
         # `using M: a as b` -> identifier for "b"
@@ -263,7 +263,7 @@ function get_local_import_identifier(st0::JS.SyntaxTree)
     end
 end
 
-function get_import_sort_key(st0::JS.SyntaxTree)
+function get_import_sort_key(st0::SyntaxTreeC)
     kind = JS.kind(st0)
     if kind === JS.K"as"
         return get_import_sort_key(st0[1])
@@ -285,13 +285,13 @@ function get_import_sort_key(st0::JS.SyntaxTree)
 end
 
 """
-    foreach_inert_identifier(callback, st::JS.SyntaxTree)
+    foreach_inert_identifier(callback, st::SyntaxTreeC)
 
 Traverse `st` looking for `K"inert"` nodes, and call `f(id_node)` for each
 `K"Identifier"` found inside them. `callback` should return `true` to continue
 traversal or `false` to stop early.
 """
-function foreach_inert_identifier(callback, node::JS.SyntaxTree)
+function foreach_inert_identifier(callback, node::SyntaxTreeC)
     if JS.kind(node) === JS.K"inert"
         foreach_identifier_in_inert(callback, node) || return false
     else
@@ -301,7 +301,7 @@ function foreach_inert_identifier(callback, node::JS.SyntaxTree)
     end
     return true
 end
-function foreach_identifier_in_inert(callback, node::JS.SyntaxTree)
+function foreach_identifier_in_inert(callback, node::SyntaxTreeC)
     if JS.kind(node) === JS.K"Identifier"
         callback(node) || return false
     end
@@ -311,9 +311,9 @@ function foreach_identifier_in_inert(callback, node::JS.SyntaxTree)
     return true
 end
 
-function find_inert_identifier_name(st::JS.SyntaxTree, offset::Int)
+function find_inert_identifier_name(st::SyntaxTreeC, offset::Int)
     name = Ref{Union{Nothing,String}}(nothing)
-    foreach_inert_identifier(st) do id_node::JS.SyntaxTree
+    foreach_inert_identifier(st) do id_node::SyntaxTreeC
         if offset in JS.byte_range(id_node)
             JS.hasattr(id_node, :name_val) || return true
             name_val = id_node.name_val
@@ -326,7 +326,7 @@ function find_inert_identifier_name(st::JS.SyntaxTree, offset::Int)
     return name[]
 end
 
-function is_nospecialize_or_specialize_macrocall3(st3::JS.SyntaxTree)
+function is_nospecialize_or_specialize_macrocall3(st3::SyntaxTreeC)
     JS.kind(st3) === JS.K"macrocall" || return false
     JS.numchildren(st3) >= 1 || return false
     macro_name = st3[1]
@@ -338,7 +338,7 @@ function is_nospecialize_or_specialize_macrocall3(st3::JS.SyntaxTree)
     return macro_name.name_val == "nospecialize" || macro_name.name_val == "specialize"
 end
 
-function _remove_macrocalls(st0::SyntaxTree0)
+function _remove_macrocalls(st0::SyntaxTreeC)
     if JS.kind(st0) === JS.K"macrocall"
         if is_new_style_macrocall0(st0)
             # Macros with new-style JuliaLowering implementations preserve
@@ -400,7 +400,7 @@ function _remove_macrocalls(st0::SyntaxTree0)
 end
 
 """
-    desugar_main_macrocall(st0::SyntaxTree0) -> Tuple{SyntaxTree0, Bool}
+    desugar_main_macrocall(st0::SyntaxTreeC) -> Tuple{SyntaxTreeC, Bool}
 
 If `st0` is a `function (@main)(args...) ... end`, `(@main)(args...) = ...`,
 `function @main(args...) ... end`, or `@main(args...) = ...` definition, replace
@@ -410,7 +410,7 @@ This avoids macro expansion failure when multiple standalone files defining
 `@main` are analyzed in the same session — the second file's sandbox module
 already has `main` imported from the first, causing `@main` expansion to error.
 """
-function desugar_main_macrocall(st0::SyntaxTree0)
+function desugar_main_macrocall(st0::SyntaxTreeC)
     k = JS.kind(st0)
     if k === JS.K"function"
         JS.numchildren(st0) >= 1 || return (st0, false)
@@ -458,7 +458,7 @@ function desugar_main_macrocall(st0::SyntaxTree0)
 end
 
 """
-    remove_macrocalls(st0::JS.SyntaxTree) -> JS.SyntaxTree
+    remove_macrocalls(st0::SyntaxTreeC) -> SyntaxTreeC
 
 Convert each `macrocall` node to a `block` node, keeping the arguments intact so that
 identifiers passed to macros retain their original source locations. The transformed
@@ -498,26 +498,26 @@ any bindings or control flow the macros themselves would have introduced.
     `desugar_main_macrocall`. As more macros migrate to the new style, the scope
     of this transformation is expected to shrink.
 """
-function remove_macrocalls(st0::SyntaxTree0)
+function remove_macrocalls(st0::SyntaxTreeC)
     ensure_jl_source_attr!(JS.syntax_graph(st0))
     return first(_remove_macrocalls(st0))
 end
 
-function unwrap_where(node::JS.SyntaxTree)
+function unwrap_where(node::SyntaxTreeC)
     while JS.kind(node) === JS.K"where" && JS.numchildren(node) ≥ 1
         node = node[1]
     end
     return node
 end
 
-extract_name_val(node::JS.SyntaxTree) =
+extract_name_val(node::SyntaxTreeC) =
     hasproperty(node, :name_val) ? node.name_val::String : nothing
 
 """
 Like `Base.unique`, but over node ids, and with this comment promising that the
 lowest-index copy of each node is kept.
 """
-function deduplicate_syntaxlist(sl::JS.SyntaxList)
+function deduplicate_syntaxlist(sl::SyntaxListC)
     sl2 = JS.SyntaxList(sl.graph)
     seen = Set{JS.NodeId}()
     for st in sl
@@ -530,7 +530,7 @@ function deduplicate_syntaxlist(sl::JS.SyntaxList)
 end
 
 """
-    traverse(callback, st::JS.SyntaxTree, postorder::Bool=false)
+    traverse(callback, st::SyntaxTreeC, postorder::Bool=false)
 
 Traverse a `SyntaxTree`, calling `callback(node)` on each node.
 By default traverses in pre-order (parent before children).
@@ -546,7 +546,7 @@ The `callback` can control traversal by returning one of:
 The stored value from the last `TraversalReturn` is returned from `traverse`
 (or `nothing` if no `TraversalReturn` was used).
 """
-function traverse(@specialize(callback), st::JS.SyntaxTree, postorder::Bool=false)
+function traverse(@specialize(callback), st::SyntaxTreeC, postorder::Bool=false)
     stack = JS.SyntaxList(st)
     if postorder
         _traverse_postorder(callback, stack)
@@ -565,7 +565,7 @@ struct TraversalNoRecurse end
 const traversal_terminator = TraversalTerminator()
 const traversal_no_recurse = TraversalNoRecurse()
 
-function _traverse_preorder(@specialize(callback), stack::JS.SyntaxList)
+function _traverse_preorder(@specialize(callback), stack::SyntaxListC)
     local retval = nothing
     while !isempty(stack)
         x = pop!(stack)
@@ -586,7 +586,7 @@ function _traverse_preorder(@specialize(callback), stack::JS.SyntaxList)
     return retval
 end
 
-function _traverse_postorder(@specialize(callback), stack::JS.SyntaxList)
+function _traverse_postorder(@specialize(callback), stack::SyntaxListC)
     local retval = nothing
     output = JS.SyntaxList(stack.graph)
     while !isempty(stack)
@@ -610,7 +610,7 @@ end
 
 # TODO use something like `JuliaInterpreter.ExprSplitter`
 
-function iterate_toplevel_tree(callback, st0_top::SyntaxTree0)
+function iterate_toplevel_tree(callback, st0_top::SyntaxTreeC)
     sl = JS.SyntaxList(st0_top)
     while !isempty(sl)
         st0 = pop!(sl)
@@ -635,8 +635,8 @@ function iterate_toplevel_tree(callback, st0_top::SyntaxTree0)
 end
 
 """
-    byte_ancestors([flt,] st::JS.SyntaxTree, rng::UnitRange{Int})
-    byte_ancestors([flt,] st::JS.SyntaxTree, byte::Int)
+    byte_ancestors([flt,] st::SyntaxTreeC, rng::UnitRange{Int})
+    byte_ancestors([flt,] st::SyntaxTreeC, byte::Int)
 
 Get a SyntaxList of `SyntaxTree`s containing certain bytes.
 
@@ -650,7 +650,7 @@ that satisfy the predicate.
 """
 byte_ancestors(args...) = byte_ancestors(Returns(true), args...)
 
-function byte_ancestors(flt, st::JS.SyntaxTree, rng::UnitRange{<:Integer})
+function byte_ancestors(flt, st::SyntaxTreeC, rng::UnitRange{<:Integer})
     sl = JS.SyntaxList(JS.syntax_graph(st))
     if rng ⊆ JS.byte_range(st) && flt(st)
         push!(sl, st)
@@ -667,15 +667,15 @@ function byte_ancestors(flt, st::JS.SyntaxTree, rng::UnitRange{<:Integer})
     # delete later duplicates when sorted parent->child
     return reverse!(deduplicate_syntaxlist(sl))
 end
-byte_ancestors(flt, st::JS.SyntaxTree, byte::Integer) = byte_ancestors(flt, st, byte:byte)
+byte_ancestors(flt, st::SyntaxTreeC, byte::Integer) = byte_ancestors(flt, st, byte:byte)
 
 """
-    greatest_local(st0::JS.SyntaxTree, offset::Int) -> st::Union{JS.SyntaxTree, Nothing}
+    greatest_local(st0::SyntaxTreeC, offset::Int) -> st::Union{SyntaxTreeC, Nothing}
 
 Return the largest tree that can introduce local bindings that are visible to the cursor
 (if any such tree exists).
 """
-function greatest_local(st0::JS.SyntaxTree, offset::Int)
+function greatest_local(st0::SyntaxTreeC, offset::Int)
     result = _find_greatest_local(st0, offset)
     result !== nothing && return result
     # When the cursor sits just past the last token of a line (e.g. `export
@@ -686,10 +686,10 @@ function greatest_local(st0::JS.SyntaxTree, offset::Int)
     return offset > 1 ? _find_greatest_local(st0, offset - 1) : nothing
 end
 
-function _find_greatest_local(st0::JS.SyntaxTree, offset::Int)
+function _find_greatest_local(st0::SyntaxTreeC, offset::Int)
     bas = byte_ancestors(st0, offset)
     first_global = @something begin
-        findfirst(st::JS.SyntaxTree -> JS.kind(st) in JS.KSet"toplevel module", bas)
+        findfirst(st::SyntaxTreeC -> JS.kind(st) in JS.KSet"toplevel module", bas)
     end return nothing
     if first_global == 1
         return nothing
@@ -976,20 +976,20 @@ end
 # TODO: This is used so that `r"foo"|` or `r"foo" |` don't show signature help,
 # but this edge case might be acceptable given that `r"foo" anything|` shouldn't
 # show signature help
-is_special_macrocall(st0::JS.SyntaxTree) =
+is_special_macrocall(st0::SyntaxTreeC) =
     JS.kind(st0) === JS.K"macrocall" && JS.numchildren(st0) >= 1 &&
     let mname = kind(st0[1]) === JS.K"." && JS.numchildren(st0[1]) === 2 ? st0[1][2] : st0[1]
         mname_s = hasproperty(mname, :name_val) ? mname.name_val : ""
         endswith(mname_s, "_str") || endswith(mname_s, "_cmd")
     end
 
-noparen_macrocall(st0::JS.SyntaxTree) =
+noparen_macrocall(st0::SyntaxTreeC) =
     JS.kind(st0) === JS.K"macrocall" &&
     !JS.has_flags(st0, JS.PARENS_FLAG) &&
     !is_special_macrocall(st0)
 
 """
-    select_target_identifier(st0::JS.SyntaxTree, offset::Int) -> target::Union{JS.SyntaxTree,Nothing}
+    select_target_identifier(st0::SyntaxTreeC, offset::Int) -> target::Union{SyntaxTreeC,Nothing}
 
 Determines the node that the user most likely intends to navigate to.
 Returns `nothing` if no suitable one is found.
@@ -1002,7 +1002,7 @@ refs:
 - https://github.com/rust-lang/rust-analyzer/blob/6acff6c1f8306a0a1d29be8fd1ffa63cff1ad598/crates/ide/src/goto_definition.rs#L47-L62
 - https://github.com/aviatesk/JETLS.jl/pull/61#discussion_r2134707773
 """
-function select_target_identifier(st0::JS.SyntaxTree, offset::Int)
+function select_target_identifier(st0::SyntaxTreeC, offset::Int)
     filter = function (bas)
         JS.is_identifier(first(bas))
     end
@@ -1025,7 +1025,7 @@ function select_target_identifier(st0::JS.SyntaxTree, offset::Int)
     return select_target_node(filter, selector, st0, offset)
 end
 
-function select_target_string(st0::JS.SyntaxTree, offset::Int)
+function select_target_string(st0::SyntaxTreeC, offset::Int)
     filter = function (bas)
         JS.kind(first(bas)) === JS.K"String"
     end
@@ -1036,7 +1036,7 @@ function select_target_string(st0::JS.SyntaxTree, offset::Int)
 end
 
 """
-    resolve_path_string_literal(string_node::JS.SyntaxTree, basedir::AbstractString)
+    resolve_path_string_literal(string_node::SyntaxTreeC, basedir::AbstractString)
         -> Union{Nothing, @NamedTuple{value::String, path::String}}
 
 If `string_node` is a non-interpolated string literal whose value joins with
@@ -1044,7 +1044,7 @@ If `string_node` is a non-interpolated string literal whose value joins with
 `path`. Otherwise return `nothing`.
 """
 function resolve_path_string_literal(
-        string_node::JS.SyntaxTree, basedir::AbstractString
+        string_node::SyntaxTreeC, basedir::AbstractString
     )
     JS.hasattr(string_node, :value) || return nothing
     value = string_node.value
@@ -1054,7 +1054,7 @@ function resolve_path_string_literal(
     return (; value = String(value), path = String(path))
 end
 
-function select_target_node(filter, selector, st0::JS.SyntaxTree, offset::Int)
+function select_target_node(filter, selector, st0::SyntaxTreeC, offset::Int)
     bas = @somereal byte_ancestors(st0, offset) @goto minus1
     if !filter(bas)
         @label minus1
@@ -1069,13 +1069,13 @@ function select_target_node(filter, selector, st0::JS.SyntaxTree, offset::Int)
 end
 
 """
-    select_dotprefix_identifier(st::JS.SyntaxTree, offset::Int) -> dotprefix::Union{JS.SyntaxTree,Nothing}
+    select_dotprefix_identifier(st::SyntaxTreeC, offset::Int) -> dotprefix::Union{SyntaxTreeC,Nothing}
 
 If the code at `offset` position is dot accessor code, get the code being dot accessed.
 For example, `Base.show_│` returns the `SyntaxTree` of `Base`.
 If it's not dot accessor code, return `nothing`.
 """
-function select_dotprefix_identifier(st::JS.SyntaxTree, offset::Int)
+function select_dotprefix_identifier(st::SyntaxTreeC, offset::Int)
     bas = byte_ancestors(st, offset-1)
     dotprefix = nothing
     for i = 1:length(bas)
@@ -1223,7 +1223,7 @@ function try_extract_field_line(node::JS.SyntaxNode, structname::Symbol, fname::
 end
 
 """
-    is_from_user_ast(provs::JS.SyntaxList) -> Bool
+    is_from_user_ast(provs::SyntaxListC) -> Bool
 
 Determine whether a binding with the given provenances originates from user-written code.
 
@@ -1239,7 +1239,7 @@ like internal variables from `@ast`.
 !!! note
     This currently does not support old-style macros due to JuliaLowering limitations.
 """
-function is_from_user_ast(provs::JS.SyntaxList)
+function is_from_user_ast(provs::SyntaxListC)
     length(provs) == 1 && return true
     fprov, lprov = first(provs), last(provs)
     JS.sourcefile(lprov) == JS.sourcefile(fprov) || return false
@@ -1247,7 +1247,7 @@ function is_from_user_ast(provs::JS.SyntaxList)
 end
 
 function is_noreturn_call(
-        ctx3::JL.VariableAnalysisContext, st3::JS.SyntaxTree,
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC,
         allow_noreturn_optimization::Vector{Symbol}
     )
     JS.kind(st3) === JS.K"call" || return false

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -4,7 +4,7 @@ function binding_scope_layer(ctx3, binding::JL.BindingInfo)
     st3 = JL.binding_ex(ctx3, binding.id)
     while get(st3, :source, nothing) isa JS.NodeId
         JS.hasattr(st3, :scope_layer) && return st3.scope_layer
-        st3 = JS.SyntaxTree(JS.syntax_graph(st3), st3.source)
+        st3 = SyntaxTreeC(JS.syntax_graph(st3), st3.source)
     end
     return 1
 end
@@ -15,9 +15,9 @@ Heuristic for showing completions.  A binding is relevant when all are true:
 - if nonglobal, it's defined before the cursor
 - (if global) it doesn't contain or immediately precede the cursor
 """
-function is_relevant(ctx3::JL.AbstractLoweringContext,
-                     binding::JL.BindingInfo,
-                     cursor::Int)
+function is_relevant(
+        ctx3::JL.AbstractLoweringContext, binding::JL.BindingInfo, cursor::Int
+    )
     (;start, stop) = JS.byte_range(JL.binding_ex(ctx3, binding.id))
     !binding.is_internal &&
         binding_scope_layer(ctx3, binding) === 1 && # hygiene: JL-expanded macros
@@ -31,7 +31,7 @@ end
 
 """
     jl_lower_for_scope_resolution(
-            mod::Module, st0::JS.SyntaxTree;
+            mod::Module, st0::SyntaxTreeC;
             trim_error_nodes::Bool = true,
             recover_from_macro_errors::Bool = true,
             convert_closures::Bool = false,
@@ -55,7 +55,7 @@ Throw if lowering fails otherwise.
 Note that ctx objects share mutable information, so we only return `ctx3`
 """
 function jl_lower_for_scope_resolution(
-        mod::Module, st0::JS.SyntaxTree, world::UInt = Base.get_world_counter();
+        mod::Module, st0::SyntaxTreeC, world::UInt = Base.get_world_counter();
         trim_error_nodes::Bool = true,
         recover_from_macro_errors::Bool = true,
         convert_closures::Bool = false,
@@ -78,7 +78,7 @@ function jl_lower_for_scope_resolution(
 end
 
 function _jl_lower_for_scope_resolution(
-        ctx1::JL.MacroExpansionContext, st0::JS.SyntaxTree, st1::JS.SyntaxTree;
+        ctx1::JL.MacroExpansionContext, st0::SyntaxTreeC, st1::SyntaxTreeC;
         convert_closures::Bool = false,
         soft_scope::Bool = false,
     )
@@ -98,7 +98,7 @@ as an ephemeral stack.)  We work around this by taking all available bindings
 and filtering out any that aren't declared in a scope containing the cursor.
 """
 function cursor_bindings(
-        st0_top::JS.SyntaxTree, offset::Int, mod::Module;
+        st0_top::SyntaxTreeC, offset::Int, mod::Module;
         soft_scope::Bool = false
     )
     st0 = @something greatest_local(st0_top, offset) return nothing # nothing we can lower
@@ -116,10 +116,10 @@ function cursor_bindings(
     binfos = filter(binfo -> is_relevant(ctx3, binfo, offset), ctx3.bindings.info)
 
     # for each binding: binfo, all syntaxtrees containing it, and the scope it belongs to
-    bscopeinfos = Tuple{JL.BindingInfo, Union{JS.SyntaxTree, Nothing}}[]
+    bscopeinfos = Tuple{JL.BindingInfo, Union{SyntaxTreeC, Nothing}}[]
     for binfo in binfos
         # TODO: find tree parents instead of byte parents?
-        bas = byte_ancestors(st2, JS.byte_range(JL.binding_ex(ctx3, binfo.id))) do st2′::JS.SyntaxTree
+        bas = byte_ancestors(st2, JS.byte_range(JL.binding_ex(ctx3, binfo.id))) do st2′::SyntaxTreeC
             # find the innermost hard scope containing this binding decl.  we shouldn't
             # be in multiple overlapping scopes that are not direct ancestors; that
             # should indicate a provenance failure
@@ -172,17 +172,17 @@ end
 # These span the full signature byte range and should not be selected by cursor.
 const _IMPLICIT_BINDING_NAMES = ("__context__", "__module__", "__source__")
 
-function find_target_binding(ctx3::JL.VariableAnalysisContext, st3::JS.SyntaxTree, offset::Int)
-    return traverse(st3) do st::JS.SyntaxTree
-        k = JS.kind(st)
-        if k === JS.K"lambda" && is_kwcall_lambda(ctx3, st)
+function find_target_binding(ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, offset::Int)
+    return traverse(st3) do st3′::SyntaxTreeC
+        k = JS.kind(st3′)
+        if k === JS.K"lambda" && is_kwcall_lambda(ctx3, st3′)
             # Don't select a binding with `kwcall` definition.
             # What usually interesting to us is information about the main method.
             return traversal_no_recurse
         end
-        offset in JS.byte_range(st) || return nothing
+        offset in JS.byte_range(st3′) || return nothing
         k === JS.K"BindingId" || return nothing
-        binfo = JL.get_binding(ctx3, st)
+        binfo = JL.get_binding(ctx3, st3′)
         if binfo.is_internal || startswith(binfo.name, "#") || binfo.name in _IMPLICIT_BINDING_NAMES
             return nothing
         end
@@ -192,11 +192,11 @@ function find_target_binding(ctx3::JL.VariableAnalysisContext, st3::JS.SyntaxTre
         # `$`-escaped user bindings stay at layer 1, so this only filters out
         # macro-local bindings.
         binding_scope_layer(ctx3, binfo) === 1 || return nothing
-        return TraversalReturn(st)
+        return TraversalReturn(st3′)
     end
 end
 
-function is_kwcall_lambda(ctx3::JL.VariableAnalysisContext, st3::JS.SyntaxTree)
+function is_kwcall_lambda(ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC)
     @assert JS.kind(st3) === JS.K"lambda" "Expected `lambda` kind"
     JS.numchildren(st3) ≥ 1 || return false
     arglist = st3[1]
@@ -217,7 +217,7 @@ function is_kwcall_lambda(ctx3::JL.VariableAnalysisContext, st3::JS.SyntaxTree)
 end
 
 function _select_target_binding(
-        ctx3::JL.VariableAnalysisContext, st3::JS.SyntaxTree, offset::Int;
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, offset::Int;
         is_generated::Bool = false)
     return @something(
         find_target_binding(ctx3, st3, offset),
@@ -236,7 +236,7 @@ contains `(; ctx3, st3, st0, binding)` where `binding` satisfies
 `JS.kind(binding) === JS.K"BindingId"`.
 """
 function select_target_binding(
-        st0_top::JS.SyntaxTree, offset::Int, mod::Module;
+        st0_top::SyntaxTreeC, offset::Int, mod::Module;
         caller::AbstractString = "select_target_binding",
         soft_scope::Bool = false
     )
@@ -273,7 +273,7 @@ function select_target_binding(
 end
 
 function find_inert_target_binding(
-        ctx3::JL.VariableAnalysisContext, st3::JS.SyntaxTree, offset::Int)
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, offset::Int)
     name = @something find_inert_identifier_name(st3, offset) return nothing
     for binfo in ctx3.bindings.info
         binfo.kind === :argument || continue
@@ -284,7 +284,7 @@ function find_inert_target_binding(
 end
 
 find_inert_global_target_binding(
-    st0::JS.SyntaxTree, st3::JS.SyntaxTree, offset::Int, mod::Module;
+    st0::SyntaxTreeC, st3::SyntaxTreeC, offset::Int, mod::Module;
     soft_scope::Bool = false
 ) = @something(
     _find_inert_global_target_binding(st0, st3, offset, mod; soft_scope),
@@ -293,7 +293,7 @@ find_inert_global_target_binding(
     return nothing)
 
 function _find_inert_global_target_binding(
-        st0::JS.SyntaxTree, st3::JS.SyntaxTree, offset::Int, mod::Module;
+        st0::SyntaxTreeC, st3::SyntaxTreeC, offset::Int, mod::Module;
         soft_scope::Bool = false
     )
     name = @something find_inert_identifier_name(st3, offset) return nothing
@@ -316,10 +316,10 @@ end
 
 # Find the innermost `K"inert"` node in `st3` whose byte range contains
 # `offset`. Used to run fresh scope resolution on just that inert subtree.
-function enclosing_inert_tree(st3::JS.SyntaxTree, offset::Int)
-    best = Ref{Union{Nothing,JS.SyntaxTree}}(nothing)
+function enclosing_inert_tree(st3::SyntaxTreeC, offset::Int)
+    best = Ref{Union{Nothing,SyntaxTreeC}}(nothing)
     best_len = Ref(typemax(Int))
-    traverse(st3) do st::JS.SyntaxTree
+    traverse(st3) do st::SyntaxTreeC
         JS.kind(st) === JS.K"inert" || return nothing
         offset in JS.byte_range(st) || return nothing
         len = length(JS.byte_range(st))
@@ -338,7 +338,7 @@ end
 # XXX: The returned binding may have `is_internal=true` — callers that inspect
 # this flag should be aware of this.
 function normalize_local_alias_to_global(
-        ctx3::JL.VariableAnalysisContext, binding::JS.SyntaxTree,
+        ctx3::JL.VariableAnalysisContext, binding::SyntaxTreeC,
     )
     binfo = JL.get_binding(ctx3, binding)
     binfo.kind === :local && isnothing(binfo.mod) || return binding
@@ -351,10 +351,10 @@ function normalize_local_alias_to_global(
 end
 
 function select_macrocall_binding(
-        st0::JS.SyntaxTree, offset::Int, mod::Module, caller::AbstractString;
+        st0::SyntaxTreeC, offset::Int, mod::Module, caller::AbstractString;
         soft_scope::Bool = false
     )
-    is_macrocall_name = (offset::Int) -> (st0′::JS.SyntaxTree) ->
+    is_macrocall_name = (offset::Int) -> (st0′::SyntaxTreeC) ->
         JS.kind(st0′) === JS.K"macrocall" && JS.numchildren(st0′) ≥ 1 && !is_doc0(st0′) &&
         offset in JS.byte_range(st0′[1])
     bas = byte_ancestors(is_macrocall_name(offset), st0, offset)
@@ -386,10 +386,10 @@ end
 # Detect that case directly and lower just the single identifier under the
 # cursor so callers receive a normal `(ctx3, st3, st0, binding)` tuple.
 function select_export_public_binding(
-        st0::JS.SyntaxTree, offset::Int, mod::Module, caller::AbstractString;
+        st0::SyntaxTreeC, offset::Int, mod::Module, caller::AbstractString;
         soft_scope::Bool = false
     )
-    find_name_node = (offset::Int) -> (st0′::JS.SyntaxTree) -> begin
+    find_name_node = (offset::Int) -> (st0′::SyntaxTreeC) -> begin
         JS.kind(st0′) in JS.KSet"export public" || return false
         for i = 1:JS.numchildren(st0′)
             c = st0′[i]
@@ -431,19 +431,19 @@ end
 # detect the cursor against `foreach_local_import_identifier` and lower the
 # single matching identifier to synthesize a normal binding tuple.
 function select_import_using_binding(
-        st0::JS.SyntaxTree, offset::Int, mod::Module, caller::AbstractString;
+        st0::SyntaxTreeC, offset::Int, mod::Module, caller::AbstractString;
         soft_scope::Bool = false
     )
-    find_name_node_at = function (offset::Int, st0′::JS.SyntaxTree)
-        hit = Ref{Union{Nothing,JS.SyntaxTree}}(nothing)
-        foreach_local_import_identifier(st0′) do id_st::JS.SyntaxTree
+    find_name_node_at = function (offset::Int, st0′::SyntaxTreeC)
+        hit = Ref{Union{Nothing,SyntaxTreeC}}(nothing)
+        foreach_local_import_identifier(st0′) do id_st::SyntaxTreeC
             offset in JS.byte_range(id_st) || return
             hit[] = id_st
             return
         end
         return hit[]
     end
-    find_container = (offset::Int) -> (st0′::JS.SyntaxTree) ->
+    find_container = (offset::Int) -> (st0′::SyntaxTreeC) ->
         JS.kind(st0′) in JS.KSet"import using" &&
             find_name_node_at(offset, st0′) !== nothing
     bas = byte_ancestors(find_container(offset), st0, offset)
@@ -471,18 +471,18 @@ function select_import_using_binding(
 end
 
 """
-    select_target_binding_definitions(st0_top::JS.SyntaxTree, offset::Int, mod::Module) ->
-        nothing or (binding::JS.SyntaxTree, definitions::JS.SyntaxList)
+    select_target_binding_definitions(st0_top::SyntaxTreeC, offset::Int, mod::Module) ->
+        nothing or (binding::SyntaxTreeC, definitions::SyntaxListC)
 
 Find the binding at the cursor position and return all of its definition sites.
 
 Returns `nothing` if lowering fails, no binding is found at the cursor, or the binding
 has no definitions. Otherwise returns a tuple of `(binding, definitions)` where:
-- `binding` is the `JS.SyntaxTree` node representing the binding at the cursor
-- `definitions` is a `JS.SyntaxList` containing all definition sites for that binding
+- `binding` is the `SyntaxTreeC` node representing the binding at the cursor
+- `definitions` is a `SyntaxListC` containing all definition sites for that binding
 """
 function select_target_binding_definitions(
-        st0_top::JS.SyntaxTree, offset::Int, mod::Module;
+        st0_top::SyntaxTreeC, offset::Int, mod::Module;
         soft_scope::Bool = false, skip_global::Bool = false
     )
     (; ctx3, st3, binding) = @something select_target_binding(st0_top, offset, mod; soft_scope) return nothing
@@ -492,15 +492,15 @@ function select_target_binding_definitions(
     return binding, definitions
 end
 
-is_same_binding(x::JS.SyntaxTree, id::Int) = JS.kind(x) === JS.K"BindingId" && id == JL._binding_id(x)
+is_same_binding(x::SyntaxTreeC, id::Int) = JS.kind(x) === JS.K"BindingId" && id == JL._binding_id(x)
 
 is_local_binding(binfo::JL.BindingInfo) =
     binfo.kind === :argument || binfo.kind === :static_parameter || binfo.kind === :local
 
 """
-    lookup_binding_definitions(st3::JS.SyntaxTree, binfo::JL.BindingInfo) -> definitions::JS.SyntaxList
+    lookup_binding_definitions(st3::SyntaxTreeC, binfo::JL.BindingInfo) -> definitions::SyntaxListC
 
-Find all definition sites for a given binding in the syntax tree. Returns a `JS.SyntaxList`
+Find all definition sites for a given binding in the syntax tree. Returns a `SyntaxListC`
 containing the syntax nodes where the binding may be defined.
 
 This function traverses the syntax tree to collect `definitions` that tracks all the
@@ -508,7 +508,7 @@ assignment expressions (`=`) and function declarations where the binding may be 
 For `:argument` or `:static_parameter` bindings, `definitions` also includes the argument
 or static parameter declaration itself.
 """
-function lookup_binding_definitions(st3::JS.SyntaxTree, binfo::JL.BindingInfo)
+function lookup_binding_definitions(st3::SyntaxTreeC, binfo::JL.BindingInfo)
     if binfo.kind === :argument || binfo.kind === :static_parameter
         sl = JS.SyntaxList(JS.syntax_graph(st3), [binfo.node_id])
     else
@@ -517,15 +517,15 @@ function lookup_binding_definitions(st3::JS.SyntaxTree, binfo::JL.BindingInfo)
     return _lookup_binding_definitions!(sl, st3, binfo.id)
 end
 
-function _lookup_binding_definitions!(sl::JS.SyntaxList, st3::JS.SyntaxTree, binding_id::Int)
-    traverse(st3) do st::JS.SyntaxTree
-        if JS.kind(st) in JS.KSet"= kw" && JS.numchildren(st) ≥ 2
-            lhs = st[1]
+function _lookup_binding_definitions!(sl::SyntaxListC, st3::SyntaxTreeC, binding_id::Int)
+    traverse(st3) do st3′::SyntaxTreeC
+        if JS.kind(st3′) in JS.KSet"= kw" && JS.numchildren(st3′) ≥ 2
+            lhs = st3′[1]
             if is_same_binding(lhs, binding_id)
                 push!(sl, lhs)
             end
-        elseif JS.kind(st) === JS.K"function_decl" && JS.numchildren(st) ≥ 1
-            func = st[1]
+        elseif JS.kind(st3′) === JS.K"function_decl" && JS.numchildren(st3′) ≥ 1
+            func = st3′[1]
             if is_same_binding(func, binding_id)
                 push!(sl, func)
             end

--- a/src/utils/jl-syntax-macros.jl
+++ b/src/utils/jl-syntax-macros.jl
@@ -10,7 +10,7 @@
 Like `JS.mapchildren(f, ctx, ex)`, but applies `f` only to children at the
 given `indices`, leaving other children unchanged.
 """
-function mapchildren(f, ctx, ex::JS.SyntaxTree, indices::UnitRange{<:Integer})
+function mapchildren(f, ctx, ex::SyntaxTreeC, indices::UnitRange{<:Integer})
     i = Ref(0)
     JS.mapchildren(ctx, ex) do c
         i[] += 1
@@ -18,24 +18,24 @@ function mapchildren(f, ctx, ex::JS.SyntaxTree, indices::UnitRange{<:Integer})
     end
 end
 
-@noinline throw_macro_error(node::JS.SyntaxTree, msg::AbstractString) =
+@noinline throw_macro_error(node::SyntaxTreeC, msg::AbstractString) =
     throw(JL.MacroExpansionError(node, msg))
 
 function Base.var"@specialize"(__context__::JL.MacroContext)
     JL.@ast(__context__,
-            __context__.macrocall::JS.SyntaxTree,
+            __context__.macrocall::SyntaxTreeC,
             [JS.K"meta" "specialize"::JS.K"Identifier"])
 end
 
-function Base.var"@specialize"(__context__::JL.MacroContext, ex::JS.SyntaxTree)
-    JL.@ast(__context__, __context__.macrocall::JS.SyntaxTree, ex)
+function Base.var"@specialize"(__context__::JL.MacroContext, ex::SyntaxTreeC)
+    JL.@ast(__context__, __context__.macrocall::SyntaxTreeC, ex)
 end
 
 function Base.var"@specialize"(
         __context__::JL.MacroContext,
-        ex1::JS.SyntaxTree, ex2::JS.SyntaxTree, exs::JS.SyntaxTree...
+        ex1::SyntaxTreeC, ex2::SyntaxTreeC, exs::SyntaxTreeC...
     )
-    JL.@ast(__context__, __context__.macrocall::JS.SyntaxTree,
+    JL.@ast(__context__, __context__.macrocall::SyntaxTreeC,
             [JS.K"block" ex1 ex2 exs...])
 end
 
@@ -69,21 +69,21 @@ end
 # rejected so the user gets immediate LSP feedback.
 const _SPAWN_THREADPOOLS = ("interactive", "default", "samepool")
 
-function Base.Threads.var"@spawn"(__context__::JL.MacroContext, ex::JS.SyntaxTree)
-    return JL.@ast(__context__, __context__.macrocall::JS.SyntaxTree,
+function Base.Threads.var"@spawn"(__context__::JL.MacroContext, ex::SyntaxTreeC)
+    return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC,
         unwrap_interpolations(ex))
 end
 
 function Base.Threads.var"@spawn"(
         __context__::JL.MacroContext,
-        threadpool::JS.SyntaxTree, ex::JS.SyntaxTree
+        threadpool::SyntaxTreeC, ex::SyntaxTreeC
     )
     _validate_spawn_threadpool(threadpool)
-    return JL.@ast(__context__, __context__.macrocall::JS.SyntaxTree,
+    return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC,
         [JS.K"block" threadpool unwrap_interpolations(ex)])
 end
 
-function _validate_spawn_threadpool(threadpool::JS.SyntaxTree)
+function _validate_spawn_threadpool(threadpool::SyntaxTreeC)
     k = JS.kind(threadpool)
     if k === JS.K"Identifier"
         return # variable reference — assumed to evaluate to a Symbol at runtime
@@ -103,8 +103,8 @@ function _validate_spawn_threadpool(threadpool::JS.SyntaxTree)
         "threadpool argument in @spawn must be `:default`, `:interactive`, `:samepool`, or a bare variable")
 end
 
-function Base.Threads.var"@spawn"(__context__::JL.MacroContext, ::JS.SyntaxTree...)
-    throw_macro_error(__context__.macrocall::JS.SyntaxTree,
+function Base.Threads.var"@spawn"(__context__::JL.MacroContext, ::SyntaxTreeC...)
+    throw_macro_error(__context__.macrocall::SyntaxTreeC,
         "wrong number of arguments in @spawn")
 end
 
@@ -115,14 +115,14 @@ end
 # The block forms documented in `Base.@label` (`@label expr`, `@label name
 # expr`) are intentionally not supported here — the goto-target form is the
 # common case and the only one needed for most LSP analyses.
-function Base.var"@label"(__context__::JL.MacroContext, ex::JS.SyntaxTree)
+function Base.var"@label"(__context__::JL.MacroContext, ex::SyntaxTreeC)
     JS.kind(ex) === JS.K"Identifier" ||
         throw_macro_error(ex, "@label requires an identifier")
     return JL.@ast(__context__, ex, [JS.K"symboliclabel" ex])
 end
 
-function Base.var"@label"(__context__::JL.MacroContext, ::JS.SyntaxTree...)
-    throw_macro_error(__context__.macrocall::JS.SyntaxTree,
+function Base.var"@label"(__context__::JL.MacroContext, ::SyntaxTreeC...)
+    throw_macro_error(__context__.macrocall::SyntaxTreeC,
         "@label currently only supports the `@label name` form")
 end
 
@@ -133,8 +133,8 @@ end
 # CFG, so LSP analyses (`lowering/unreachable-code`, `lowering/undef-local-var`, ...)
 # account for which paths each arg's body actually executes on.  The fresh `val_i` names
 # live in the macro's scope layer so they cannot clash with user code.
-function Base.var"@something"(__context__::JL.MacroContext, args::JS.SyntaxTree...)
-    mc = __context__.macrocall::JS.SyntaxTree
+function Base.var"@something"(__context__::JL.MacroContext, args::SyntaxTreeC...)
+    mc = __context__.macrocall::SyntaxTreeC
     expr = JL.@ast(__context__, mc,
         [JS.K"call" "something"::JS.K"Identifier" nothing::JS.K"Value"])
     for i in length(args):-1:1
@@ -157,7 +157,7 @@ end
 # New-style `@kwdef` macro that preserves provenance information.
 # This strips default values from struct fields and generates keyword constructors,
 # matching the semantics of Base.@kwdef.
-function Base.var"@kwdef"(__context__::JL.MacroContext, ex::JS.SyntaxTree)
+function Base.var"@kwdef"(__context__::JL.MacroContext, ex::SyntaxTreeC)
     JS.kind(ex) === JS.K"struct" ||
         throw_macro_error(ex, "Invalid usage of @kwdef")
 
@@ -165,12 +165,12 @@ function Base.var"@kwdef"(__context__::JL.MacroContext, ex::JS.SyntaxTree)
     type_sig = ex[2]
     type_body = ex[3]
 
-    field_names = JS.SyntaxTree[]
-    field_defaults = Union{Nothing,JS.SyntaxTree}[]
-    stripped = JS.SyntaxTree[]
+    field_names = SyntaxTreeC[]
+    field_defaults = Union{Nothing,SyntaxTreeC}[]
+    stripped = SyntaxTreeC[]
     _kwdef_collect_fields!(__context__, type_body, field_names, field_defaults, stripped)
 
-    stripped_body = JL.@ast(__context__, type_body::JS.SyntaxTree,
+    stripped_body = JL.@ast(__context__, type_body::SyntaxTreeC,
                            [JS.K"block" stripped...])
     new_struct = mapchildren(_ -> stripped_body, __context__, ex, 3:3)
 
@@ -181,14 +181,14 @@ function Base.var"@kwdef"(__context__::JL.MacroContext, ex::JS.SyntaxTree)
     constructors = _kwdef_make_constructors(
         __context__, type_sig, field_names, field_defaults)
 
-    return JL.@ast(__context__, __context__.macrocall::JS.SyntaxTree,
+    return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC,
                    [JS.K"block" new_struct constructors...])
 end
 
 function _kwdef_collect_fields!(
-        ctx::JL.MacroContext, body::JS.SyntaxTree, field_names::Vector{JS.SyntaxTree},
-        field_defaults::Vector{Union{Nothing,JS.SyntaxTree}},
-        stripped::Vector{JS.SyntaxTree}
+        ctx::JL.MacroContext, body::SyntaxTreeC, field_names::Vector{SyntaxTreeC},
+        field_defaults::Vector{Union{Nothing,SyntaxTreeC}},
+        stripped::Vector{SyntaxTreeC}
     )
     for field in JS.children(body)
         k = JS.kind(field)
@@ -215,8 +215,8 @@ function _kwdef_collect_fields!(
 end
 
 function _kwdef_push_field!(
-        decl::JS.SyntaxTree, default::JS.SyntaxTree, field_names::Vector{JS.SyntaxTree},
-        field_defaults::Vector{Union{Nothing,JS.SyntaxTree}}
+        decl::SyntaxTreeC, default::SyntaxTreeC, field_names::Vector{SyntaxTreeC},
+        field_defaults::Vector{Union{Nothing,SyntaxTreeC}}
     )
     name = _kwdef_extract_name(decl)
     if name !== nothing
@@ -225,7 +225,7 @@ function _kwdef_push_field!(
     end
 end
 
-function _kwdef_extract_name(st::JS.SyntaxTree)
+function _kwdef_extract_name(st::SyntaxTreeC)
     k = JS.kind(st)
     if k === JS.K"Identifier"
         return st
@@ -241,16 +241,16 @@ function _kwdef_extract_name(st::JS.SyntaxTree)
 end
 
 function _kwdef_make_constructors(
-        ctx::JL.MacroContext, type_sig::JS.SyntaxTree, field_names::Vector{JS.SyntaxTree},
-        field_defaults::Vector{Union{Nothing,JS.SyntaxTree}}
+        ctx::JL.MacroContext, type_sig::SyntaxTreeC, field_names::Vector{SyntaxTreeC},
+        field_defaults::Vector{Union{Nothing,SyntaxTreeC}}
     )
-    mc = __source__ = ctx.macrocall::JS.SyntaxTree
+    mc = __source__ = ctx.macrocall::SyntaxTreeC
 
     if JS.kind(type_sig) === JS.K"<:"
         type_sig = type_sig[1]
     end
 
-    params = JS.SyntaxTree[]
+    params = SyntaxTreeC[]
     for (name, default) in zip(field_names, field_defaults)
         if default !== nothing
             push!(params, JL.@ast(ctx, name, [JS.K"kw" name default]))
@@ -265,11 +265,11 @@ function _kwdef_make_constructors(
         body = JL.@ast(ctx, mc, [JS.K"block"
             [JS.K"call" type_sig field_names...]
         ])
-        return JS.SyntaxTree[JL.@ast(ctx, mc, [JS.K"function" sig body])]
+        return SyntaxTreeC[JL.@ast(ctx, mc, [JS.K"function" sig body])]
     elseif JS.kind(type_sig) === JS.K"curly"
         S = type_sig[1]
-        P = JS.SyntaxTree[type_sig[i] for i::Int in 2:JS.numchildren(type_sig)]
-        Q = JS.SyntaxTree[JS.kind(p) === JS.K"<:" ? p[1] : p for p in P]
+        P = SyntaxTreeC[type_sig[i] for i::Int in 2:JS.numchildren(type_sig)]
+        Q = SyntaxTreeC[JS.kind(p) === JS.K"<:" ? p[1] : p for p in P]
         SQ = JL.@ast(ctx, type_sig, [JS.K"curly" S Q...])
 
         # def1: S(; a=default, b) = S(a, b)
@@ -287,7 +287,7 @@ function _kwdef_make_constructors(
         ])
         def2 = JL.@ast(ctx, mc, [JS.K"function" sig2 body2])
 
-        return JS.SyntaxTree[def1, def2]
+        return SyntaxTreeC[def1, def2]
     else
         throw_macro_error(type_sig, "Invalid type signature for @kwdef")
     end
@@ -299,8 +299,8 @@ end
 # Other kws (e.g. `atol=0.1`) are passed through unchecked since the real
 # `Test.@test` forwards them to the test expression. We expand to `ex` alone
 # because a `K"="` kw node in expression position would fail later lowering.
-function Test.var"@test"(__context__::JL.MacroContext, ex::JS.SyntaxTree, kws::JS.SyntaxTree...)
-    mc = __context__.macrocall::JS.SyntaxTree
+function Test.var"@test"(__context__::JL.MacroContext, ex::SyntaxTreeC, kws::SyntaxTreeC...)
+    mc = __context__.macrocall::SyntaxTreeC
     seen_broken = seen_skip = seen_context = nothing
     for kw in kws
         name = _validate_test_kw(kw)
@@ -325,7 +325,7 @@ function Test.var"@test"(__context__::JL.MacroContext, ex::JS.SyntaxTree, kws::J
     return JL.@ast(__context__, mc, ex)
 end
 
-function _validate_test_kw(kw::JS.SyntaxTree)
+function _validate_test_kw(kw::SyntaxTreeC)
     JS.kind(kw) === JS.K"=" ||
         throw_macro_error(kw, "invalid test macro call: expected `keyword=value`")
     JS.numchildren(kw) == 2 ||
@@ -341,8 +341,8 @@ end
 # reproduce the local scope the real macro creates via `try`/`catch` —
 # without it, bindings would leak into the enclosing scope and sibling
 # testsets would share names.
-function Test.var"@testset"(__context__::JL.MacroContext, args::JS.SyntaxTree...)
-    mc = __context__.macrocall::JS.SyntaxTree
+function Test.var"@testset"(__context__::JL.MacroContext, args::SyntaxTreeC...)
+    mc = __context__.macrocall::SyntaxTreeC
     isempty(args) && throw_macro_error(mc, "No arguments to @testset")
 
     body = last(args)
@@ -380,7 +380,7 @@ function Test.var"@testset"(__context__::JL.MacroContext, args::JS.SyntaxTree...
             [JS.K"block" body]])
 end
 
-function _validate_testset_option(arg::JS.SyntaxTree)
+function _validate_testset_option(arg::SyntaxTreeC)
     JS.numchildren(arg) == 2 ||
         throw_macro_error(arg, "@testset: malformed option")
     name = arg[1]


### PR DESCRIPTION
`JS.SyntaxTree` is a `UnionAll` and using it as a field type in container structs caused type instability. JETLS only ever works with the unfrozen attribute graph `Dict{Symbol, Dict{Int64, Any}}`, so a single concrete alias covers every lowering phase.

Now all `JS.SyntaxTree`/`JS.SyntaxList` annotations that operate on this concrete graph form are migrated to `SyntaxTreeC`/ `SyntaxListC` accordingly. Also this replaces the `SyntaxTree0` alias with `SyntaxTreeC`.

Phase information is now conveyed through variable names (`st0`, `st3`, etc.) and context arguments
(`ctx3::JL.VariableAnalysisContext`), which already disambiguate the lowering stage at call sites.