### PR TITLE
occurrence-analysis: Always include global bindings in cache

### DIFF
--- a/src/analysis/occurrence-analysis.jl
+++ b/src/analysis/occurrence-analysis.jl
@@ -319,14 +319,13 @@ function is_matching_global_binding(
 end
 
 function find_global_binding_occurrences!(
-        state::ServerState, uri::URI, fi::FileInfo, st0_top::SyntaxTreeC,
-        binfo::JL.BindingInfo;
-        kwargs...
+        state::ServerState, uri::URI, fi::FileInfo, st0_top::SyntaxTreeC, binfo::JL.BindingInfo;
+        lookup_func = gen_lookup_out_of_scope!(state, uri),
     )
     ret = Set{CachedBindingOccurrence}()
     iterate_toplevel_tree(st0_top) do st0::SyntaxTreeC
         binding_occurrences = @something get_binding_occurrences!(
-            state, uri, fi, st0; include_global_bindings = true, kwargs...) return
+            state, uri, fi, st0; lookup_func) return
         for (binfo′, occurrences) in binding_occurrences
             if is_matching_global_binding(binfo′, binfo)
                 for occurrence in occurrences
@@ -338,8 +337,14 @@ function find_global_binding_occurrences!(
     return ret
 end
 
+# Cached entry point. The cache key is only the byte range — `lookup_func`
+# is *not* part of the key. Production callers all rely on the default
+# `gen_lookup_out_of_scope!`, so they share the cache safely. Tests that
+# pass a custom `lookup_func` use isolated `ServerState` instances and
+# therefore don't collide with the production cache.
 function get_binding_occurrences!(
-        state::ServerState, uri::URI, fi::FileInfo, st0::SyntaxTreeC; kwargs...
+        state::ServerState, uri::URI, fi::FileInfo, st0::SyntaxTreeC;
+        lookup_func = gen_lookup_out_of_scope!(state, uri),
     )
     cache_uri = canonical_cache_uri(state, uri)
     range_key = JS.byte_range(st0)
@@ -350,7 +355,7 @@ function get_binding_occurrences!(
         end
         # Cache lowering failures as empty results so repeated calls for the same statement
         cache_result = BindingOccurrencesResult()
-        result = compute_binding_occurrences_st0(state, uri, fi, st0; kwargs...)
+        result = compute_full_binding_occurrences(state, uri, fi, st0; lookup_func)
         if result !== nothing
             for (binfo, occurrences) in result
                 cached_set = get!(Set{CachedBindingOccurrence}, cache_result, BindingInfoKey(binfo))
@@ -368,10 +373,9 @@ function get_binding_occurrences!(
     end
 end
 
-function compute_binding_occurrences_st0(
+function compute_full_binding_occurrences(
         state::ServerState, uri::URI, fi::FileInfo, st0::SyntaxTreeC;
         lookup_func = gen_lookup_out_of_scope!(state, uri),
-        include_global_bindings::Bool = false
     )
     soft_scope = is_notebook_cell_uri(state, uri) ||
         # Handlers like References and Rename receive notebook cell URIs, just like
@@ -388,17 +392,15 @@ function compute_binding_occurrences_st0(
     #   binding in the surrounding module.
     # - `using M: foo`/`import M: foo`/`import M.foo`: record the local alias identifier
     #   (`foo`, or `bar` in `foo as bar`) as a `:def` of the local global binding.
-    if include_global_bindings
-        k0 = JS.kind(st0)
-        if k0 in JS.KSet"export public"
-            binding_occurrences = Dict{JL.BindingInfo,Set{BindingOccurrence}}()
-            collect_export_public_occurrences!(binding_occurrences, st0, mod)
-            return binding_occurrences
-        elseif k0 in JS.KSet"import using"
-            binding_occurrences = Dict{JL.BindingInfo,Set{BindingOccurrence}}()
-            collect_import_using_occurrences!(binding_occurrences, st0, mod)
-            return binding_occurrences
-        end
+    k0 = JS.kind(st0)
+    if k0 in JS.KSet"export public"
+        binding_occurrences = Dict{JL.BindingInfo,Set{BindingOccurrence}}()
+        collect_export_public_occurrences!(binding_occurrences, st0, mod)
+        return binding_occurrences
+    elseif k0 in JS.KSet"import using"
+        binding_occurrences = Dict{JL.BindingInfo,Set{BindingOccurrence}}()
+        collect_import_using_occurrences!(binding_occurrences, st0, mod)
+        return binding_occurrences
     end
 
     (; ctx3, st3) = try
@@ -411,16 +413,14 @@ function compute_binding_occurrences_st0(
     end
     is_generated = is_generated0(st0)
     binding_occurrences = compute_binding_occurrences(ctx3, st3, is_generated;
-        include_global_bindings)
+        include_global_bindings = true)
 
-    if include_global_bindings
-        collect_macrocall_occurrences!(binding_occurrences, mod, st0; soft_scope)
-        # Global bindings used inside inert nodes (quoted expressions) are not
-        # resolved by scope analysis. This applies to `@generated` functions,
-        # macro definitions, and any function that constructs quoted expressions.
-        # Run independent scope resolution on inert content to collect them.
-        collect_inert_global_occurrences!(binding_occurrences, ctx3, st3, mod; soft_scope)
-    end
+    collect_macrocall_occurrences!(binding_occurrences, mod, st0; soft_scope)
+    # Global bindings used inside inert nodes (quoted expressions) are not
+    # resolved by scope analysis. This applies to `@generated` functions,
+    # macro definitions, and any function that constructs quoted expressions.
+    # Run independent scope resolution on inert content to collect them.
+    collect_inert_global_occurrences!(binding_occurrences, ctx3, st3, mod; soft_scope)
 
     return binding_occurrences
 end

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -1398,7 +1398,7 @@ function compute_unit_used_names(
 
         iterate_toplevel_tree(search_st0_top) do st0::SyntaxTreeC
             binding_occurrences = @something get_binding_occurrences!(
-                state, search_uri, search_fi, st0; include_global_bindings = true) return
+                state, search_uri, search_fi, st0) return
             mod = get_context_module(state, search_uri, offset_to_xy(search_fi, JS.first_byte(st0)))
             for (binfo_key, occurrences) in binding_occurrences
                 binfo_key.kind === :global || continue

--- a/test/analysis/test_occurrence_analysis.jl
+++ b/test/analysis/test_occurrence_analysis.jl
@@ -438,27 +438,27 @@ end
     end
 end
 
-function get_binding_occurrences_st0(text::AbstractString;
+function get_full_binding_occurrences(text::AbstractString;
         filename::String = joinpath(@__DIR__, "testfile.jl"),
-        include_global_bindings::Bool = true, kwargs...)
+        kwargs...)
     fi = JETLS.FileInfo(#=version=#0, text, filename)
     st0 = jlparse(text; rule=:statement)
     uri = filename2uri(filename)
     state = JETLS.ServerState()
-    return JETLS.compute_binding_occurrences_st0(state, uri, fi, st0;
+    return JETLS.compute_full_binding_occurrences(state, uri, fi, st0;
         lookup_func = Returns(JETLS.OutOfScope(lowering_module)),
-        include_global_bindings, kwargs...)
+        kwargs...)
 end
 
-@testset "compute_binding_occurrences_st0" begin
+@testset "compute_full_binding_occurrences" begin
     @testset "macro calls" begin
-        let boccs = get_binding_occurrences_st0("@nospecialize")
+        let boccs = get_full_binding_occurrences("@nospecialize")
             @test length(boccs) == 1
             binfo, occs = only(boccs)
             @test binfo.name == "@nospecialize"
             @test length(occs) == 1
         end
-        let boccs = get_binding_occurrences_st0("Base.@nospecialize")
+        let boccs = get_full_binding_occurrences("Base.@nospecialize")
             @test length(boccs) == 1
             binfo, occs = only(boccs)
             @test binfo.name == "Base"
@@ -467,7 +467,7 @@ end
     end
 
     @testset "export/public" begin
-        let boccs = get_binding_occurrences_st0("export foo, @bar, baz")
+        let boccs = get_full_binding_occurrences("export foo, @bar, baz")
             @test length(boccs) == 3
             for name in ("foo", "@bar", "baz")
                 i = @something findfirst(((b, _),) -> b.name == name, collect(boccs))
@@ -477,24 +477,19 @@ end
                 @test only(occs).kind === :use
             end
         end
-        let boccs = get_binding_occurrences_st0("public qux")
+        let boccs = get_full_binding_occurrences("public qux")
             @test length(boccs) == 1
             binfo, occs = only(boccs)
             @test binfo.name == "qux"
             @test binfo.kind === :global
             @test only(occs).kind === :use
         end
-        # Without `include_global_bindings`, export/public yields no occurrences
-        let boccs = get_binding_occurrences_st0("export foo";
-                                                include_global_bindings=false)
-            @test boccs !== nothing && isempty(boccs)
-        end
     end
 
     @testset "import/using" begin
         # `using M: a, b` / `import M: a, b` — each name as `:decl`
         for keyword in ("using", "import")
-            let boccs = get_binding_occurrences_st0("$keyword Base: foo, bar")
+            let boccs = get_full_binding_occurrences("$keyword Base: foo, bar")
                 @test length(boccs) == 2
                 for name in ("foo", "bar")
                     i = @something findfirst(((b, _),) -> b.name == name, collect(boccs))
@@ -506,14 +501,14 @@ end
             end
         end
         # `using M: a as b` — the alias is the local binding
-        let boccs = get_binding_occurrences_st0("using Base: foo as bar")
+        let boccs = get_full_binding_occurrences("using Base: foo as bar")
             @test length(boccs) == 1
             binfo, occs = only(boccs)
             @test binfo.name == "bar"
             @test only(occs).kind === :decl
         end
         # `import M.a` — last component is the local binding
-        let boccs = get_binding_occurrences_st0("import Base.foo")
+        let boccs = get_full_binding_occurrences("import Base.foo")
             @test length(boccs) == 1
             binfo, occs = only(boccs)
             @test binfo.name == "foo"
@@ -521,7 +516,7 @@ end
         end
         # `using M` / `import M` — the module name is the local binding
         for keyword in ("using", "import")
-            let boccs = get_binding_occurrences_st0("$keyword Base")
+            let boccs = get_full_binding_occurrences("$keyword Base")
                 @test length(boccs) == 1
                 binfo, occs = only(boccs)
                 @test binfo.name == "Base"
@@ -529,7 +524,7 @@ end
             end
         end
         # `using A, B` — each module name
-        let boccs = get_binding_occurrences_st0("using Base, LinearAlgebra")
+        let boccs = get_full_binding_occurrences("using Base, LinearAlgebra")
             @test length(boccs) == 2
             for name in ("Base", "LinearAlgebra")
                 i = @something findfirst(((b, _),) -> b.name == name, collect(boccs))
@@ -539,7 +534,7 @@ end
         end
         # `using M.a` / `import M.a` — trailing component is the local binding
         for keyword in ("using", "import")
-            let boccs = get_binding_occurrences_st0("$keyword Base.Iterators")
+            let boccs = get_full_binding_occurrences("$keyword Base.Iterators")
                 @test length(boccs) == 1
                 binfo, occs = only(boccs)
                 @test binfo.name == "Iterators"
@@ -547,7 +542,7 @@ end
             end
         end
         # Relative: `using .A` / `import ..A.B` — trailing component
-        let boccs = get_binding_occurrences_st0("using .Inner")
+        let boccs = get_full_binding_occurrences("using .Inner")
             @test length(boccs) == 1
             binfo, occs = only(boccs)
             @test binfo.name == "Inner"
@@ -558,7 +553,7 @@ end
     @testset "local declaration" begin
         only_locals(boccs) = filter(((b, _),) -> b.kind === :local, collect(boccs))
         # `local x = 1` inside a function — `x` gets `:decl` and `:def`.
-        let locals = only_locals(get_binding_occurrences_st0(
+        let locals = only_locals(get_full_binding_occurrences(
                 "function f(); local x = 1; end"))
             @test length(locals) == 1
             binfo, occs = only(locals)
@@ -568,7 +563,7 @@ end
         end
         # `local x, y` — each name recorded as `:decl` (plus `:def` from the
         # following assignment).
-        let locals = only_locals(get_binding_occurrences_st0(
+        let locals = only_locals(get_full_binding_occurrences(
                 "function f(); local x, y; x = 1; y = 2; end"))
             @test length(locals) == 2
             for name in ("x", "y")
@@ -579,7 +574,7 @@ end
             end
         end
         # Bare `local x` followed by an assignment and a use.
-        let locals = only_locals(get_binding_occurrences_st0(
+        let locals = only_locals(get_full_binding_occurrences(
                 "function f(); local x; x = 1; x; end"))
             @test length(locals) == 1
             binfo, occs = only(locals)
@@ -589,7 +584,7 @@ end
             @test count(o -> o.kind === :use, occs) == 1
         end
         # `local` also works in a `let` block.
-        let locals = only_locals(get_binding_occurrences_st0(
+        let locals = only_locals(get_full_binding_occurrences(
                 "let; local x = 1; end"))
             @test length(locals) == 1
             binfo, occs = only(locals)
@@ -601,7 +596,7 @@ end
 
     @testset "global declaration" begin
         # `global x = 1` — the name is recorded as `:decl` (plus its `:def`).
-        let boccs = get_binding_occurrences_st0("global x = 1")
+        let boccs = get_full_binding_occurrences("global x = 1")
             @test length(boccs) == 1
             binfo, occs = only(boccs)
             @test binfo.name == "x"
@@ -610,7 +605,7 @@ end
             @test count(o -> o.kind === :def, occs) == 1
         end
         # `global x, y` — each name recorded as `:decl`.
-        let boccs = get_binding_occurrences_st0("global x, y")
+        let boccs = get_full_binding_occurrences("global x, y")
             @test length(boccs) == 2
             for name in ("x", "y")
                 i = @something findfirst(((b, _),) -> b.name == name, collect(boccs))
@@ -620,18 +615,12 @@ end
             end
         end
         # Bare `global x` — single `:decl` occurrence.
-        let boccs = get_binding_occurrences_st0("global x")
+        let boccs = get_full_binding_occurrences("global x")
             @test length(boccs) == 1
             binfo, occs = only(boccs)
             @test binfo.name == "x"
             @test binfo.kind === :global
             @test only(occs).kind === :decl
-        end
-        # Without `include_global_bindings`, `global` yields no occurrences
-        # (no local/argument bindings to track).
-        let boccs = get_binding_occurrences_st0("global x = 1";
-                                                include_global_bindings=false)
-            @test boccs !== nothing && isempty(boccs)
         end
     end
 
@@ -640,7 +629,7 @@ end
     # interpolations (e.g. `K"unknown_head"` from compound assignments like `+=`)
     # so that lowering succeeds and global bindings inside the quote are recorded.
     @testset "inert content with compound assignment + interpolation" begin
-        let boccs = get_binding_occurrences_st0("""
+        let boccs = get_full_binding_occurrences("""
                 @generated function f(x)
                     return quote
                         total = 0
@@ -668,7 +657,7 @@ end
     # Note: `@mymacro` does not need to exist — the macrocall is stripped
     # before `jl_lower_for_scope_resolution` runs.
     @testset "macrocall argument with interpolation" begin
-        let boccs = get_binding_occurrences_st0("""
+        let boccs = get_full_binding_occurrences("""
                 let valid = MY_CONST
                     @mymacro something(::Type{Int}) = \$valid
                 end


### PR DESCRIPTION
`get_binding_occurrences!`'s cache key was just the byte range, but the underlying `compute_binding_occurrences_st0` accepted an `include_global_bindings` keyword that changed what was stored. All production callers happened to pass `include_global_bindings = true`, but a future caller passing `false` (or relying on the default) would poison the cache for everyone else, since the cached result could not be distinguished from the "global-included" one.

Resolve the inconsistency by removing the keyword from both `get_binding_occurrences!` and the renamed wrapper `compute_full_binding_occurrences` (formerly
`compute_binding_occurrences_st0`). The cached pipeline now unconditionally collects globals, special-case occurrences for `export`/`public`/`import`/`using` statements, macrocall scope resolution, and inert (quoted) content. Callers that only need local bindings can still use the lower-level
`compute_binding_occurrences` directly with
`include_global_bindings = false`.

The `lookup_func` keyword is preserved as an explicit argument rather than `kwargs...` so that test callers can override the context module, while making it clear that it is *not* part of the cache key — production callers all rely on the default `gen_lookup_out_of_scope!`, and tests use isolated `ServerState` instances anyway.