### PR TITLE
string: Cache `line_starts` on `FileInfo` for fast offset↔Position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > This disables analysis for matched files. Basic features like completion still might work, but most LSP features will be unfunctional.
 > Note that `analysis_overrides` is provided as a temporary workaround and may be removed or changed at any time. A proper fix is being worked on.
 
+### Changed
+
+- Significantly reduced latency on large files across most LSP features (hover, completion, diagnostics, inlay hint, code lens, …). For example, code lens generation on a file with 1000 `@testset` blocks dropped from ~590ms to ~1.4ms.
+
 ## 2026-05-02
 
 - Commit: [`28972ef`](https://github.com/aviatesk/JETLS.jl/commit/28972ef)

--- a/src/app/cli-check.jl
+++ b/src/app/cli-check.jl
@@ -525,6 +525,8 @@ function print_diagnostics(
             continue
         end
         src = JS.SourceFile(text; filename=filepath)
+        textbuf = Vector{UInt8}(text)
+        line_starts = build_line_starts(textbuf)
 
         rel_path = relpath(filepath, root_path)
         sorted_diagnostics = sort(diagnostics; by=d->(d.range.start.line, d.range.start.character))
@@ -548,9 +550,8 @@ function print_diagnostics(
                 severity_str = "hint"
             end
 
-            textbuf = Vector{UInt8}(text)
-            start_byte = _xy_to_offset(textbuf, diagnostic.range.start, PositionEncodingKind.UTF16)
-            end_byte = _xy_to_offset(textbuf, diagnostic.range.var"end", PositionEncodingKind.UTF16)
+            start_byte = _xy_to_offset(textbuf, diagnostic.range.start, PositionEncodingKind.UTF16, line_starts)
+            end_byte = _xy_to_offset(textbuf, diagnostic.range.var"end", PositionEncodingKind.UTF16, line_starts)
             note = get_raw_message(diagnostic)
             if diagnostic.code !== nothing
                 note *= " [$severity_str:$(diagnostic.code)]"

--- a/src/types.jl
+++ b/src/types.jl
@@ -23,6 +23,36 @@ end
 
 const EMPTY_TESTSETINFOS = TestsetInfo[]
 
+"""
+    LineStartsIndex
+
+`Vector{Int}` of 1-based byte offsets where each line begins. `line_starts[i]` is
+the byte at which line `i-1` (0-based, LSP convention) starts; `line_starts[1]`
+is always `1`. Built once per textbuf by [`build_line_starts`](@ref) so position
+↔ offset conversions on a [`FileInfo`](@ref) can locate the line in O(log N)
+instead of O(N).
+"""
+const LineStartsIndex = Vector{Int}
+
+"""
+    build_line_starts(textbuf::Vector{UInt8}) -> LineStartsIndex
+
+Walk `textbuf` once and return the byte offsets where each line begins. The first
+entry is always `1`; each subsequent entry is the byte immediately after a `'\\n'`.
+A trailing newline produces a phantom empty last line whose start is one past the
+end of the buffer (matching how LSP positions can land just past a terminating
+newline).
+"""
+function build_line_starts(textbuf::Vector{UInt8})
+    starts = Int[1]
+    @inbounds for i in 1:length(textbuf)
+        if textbuf[i] == UInt8('\n')
+            push!(starts, i + 1)
+        end
+    end
+    return starts
+end
+
 # Primary file cache for document synchronization.
 # Created on `textDocument/didOpen` and updated on `textDocument/didChange`.
 # Contains the current editor state, including unsaved edits.
@@ -33,6 +63,11 @@ struct FileInfo
     encoding::LSP.PositionEncodingKind.Ty
     testsetinfos::Vector{TestsetInfo}
     syntax_tree0::Union{Nothing,SyntaxTreeC}
+    # Cached line-starts index for the current `parsed_stream.textbuf`. `offset_to_xy`
+    # / `xy_to_offset` are called heavily by every LSP feature, so amortizing the
+    # O(N) line scan once per FileInfo (constructed on didOpen / didChange) is a
+    # net win across the server.
+    line_starts::LineStartsIndex
 
     function FileInfo(
             version::Int, parsed_stream::JS.ParseStream, filename::AbstractString,
@@ -48,7 +83,8 @@ struct FileInfo
         else
             syntax_tree0 = nothing
         end
-        new(version, parsed_stream, filename, encoding, testsetinfos, syntax_tree0)
+        line_starts = build_line_starts(parsed_stream.textbuf)
+        new(version, parsed_stream, filename, encoding, testsetinfos, syntax_tree0, line_starts)
     end
 end
 @define_override_constructor FileInfo # For testsetinfos update
@@ -74,11 +110,13 @@ struct SavedFileInfo
     parsed_stream::JS.ParseStream
     syntax_node::JS.SyntaxNode
     encoding::LSP.PositionEncodingKind.Ty
+    line_starts::LineStartsIndex
 
     function SavedFileInfo(parsed_stream::JS.ParseStream, uri::URI, encoding::LSP.PositionEncodingKind.Ty)
         filename = uri2filename(uri)
         syntax_node = JS.build_tree(JS.SyntaxNode, parsed_stream; filename)
-        new(parsed_stream, syntax_node, encoding)
+        line_starts = build_line_starts(parsed_stream.textbuf)
+        new(parsed_stream, syntax_node, encoding, line_starts)
     end
 end
 

--- a/src/utils/string.jl
+++ b/src/utils/string.jl
@@ -24,52 +24,30 @@ function apply_text_change(
         text::String, range::Range, new_text::String, encoding::PositionEncodingKind.Ty
     )
     textbuf = Vector{UInt8}(text)
-    start_byte = _xy_to_offset(textbuf, range.start, encoding)
-    end_byte = _xy_to_offset(textbuf, range.var"end", encoding)
+    line_starts = build_line_starts(textbuf)
+    start_byte = _xy_to_offset(textbuf, range.start, encoding, line_starts)
+    end_byte = _xy_to_offset(textbuf, range.var"end", encoding, line_starts)
     return String(textbuf[1:start_byte-1]) * new_text * String(textbuf[end_byte:end])
 end
 
-"""
-    pos_to_utf8_offset(s::String, ch::UInt, encoding::PositionEncodingKind.Ty = PositionEncodingKind.UTF16) -> offset::Int
-
-Convert a character position to a UTF-8 byte offset in a Julia string.
-
-# Arguments
-- `s::String`: A Julia string (UTF-8 encoded) representing a single line (no newlines)
-- `ch::UInt`: 0-based character/code-unit position in the specified encoding
-- `encoding::PositionEncodingKind.Ty`: The encoding that `ch` is based on (default: UTF-16)
-
-# Returns
-1-based byte offset in the UTF-8 encoded string `s`
-
-# Details
-According to the LSP specification:
-- For UTF-8: `ch` represents byte offset
-- For UTF-16: `ch` represents UTF-16 code units (characters in BMP count as 1, outside BMP count as 2)
-- For UTF-32: `ch` represents character count (each Unicode character counts as 1)
-"""
-function pos_to_utf8_offset(s::String, ch::UInt, encoding::PositionEncodingKind.Ty)
-    offset = 1
-    char_count = 0
-    if encoding == PositionEncodingKind.UTF16
-        while offset <= sizeof(s) && char_count < ch
-            cp = codepoint(s[offset])
-            utf16_units = cp < 0x10000 ? 1 : 2
-            char_count += utf16_units
-            if char_count > ch
-                break
-            end
-            offset = nextind(s, offset)
-        end
-    elseif encoding == PositionEncodingKind.UTF8 # UTF-8 counts bytes
-        offset = min(Int(ch), sizeof(s)) + 1
-    else # UTF-32 counts characters
-        while offset <= sizeof(s) && char_count < ch
-            char_count += 1
-            offset = nextind(s, offset)
-        end
+# UTF-8 leading byte → (n_bytes_in_sequence, n_code_units_in_target_encoding).
+# Continuation bytes (0x80..0xBF) appearing as a "leading byte" indicate malformed
+# UTF-8; we treat them as a single 1-unit char rather than throwing — matching the
+# robustness contract the LSP layer expects from invalid client input.
+# `encoding` only differentiates the 4-byte branch (UTF-16 surrogate pair = 2 units
+# vs. 1 unit elsewhere); callers short-circuit the UTF-8 path before reaching here.
+@inline function utf8_seq_info(byte::UInt8, encoding::PositionEncodingKind.Ty)
+    if byte < 0x80
+        return 1, UInt(1)
+    elseif byte < 0xC0
+        return 1, UInt(1)
+    elseif byte < 0xE0
+        return 2, UInt(1)
+    elseif byte < 0xF0
+        return 3, UInt(1)
+    else
+        return 4, encoding == PositionEncodingKind.UTF16 ? UInt(2) : UInt(1)
     end
-    return offset
 end
 
 """
@@ -95,25 +73,47 @@ closest valid position.
 """
 function xy_to_offset end
 
-xy_to_offset(fi::FileInfo, pos::Position) = _xy_to_offset(fi.parsed_stream.textbuf, pos, fi.encoding)
+xy_to_offset(fi::FileInfo, pos::Position) =
+    _xy_to_offset(fi.parsed_stream.textbuf, pos, fi.encoding, fi.line_starts)
 xy_to_offset( # used by tests
     s::Union{Vector{UInt8},AbstractString}, pos::Position, filename::AbstractString,
     encoding::PositionEncodingKind.Ty = PositionEncodingKind.UTF16
 ) = xy_to_offset(FileInfo(#=version=#0, s, filename, encoding), pos)
 
-function _xy_to_offset(textbuf::Vector{UInt8}, pos::Position, encoding::PositionEncodingKind.Ty)
-    b = 0
-    for _ in 1:pos.line
-        nextb = findnext(isequal(UInt8('\n')), textbuf, b + 1)
-        if isnothing(nextb) # guard against invalid `pos`
+function _xy_to_offset(
+        textbuf::Vector{UInt8}, pos::Position, encoding::PositionEncodingKind.Ty,
+        line_starts::LineStartsIndex
+    )
+    line_idx = min(Int(pos.line) + 1, length(line_starts))
+    line_start_byte = line_starts[line_idx]
+    line_end_byte = line_idx + 1 <= length(line_starts) ?
+        line_starts[line_idx + 1] - 1 : lastindex(textbuf) + 1
+    return units_to_byte_in_line(textbuf, line_start_byte, line_end_byte, pos.character, encoding)
+end
+
+# `ch` code units into the line → 1-based byte offset within textbuf. If `ch`
+# falls in the middle of a multi-unit character (UTF-16 surrogate pair), returns
+# the byte offset of that character.
+function units_to_byte_in_line(
+        textbuf::Vector{UInt8}, line_start::Integer, line_end::Integer,
+        ch::Integer, encoding::PositionEncodingKind.Ty
+    )
+    if encoding == PositionEncodingKind.UTF8
+        return min(Int(line_start) + Int(ch), Int(line_end))
+    end
+    target = UInt(ch)
+    i = Int(line_start)
+    bend = Int(line_end)
+    units = UInt(0)
+    @inbounds while i < bend && units < target
+        n_bytes, n_units = utf8_seq_info(textbuf[i], encoding)
+        if units + n_units > target
             break
         end
-        b = nextb
+        units += n_units
+        i += n_bytes
     end
-    lend = findnext(isequal(UInt8('\n')), textbuf, b + 1)
-    lend = isnothing(lend) ? lastindex(textbuf) + 1 : lend
-    curline = String(textbuf[b+1:lend-1]) # current line, containing no newlines
-    return b + pos_to_utf8_offset(curline, pos.character, encoding)
+    return i
 end
 
 """
@@ -138,73 +138,62 @@ to the specified encoding per LSP specification:
 """
 function offset_to_xy end
 
-offset_to_xy(fi::FileInfo, byte::Integer) = _offset_to_xy(fi.parsed_stream.textbuf, byte, fi.encoding)
-offset_to_xy(sfi::SavedFileInfo, byte::Integer) = _offset_to_xy(sfi.parsed_stream.textbuf, byte, sfi.encoding)
-
+offset_to_xy(fi::FileInfo, byte::Integer) =
+    _offset_to_xy(fi.parsed_stream.textbuf, byte, fi.encoding, fi.line_starts)
+offset_to_xy(sfi::SavedFileInfo, byte::Integer) =
+    _offset_to_xy(sfi.parsed_stream.textbuf, byte, sfi.encoding, sfi.line_starts)
 offset_to_xy( # used by tests
     s::Union{Vector{UInt8},AbstractString}, byte::Integer, filename::AbstractString,
     encoding::PositionEncodingKind.Ty = PositionEncodingKind.UTF16
 ) = offset_to_xy(FileInfo(#=version=#0, s, filename, encoding), byte)
 
-function _offset_to_xy(textbuf::Vector{UInt8}, byte::Integer, encoding::PositionEncodingKind.Ty)
+# One-shot overload for callers that don't have a cached index and only convert
+# a single offset (e.g. `cell_range`); builds `line_starts` internally.
+_offset_to_xy(textbuf::Vector{UInt8}, byte::Integer, encoding::PositionEncodingKind.Ty) =
+    _offset_to_xy(textbuf, byte, encoding, build_line_starts(textbuf))
+
+function _offset_to_xy(
+        textbuf::Vector{UInt8}, byte::Integer, encoding::PositionEncodingKind.Ty,
+        line_starts::LineStartsIndex
+    )
     if byte < 1
         throw(ArgumentError(lazy"Byte offset must be >= 1, got $byte"))
     elseif byte > lastindex(textbuf) + 1
         byte = lastindex(textbuf) + 1
     end
 
-    # Find which line the byte is on
-    line = 0
-    line_start_byte = 1
-    current_byte = 1
-
-    while current_byte < byte && current_byte <= lastindex(textbuf)
-        if textbuf[current_byte] == UInt8('\n')
-            line += 1
-            line_start_byte = current_byte + 1
-        end
-        current_byte += 1
-    end
-
-    # Find the end of the current line
-    line_end_byte = findnext(isequal(UInt8('\n')), textbuf, line_start_byte)
-    if isnothing(line_end_byte)
-        line_end_byte = lastindex(textbuf) + 1
-    end
-
-    target_byte_in_line = min(byte, line_end_byte)
-
-    # Count characters from line start to just before the target position
-    if target_byte_in_line > line_start_byte
-        if encoding == PositionEncodingKind.UTF8
-            # For UTF-8, character is the byte offset within the line (0-based)
-            character = target_byte_in_line - line_start_byte
-        else
-            character = 0
-            full_text = String(copy(textbuf))
-            byte_idx = line_start_byte
-
-            while byte_idx < target_byte_in_line && byte_idx <= sizeof(full_text)
-                next_byte_idx = nextind(full_text, byte_idx)
-                if next_byte_idx > target_byte_in_line
-                    break
-                end
-
-                if encoding == PositionEncodingKind.UTF16
-                    cp = codepoint(full_text[byte_idx])
-                    character += cp < 0x10000 ? 1 : 2
-                else # UTF-32
-                    character += 1
-                end
-
-                byte_idx = next_byte_idx
-            end
-        end
-    else
-        character = 0
-    end
-
+    line_idx = searchsortedlast(line_starts, byte)
+    line = line_idx - 1
+    line_start_byte = line_starts[line_idx]
+    line_end_byte = line_idx + 1 <= length(line_starts) ?
+        line_starts[line_idx + 1] - 1 :
+        lastindex(textbuf) + 1
+    target = min(Int(byte), line_end_byte)
+    character = Int(count_units_in_byte_range(textbuf, line_start_byte, target, encoding))
     return Position(; line, character)
+end
+
+# Byte range → number of code units of the requested encoding. Walks the line
+# only (not the whole textbuf) and avoids `String(copy(...))` allocations.
+function count_units_in_byte_range(
+        textbuf::Vector{UInt8}, b_start::Integer, b_end::Integer,
+        encoding::PositionEncodingKind.Ty
+    )
+    if encoding == PositionEncodingKind.UTF8
+        return UInt(b_end - b_start)
+    end
+    units = UInt(0)
+    i = Int(b_start)
+    bend = Int(b_end)
+    @inbounds while i < bend
+        n_bytes, n_units = utf8_seq_info(textbuf[i], encoding)
+        if i + n_bytes > bend
+            break # partial char at the end (shouldn't happen for well-formed input)
+        end
+        units += n_units
+        i += n_bytes
+    end
+    return units
 end
 
 """

--- a/test/utils/test_string.jl
+++ b/test/utils/test_string.jl
@@ -1,104 +1,9 @@
 module test_string
 
 using Test
-using JETLS: JETLS, apply_text_change, encoded_length, offset_to_xy, pos_to_utf8_offset, xy_to_offset
+using JETLS: JETLS, apply_text_change, encoded_length, offset_to_xy, xy_to_offset
 using JETLS.LSP
 using JETLS.LSP.PositionEncodingKind: UTF16, UTF32, UTF8
-
-@testset "pos_to_utf8_offset" begin
-    @testset "ASCII (all encodings identical)" begin
-        s = "hello"
-        # All encodings produce the same results for ASCII
-        for ch in UInt(0):UInt(5)
-            utf8  = pos_to_utf8_offset(s, ch, UTF8)
-            utf16 = pos_to_utf8_offset(s, ch, UTF16)
-            utf32 = pos_to_utf8_offset(s, ch, UTF32)
-            @test utf8 == utf16 == utf32 == ch + 1
-        end
-    end
-
-    @testset "BMP characters (UTF-16 = UTF-32)" begin
-        s = "café"  # é is 2 bytes in UTF-8, but 1 unit in UTF-16/32
-        # UTF-8: ch is byte offset (0-based)
-        # UTF-16/32: ch is character count for BMP
-        for (ch, utf8_expected, utf16_expected) in [(0, 1, 1), (1, 2, 2), (2, 3, 3), (3, 4, 4), (4, 5, 6), (5, 6, 6)]
-            ch = UInt(ch)
-            @test pos_to_utf8_offset(s, ch, UTF8) == utf8_expected
-            @test pos_to_utf8_offset(s, ch, UTF16) == utf16_expected
-            @test pos_to_utf8_offset(s, ch, UTF32) == utf16_expected
-        end
-    end
-
-    @testset "Emoji with surrogate pairs (UTF-16 differs)" begin
-        s = "a😀b"  # 😀 needs 2 UTF-16 units (surrogate pair), 4 bytes in UTF-8
-
-        # UTF-8: character positions are byte offsets
-        # UTF-16: character positions are UTF-16 code unit counts
-        # UTF-32: character positions are character counts
-        @test pos_to_utf8_offset(s, UInt(2), UTF8) == 3   # Byte 2 (in middle of 'a')
-        @test pos_to_utf8_offset(s, UInt(2), UTF16) == 2  # After 'a', mid-emoji
-        @test pos_to_utf8_offset(s, UInt(2), UTF32) == 6  # After emoji
-
-        @test pos_to_utf8_offset(s, UInt(5), UTF8) == 6   # Byte 5 (in middle of emoji)
-        @test pos_to_utf8_offset(s, UInt(3), UTF16) == 6  # After emoji
-        @test pos_to_utf8_offset(s, UInt(3), UTF32) == 7  # After 'b'
-    end
-
-    @testset "ZWJ sequences (complex UTF-16 handling)" begin
-        s = "👨‍👩‍👧‍👦"  # Family: 4 emojis + 3 ZWJs = 25 bytes in UTF-8
-        # UTF-8: byte offset (25 bytes total)
-        # UTF-16: 11 UTF-16 units
-        # UTF-32: 7 characters
-        @test pos_to_utf8_offset(s, UInt(25), UTF8) == 26
-        @test pos_to_utf8_offset(s, UInt(11), UTF16) == 26
-        @test pos_to_utf8_offset(s, UInt(7), UTF32) == 26
-    end
-
-    @testset "Edge cases" begin
-        # Empty string
-        @test pos_to_utf8_offset("", UInt(0), UTF16) == 1
-        @test pos_to_utf8_offset("", UInt(10), UTF16) == 1
-        @test pos_to_utf8_offset("", UInt(0), UTF8) == 1
-        @test pos_to_utf8_offset("", UInt(10), UTF8) == 1  # Clamped to end
-
-        # Position beyond string - UTF-8 should clamp to string bounds
-        @test pos_to_utf8_offset("ab", UInt(10), UTF16) == 3
-        @test pos_to_utf8_offset("ab", UInt(10), UTF8) == 3  # Clamped to sizeof("ab")+1
-        @test pos_to_utf8_offset("abc", UInt(100), UTF8) == 4  # Clamped to end
-
-        # Position exactly at end of string
-        @test pos_to_utf8_offset("abc", UInt(3), UTF8) == 4  # Exactly at end
-
-        # Single emoji - UTF-16 stops mid-emoji at position 1
-        @test pos_to_utf8_offset("😀", UInt(1), UTF8) == 2  # Byte offset 1
-        @test pos_to_utf8_offset("😀", UInt(1), UTF16) == 1  # Mid-emoji!
-        @test pos_to_utf8_offset("😀", UInt(2), UTF16) == 5
-        @test pos_to_utf8_offset("😀", UInt(10), UTF8) == 5  # Clamped to end (4 bytes + 1)
-    end
-
-    @testset "UTF-16 vs UTF-8 differences" begin
-        s = "a😀b"
-        # Position 2: UTF-16 stops mid-emoji, UTF-8 is byte offset 2
-        @test pos_to_utf8_offset(s, UInt(2), UTF16) == 2  # Mid-emoji
-        @test pos_to_utf8_offset(s, UInt(2), UTF8) == 3   # Byte offset 2
-        @test pos_to_utf8_offset(s, UInt(2), UTF16) != pos_to_utf8_offset(s, UInt(2), UTF8)
-    end
-
-    @testset "Double latex symbols completion" begin
-        s = "≈\\"
-
-        # UTF-8: positions are byte offsets
-        @test pos_to_utf8_offset(s, UInt(0), UTF8) == 1  # Start
-        @test pos_to_utf8_offset(s, UInt(1), UTF8) == 2  # Byte 1 (inside ≈)
-        @test pos_to_utf8_offset(s, UInt(3), UTF8) == 4  # After ≈
-        @test pos_to_utf8_offset(s, UInt(4), UTF8) == 5  # After \
-
-        # UTF-16: positions are character counts (both are BMP characters)
-        @test pos_to_utf8_offset(s, UInt(0), UTF16) == 1  # Start
-        @test pos_to_utf8_offset(s, UInt(1), UTF16) == 4  # After ≈
-        @test pos_to_utf8_offset(s, UInt(2), UTF16) == 5  # After \
-    end
-end
 
 @testset "offset_to_xy with different encodings" begin
     @testset "ASCII text" begin
@@ -282,6 +187,30 @@ end
         @test xy_to_offset(textbuf, pos_utf16, @__FILE__, UTF16) == 10
     end
 
+    # Each grapheme is a non-BMP emoji (4 UTF-8 bytes / 2 UTF-16 units) joined
+    # by ZWJ (3 UTF-8 bytes / 1 UTF-16 unit / 1 UTF-32 char). Code-unit counts
+    # diverge sharply across encodings, which is where unit accumulation bugs
+    # tend to surface.
+    @testset "ZWJ sequences" begin
+        text = "👨‍👩‍👧‍👦" # Family: 4 emojis + 3 ZWJs = 25 bytes UTF-8 / 11 UTF-16 / 7 UTF-32
+        textbuf = Vector{UInt8}(text)
+        @test xy_to_offset(textbuf, Position(; line=0, character=25), @__FILE__, UTF8) == 26
+        @test xy_to_offset(textbuf, Position(; line=0, character=11), @__FILE__, UTF16) == 26
+        @test xy_to_offset(textbuf, Position(; line=0, character=7), @__FILE__, UTF32) == 26
+    end
+
+    # `≈\` is a real input shape from LaTeX-symbol completion (`\approx\<TAB>`):
+    # `≈` is a 3-byte BMP char (1 UTF-16 unit) followed by a 1-byte `\`. Regression
+    # guard for the off-by-one that earlier completion code hit here.
+    @testset "LaTeX symbol completion shape (≈\\\\)" begin
+        text = "≈\\"
+        textbuf = Vector{UInt8}(text)
+        @test xy_to_offset(textbuf, Position(; line=0, character=3), @__FILE__, UTF8) == 4   # after ≈
+        @test xy_to_offset(textbuf, Position(; line=0, character=4), @__FILE__, UTF8) == 5   # after \
+        @test xy_to_offset(textbuf, Position(; line=0, character=1), @__FILE__, UTF16) == 4  # after ≈
+        @test xy_to_offset(textbuf, Position(; line=0, character=2), @__FILE__, UTF16) == 5  # after \
+    end
+
     @testset "Beyond line end" begin
         text = "short\nlonger line\nx"
         textbuf = Vector{UInt8}(text)
@@ -346,6 +275,33 @@ end
                 pos = offset_to_xy(textbuf, byte, @__FILE__, encoding)
                 recovered = xy_to_offset(textbuf, pos, @__FILE__, encoding)
                 @test recovered == byte
+            end
+        end
+    end
+
+    # Mid-char input does NOT round-trip (snap loses information), but the
+    # snap is idempotent: byte → Position → byte_start → Position → same
+    # byte_start. Cross-direction guard against accidentally flipping snap
+    # direction in only one of the two functions.
+    @testset "Mid-char snap is idempotent" begin
+        # "café": é spans bytes 4-5; mid-char byte=5 should snap to byte=4
+        let textbuf = Vector{UInt8}("café")
+            for encoding in (UTF16, UTF32)
+                pos1 = offset_to_xy(textbuf, 5, @__FILE__, encoding)
+                byte1 = xy_to_offset(textbuf, pos1, @__FILE__, encoding)
+                @test byte1 == 4 # snapped to start of é, not original 5
+                pos2 = offset_to_xy(textbuf, byte1, @__FILE__, encoding)
+                @test xy_to_offset(textbuf, pos2, @__FILE__, encoding) == byte1
+            end
+        end
+        # "😀b": emoji spans bytes 1-4; any mid-emoji byte snaps to byte=1
+        let textbuf = Vector{UInt8}("😀b")
+            for encoding in (UTF16, UTF32), b in 2:4
+                pos1 = offset_to_xy(textbuf, b, @__FILE__, encoding)
+                byte1 = xy_to_offset(textbuf, pos1, @__FILE__, encoding)
+                @test byte1 == 1
+                pos2 = offset_to_xy(textbuf, byte1, @__FILE__, encoding)
+                @test xy_to_offset(textbuf, pos2, @__FILE__, encoding) == byte1
             end
         end
     end


### PR DESCRIPTION
`offset_to_xy` / `xy_to_offset` are called by virtually every LSP feature (hover, completion, diagnostics, inlay hint, …). The old implementation was O(N) per call (linear scan from the start of `textbuf`) and the UTF-16/32 path additionally allocated `String(copy(textbuf))` on each invocation, so a 5000-line file reaching `_offset_to_xy` ~28k times in a single inlay-hint request showed ~3s in `String` allocations alone.

Introduce `LineStartsIndex = Vector{Int}` and a `build_line_starts` helper in `types.jl`, and add `line_starts::LineStartsIndex` fields to both `FileInfo` and `SavedFileInfo`, computed once in their constructors. Rewrite `_offset_to_xy` / `_xy_to_offset` to take `line_starts` and locate the target line via `searchsortedlast` (O(log N)), then count code units within that line only. Code-unit counting now walks the UTF-8 bytes of the line directly through a small `utf8_seq_info` lead-byte classifier, so the `String(copy(textbuf))` allocation is gone. The existing helper `pos_to_utf8_offset` was its own copy of the per-line counting logic operating on `String` inputs; its only caller was `_xy_to_offset` and its only remaining users are tests, so it is removed in favor of the allocation-free `units_to_byte_in_line`.

Public `offset_to_xy(fi, byte)` and `xy_to_offset(fi, pos)` now read `fi.line_starts` directly — no plumbing required at the call site, and all LSP features automatically benefit. Callers that operate on raw `textbuf` without a `FileInfo` are split by access pattern: `apply_text_change` (two conversions on the same buffer) and `print_diagnostics` in `cli-check` (loop over many diagnostics) precompute `line_starts` and pass it through the 4-arg internal form so cost stays O(N) rather than O(N·M); `cell_range` in `formatting` only converts a single offset and uses a 3-arg `_offset_to_xy` overload that builds the index internally.

For 5000-line / 10000-line synthetic files in a worst-case inlay-hint scenario (full-file range request), this drops `offset_to_xy`'s share of total time from ~32% (linear scan + String allocation) to <2% (binary search + in-place byte walk), which on its own roughly halves the full-file runtime (5000 lines: 6.3s → 3.4s; 10000 lines: 18.3s → 6.9s).

Tests for `pos_to_utf8_offset` mostly duplicated `xy_to_offset` coverage, so they are removed; the two non-trivial unique cases (ZWJ-joined emoji sequence and the LaTeX-completion `≈\\` shape) are migrated into the `xy_to_offset with different encodings` testset. A new `Mid-char snap is idempotent` testset asserts that a `byte` landing inside a multi-byte UTF-8 char snaps DOWN to the start of the char on both directions, so the conversion pair stays self-consistent under regression.