### PR TITLE
TypeAnnotation: Filter user returns from branching expression value

### DIFF
--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -498,13 +498,21 @@ end
 # =======
 
 """
-    InferredTreeContext(inferred_tree::SyntaxTreeC) -> ctx::InferredTreeContext
+    InferredTreeContext(inferred_tree::SyntaxTreeC, st3::SyntaxTreeC) -> ctx::InferredTreeContext
 
 Public type-query handle for a lowered, inferred syntax tree. Bundles
 `inferred_tree` (the result of [`infer_toplevel_tree`](@ref)) with a set of
 prebuilt indexes so that [`get_type_for_range`](@ref) (and friends) can answer
 each query in O(1) — or O(log N) for the branching case — without re-walking
 the tree per call.
+
+`st3` is the post-scope-resolution tree (the `st3` field returned by
+[`get_inferrable_tree`](@ref)). It's used to identify byte ranges of
+*user-written* `return` values, which `type_for_branching` filters out so
+they don't pollute the value type of an enclosing branching expression.
+`st3` (rather than the surface tree) lets the analysis see through
+desugared `&&` / `||` / `?:` / chained comparisons (now `K"if"`) and
+through expanded macros — without it, those constructs would leak.
 
 # Lifecycle
 
@@ -515,9 +523,8 @@ populates all indexes simultaneously. Typical usage:
 - in `JETLS` itself: cache an `InferredTreeContext` alongside (or in place
   of) the inferred tree on the server's per-file state, rebuilding only when
   the tree is rebuilt;
-- in tests / one-off callers: pass `inferred_tree` directly to the two-arg
-  convenience overload `get_type_for_range(inferred_tree, rng)`, which builds
-  a fresh context per call.
+- in tests / one-off callers: build a context per inferred tree, then query
+  against it.
 
 Consumers should normally just call [`get_type_for_range`](@ref) and treat
 this type as opaque; the fields are implementation detail and may be
@@ -528,27 +535,40 @@ struct InferredTreeContext
     # `byte_range => kind` for the surface node each lowered node was lowered
     # from (first element of `JS.flattened_provenance`). First-write-wins,
     # mirroring a `traverse`-then-pick-first lookup.
-    surface_kind_index::Dict{UnitRange{UInt32}, JS.Kind}
+    surface_kind_index::Dict{UnitRange{Int}, JS.Kind}
     # Every lowered node keyed by its own `byte_range`, in preorder. The
     # preorder property is load-bearing for the "last `K"call"` wins"
     # semantics in `type_for_call`.
-    by_byte_range::Dict{UnitRange{UInt32}, Vector{SyntaxTreeC}}
+    by_byte_range::Dict{UnitRange{Int}, Vector{SyntaxTreeC}}
     # Typed `K"call"` nodes whose first provenance is a `K"macrocall"`, keyed
     # by the **macrocall's** `byte_range` (not the lowered call's own range —
     # string macros lower to a `K"call"` with a smaller span than the
     # macrocall, so we key by the surface span the user wrote).
-    macrocall_typed_calls::Dict{UnitRange{UInt32}, Vector{SyntaxTreeC}}
+    macrocall_typed_calls::Dict{UnitRange{Int}, Vector{SyntaxTreeC}}
     # Every `K"return"` node, in two parallel `Vector`s sorted by
     # `JS.first_byte` (so `searchsortedfirst` is valid on `return_first_bytes`).
-    return_first_bytes::Vector{UInt32}
+    return_first_bytes::Vector{Int}
     return_nodes::Vector{SyntaxTreeC}
+    # Maps each tail-position byte range `R` of a user-written `return X`
+    # to the *innermost* user return value byte range that produced it
+    # (i.e. `byte_range(X)` for the closest enclosing user `return`).
+    # Computed by walking `st3` for `K"return"` nodes and descending into
+    # tail-recursing forms (`K"if"` branches, `K"block"` last child, …).
+    # `type_for_branching(rng)` filters a contained `K"return"` at `R`
+    # when `rng` *strictly* contains the recorded URV — meaning the user
+    # `return` is fully inside the queried expression, so its exit shouldn't
+    # pollute the queried value. When `rng ⊆ URV` (the queried expression
+    # is the user return value itself, or a sub-expression of it), the
+    # `K"return"` is part of the queried branching's value and isn't
+    # filtered.
+    user_return_value_ranges::Dict{UnitRange{Int}, UnitRange{Int}}
 end
 
-function InferredTreeContext(inferred_tree::SyntaxTreeC)
-    surface_kind_index = Dict{UnitRange{UInt32}, JS.Kind}()
-    by_byte_range = Dict{UnitRange{UInt32}, Vector{SyntaxTreeC}}()
-    macrocall_typed_calls = Dict{UnitRange{UInt32}, Vector{SyntaxTreeC}}()
-    return_first_bytes = UInt32[]
+function InferredTreeContext(inferred_tree::SyntaxTreeC, st3::SyntaxTreeC)
+    surface_kind_index = Dict{UnitRange{Int}, JS.Kind}()
+    by_byte_range = Dict{UnitRange{Int}, Vector{SyntaxTreeC}}()
+    macrocall_typed_calls = Dict{UnitRange{Int}, Vector{SyntaxTreeC}}()
+    return_first_bytes = Int[]
     return_nodes = SyntaxTreeC[]
 
     traverse(inferred_tree) do st::SyntaxTreeC
@@ -582,23 +602,105 @@ function InferredTreeContext(inferred_tree::SyntaxTreeC)
     permute!(return_first_bytes, perm)
     permute!(return_nodes, perm)
 
+    user_return_value_ranges = Dict{UnitRange{Int}, UnitRange{Int}}()
+    collect_user_return_value_ranges!(user_return_value_ranges, st3)
+
     return InferredTreeContext(
         inferred_tree, surface_kind_index, by_byte_range,
-        macrocall_typed_calls, return_first_bytes, return_nodes)
+        macrocall_typed_calls, return_first_bytes, return_nodes,
+        user_return_value_ranges)
+end
+
+# Walk `st`, find every `K"return"` node, and record the byte ranges of all
+# tail-position values of its return value into `D`, mapped to the innermost
+# enclosing user return's value byte range. Operates on `st3`
+# (post-desugaring, post-macro-expansion), so `&&` / `||` / `?:` / chained
+# comparisons all show up as `K"if"` and macros are already expanded.
+function collect_user_return_value_ranges!(
+        D::Dict{UnitRange{Int}, UnitRange{Int}}, st::SyntaxTreeC
+    )
+    if JS.kind(st) === JS.K"return" && JS.numchildren(st) >= 1
+        urv = JS.byte_range(st[1])
+        record_user_return_tails!(D, st[1], urv)
+    end
+    for i = 1:JS.numchildren(st)
+        collect_user_return_value_ranges!(D, st[i])
+    end
+end
+
+# Recursively descend `value` (the RHS of a user `return`), and for every
+# tail-position leaf record `byte_range(leaf) => urv`. When a nested
+# `K"return"` is encountered, its own value becomes the innermost `urv` for
+# its sub-walk so the entries point at the closest enclosing user return —
+# `type_for_branching`'s strict-contains check then correctly distinguishes
+# "queried expression is inside the user return" from "queried expression
+# strictly contains the user return".
+function record_user_return_tails!(D::Dict{UnitRange{Int}, UnitRange{Int}},
+                                   value::SyntaxTreeC, urv::UnitRange{<:Integer})
+    k = JS.kind(value)
+    if k === JS.K"if" || k === JS.K"elseif"
+        # `K"if"` shape: cond, then, optional else.
+        n = JS.numchildren(value)
+        n >= 2 && record_user_return_tails!(D, value[2], urv)
+        if n >= 3
+            record_user_return_tails!(D, value[3], urv)
+        else
+            # No-else branch: lowering synthesizes `K"return"(nothing)` with
+            # srcref = the `K"if"` itself, so its byte range is `value`'s.
+            record_tail!(D, JS.byte_range(value), urv)
+        end
+    elseif k === JS.K"block" || k === JS.K"scope_block"
+        n = JS.numchildren(value)
+        if n >= 1
+            record_user_return_tails!(D, value[n], urv)
+        else
+            record_tail!(D, JS.byte_range(value), urv)
+        end
+    elseif k === JS.K"return"
+        # Nested `return` inside the value subtree: switch to its own URV so
+        # this nested return's tail SSAs trace back to *it* (innermost),
+        # not the wrapping return.
+        if JS.numchildren(value) >= 1
+            inner_urv = JS.byte_range(value[1])
+            record_user_return_tails!(D, value[1], inner_urv)
+        else
+            record_tail!(D, JS.byte_range(value), urv)
+        end
+    else
+        # Leaf or non-tail-recursing form (call, identifier, literal,
+        # `K"trycatchelse"` / `K"tryfinally"` — the last two are unhandled
+        # for now and may leak; covered by `@test_broken` in the test file).
+        record_tail!(D, JS.byte_range(value), urv)
+    end
+end
+
+# Keep the smaller (more strictly-contained) URV when a tail range is
+# encountered via multiple traversal paths. Smaller URV = more innermost
+# user return = the right URV to compare the queried `rng` against.
+function record_tail!(D::Dict{UnitRange{Int}, UnitRange{Int}},
+                      R::UnitRange{<:Integer}, urv::UnitRange{<:Integer})
+    cur = get(D, R, nothing)
+    if cur === nothing || length(urv) < length(cur)
+        D[R] = urv
+    end
+end
+
+# `outer` strictly contains `inner` (proper superset): same start/stop
+# constraints as `⊆` but at least one bound is strict.
+function strictly_contains(outer::UnitRange{<:Integer}, inner::UnitRange{<:Integer})
+    return outer.start <= inner.start && inner.stop <= outer.stop &&
+           (outer.start < inner.start || inner.stop < outer.stop)
 end
 
 """
     get_type_for_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
-    get_type_for_range(inferred_tree::SyntaxTreeC, rng::UnitRange{<:Integer})
 
 Look up the inferred type at surface byte range `rng`.
 Returns `nothing` if no lowered node corresponding to `rng` carries a `:type` attribute.
 
-The first form is the production entry point: pass an [`InferredTreeContext`](@ref) so the
-per-tree O(N) index build is amortized across all queries against the same inferred tree.
-The second form is a convenience that constructs a fresh context per call — meant for tests
-and one-off use, **not** for batch queries against a single tree (you'd rebuild the indexes
-for every `rng`).
+Build the [`InferredTreeContext`](@ref) once per inferred tree and reuse it across
+queries — the per-tree O(N) index build is amortized across all queries against
+the same context.
 
 # Dispatch
 
@@ -651,9 +753,6 @@ function get_type_for_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
     return tmerge_at_range(ctx, rng)
 end
 
-get_type_for_range(inferred_tree::SyntaxTreeC, rng::UnitRange{<:Integer}) =
-    get_type_for_range(InferredTreeContext(inferred_tree), rng)
-
 surface_kind_at_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer}) =
     get(ctx.surface_kind_index, rng, nothing)
 
@@ -682,14 +781,21 @@ end
 # lowered branches show up as either:
 # - merge-slot assignments (`K"="` whose byte range equals the surface `rng`)
 #   when the surface is in `K"="` RHS or any non-tail position; or
-# - tail returns (`K"return"` whose byte range is contained in `rng`) when
-#   the surface is in tail position of a function body.
+# - synthetic tail returns (`K"return"` whose byte range is contained in
+#   `rng`) when the surface is in tail position of a function body.
 # The expression's value type is the `tmerge` over all such branch values.
 #
 # A `K"return"` that spans exactly `rng` (synthesized when the branching
 # expression is itself the function body) lives in both `by_byte_range[rng]`
 # and the K"return" containment scan, so the explicit `continue` below skips
 # it in the second scan to avoid double-counting.
+#
+# *User-written* `K"return"` exits the function and must not contribute to
+# the enclosing expression's value (e.g. `out = if cond; return X; end` —
+# the if's value is `Nothing`, not `Union{Nothing, typeof(X)}`). They're
+# filtered via `ctx.user_return_value_ranges`, which records the byte
+# ranges of every tail-position value reachable from a user `return`'s
+# right-hand side.
 function type_for_branching(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
     typ = nothing
     # (1) equality match — any lowered kind, including merge-slot `K"="`.
@@ -698,7 +804,8 @@ function type_for_branching(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
         ntyp = st.type
         typ = typ === nothing ? ntyp : CC.tmerge(ntyp, typ)
     end
-    # (2) containment match — tail-position `K"return"` strictly inside `rng`.
+    # (2) containment match — `K"return"` strictly inside `rng`, excluding
+    #     user-written returns.
     rng_start = rng.start
     rng_stop = rng.stop
     lo = searchsortedfirst(ctx.return_first_bytes, rng_start)
@@ -709,6 +816,14 @@ function type_for_branching(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
         last_byte = JS.last_byte(st)
         last_byte > rng_stop && continue
         first_byte == rng_start && last_byte == rng_stop && continue # already counted
+        # Skip user-return tails when their URV is strictly contained in
+        # `rng` — i.e. the user `return` is fully inside `rng`, so its
+        # exit doesn't contribute to `rng`'s value. When `rng ⊆ URV`
+        # (queried expression IS inside the return value), the K"return"
+        # is a branch tail of `rng` itself and stays.
+        let urv = get(ctx.user_return_value_ranges, first_byte:last_byte, nothing)
+            urv !== nothing && strictly_contains(rng, urv) && continue
+        end
         hasproperty(st, :type) || continue
         ntyp = st.type
         typ = typ === nothing ? ntyp : CC.tmerge(ntyp, typ)

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -6,15 +6,19 @@ using JETLS: JL, JS
 using JETLS.TypeAnnotation
 using JETLS.JET: CC
 
-# Run the full pipeline a typical caller would: parse → lower → infer.
-# Returns `(fi, inferred)` so byte-range queries against `inferred` line up with `code`.
+# Run the full pipeline a typical caller would: parse → lower → infer, then
+# wrap the chunk's inferred tree (and `st3`, used to identify user-written
+# return values) in an `InferredTreeContext` ready for byte-range queries.
+# Returns `(fi, ctx)` so the test can also access `fi` for `xy_to_offset` etc.
 function type_annotate(code::AbstractString, mod::Module = Main; expect_degrade::Bool=false)
     fi = JETLS.FileInfo(1, code, @__FILE__)
     st0_top = JETLS.build_syntax_tree(fi)
+    st3_ref = Ref{JETLS.SyntaxTreeC}()
     inferred = Ref{JETLS.SyntaxTreeC}()
     JETLS.iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
         result = @something get_inferrable_tree(st0, mod) return nothing
         (; ctx3, st3) = result
+        st3_ref[] = st3
         inferred[] = infer_toplevel_tree(ctx3, st3, mod)
         return nothing
     end
@@ -24,7 +28,7 @@ function type_annotate(code::AbstractString, mod::Module = Main; expect_degrade:
     else
         @test isassigned(inferred)
     end
-    return fi, inferred[]
+    return fi, InferredTreeContext(inferred[], st3_ref[])
 end
 
 # Byte range of the literal substring `s` inside `code`, in `JS.byte_range`
@@ -55,13 +59,13 @@ widenconst(typ) = CC.widenconst(@something typ return nothing)
 # assert that **every** occurrence of an identifier (or expression) gets
 # an annotation, not just the first one.
 function query_all_types(
-        fi::JETLS.FileInfo, inferred::JETLS.SyntaxTreeC, text::AbstractString
+        fi::JETLS.FileInfo, ctx::InferredTreeContext, text::AbstractString
     )
     st0_top = JETLS.build_syntax_tree(fi)
     types = Any[]
     JETLS.traverse(st0_top) do node::JS.SyntaxTree
         if JS.sourcetext(node) == text
-            push!(types, get_type_for_range(inferred, JS.byte_range(node)))
+            push!(types, get_type_for_range(ctx, JS.byte_range(node)))
         end
         return nothing
     end
@@ -123,8 +127,8 @@ end
                 x + 1
             end
             """
-            _, inferred = type_annotate(code)
-            @test widenconst(get_type_for_range(inferred, range_of(code, "x + 1"))) === Int
+            _, ctx = type_annotate(code)
+            @test widenconst(get_type_for_range(ctx, range_of(code, "x + 1"))) === Int
         end
     end
 
@@ -138,8 +142,8 @@ end
                 s
             end
             """
-            _, inferred = type_annotate(code)
-            @test widenconst(get_type_for_range(inferred, range_of(code, "init + xs[1]"))) === Int
+            _, ctx = type_annotate(code)
+            @test widenconst(get_type_for_range(ctx, range_of(code, "init + xs[1]"))) === Int
         end
     end
 
@@ -152,9 +156,9 @@ end
                 inner(xs[1])
             end
             """
-            _, inferred = type_annotate(code)
+            _, ctx = type_annotate(code)
             @testset "body" begin
-                @test widenconst(get_type_for_range(inferred, range_of(code, "y * 2"))) === Int
+                @test widenconst(get_type_for_range(ctx, range_of(code, "y * 2"))) === Int
             end
 
             # Limitation: from the enclosing function's body, calling a closure
@@ -162,7 +166,7 @@ end
             # call site degrades to `Any`. Recorded as `@test_broken` to flip when
             # the synthetic-name lookup gap is closed.
             @testset "closure call from outer body" begin
-                @test_broken widenconst(get_type_for_range(inferred, range_of(code, "inner(xs[1])"))) === Int
+                @test_broken widenconst(get_type_for_range(ctx, range_of(code, "inner(xs[1])"))) === Int
             end
         end
 
@@ -179,8 +183,8 @@ end
                     inner(xs[1])
                 end
                 """
-                _, inferred = type_annotate(code)
-                @test_broken widenconst(get_type_for_range(inferred, range_of(code, "y * factor"))) === Int
+                _, ctx = type_annotate(code)
+                @test_broken widenconst(get_type_for_range(ctx, range_of(code, "y * factor"))) === Int
             end
         end
     end
@@ -197,9 +201,9 @@ end
                 NamedTuple{(:a,)}((b ? "Z" : nothing,))
             end
             """
-            _, inferred = type_annotate(code)
+            _, ctx = type_annotate(code)
             rng = range_of(code, "NamedTuple{(:a,)}((b ? \"Z\" : nothing,))")
-            @test widenconst(get_type_for_range(inferred, rng)) <:
+            @test widenconst(get_type_for_range(ctx, rng)) <:
                 NamedTuple{(:a,), <:Tuple{Union{Nothing, String}}}
         end
     end
@@ -215,9 +219,9 @@ end
                 convert(T, 1)
             end
             """
-            _, inferred = type_annotate(code)
+            _, ctx = type_annotate(code)
             # A static-parameter-aware path would land somewhere `<: Number`.
-            @test_broken widenconst(get_type_for_range(inferred, range_of(code, "convert(T, 1)"))) <: Number
+            @test_broken widenconst(get_type_for_range(ctx, range_of(code, "convert(T, 1)"))) <: Number
         end
     end
 end
@@ -227,8 +231,8 @@ end
     # tmerge path collapses to that node's type.
     @testset "generic byte-range fallback" begin
         let code = "let x = [1.0]; x; end"
-            _, inferred = type_annotate(code)
-            @test widenconst(get_type_for_range(inferred, range_of(code, "[1.0]"))) ===
+            _, ctx = type_annotate(code)
+            @test widenconst(get_type_for_range(ctx, range_of(code, "[1.0]"))) ===
                 Vector{Float64}
         end
     end
@@ -237,15 +241,15 @@ end
     # can distinguish "no annotation" from "annotation says `nothing`".
     @testset "returns nothing for non-matching range" begin
         let code = "let x = 1; x; end"
-            _, inferred = type_annotate(code)
-            @test get_type_for_range(inferred, 10_000:10_001) === nothing
+            _, ctx = type_annotate(code)
+            @test get_type_for_range(ctx, 10_000:10_001) === nothing
         end
     end
 
     @testset "regular call dispatches to the user's call result" begin
         let code = "let v = [1.0, 2.0]; sum(v); end"
-            _, inferred = type_annotate(code)
-            @test widenconst(get_type_for_range(inferred, range_of(code, "sum(v)"))) ===
+            _, ctx = type_annotate(code)
+            @test widenconst(get_type_for_range(ctx, range_of(code, "sum(v)"))) ===
                 Float64
         end
     end
@@ -260,9 +264,9 @@ end
                 parse(Int, s; base = 10)
             end
             """
-            _, inferred = type_annotate(code)
+            _, ctx = type_annotate(code)
             typ = widenconst(get_type_for_range(
-                inferred, range_of(code, "parse(Int, s; base = 10)")))
+                ctx, range_of(code, "parse(Int, s; base = 10)")))
             @test typ === Int
             @test !occursin("NamedTuple", string(typ))
             @test !occursin("Tuple", string(typ))
@@ -272,9 +276,9 @@ end
     # `_str` macros expand to a single Core call.
     @testset "string macro returns the expansion result type" begin
         let code = "lazy\"hello\""
-            _, inferred = type_annotate(code)
+            _, ctx = type_annotate(code)
             @test widenconst(get_type_for_range(
-                inferred, range_of(code, "lazy\"hello\""))) <: Base.LazyString
+                ctx, range_of(code, "lazy\"hello\""))) <: Base.LazyString
         end
     end
 
@@ -288,9 +292,9 @@ end
                 @something x return false
             end
             """
-            _, inferred = type_annotate(code)
+            _, ctx = type_annotate(code)
             @test widenconst(get_type_for_range(
-                inferred, range_of(code, "@something x return false"))) === Int
+                ctx, range_of(code, "@something x return false"))) === Int
         end
     end
 
@@ -307,9 +311,9 @@ end
                     end
                 end
                 """
-                _, inferred = type_annotate(code)
+                _, ctx = type_annotate(code)
                 rng = range_of(code, "for x in xs\n        print(x)\n    end")
-                @test get_type_for_range(inferred, rng) === Core.Const(nothing)
+                @test get_type_for_range(ctx, rng) === Core.Const(nothing)
             end
         end
         @testset "while loop returns Const(nothing)" begin
@@ -320,9 +324,9 @@ end
                     end
                 end
                 """
-                _, inferred = type_annotate(code)
+                _, ctx = type_annotate(code)
                 rng = range_of(code, "while i < 3\n        i += 1\n    end")
-                @test get_type_for_range(inferred, rng) === Core.Const(nothing)
+                @test get_type_for_range(ctx, rng) === Core.Const(nothing)
             end
         end
     end
@@ -339,9 +343,9 @@ end
                     return x + 1
                 end
                 """
-                _, inferred = type_annotate(code)
+                _, ctx = type_annotate(code)
                 rng = range_of(code, rstrip(code, '\n'))
-                @test widenconst(get_type_for_range(inferred, rng)) === Int
+                @test widenconst(get_type_for_range(ctx, rng)) === Int
             end
         end
 
@@ -356,9 +360,9 @@ end
                     end
                 end
                 """
-                _, inferred = type_annotate(code)
+                _, ctx = type_annotate(code)
                 rng = range_of(code, rstrip(code, '\n'))
-                typ = widenconst(get_type_for_range(inferred, rng))
+                typ = widenconst(get_type_for_range(ctx, rng))
                 @test typ === Union{Int, Nothing}
             end
         end
@@ -370,9 +374,9 @@ end
                     return :(1 + 1)
                 end
                 """
-                _, inferred = type_annotate(code)
+                _, ctx = type_annotate(code)
                 rng = range_of(code, rstrip(code, '\n'))
-                @test widenconst(get_type_for_range(inferred, rng)) === Expr
+                @test widenconst(get_type_for_range(ctx, rng)) === Expr
             end
         end
 
@@ -382,9 +386,9 @@ end
                     return x + 1
                 end
                 """
-                _, inferred = type_annotate(code)
+                _, ctx = type_annotate(code)
                 rng = range_of(code, rstrip(code, '\n'))
-                @test widenconst(get_type_for_range(inferred, rng)) === Int
+                @test widenconst(get_type_for_range(ctx, rng)) === Int
             end
         end
 
@@ -394,9 +398,9 @@ end
                     x + y + z
                 end
                 """
-                _, inferred = type_annotate(code)
+                _, ctx = type_annotate(code)
                 rng = range_of(code, rstrip(code, '\n'))
-                @test widenconst(get_type_for_range(inferred, rng)) === Int
+                @test widenconst(get_type_for_range(ctx, rng)) === Int
             end
         end
 
@@ -410,9 +414,9 @@ end
                     s
                 end
                 """
-                _, inferred = type_annotate(code)
+                _, ctx = type_annotate(code)
                 rng = range_of(code, rstrip(code, '\n'))
-                @test widenconst(get_type_for_range(inferred, rng)) === Int
+                @test widenconst(get_type_for_range(ctx, rng)) === Int
             end
         end
     end
@@ -427,9 +431,9 @@ end
                     r = 0 < x < 10
                 end
                 """
-                _, inferred = type_annotate(code)
+                _, ctx = type_annotate(code)
                 rng = range_of(code, "0 < x < 10")
-                @test widenconst(get_type_for_range(inferred, rng)) === Bool
+                @test widenconst(get_type_for_range(ctx, rng)) === Bool
             end
         end
         @testset "chained comparison in tail position" begin
@@ -438,9 +442,9 @@ end
                     return 0 < x < 10
                 end
                 """
-                _, inferred = type_annotate(code)
+                _, ctx = type_annotate(code)
                 rng = range_of_kind(code, JS.K"comparison")
-                @test widenconst(get_type_for_range(inferred, rng)) === Bool
+                @test widenconst(get_type_for_range(ctx, rng)) === Bool
             end
         end
 
@@ -451,9 +455,9 @@ end
                     r
                 end
                 """
-                _, inferred = type_annotate(code)
+                _, ctx = type_annotate(code)
                 rng = range_of(code, "x > 0 && x")
-                @test widenconst(get_type_for_range(inferred, rng)) === Union{Bool, Int}
+                @test widenconst(get_type_for_range(ctx, rng)) === Union{Bool, Int}
             end
         end
         @testset "&& in tail position" begin
@@ -462,9 +466,9 @@ end
                     return x > 0 && x
                 end
                 """
-                _, inferred = type_annotate(code)
+                _, ctx = type_annotate(code)
                 rng = range_of_kind(code, JS.K"&&")
-                @test widenconst(get_type_for_range(inferred, rng)) === Union{Bool, Int}
+                @test widenconst(get_type_for_range(ctx, rng)) === Union{Bool, Int}
             end
         end
         @testset "|| in tail position" begin
@@ -473,9 +477,9 @@ end
                     return x > 0 || nothing
                 end
                 """
-                _, inferred = type_annotate(code)
+                _, ctx = type_annotate(code)
                 rng = range_of_kind(code, JS.K"||")
-                @test widenconst(get_type_for_range(inferred, rng)) === Union{Bool, Nothing}
+                @test widenconst(get_type_for_range(ctx, rng)) === Union{Bool, Nothing}
             end
         end
 
@@ -489,9 +493,9 @@ end
                     r
                 end
                 """
-                _, inferred = type_annotate(code)
+                _, ctx = type_annotate(code)
                 rng = range_of(code, "b ? x : nothing")
-                @test widenconst(get_type_for_range(inferred, rng)) === Union{Int, Nothing}
+                @test widenconst(get_type_for_range(ctx, rng)) === Union{Int, Nothing}
             end
         end
         @testset "ternary in tail position" begin
@@ -500,9 +504,9 @@ end
                     return b ? x : nothing
                 end
                 """
-                _, inferred = type_annotate(code)
+                _, ctx = type_annotate(code)
                 rng = range_of_kind(code, JS.K"if")
-                @test widenconst(get_type_for_range(inferred, rng)) === Union{Int, Nothing}
+                @test widenconst(get_type_for_range(ctx, rng)) === Union{Int, Nothing}
             end
         end
 
@@ -516,9 +520,9 @@ end
                     end
                 end
                 """
-                _, inferred = type_annotate(code)
+                _, ctx = type_annotate(code)
                 rng = range_of_kind(code, JS.K"if")
-                @test widenconst(get_type_for_range(inferred, rng)) === Union{Int, Nothing}
+                @test widenconst(get_type_for_range(ctx, rng)) === Union{Int, Nothing}
             end
         end
         @testset "if-elseif-else" begin
@@ -533,10 +537,188 @@ end
                     end
                 end
                 """
-                _, inferred = type_annotate(code)
+                _, ctx = type_annotate(code)
                 rng = range_of_kind(code, JS.K"if")
-                typ = widenconst(get_type_for_range(inferred, rng))
+                typ = widenconst(get_type_for_range(ctx, rng))
                 @test typ === Union{Int, String, Nothing}
+            end
+        end
+        # A user-written `return X` inside a branching expression exits the
+        # function entirely; `X` must not contribute to the enclosing
+        # expression's value (only the implicit fall-through does). When
+        # `X` is itself a tail-recursing form (`if` / `&&` / `||` / ternary
+        # / comparison / `block`), lowering splits it into per-branch tail
+        # returns at narrower byte ranges than `X` itself, so a literal
+        # byte-range match doesn't suffice. The walker over `st3`
+        # (post-desugaring, post-macro-expansion) handles all these uniform
+        # cases since they're already collapsed to `K"if"` / `K"block"` /
+        # nested `K"return"`.
+        #
+        # In every case below, the outer `if b ... end` should resolve to
+        # `Nothing` (the implicit fall-through is the only path that reaches
+        # `out`). `try` / `catch` is not yet covered (recorded as
+        # `@test_broken`).
+        @testset "user return inside branching expression" begin
+            @testset "simple value" begin
+                let code = """
+                    function format(x::Union{Int, Nothing})
+                        out = if x isa Int
+                            return string(x; base = 16)
+                        end
+                        return out
+                    end
+                    """
+                    _, ctx = type_annotate(code)
+                    rng = range_of_kind(code, JS.K"if")
+                    @test get_type_for_range(ctx, rng) === Core.Const(nothing)
+                end
+            end
+            @testset "wraps another if-else" begin
+                let code = """
+                    function f(b::Bool, c::Bool)
+                        out = if b
+                            return if c; 1; else; "x"; end
+                        end
+                        out
+                    end
+                    """
+                    _, ctx = type_annotate(code)
+                    # Inner if (the user's literal return value) tmerges its
+                    # branches correctly, as for any branching expression.
+                    inner_rng = range_of(code, "if c; 1; else; \"x\"; end")
+                    @test widenconst(get_type_for_range(ctx, inner_rng)) === Union{Int, String}
+                    outer_rng = range_of_kind(code, JS.K"if")
+                    @test widenconst(get_type_for_range(ctx, outer_rng)) === Nothing
+                end
+            end
+            @testset "wraps if-elseif-else" begin
+                let code = """
+                    function f(b::Bool, c::Bool, d::Bool)
+                        out = if b
+                            return if c; 1; elseif d; 2; else; 3; end
+                        end
+                        out
+                    end
+                    """
+                    _, ctx = type_annotate(code)
+                    outer_rng = range_of_kind(code, JS.K"if")
+                    @test widenconst(get_type_for_range(ctx, outer_rng)) === Nothing
+                end
+            end
+            @testset "wraps ternary" begin
+                let code = """
+                    function f(b::Bool, c::Bool)
+                        out = if b
+                            return c ? 1 : "x"
+                        end
+                        out
+                    end
+                    """
+                    _, ctx = type_annotate(code)
+                    outer_rng = range_of_kind(code, JS.K"if")
+                    @test widenconst(get_type_for_range(ctx, outer_rng)) === Nothing
+                end
+            end
+            @testset "wraps &&" begin
+                let code = """
+                    function f(b::Bool, c::Bool, x::Int)
+                        out = if b
+                            return c && x
+                        end
+                        out
+                    end
+                    """
+                    _, ctx = type_annotate(code)
+                    outer_rng = range_of_kind(code, JS.K"if")
+                    @test widenconst(get_type_for_range(ctx, outer_rng)) === Nothing
+                end
+            end
+            @testset "wraps ||" begin
+                let code = """
+                    function f(b::Bool, c::Bool, x::Int)
+                        out = if b
+                            return c || x
+                        end
+                        out
+                    end
+                    """
+                    _, ctx = type_annotate(code)
+                    outer_rng = range_of_kind(code, JS.K"if")
+                    @test widenconst(get_type_for_range(ctx, outer_rng)) === Nothing
+                end
+            end
+            @testset "wraps chained comparison" begin
+                let code = """
+                    function f(b::Bool, x::Int)
+                        out = if b
+                            return 0 < x < 10
+                        end
+                        out
+                    end
+                    """
+                    _, ctx = type_annotate(code)
+                    outer_rng = range_of_kind(code, JS.K"if")
+                    @test widenconst(get_type_for_range(ctx, outer_rng)) === Nothing
+                end
+            end
+            @testset "wraps begin/end block" begin
+                let code = """
+                    function f(b::Bool, x::Int)
+                        out = if b
+                            return begin x; "tail" end
+                        end
+                        out
+                    end
+                    """
+                    _, ctx = type_annotate(code)
+                    outer_rng = range_of_kind(code, JS.K"if")
+                    @test widenconst(get_type_for_range(ctx, outer_rng)) === Nothing
+                end
+            end
+            @testset "wraps try/catch" begin
+                let code = """
+                    function f(b::Bool)
+                        out = if b
+                            return try; 1; catch; "x"; end
+                        end
+                        out
+                    end
+                    """
+                    _, ctx = type_annotate(code)
+                    outer_rng = range_of_kind(code, JS.K"if")
+                    @test_broken widenconst(get_type_for_range(ctx, outer_rng)) === Nothing
+                end
+            end
+        end
+
+        # A `return` inside a macro expansion is invisible at the surface
+        # but visible in `st3` (post-expansion). The walker picks it up
+        # the same as a directly-written `return`.
+        @testset "return hidden by macro expansion" begin
+            # `@something args... return X` expands such that the literal
+            # `return X` exits the function when none of the args are
+            # non-`nothing`. Without filtering the macro-expanded
+            # `K"return"` SSA, the outer `if`'s value would leak the
+            # return-value type (`String` below).
+            @testset "Base.@something with `return` fallback" begin
+                let code = """
+                    function f(x::Union{Int, Nothing}, y::Union{Int, Nothing})
+                        out = if x isa Int
+                            @something y return "no value"
+                        end
+                        out
+                    end
+                    """
+                    _, ctx = type_annotate(code)
+                    outer_rng = range_of_kind(code, JS.K"if")
+                    @test widenconst(get_type_for_range(ctx, outer_rng)) === Union{Int, Nothing}
+                    # `out` at its trailing-line use site: the `String` from
+                    # `return "no value"` exits the function rather than
+                    # flowing through, so `out`'s narrowed type omits it
+                    # (it's `Union{Int, Nothing}`, not `Union{Int, Nothing, String}`).
+                    out_use_rng = findlast("out", code)
+                    @test widenconst(get_type_for_range(ctx, out_use_rng)) === Union{Int, Nothing}
+                end
             end
         end
     end
@@ -554,11 +736,11 @@ end
                 a + b
             end
             """
-            _, inferred = type_annotate(code)
+            _, ctx = type_annotate(code)
             @test widenconst(get_type_for_range(
-                inferred, range_of(code, "sincos(xs[1])"))) === Tuple{Float64, Float64}
+                ctx, range_of(code, "sincos(xs[1])"))) === Tuple{Float64, Float64}
             @test widenconst(get_type_for_range(
-                inferred, range_of(code, "a + b"))) === Float64
+                ctx, range_of(code, "a + b"))) === Float64
         end
     end
 
@@ -568,15 +750,15 @@ end
     # show useful information when the cursor is anywhere along the access.
     @testset "property access via dereferenced Ref" begin
         let code = "Ref((; scale = 2.0))[].scale"
-            _, inferred = type_annotate(code)
+            _, ctx = type_annotate(code)
             @test widenconst(get_type_for_range(
-                inferred, range_of(code, "Ref((; scale = 2.0))"))) ===
+                ctx, range_of(code, "Ref((; scale = 2.0))"))) ===
                 Base.RefValue{NamedTuple{(:scale,), Tuple{Float64}}}
             @test widenconst(get_type_for_range(
-                inferred, range_of(code, "Ref((; scale = 2.0))[]"))) ===
+                ctx, range_of(code, "Ref((; scale = 2.0))[]"))) ===
                 NamedTuple{(:scale,), Tuple{Float64}}
             @test widenconst(get_type_for_range(
-                inferred, range_of(code, "Ref((; scale = 2.0))[].scale"))) ===
+                ctx, range_of(code, "Ref((; scale = 2.0))[].scale"))) ===
                 Float64
         end
     end
@@ -594,15 +776,15 @@ end
                 result
             end
             """
-            fi, inferred = type_annotate(code)
-            cfg_types = query_all_types(fi, inferred, "cfg")
+            fi, ctx = type_annotate(code)
+            cfg_types = query_all_types(fi, ctx, "cfg")
             @test length(cfg_types) == 3 # binding + two field accesses
             @test all(t -> widenconst(t) ===
                 NamedTuple{(:scale, :offset), Tuple{Float64, Int}}, cfg_types)
-            raw_types = query_all_types(fi, inferred, "raw")
+            raw_types = query_all_types(fi, ctx, "raw")
             @test length(raw_types) == 2 # binding + reference in `raw * cfg.offset`
             @test all(t -> widenconst(t) === Float64, raw_types)
-            result_types = query_all_types(fi, inferred, "result")
+            result_types = query_all_types(fi, ctx, "result")
             @test length(result_types) == 2 # binding + tail reference
             @test all(t -> widenconst(t) === Float64, result_types)
         end
@@ -620,8 +802,8 @@ end
                 end
             end
             """
-            fi, inferred = type_annotate(code)
-            types = query_all_types(fi, inferred, "xxx")
+            fi, ctx = type_annotate(code)
+            types = query_all_types(fi, ctx, "xxx")
             @test any(t -> widenconst(t) === Int, types)
             @test any(t -> widenconst(t) === String, types)
         end
@@ -638,8 +820,8 @@ end
         # Toplevel `sin(`: the trailing `(error-t)` arg is stripped, leaving `(call sin)`.
         # The `sin` reference itself still resolves — usable for signature help on a half-typed call.
         let code = "sin("
-            _, inferred = type_annotate(code)
-            @test get_type_for_range(inferred, range_of(code, "sin")) === Core.Const(sin)
+            _, ctx = type_annotate(code)
+            @test get_type_for_range(ctx, range_of(code, "sin")) === Core.Const(sin)
         end
         # K"error" buried inside a function body: the body parses to `(. x (inert end))`
         # plus a sibling K"error", stripping the latter leaves a well-formed function.
@@ -650,8 +832,8 @@ end
                 x.
             end
             """
-            fi, inferred = type_annotate(code)
-            x_types = query_all_types(fi, inferred, "x")
+            fi, ctx = type_annotate(code)
+            x_types = query_all_types(fi, ctx, "x")
             @test any(t -> widenconst(t) === Some{String}, x_types)
         end
         # Locally bound variable with no declared type: `s` gets `Float64` from `sum(xs)`,
@@ -662,8 +844,8 @@ end
                 s.
             end
             """
-            fi, inferred = type_annotate(code)
-            s_types = query_all_types(fi, inferred, "s")
+            fi, ctx = type_annotate(code)
+            s_types = query_all_types(fi, ctx, "s")
             @test any(t -> widenconst(t) === Float64, s_types)
         end
     end
@@ -676,8 +858,8 @@ end
     # before inference so the RHS keeps a precise `Float64`.
     @testset "top-level bare assignment RHS" begin
         let code = "global x = sin(1.0)"
-            _, inferred = type_annotate(code)
-            @test widenconst(get_type_for_range(inferred, range_of(code, "sin(1.0)"))) === Float64
+            _, ctx = type_annotate(code)
+            @test widenconst(get_type_for_range(ctx, range_of(code, "sin(1.0)"))) === Float64
         end
     end
 end


### PR DESCRIPTION
A user-written `return X` inside a branching expression should not contribute to the surrounding expression's value — it exits the function before that expression yields. But the lowered `K"return"` SSA at `byte_range(X)` was indistinguishable from a synthetic branch tail, so `out = if cond; return X; end` inferred as `Union{Nothing, typeof(X)}` rather than `Nothing`.

Walk `st3` (post-desugaring, post-macro-expansion) to map each tail-position byte range of every `K"return"`'s value to the innermost user-return value byte range (URV). The walker descends `K"if"` branches, `K"block"` last children, and nested `K"return"`s — the forms lowering tail-recurses through. `type_for_branching` then filters a contained `K"return"` SSA when its mapped URV is strictly contained in the queried range; when the queried range is inside or equal to the URV, the SSA is the queried branching expression's own tail and is kept.

Working at `st3` makes the analysis transparent to constructs that lowering already collapses: `&&` / `||` / `?:` / chained comparisons all show up as `K"if"`, and macros are already expanded so a `return` hidden inside `Base.@something y return X` is visible.

`InferredTreeContext`'s constructor now takes `st3` as a required argument. `try` / `catch` returns in tail position are not yet covered.