### PR TITLE
inlay-hint: Fix coordinate handling for notebook cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Significantly reduced latency on large files across most LSP features (hover, completion, diagnostics, inlay hint, code lens, …). For example, code lens generation on a file with 1000 `@testset` blocks dropped from ~590ms to ~1.4ms.
 
+### Fixed
+
+- Fixed `textDocument/inlayHint` for notebook cells, which previously misplaced hints (or rendered none at all) by treating the requested viewport and emitted hint positions as notebook-global coordinates rather than cell-local.
+
 ## 2026-05-02
 
 - Commit: [`28972ef`](https://github.com/aviatesk/JETLS.jl/commit/28972ef)

--- a/src/inlay-hint.jl
+++ b/src/inlay-hint.jl
@@ -24,10 +24,13 @@ end
 
 function handle_InlayHintRequest(
         server::Server, msg::InlayHintRequest, cancel_flag::CancelFlag)
+    state = server.state
     uri = msg.params.textDocument.uri
-    range = msg.params.range
+    range = Range(;
+        start = adjust_position(state, uri, msg.params.range.start),
+        var"end" = adjust_position(state, uri, msg.params.range.var"end"))
 
-    result = get_file_info(server.state, uri, cancel_flag)
+    result = get_file_info(state, uri, cancel_flag)
     if isnothing(result)
         return send(server, InlayHintResponse(; id = msg.id, result = null))
     elseif result isa ResponseError
@@ -37,12 +40,12 @@ function handle_InlayHintRequest(
 
     min_lines = get_config(server, :inlay_hint, :block_end_min_lines)
     inlay_hints = InlayHint[]
-    symbols = get_document_symbols!(server.state, uri, fi)
+    symbols = get_document_symbols!(state, uri, fi)
     syntactic_inlay_hints!(inlay_hints, symbols, fi, range; min_lines)
 
     return send(server, InlayHintResponse(;
         id = msg.id,
-        result = @somereal inlay_hints null))
+        result = @somereal localize_inlay_hints(state, uri, inlay_hints) null))
 end
 
 const INLAY_HINT_MIN_LINES = 25

--- a/src/notebook.jl
+++ b/src/notebook.jl
@@ -341,6 +341,11 @@ function localize_notebook_diagnostics(
         state::ServerState, notebook_uri::URI, cell_uri::URI, diagnostics::Vector{Diagnostic}
     )
     notebook_info = @something get_notebook_info(state, notebook_uri) return Diagnostic[]
+    return _localize_notebook_diagnostics(state, notebook_info, cell_uri, diagnostics)
+end
+function _localize_notebook_diagnostics(
+        state::ServerState, notebook_info::NotebookInfo, cell_uri::URI, diagnostics::Vector{Diagnostic}
+    )
     concat = notebook_info.concat
     result = Diagnostic[]
     for diag in diagnostics
@@ -397,6 +402,56 @@ function localize_document_symbol(
         range = new_range,
         selectionRange = new_selection_range,
         children = @somereal new_children Some(nothing))
+end
+
+# Inlay hint
+# ==========
+
+"""
+    localize_inlay_hints(
+            state::ServerState, uri::URI, inlay_hints::Vector{InlayHint}
+        ) -> Vector{InlayHint}
+
+When `uri` is a notebook cell, convert each hint's `position` and the ranges of
+its `textEdits` from notebook-global coordinates to cell-local coordinates, and
+drop hints whose position does not belong to that cell. Returns `inlay_hints`
+unchanged when `uri` is not a notebook cell URI.
+"""
+function localize_inlay_hints(
+        state::ServerState, uri::URI, inlay_hints::Vector{InlayHint}
+    )
+    notebook_uri = @something get_notebook_uri_for_cell(state, uri) return inlay_hints
+    notebook_info = @something get_notebook_info(state, notebook_uri) return inlay_hints
+    return _localize_inlay_hints(uri, inlay_hints, notebook_info)
+end
+function _localize_inlay_hints(
+        uri::URI, inlay_hints::Vector{InlayHint}, notebook_info::NotebookInfo
+    )
+    new_hints = InlayHint[]
+    concat = notebook_info.concat
+    for hint in inlay_hints
+        pos_result = @something global_to_cell_position(concat, hint.position) continue
+        cell_pos, hint_cell_uri = pos_result
+        hint_cell_uri == uri || continue
+        textEdits = hint.textEdits
+        new_textEdits = if textEdits === nothing
+            nothing
+        else
+            edits = TextEdit[]
+            for edit in textEdits
+                range_result = global_to_cell_range(concat, edit.range)
+                isnothing(range_result) && continue
+                edit_cell_uri, cell_range = range_result
+                edit_cell_uri == uri || continue
+                push!(edits, TextEdit(edit; range = cell_range))
+            end
+            edits
+        end
+        push!(new_hints, InlayHint(hint;
+            position = cell_pos,
+            textEdits = @somereal new_textEdits Some(nothing)))
+    end
+    return new_hints
 end
 
 # Position

--- a/src/utils/lsp.jl
+++ b/src/utils/lsp.jl
@@ -16,6 +16,8 @@ overlap(rng1::Range, rng2::Range) = max(rng1.start, rng2.start) <= min(rng1.var"
 @define_override_constructor LSP.Position
 @define_override_constructor LSP.Range
 @define_override_constructor LSP.DocumentSymbol
+@define_override_constructor LSP.InlayHint
+@define_override_constructor LSP.TextEdit
 
 const DEFAULT_DOCUMENT_SELECTOR = DocumentFilter[
     DocumentFilter(; language = "julia")

--- a/test/test_notebook.jl
+++ b/test/test_notebook.jl
@@ -81,6 +81,14 @@ function make_CodeLensRequest(id::Int, uri::URI)
             textDocument = TextDocumentIdentifier(; uri)))
 end
 
+function make_InlayHintRequest(id::Int, uri::URI, range::Range)
+    return InlayHintRequest(;
+        id,
+        params = InlayHintParams(;
+            textDocument = TextDocumentIdentifier(; uri),
+            range))
+end
+
 @testset "notebook end to end" begin
     mktempdir() do tempdir; Pkg.activate(tempdir) do
         Pkg.add("Example"; io=devnull)
@@ -252,81 +260,27 @@ end
     end; end # mktempdir() do tempdir; Pkg.activate(tempdir) do
 end
 
-@testset "notebook formatting" begin
+@testset "notebook per-cell features" begin
     mktempdir() do tempdir
         notebook_uri = filepath2uri(normpath(tempdir, "test.ipynb"))
 
-        # Use `cat` as a test formatter (just echoes input)
         settings = Dict{String,Any}(
+            # `code_lens.references` defaults to false, enable it for this test
+            "code_lens" => Dict{String,Any}(
+                "references" => true,
+            ),
+            # Lower the block-end threshold so the small test cells emit
+            # hints, and disable type inlay hints to avoid noise from
+            # inferred types.
+            "inlay_hint" => Dict{String,Any}(
+                "block_end_min_lines" => 0,
+            ),
+            # Use `cat` as a test formatter (just echoes input)
             "formatter" => Dict{String,Any}(
                 "custom" => Dict{String,Any}(
                     "executable" => "cat"
                 )
-            )
-        )
-
-        withserver(; settings) do (; server, writemsg, writereadmsg, id_counter)
-            cell1_uri = make_cell_uri(tempdir, 1)
-            cell2_uri = make_cell_uri(tempdir, 2)
-
-            # Open notebook with two cells and wait for diagnostics
-            # read=2: PublishDiagnosticsNotification for each cell
-            let cell1_text = "x = 1"
-                cell2_text = "y = 2\nz = 3"
-                cells = NotebookCell[
-                    NotebookCell(; kind = NotebookCellKind.Code, document = cell1_uri),
-                    NotebookCell(; kind = NotebookCellKind.Code, document = cell2_uri),
-                ]
-                cell_texts = Dict{URI,String}(cell1_uri => cell1_text, cell2_uri => cell2_text)
-                writereadmsg(make_DidOpenNotebookDocumentNotification(notebook_uri, cells, cell_texts); read=2)
-            end
-
-            # Request formatting for cell 1 only
-            let id = id_counter[] += 1
-                (; raw_res) = writereadmsg(make_DocumentFormattingRequest(id, cell1_uri))
-                @test raw_res isa DocumentFormattingResponse
-                edits = raw_res.result
-                @test edits !== nothing
-                @test length(edits) == 1
-                edit = edits[1]
-                # Verify the range is cell-local (covers just "x = 1")
-                @test edit.range.start.line == 0
-                @test edit.range.start.character == 0
-                @test edit.range.var"end".line == 0
-                @test edit.range.var"end".character == 5
-                # Verify the formatted text (cat just echoes input)
-                @test edit.newText == "x = 1"
-            end
-
-            # Verify cell 2 is independent - request formatting for cell 2
-            let id = id_counter[] += 1
-                (; raw_res) = writereadmsg(make_DocumentFormattingRequest(id, cell2_uri))
-                @test raw_res isa DocumentFormattingResponse
-                edits = raw_res.result
-                @test edits !== nothing
-                @test length(edits) == 1
-                edit = edits[1]
-                # Verify the range is cell-local (covers "y = 2\nz = 3")
-                @test edit.range.start.line == 0
-                @test edit.range.start.character == 0
-                @test edit.range.var"end".line == 1
-                @test edit.range.var"end".character == 5
-                # Verify the formatted text (cat just echoes input)
-                @test edit.newText == "y = 2\nz = 3"
-            end
-        end
-    end
-end
-
-@testset "notebook documentSymbol and codeLens" begin
-    mktempdir() do tempdir
-        notebook_uri = filepath2uri(normpath(tempdir, "test.ipynb"))
-
-        # `code_lens.references` defaults to false, enable it for this test
-        settings = Dict{String,Any}(
-            "code_lens" => Dict{String,Any}(
-                "references" => true,
-            )
+            ),
         )
 
         withserver(; settings) do (; writereadmsg, id_counter)
@@ -397,6 +351,95 @@ end
                 @test data isa JETLS.ReferencesCodeLensData
                 @test data.uri == cell2_uri
                 @test data.line == 0
+            end
+
+            # inlayHint for cell 1 — viewport spans the whole cell. The single
+            # `let` block-end hint should land at cell-local line 2 and its
+            # textEdit range must also be cell-local.
+            let id = id_counter[] += 1
+                viewport = Range(;
+                    start = Position(; line = 0, character = 0),
+                    var"end" = Position(; line = 3, character = 0))
+                (; raw_res) = writereadmsg(make_InlayHintRequest(id, cell1_uri, viewport))
+                @test raw_res isa InlayHintResponse
+                hints = raw_res.result
+                @test hints isa Vector{InlayHint}
+                @test length(hints) == 1
+                hint = hints[1]
+                @test hint.position.line == 2
+                @test hint.label == "let x = 1"
+                textEdits = hint.textEdits
+                @test textEdits isa Vector{TextEdit} && length(textEdits) == 1
+                @test textEdits[1].range.start.line == 2
+                @test textEdits[1].range.var"end".line == 2
+            end
+
+            # inlayHint for cell 2 — viewport spans the whole cell. The
+            # `function` hint must appear at cell-local line 2 (not the
+            # notebook-global line 5) and only cell 2's hint comes back
+            # (`result = …` is a one-liner, no block-end hint).
+            let id = id_counter[] += 1
+                viewport = Range(;
+                    start = Position(; line = 0, character = 0),
+                    var"end" = Position(; line = 4, character = 0))
+                (; raw_res) = writereadmsg(make_InlayHintRequest(id, cell2_uri, viewport))
+                @test raw_res isa InlayHintResponse
+                hints = raw_res.result
+                @test hints isa Vector{InlayHint}
+                @test length(hints) == 1
+                hint = hints[1]
+                @test hint.position.line == 2
+                @test hint.label == "function myfunc"
+                textEdits = hint.textEdits
+                @test textEdits isa Vector{TextEdit} && length(textEdits) == 1
+                @test textEdits[1].range.start.line == 2
+                @test textEdits[1].range.var"end".line == 2
+            end
+
+            # A viewport that doesn't cover the block end should produce no
+            # hints — verifies the cell-local viewport is honored, not silently
+            # promoted to the whole notebook.
+            let id = id_counter[] += 1
+                viewport = Range(;
+                    start = Position(; line = 0, character = 0),
+                    var"end" = Position(; line = 1, character = 0))
+                (; raw_res) = writereadmsg(make_InlayHintRequest(id, cell2_uri, viewport))
+                @test raw_res isa InlayHintResponse
+                @test raw_res.result isa LSP.Null ||
+                    (raw_res.result isa Vector && isempty(raw_res.result))
+            end
+
+            # formatting for cell 1 — `cat` echoes input. The edit range must
+            # be cell-local: cell 1 ends at line 2 (`end`, length 3).
+            let id = id_counter[] += 1
+                (; raw_res) = writereadmsg(make_DocumentFormattingRequest(id, cell1_uri))
+                @test raw_res isa DocumentFormattingResponse
+                edits = raw_res.result
+                @test edits !== nothing
+                @test length(edits) == 1
+                edit = edits[1]
+                @test edit.range.start.line == 0
+                @test edit.range.start.character == 0
+                @test edit.range.var"end".line == 2
+                @test edit.range.var"end".character == 3
+                @test edit.newText == "let x = 1\nprintln(sin(x))\nend"
+            end
+
+            # formatting for cell 2 — independent of cell 1. The edit range
+            # must end at cell-local line 3 (`result = myfunc(42)`, length 19),
+            # not the notebook-global line 6.
+            let id = id_counter[] += 1
+                (; raw_res) = writereadmsg(make_DocumentFormattingRequest(id, cell2_uri))
+                @test raw_res isa DocumentFormattingResponse
+                edits = raw_res.result
+                @test edits !== nothing
+                @test length(edits) == 1
+                edit = edits[1]
+                @test edit.range.start.line == 0
+                @test edit.range.start.character == 0
+                @test edit.range.var"end".line == 3
+                @test edit.range.var"end".character == 19
+                @test edit.newText == "function myfunc(y)\n    y + 1\nend\nresult = myfunc(42)"
             end
         end
     end


### PR DESCRIPTION
`handle_InlayHintRequest` previously treated the cell-local viewport `range` and the resulting hint coordinates as if they were in the concatenated notebook's global coordinate system, which caused inlay hints to be miscategorized or misplaced for any notebook cell.

Promote the incoming viewport via `adjust_position` and run the new `localize_inlay_hints` over the produced hints to convert each `InlayHint.position` and `textEdits[].range` back to cell-local coordinates (and drop hints whose position resolves to a different cell). For non-notebook URIs the helper is a no-op.

Also register override constructors for `LSP.InlayHint` and `LSP.TextEdit` to support `T(x; field = …)` copy-with-override.

Add notebook regression coverage by folding the existing `"notebook formatting"` and `"notebook documentSymbol and codeLens"` testsets into a single `"notebook per-cell features"` testset that also exercises `textDocument/inlayHint`.