### PR TITLE
full-analysis: Handle close of unsaved buffers cleanly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed `lowering/captured-box` related-information ("Captured by closure") highlighting the entire enclosing macrocall (e.g. a whole `@testset begin ... end` block) instead of the captured identifier when the captured reference lived inside a macro expansion.
 
+- Fixed an "Unsupported URI" error that could occur when an unsaved (`untitled:`) buffer was edited and then closed in quick succession. Closing an unsaved buffer now also clears any analysis state associated with it, so previously analyzed top-level overloads no longer linger as ghost entries in completions or signature help.
+
 ## 2026-04-28
 
 - Commit: [`e784de8`](https://github.com/aviatesk/JETLS.jl/commit/e784de8)

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -375,6 +375,11 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
         @goto next_request
     end
 
+    if is_abandoned_unsaved_buffer(server, request.uri)
+        JETLS_DEV_MODE && @info "Skipped analysis for closed unsaved buffer" entry=progress_title(request.entry) uri=request.uri
+        @goto next_request
+    end
+
     if has_any_parse_errors(server, request)
         JETLS_DEV_MODE && @info "Requested analysis unit has parse errors" entry=progress_title(request.entry) uri=request.uri generation=get_generation(manager,request.entry)
         @goto next_request
@@ -411,6 +416,16 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
     end
     tm = round(time() - s, digits=2)
     JETLS_DEV_MODE && @info "Analysis completed in $tm seconds:" entry=progress_title(request.entry) uri=request.uri generation=get_generation(manager,request.entry)
+
+    if is_abandoned_unsaved_buffer(server, request.uri)
+        # Buffer was closed mid-analysis. `file_cache` becoming empty means didClose
+        # already ran (or is racing with us) and `cleanup_unsaved_analysis!` is taking care
+        # of `manager.cache`/generations/debounced + the OLD prev_result's methods.
+        # We just need to drop the methods this analysis just defined and skip the cache write.
+        JETLS_DEV_MODE && @info "Discarding analysis result for closed unsaved buffer" entry=progress_title(request.entry) uri=request.uri
+        cleanup_prev_methods(analysis_result)
+        @goto next_request
+    end
 
     update_analysis_cache!(server.state, analysis_result)
     mark_analyzed_generation!(manager, request)
@@ -499,6 +514,67 @@ function cleanup_prev_methods(prev_result::AnalysisResult)
             JETLS_DEV_MODE && @warn "Failed to delete method $m"
             JETLS_DEV_MODE && Base.showerror(stderr, e, catch_backtrace())
         end
+    end
+end
+
+# An unsaved (`untitled:`/`buffer:`) URI is "abandoned" once `file_cache` no
+# longer holds it: didClose has already cleared the buffer and the URI is
+# unique per session, so any remaining analysis work for it would only leak.
+is_abandoned_unsaved_buffer(server::Server, uri::URI) =
+    isunsaveduri(uri) && get_file_info(server.state, uri) === nothing
+
+"""
+    cleanup_unsaved_analysis!(server::Server, uri::URI)
+
+Drop the analysis state for an unsaved URI when its buffer is closed.
+Untitled URIs are unique per session, so leaving state behind would leak both
+the cache and the methods registered in `Core.methodtable` by previous
+analyses (otherwise visible as ghost entries in completions/signature help).
+
+This only handles state already in the caches. Any in-flight or queued analysis
+for this entry is short-circuited separately by `is_abandoned_unsaved_buffer`
+checks in `resolve_analysis_request`.
+"""
+function cleanup_unsaved_analysis!(server::Server, uri::URI)
+    @assert isunsaveduri(uri)
+    manager = server.state.analysis_manager
+    prev_result = get_analysis_info(manager, uri)
+    if prev_result isa AnalysisResult
+        entry = prev_result.entry
+        store!(manager.debounced) do debounced
+            haskey(debounced, entry) || return debounced, nothing
+            timer, completion = debounced[entry]
+            close(timer)
+            notify(completion)
+            new_debounced = copy(debounced)
+            delete!(new_debounced, entry)
+            return new_debounced, nothing
+        end
+        store!(manager.current_generations) do gens
+            haskey(gens, entry) || return gens, nothing
+            new_gens = copy(gens)
+            delete!(new_gens, entry)
+            return new_gens, nothing
+        end
+        store!(manager.analyzed_generations) do gens
+            haskey(gens, entry) || return gens, nothing
+            new_gens = copy(gens)
+            delete!(new_gens, entry)
+            return new_gens, nothing
+        end
+        cleanup_prev_methods(prev_result)
+    end
+    store!(manager.cache) do cache
+        new_cache = copy(cache)
+        if prev_result isa AnalysisResult
+            for analyzed_uri in analyzed_file_uris(prev_result)
+                delete!(new_cache, analyzed_uri)
+            end
+        else
+            haskey(new_cache, uri) || return cache, nothing
+            delete!(new_cache, uri)
+        end
+        return new_cache, nothing
     end
 end
 
@@ -610,13 +686,13 @@ function analyze_parsed_if_exist(
     )
     uri = entryuri(request.entry)
     jetconfigs = getjetconfigs(request.entry)
-    fi = get_saved_file_info(server.state, uri)
-    if isnothing(fi)
-        filepath = @something uri2filepath(uri) error(lazy"Unsupported URI: $uri")
-        interp = LSInterpreter(server, request; activation_done)
-        return interp, JET.analyze_and_report_file!(interp, filepath, args...; jetconfigs...)
-    elseif isunsaveduri(uri)
-        interp = LSInterpreter(server, request; activation_done)
+    interp = LSInterpreter(server, request; activation_done)
+    if isunsaveduri(uri)
+        # Unsaved buffers (`untitled:`/`buffer:`) are never persisted to the
+        # `saved_file_cache`; consult the live `file_cache` instead. When that is
+        # also empty (e.g. the buffer was closed before a debounced analysis fired),
+        # fall back to analyzing empty text so any methods previously defined by
+        # this entry get cleaned up.
         filename = uri2filename(uri)
         fi = get_file_info(server.state, uri)
         if isnothing(fi)
@@ -625,11 +701,13 @@ function analyze_parsed_if_exist(
             syntax_node = JS.build_tree(JS.SyntaxNode, fi.parsed_stream; filename)
             return interp, JET.analyze_and_report_expr!(interp, syntax_node, filename, args...; jetconfigs...)
         end
-    else
-        interp = LSInterpreter(server, request; activation_done)
-        filename = uri2filename(uri)
-        return interp, JET.analyze_and_report_expr!(interp, fi.syntax_node, filename, args...; jetconfigs...)
     end
+    fi = @something get_saved_file_info(server.state, uri) begin
+        filepath = @something uri2filepath(uri) error(lazy"Unsupported URI: $uri")
+        return interp, JET.analyze_and_report_file!(interp, filepath, args...; jetconfigs...)
+    end
+    filename = uri2filename(uri)
+    return interp, JET.analyze_and_report_expr!(interp, fi.syntax_node, filename, args...; jetconfigs...)
 end
 
 # update `AnalyzerState(analyzer).world` so that `analyzer` can infer any newly defined methods

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -126,8 +126,14 @@ function handle_DidCloseTextDocumentNotification(server::Server, msg::DidCloseTe
     # Extra diagnostics should only be published for open files
     clear_extra_diagnostics!(server, uri)
     # Republish textDocument/publishDiagnostics for cases with `diagnostic.all_files === false`,
-    # where diagnostics for this file must be suppressed
+    # where diagnostics for this file must be suppressed.
+    # This must run before `cleanup_unsaved_analysis!` below, since the suppression
+    # branch in `notify_diagnostics!` only emits the clearing notification when the
+    # analysis cache still reports non-empty diagnostics for this URI.
     notify_diagnostics!(server; ensure_cleared=uri)
+    if isunsaveduri(uri)
+        cleanup_unsaved_analysis!(server, uri)
+    end
     # Retrigger workspace/diagnostic to recalculate diagnostics for this closed file
     request_diagnostic_refresh!(server)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,5 +49,6 @@ end
     @testset "document link" include("test_document_link.jl")
     @testset "testrunner" include("test_testrunner.jl")
     @testset "full lifecycle" include("test_full_lifecycle.jl")
+    @testset "unsaved buffer" include("test_unsaved_buffer.jl")
     @testset "notebook" include("test_notebook.jl")
 end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -293,3 +293,9 @@ function make_DidChangeTextDocumentNotification(uri, text, version)
             textDocument = VersionedTextDocumentIdentifier(; uri, version),
             contentChanges = [TextDocumentContentChangeEvent(; text)]))
 end
+
+function make_DidCloseTextDocumentNotification(uri::URI)
+    return DidCloseTextDocumentNotification(;
+        params = DidCloseTextDocumentParams(;
+            textDocument = TextDocumentIdentifier(; uri)))
+end

--- a/test/test_unsaved_buffer.jl
+++ b/test/test_unsaved_buffer.jl
@@ -1,0 +1,129 @@
+module test_unsaved_buffer
+
+include("setup.jl")
+
+using Test
+using JETLS
+using JETLS.LSP
+using JETLS.URIs2
+
+# Sequential notifications (`didOpen` / `didChange` / `didClose`) are dispatched
+# to a separate worker thread, so observable state changes are *not* synchronous
+# with `writemsg` returning. These helpers poll until the relevant manager state
+# settles before we assert on it.
+
+function wait_until(predicate::Function;
+                    timeout::Float64=10.0,
+                    what::AbstractString="condition")
+    deadline = time() + timeout
+    while time() < deadline
+        predicate() && return
+        sleep(0.01)
+    end
+    error("Timed out waiting for $what")
+end
+
+wait_for_analysis_cached(manager::JETLS.AnalysisManager, uri::URI) =
+    wait_until(() -> JETLS.get_analysis_info(manager, uri) isa JETLS.AnalysisResult;
+               what="analysis cache for $uri")
+
+wait_for_analysis_uncached(manager::JETLS.AnalysisManager, uri::URI) =
+    wait_until(() -> JETLS.get_analysis_info(manager, uri) === nothing;
+               what="analysis cache cleared for $uri")
+
+function any_entry_for(manager::JETLS.AnalysisManager, uri::URI, field::Symbol)
+    dict = JETLS.load(getfield(manager, field))
+    return any(entry -> JETLS.entryuri(entry) == uri, keys(dict))
+end
+
+# Disable `diagnostic.all_files` so didClose doesn't emit the empty
+# `PublishDiagnosticsNotification` triggered by `notify_diagnostics!(; ensure_cleared=uri)`.
+# Keeps these tests focused on cleanup state.
+const SETTINGS = Dict{String,Any}(
+    "diagnostic" => Dict{String,Any}(
+        "all_files" => false,
+    ),
+)
+
+@testset "didOpen + didClose clears analysis state" begin
+    untitled_uri = filename2uri("Untitled-basic")
+
+    withserver(; settings=SETTINGS) do (; server, writereadmsg)
+        # JET inference reports (e.g. `inference/method-error`) ride on
+        # `PublishDiagnosticsNotification`, so a top-level method-error here
+        # exercises the clearing-notification path on close (under
+        # `diagnostic.all_files=false`).
+        let text = "f32(x::Float32) = sin(x); f32(rand())"
+            (; raw_res) = writereadmsg(make_DidOpenTextDocumentNotification(untitled_uri, text))
+            @test raw_res isa PublishDiagnosticsNotification
+            @test raw_res.params.uri == untitled_uri
+            @test any(d -> d.code == JETLS.INFERENCE_METHOD_ERROR_CODE,
+                      raw_res.params.diagnostics)
+        end
+
+        manager = server.state.analysis_manager
+        wait_for_analysis_cached(manager, untitled_uri)
+        info = JETLS.get_analysis_info(manager, untitled_uri)::JETLS.AnalysisResult
+        entry = info.entry
+        @test JETLS.entryuri(entry) == untitled_uri
+        @test haskey(JETLS.load(manager.analyzed_generations), entry)
+
+        # didClose must publish an empty `PublishDiagnosticsNotification` to
+        # clear the previously published `unused-argument` diagnostic, and
+        # then drop the per-entry analysis state. This exercises the ordering
+        # of `notify_diagnostics!` before `cleanup_unsaved_analysis!` in
+        # `handle_DidCloseTextDocumentNotification`: if `cleanup_unsaved_analysis!`
+        # ran first the clearing notification path in `notify_diagnostics!`
+        # would have nothing to publish under `all_files=false`.
+        let (; raw_res) = writereadmsg(make_DidCloseTextDocumentNotification(untitled_uri))
+            @test raw_res isa PublishDiagnosticsNotification
+            @test raw_res.params.uri == untitled_uri
+            @test isempty(raw_res.params.diagnostics)
+        end
+        wait_for_analysis_uncached(manager, untitled_uri)
+
+        @test JETLS.get_analysis_info(manager, untitled_uri) === nothing
+        @test !haskey(JETLS.load(manager.analyzed_generations), entry)
+        @test !haskey(JETLS.load(manager.current_generations), entry)
+        @test !any_entry_for(manager, untitled_uri, :debounced)
+    end
+end
+
+@testset "didChange + immediate didClose cancels debounce timer" begin
+    untitled_uri = filename2uri("Untitled-debounced")
+
+    withserver(; settings=SETTINGS) do (; server, writemsg, writereadmsg)
+        let text = "f(x) = x + 1"
+            (; raw_res) = writereadmsg(make_DidOpenTextDocumentNotification(untitled_uri, text))
+            @test raw_res isa PublishDiagnosticsNotification
+        end
+
+        manager = server.state.analysis_manager
+        wait_for_analysis_cached(manager, untitled_uri)
+        info = JETLS.get_analysis_info(manager, untitled_uri)::JETLS.AnalysisResult
+        entry = info.entry
+
+        # The didChange handler schedules a 3.0s debounced reanalysis. The timer
+        # is registered synchronously inside the handler; wait for the sequential
+        # worker to land it in `manager.debounced` before asserting.
+        writemsg(make_DidChangeTextDocumentNotification(untitled_uri, "f(x) = x + 2", 2))
+        wait_until(() -> haskey(JETLS.load(manager.debounced), entry);
+                   what="debounce timer to be registered")
+        @test haskey(JETLS.load(manager.debounced), entry)
+
+        # didClose must cancel the timer along with the rest of the per-entry
+        # state. Without the cancellation the timer would fire 3s later and the
+        # original "Unsupported URI" error would surface in the analysis worker.
+        # Note: unlike the first @testset, no clearing `PublishDiagnosticsNotification`
+        # is emitted here because the cached diagnostics for `f(x) = x + 1` are empty,
+        # so the `!isempty(diagnostics)` guard in `notify_diagnostics!`'s suppression
+        # branch (under `all_files=false`) skips the send.
+        writemsg(make_DidCloseTextDocumentNotification(untitled_uri))
+        wait_for_analysis_uncached(manager, untitled_uri)
+
+        @test JETLS.get_analysis_info(manager, untitled_uri) === nothing
+        @test !haskey(JETLS.load(manager.debounced), entry)
+    end
+end
+
+end # module test_unsaved_buffer


### PR DESCRIPTION
Closing an unsaved (`untitled:`) buffer immediately after a `didChange` could throw an "Unsupported URI" error because `analyze_parsed_if_exist` checked `get_saved_file_info` first and fell through to a `uri2filepath` fallback that does not handle the `untitled:` scheme. Reorder the branches so unsaved URIs are dispatched first, using `file_cache` (and falling back to empty-text analysis when the buffer has already been closed).

Also clean up analysis state when an unsaved buffer is closed. Untitled URIs are unique per session, so leaving cached `AnalysisResult`s, `current_generations`/`analyzed_generations` entries, and methods previously defined under that analysis behind would leak memory and produce ghost completions/signature-help entries pointing at virtual modules whose source is gone. Add `cleanup_unsaved_analysis!`, invoked from `handle_DidCloseTextDocumentNotification` for unsaved URIs, that cancels any debounced timer for the entry, drops the related cache and generation entries, and runs `cleanup_prev_methods` on the previous result.

Pair this cache cleanup with two `is_abandoned_unsaved_buffer` checks in `resolve_analysis_request`: one before `execute_analysis_request` to short-circuit queued requests for already-closed buffers, and one after to discard methods produced by an analysis that completed mid- close (cleaning the cache itself is left to the didClose path, which runs concurrently or just after).

Add `test/test_unsaved_buffer.jl` covering the lifecycle:
- didOpen + didClose drops the analysis state and (under `diagnostic.all_files=false`) emits an empty `PublishDiagnosticsNotification` to clear previously published diagnostics, exercising the ordering of `notify_diagnostics!` before `cleanup_unsaved_analysis!`.
- didChange followed immediately by didClose cancels the debounced reanalysis timer so the original "Unsupported URI" error does not surface.