### PR TITLE
config: Add `block_end.enabled`, deprecate `block_end_min_lines`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Announcement
 
-> [!warning]
+> [!info]
 > JETLS requires Julia 1.12.2 or later.
 > It does not support Julia 1.12.1 or earlier, nor Julia 1.13+/nightly.
 
@@ -43,6 +43,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > ```
 > This disables analysis for matched files. Basic features like completion still might work, but most LSP features will be unfunctional.
 > Note that `analysis_overrides` is provided as a temporary workaround and may be removed or changed at any time. A proper fix is being worked on.
+
+> [!warning]
+> The `inlay_hint` configuration was reorganized into nested sub-tables so each hint kind has its own `enabled` toggle alongside its options.
+> The new shape adds [`inlay_hint.block_end.enabled`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/inlay_hint-block_end-enabled) for toggling block-end hints independently, and renames `inlay_hint.block_end_min_lines` to [`inlay_hint.block_end.min_lines`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/inlay_hint-block_end-min_lines).
+> Existing configs keep working for now: the legacy key is auto-migrated at load time with a one-shot deprecation warning. The legacy alias will be removed in a future release (around one month from now), so please update your config.
 
 ### Added
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -40,8 +40,9 @@ prepend_inference_result = false   # boolean, default: (unset) auto-detect
 references = false                 # boolean, default: false
 testrunner = true                  # boolean, default: true
 
-[inlay_hint]
-block_end_min_lines = 25           # integer, default: 25
+[inlay_hint.block_end]
+enabled = true                     # boolean, default: true
+min_lines = 25                     # integer, default: 25
 
 [testrunner]
 executable = "testrunner"          # string, default: "testrunner" (or "testrunner.bat" on Windows)
@@ -65,7 +66,9 @@ executable = "testrunner"          # string, default: "testrunner" (or "testrunn
   - [`[code_lens] references`](@ref config/code_lens-references)
   - [`[code_lens] testrunner`](@ref config/code_lens-testrunner)
 - [`[inlay_hint]`](@ref config/inlay_hint)
-  - [`[inlay_hint] block_end_min_lines`](@ref config/inlay_hint-block_end_min_lines)
+  - [`[inlay_hint.block_end]`](@ref config/inlay_hint-block_end)
+    - [`[inlay_hint.block_end] enabled`](@ref config/inlay_hint-block_end-enabled)
+    - [`[inlay_hint.block_end] min_lines`](@ref config/inlay_hint-block_end-min_lines)
 - [`[testrunner]`](@ref config/testrunner)
   - [`[testrunner] executable`](@ref config/testrunner-executable)
 
@@ -480,21 +483,33 @@ testrunner = false  # Disable TestRunner code lenses
 
 Configure inlay hint behavior.
 
-#### [`[inlay_hint] block_end_min_lines`](@id config/inlay_hint-block_end_min_lines)
+#### [`[inlay_hint.block_end]`](@id config/inlay_hint-block_end)
+
+Inlay hints displayed at block `end` keywords.
+See [Block-end hints](@ref features/inlay-hint/block-end) for details.
+
+##### [`[inlay_hint.block_end] enabled`](@id config/inlay_hint-block_end-enabled)
+
+- **Type**: boolean
+- **Default**: `true`
+
+Enable or disable block-end inlay hints.
+
+```toml
+[inlay_hint.block_end]
+enabled = false  # Disable block-end inlay hints
+```
+
+##### [`[inlay_hint.block_end] min_lines`](@id config/inlay_hint-block_end-min_lines)
 
 - **Type**: integer
 - **Default**: `25`
 
-Minimum number of lines a block must span before JETLS displays an inlay hint
-at its `end` keyword. Inlay hints show what construct is ending, such as
-`module Foo`, `function foo` or `@testset "foo"`, helping navigate long blocks.
-
-Supported block types include `module`, `function`, `macro`, `struct`,
-`if`/`@static if`, `let`, `for`, `while`, and `@testset`.
+Minimum number of lines a block must span before its `end`-tag inlay hint is displayed.
 
 ```toml
-[inlay_hint]
-block_end_min_lines = 10  # Show hints for blocks with 10+ lines
+[inlay_hint.block_end]
+min_lines = 10  # Show hints for blocks with 10+ lines
 ```
 
 ### [`[testrunner]`](@id config/testrunner)

--- a/docs/src/features.md
+++ b/docs/src/features.md
@@ -448,11 +448,13 @@ Run and re-run `@testset` blocks directly from the editor. See
 
 ## [Inlay hint](@id features/inlay-hint)
 
-Show inline annotations in the editor without modifying the source. JETLS
-currently supports block-end hints that label the construct a long `end`
-keyword closes. See
-[`[inlay_hint] block_end_min_lines`](@ref config/inlay_hint-block_end_min_lines)
-for the threshold configuration.
+### [Block-end hints](@id features/inlay-hint/block-end)
+
+Label the construct that a long `end` keyword closes — `module Foo`,
+`function foo`, `@testset "foo"`, and so on — to make navigation in long
+blocks easier.
+See [`[inlay_hint.block_end]`](@ref config/inlay_hint-block_end) for
+enable/disable and threshold configuration.
 
 > ```@raw html
 > <div class="display-light-only">

--- a/jetls-client/package.json
+++ b/jetls-client/package.json
@@ -359,12 +359,25 @@
               "additionalProperties": false,
               "markdownDescription": "Inlay hint configuration. See [Inlay hint configuration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/inlay_hint).",
               "properties": {
-                "block_end_min_lines": {
-                  "default": 25,
-                  "markdownDescription": "Minimum lines for a block to display an inlay hint at `end` (e.g., `end # module Foo`). Supports: `module`, `function`, `macro`, `struct`, `if`, `let`, `for`, `while`, `@testset`.",
-                  "maximum": 9223372036854775807,
-                  "minimum": -9223372036854775808,
-                  "type": "integer"
+                "block_end": {
+                  "additionalProperties": false,
+                  "markdownDescription": "Block-end inlay hints configuration. See [Block-end hints](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/inlay_hint-block_end).",
+                  "properties": {
+                    "enabled": {
+                      "default": true,
+                      "markdownDescription": "Enable or disable inlay hints displayed at block `end` keywords (e.g., `end # module Foo`). Supports: `module`, `function`, `macro`, `struct`, `if`, `let`, `for`, `while`, `@testset`.",
+                      "type": "boolean"
+                    },
+                    "min_lines": {
+                      "default": 25,
+                      "markdownDescription": "Minimum number of lines a block must span before its `end`-tag inlay hint is displayed.",
+                      "maximum": 9223372036854775807,
+                      "minimum": -9223372036854775808,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [],
+                  "type": "object"
                 }
               },
               "required": [],

--- a/schemas/config-toml.schema.json
+++ b/schemas/config-toml.schema.json
@@ -244,12 +244,25 @@
       "additionalProperties": false,
       "description": "Inlay hint configuration. See [Inlay hint configuration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/inlay_hint).",
       "properties": {
-        "block_end_min_lines": {
-          "default": 25,
-          "description": "Minimum lines for a block to display an inlay hint at `end` (e.g., `end # module Foo`). Supports: `module`, `function`, `macro`, `struct`, `if`, `let`, `for`, `while`, `@testset`.",
-          "maximum": 9223372036854775807,
-          "minimum": -9223372036854775808,
-          "type": "integer"
+        "block_end": {
+          "additionalProperties": false,
+          "description": "Block-end inlay hints configuration. See [Block-end hints](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/inlay_hint-block_end).",
+          "properties": {
+            "enabled": {
+              "default": true,
+              "description": "Enable or disable inlay hints displayed at block `end` keywords (e.g., `end # module Foo`). Supports: `module`, `function`, `macro`, `struct`, `if`, `let`, `for`, `while`, `@testset`.",
+              "type": "boolean"
+            },
+            "min_lines": {
+              "default": 25,
+              "description": "Minimum number of lines a block must span before its `end`-tag inlay hint is displayed.",
+              "maximum": 9223372036854775807,
+              "minimum": -9223372036854775808,
+              "type": "integer"
+            }
+          },
+          "required": [],
+          "type": "object"
         }
       },
       "required": [],

--- a/schemas/description.toml
+++ b/schemas/description.toml
@@ -55,4 +55,8 @@ references = "Show reference counts above top-level symbols (functions, structs,
 testrunner = "Show `Run`/`Debug` code lenses above `@testset` blocks. Some editors (e.g., Zed) show these as code actions, causing duplication; zed-julia defaults to false."
 
 [InlayHintConfig]
-block_end_min_lines = "Minimum lines for a block to display an inlay hint at `end` (e.g., `end # module Foo`). Supports: `module`, `function`, `macro`, `struct`, `if`, `let`, `for`, `while`, `@testset`."
+block_end = "Block-end inlay hints configuration. See [Block-end hints](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/inlay_hint-block_end)."
+
+[InlayHintBlockEndConfig]
+enabled = "Enable or disable inlay hints displayed at block `end` keywords (e.g., `end # module Foo`). Supports: `module`, `function`, `macro`, `struct`, `if`, `let`, `for`, `while`, `@testset`."
+min_lines = "Minimum number of lines a block must span before its `end`-tag inlay hint is displayed."

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -214,12 +214,24 @@
           "additionalProperties": false,
           "description": "Inlay hint configuration. See [Inlay hint configuration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/inlay_hint).",
           "properties": {
-            "block_end_min_lines": {
-              "default": 25,
-              "description": "Minimum lines for a block to display an inlay hint at `end` (e.g., `end # module Foo`). Supports: `module`, `function`, `macro`, `struct`, `if`, `let`, `for`, `while`, `@testset`.",
-              "maximum": 9223372036854775807,
-              "minimum": -9223372036854775808,
-              "type": "integer"
+            "block_end": {
+              "additionalProperties": false,
+              "description": "Block-end inlay hints configuration. See [Block-end hints](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/inlay_hint-block_end).",
+              "properties": {
+                "enabled": {
+                  "$ref": "#/$defs/Core.Bool",
+                  "default": true,
+                  "description": "Enable or disable inlay hints displayed at block `end` keywords (e.g., `end # module Foo`). Supports: `module`, `function`, `macro`, `struct`, `if`, `let`, `for`, `while`, `@testset`."
+                },
+                "min_lines": {
+                  "default": 25,
+                  "description": "Minimum number of lines a block must span before its `end`-tag inlay hint is displayed.",
+                  "maximum": 9223372036854775807,
+                  "minimum": -9223372036854775808,
+                  "type": "integer"
+                }
+              },
+              "type": "object"
             }
           },
           "type": "object"

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -7,6 +7,13 @@ const JETLS_VERSION = let
     isfile(version_file) ? strip(read(version_file, String)) : "unknown"
 end
 
+# Append `old_path => new_path` pairs to register a key migration.
+# Each path is a list of nested keys; `migrate_deprecated_config_keys!` consults this
+# table and rewrites raw user config dicts before parsing.
+const deprecated_configurations = Pair{Vector{String},Vector{String}}[
+    ["inlay_hint", "block_end_min_lines"] => ["inlay_hint", "block_end", "min_lines"],
+]
+
 const __init__hooks__ = Any[]
 push_init_hook!(hook) = push!(__init__hooks__, hook)
 function __init__()

--- a/src/config.jl
+++ b/src/config.jl
@@ -310,3 +310,52 @@ end
 
 unmatched_keys_msg(header_msg::AbstractString, unmatched_keys) =
     header_msg * "\n" * join(map(x -> string('`', join(x, "."), '`'), unmatched_keys), ", ")
+
+# Rewrite raw user config dicts so deprecated key paths land at their new
+# location before `Configurations.from_dict` sees them. Returns a list of
+# user-facing warnings — one per deprecation actually present.
+#
+# The struct schema only knows the current key paths, so callers must invoke
+# this *before* parsing. Already-migrated values win over the legacy alias.
+function migrate_deprecated_config_keys!(
+        config_dict::AbstractDict,
+        deprecated_configs::Vector{Pair{Vector{String},Vector{String}}} = deprecated_configurations
+    )
+    warnings = String[]
+    for (old_path, new_path) in deprecated_configs
+        old_parent = walk_nested_dict(config_dict, @view old_path[1:end-1])
+        old_parent === nothing && continue
+        haskey(old_parent, old_path[end]) || continue
+        old_value = pop!(old_parent, old_path[end])
+
+        new_parent = ensure_nested_dict!(config_dict, @view new_path[1:end-1])
+        if new_parent !== nothing && !haskey(new_parent, new_path[end])
+            new_parent[new_path[end]] = old_value
+        end
+
+        push!(warnings,
+            "`" * join(old_path, ".") * "` is deprecated; " *
+            "use `" * join(new_path, ".") * "` instead.")
+    end
+    return warnings
+end
+
+# Follow `path` into `d`; return the dict at the end, or `nothing` if any step
+# is missing or non-dict-shaped.
+function walk_nested_dict(d::AbstractDict, path)
+    for k in path
+        d = get(d, k, nothing)
+        d isa AbstractDict || return nothing
+    end
+    return d
+end
+
+# Like `walk_nested_dict` but creates missing intermediate dicts.
+# Returns `nothing` only if a non-dict value blocks the path.
+function ensure_nested_dict!(d::AbstractDict, path)
+    for k in path
+        d = get!(() -> Dict{String,Any}(), d, k)
+        d isa AbstractDict || return nothing
+    end
+    return d
+end

--- a/src/did-change-watched-files.jl
+++ b/src/did-change-watched-files.jl
@@ -85,6 +85,9 @@ function load_file_config!(on_difference, server::Server, filepath::AbstractStri
         parsed = TOML.tryparsefile(filepath)
         parsed isa TOML.ParserError && return old_data, nothing
 
+        for msg in migrate_deprecated_config_keys!(parsed)
+            show_warning_message(server, msg)
+        end
         new_file_config = parse_config_dict(parsed, filepath)
         if new_file_config isa AbstractString
             show_error_message(server, new_file_config)

--- a/src/inlay-hint.jl
+++ b/src/inlay-hint.jl
@@ -38,10 +38,12 @@ function handle_InlayHintRequest(
     end
     fi = result
 
-    min_lines = get_config(server, :inlay_hint, :block_end_min_lines)
     inlay_hints = InlayHint[]
-    symbols = get_document_symbols!(state, uri, fi)
-    syntactic_inlay_hints!(inlay_hints, symbols, fi, range; min_lines)
+    if get_config(server, :inlay_hint, :block_end, :enabled)
+        min_lines = get_config(server, :inlay_hint, :block_end, :min_lines)
+        symbols = get_document_symbols!(state, uri, fi)
+        syntactic_inlay_hints!(inlay_hints, symbols, fi, range; min_lines)
+    end
 
     return send(server, InlayHintResponse(;
         id = msg.id,

--- a/src/types.jl
+++ b/src/types.jl
@@ -533,8 +533,13 @@ end
     testrunner::Maybe{Bool}
 end
 
+@option struct InlayHintBlockEndConfig <: ConfigSection
+    enabled::Maybe{Bool}
+    min_lines::Maybe{Int}
+end
+
 @option struct InlayHintConfig <: ConfigSection
-    block_end_min_lines::Maybe{Int}
+    block_end::Maybe{InlayHintBlockEndConfig}
 end
 
 @option struct JETLSConfig <: ConfigSection
@@ -559,7 +564,8 @@ const DEFAULT_CONFIG = JETLSConfig(;
     formatter = "Runic",
     completion = CompletionConfig(LaTeXEmojiConfig(missing), MethodSignatureConfig(missing)),
     code_lens = CodeLensConfig(false, true),
-    inlay_hint = InlayHintConfig(25),
+    inlay_hint = InlayHintConfig(
+        InlayHintBlockEndConfig(true, 25)),
     initialization_options = DEFAULT_INIT_OPTIONS)
 
 function get_default_config(path::Symbol...)

--- a/src/workspace-configuration.jl
+++ b/src/workspace-configuration.jl
@@ -67,6 +67,9 @@ function store_lsp_config!(tracker::ConfigChangeTracker, server::Server, @nospec
         return delete_lsp_config!(tracker, server)
     end
     config_dict = config_value
+    for msg in migrate_deprecated_config_keys!(config_dict)
+        show_warning_message(server, msg)
+    end
     store!(server.state.config_manager) do old_data::ConfigManagerData
         new_lsp_config = parse_config_dict(config_dict)
         if new_lsp_config isa AbstractString

--- a/test/test_config.jl
+++ b/test/test_config.jl
@@ -313,4 +313,17 @@ end
     end
 end
 
+@testset "parse_config_dict accepts legacy `block_end_min_lines`" begin
+    deprecations = [
+        ["inlay_hint", "block_end_min_lines"] => ["inlay_hint", "block_end", "min_lines"]
+    ]
+    d = Dict{String,Any}(
+        "inlay_hint" => Dict{String,Any}(
+            "block_end_min_lines" => 7))
+    JETLS.migrate_deprecated_config_keys!(d, deprecations)
+    config = JETLS.parse_config_dict(d)
+    @test config isa JETLS.JETLSConfig
+    @test config.inlay_hint.block_end.min_lines == 7
+end
+
 end # test_config

--- a/test/test_notebook.jl
+++ b/test/test_notebook.jl
@@ -273,7 +273,9 @@ end
             # hints, and disable type inlay hints to avoid noise from
             # inferred types.
             "inlay_hint" => Dict{String,Any}(
-                "block_end_min_lines" => 0,
+                "block_end" => Dict{String,Any}(
+                    "min_lines" => 0,
+                ),
             ),
             # Use `cat` as a test formatter (just echoes input)
             "formatter" => Dict{String,Any}(


### PR DESCRIPTION
Promote `inlay_hint.block_end_min_lines` into a `block_end` sub-table that pairs the threshold with an `enabled` toggle, so block-end hints can now be turned off independently. Existing `block_end_min_lines` configs keep working: the key is auto-migrated to `block_end.min_lines` at load time with a one-shot deprecation warning shown via `window/showMessage`. The migration covers both `.JETLSConfig.toml` and the LSP-supplied config and is driven by a generic `deprecated_configurations` table, so future config renames need only one entry.

The legacy alias is scheduled for removal about one month from now.