### PR TITLE
TypeAnnotation: Resolve local closure types via `OpaqueClosure`

### DIFF
--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -95,6 +95,9 @@ include("utils/binding.jl")
 include("utils/lsp.jl")
 include("utils/server.jl")
 
+include("analysis/closure-to-opaque.jl")
+using .Closure2Opaque
+
 include("analysis/TypeAnnotation.jl")
 using .TypeAnnotation
 

--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -2,8 +2,8 @@ module TypeAnnotation
 
 using Core.IR
 using JET: CC
-using ..JETLS: JETLS_DEBUG_LOWERING, JETLS_DEV_MODE, JL, JS, SyntaxTreeC,
-    jl_lower_for_scope_resolution, traverse
+using ..JETLS: JETLS_DEBUG_LOWERING, JL, JS, SyntaxTreeC,
+    jl_lower_for_scope_resolution, rewrite_local_closures_to_opaque, traverse
 
 export InferredTreeContext, get_inferrable_tree, get_type_for_range, infer_toplevel_tree
 
@@ -19,6 +19,18 @@ struct ASTTypeAnnotator <: CC.AbstractInterpreter
     inf_params::CC.InferenceParams
     opt_params::CC.OptimizationParams
     inf_cache::Vector{CC.InferenceResult}
+    # OC `Method` → its body's `K"code_info"` SyntaxTree subtree. Populated by
+    # `register_oc_body_trees!` after a thunk's `resolve_definition_effects_in_ir`
+    # has replaced `:opaque_closure_method` Exprs with concrete `Method` objects;
+    # `finishinfer!` then annotates OC body frames CC has infered.
+    oc_body_trees::IdDict{Method,SyntaxTreeC}
+    # OC `Method`s that are pending body annotation — populated by the
+    # `abstract_eval_new_opaque_closure` override before the eager body
+    # inference runs, consumed by `finishinfer!` (annotate then delete). Ensures
+    # the body's citree is annotated from the eager `most_general_argtypes`
+    # specialization (signature view), not from per-call-site specializations
+    # — same model as top-level method bodies.
+    oc_methods_to_annotate::Set{Method}
     function ASTTypeAnnotator(
             toptree::SyntaxTreeC,
             topmi::MethodInstance;
@@ -27,9 +39,12 @@ struct ASTTypeAnnotator <: CC.AbstractInterpreter
                 aggressive_constant_propagation = true
             ),
             opt_params::CC.OptimizationParams = CC.OptimizationParams(),
-            inf_cache::Vector{CC.InferenceResult} = CC.InferenceResult[]
+            inf_cache::Vector{CC.InferenceResult} = CC.InferenceResult[],
+            oc_body_trees::IdDict{Method,SyntaxTreeC} = IdDict{Method,SyntaxTreeC}(),
+            oc_methods_to_annotate::Set{Method} = Set{Method}()
         )
-        return new(toptree, topmi, world, inf_params, opt_params, inf_cache)
+        return new(toptree, topmi, world, inf_params, opt_params, inf_cache,
+            oc_body_trees, oc_methods_to_annotate)
     end
 end
 CC.InferenceParams(interp::ASTTypeAnnotator) = interp.inf_params
@@ -44,13 +59,13 @@ CC.may_optimize(::ASTTypeAnnotator) = false
 # ASTTypeAnnotator doesn't need any sources to be cached, so discard them aggressively
 CC.transform_result_for_cache(::ASTTypeAnnotator, ::CC.InferenceResult, ::Core.SimpleVector) = nothing
 
-# `bail_out_toplevel_call(interp, sv::InferenceState) = sv.restrict_abstract_call_sites`
-# is `true` for thunk MIs (`def isa Module`), and `abstract_call_gf_by_type` then
-# refuses to infer any matching method whose `spec_types` isn't a `isdispatchtuple`
-# — i.e. methods with free type vars like `(::Type{NamedTuple{names}})(::Tuple)`,
-# whose result type would normally be `NamedTuple{names, Tuple{…}}`. Since we
-# always run inference on chunk thunks built from user-source method bodies, that
-# bail-out throws away precise types we'd otherwise have. Override to never bail.
+# `bail_out_toplevel_call(interp, sv::InferenceState) = sv.restrict_abstract_call_sites` is
+# `true` for thunk MIs (`def isa Module`), and `abstract_call_gf_by_type` then refuses to
+# infer any matching method whose `spec_types` isn't a `isdispatchtuple` — i.e. methods with
+# free type vars like `(::Type{NamedTuple{names}})(::Tuple)`, whose result type would
+# normally be `NamedTuple{names, Tuple{…}}`. Since we always run inference on top-level
+# thunks built from user-source method bodies, that bail-out throws away precise types
+# we'd otherwise have. Override to never bail.
 CC.bail_out_toplevel_call(::ASTTypeAnnotator, ::CC.InferenceState) = false
 
 function CC.concrete_eval_eligible(
@@ -67,6 +82,66 @@ function CC.concrete_eval_eligible(
         ret = :none
     end
     return ret
+end
+
+# Refine `PartialOpaque.typ`'s rt parameter using the OC body's eager inference
+# result, so the OC's static type carries the precise rt when it crosses
+# `widenconst` boundaries (most notably `Base.@default_eltype`'s
+# `Tuple{typeof(itr)}` widening in the `map(closure, vec)` chain). Without this,
+# the OC type stays `OpaqueClosure{argt, T} where T<:rt_ub` and downstream
+# `abstract_call_unknown` OC fallbacks see only `T<:Any`.
+#
+# This refinement is IPO-unsound in general — See JuliaLang/julia#61718 for the upstream
+# rejection. We accept the unsoundness here because `ASTTypeAnnotator` results never feed
+# optimization, caching, or runtime — they only drive tooling. The closure→OC rewrite already
+# accepts a class of incompleteness, so this unsoundness is also judged to be acceptable.
+# In most cases, it could become a problem when user code explicitly defines method
+# definitions for the `OpaqueClosure` type, and such cases are currently not very common.
+function CC.abstract_eval_new_opaque_closure(
+        interp::ASTTypeAnnotator, e::Expr, sstate::CC.StatementState, sv::CC.InferenceState
+    )
+    future = @invoke CC.abstract_eval_new_opaque_closure(
+        interp::CC.AbstractInterpreter, e::Expr, sstate::CC.StatementState, sv::CC.InferenceState)
+    rt_exct_effects = future[]
+    po = rt_exct_effects.rt
+    po isa CC.PartialOpaque || return future
+    CC.call_result_unused(sv, sv.currpc) && return future
+    # Mark this OC's `Method` so the eager body inference's `finishinfer!`
+    # annotates the citree (signature view, like top-level methods). The marker
+    # is consumed (deleted) atomically in `finishinfer!` itself; per-call-site
+    # specializations of the same Method find the marker missing and skip.
+    # We can't delete in this override's wrapper `Future` continuation because
+    # that continuation can run synchronously (when the inner `abstract_call_opaque_closure`
+    # returns an immediate `Future` due to in-progress / cache-hit body inference) —
+    # before the body's `finishinfer!` has actually run.
+    push!(interp.oc_methods_to_annotate, po.source)
+    # Re-run the eager body inference the default just did; CC's specialization
+    # cache absorbs the duplication and this avoids re-implementing the
+    # function's `:opaque_closure`-Expr argument-collection plumbing.
+    argtypes = CC.most_general_argtypes(po)
+    pushfirst!(argtypes, po.env)
+    arginfo, stmtinfo = CC.ArgInfo(nothing, argtypes), CC.StmtInfo(true, false)
+    callinfo = CC.abstract_call_opaque_closure(
+        interp, po, arginfo, stmtinfo, sv, #=check=#false)::CC.Future
+    return CC.Future{CC.RTEffects}(callinfo, interp, sv) do callinfo, _, _
+        refined_rt = refine_partial_opaque_rt(po, callinfo.rt)
+        return CC.RTEffects(refined_rt, rt_exct_effects.exct, rt_exct_effects.effects, rt_exct_effects.refinements)
+    end
+end
+
+function refine_partial_opaque_rt(po::CC.PartialOpaque, @nospecialize inferred_rt)
+    typ = po.typ
+    isa(typ, UnionAll) || return po
+    refined = CC.widenconst(inferred_rt)
+    (refined === Any || refined === Union{}) && return po
+    tv = typ.var
+    tv.lb <: refined <: tv.ub || return po
+    refined_typ = try
+        typ{refined}
+    catch
+        return po
+    end
+    return CC.PartialOpaque(refined_typ, po.env, po.parent, po.source)
 end
 
 # Slot type at a specific use site. `argextype(SlotNumber)` returns the joined
@@ -144,8 +219,67 @@ function CC.finishinfer!(frame::CC.InferenceState, interp::ASTTypeAnnotator, cyc
     ret = @invoke CC.finishinfer!(frame::CC.InferenceState, interp::CC.AbstractInterpreter, cycleid::Int)
     if frame.linfo === interp.topmi
         annotate_types!(interp.toptree[1], frame)
+    else
+        def = frame.linfo.def
+        # Annotate only when this is the eager body inference's `finishinfer!`
+        # (marker pushed by `abstract_eval_new_opaque_closure`); per-call-site
+        # specializations of the same Method find the marker missing and skip.
+        # The marker is consumed here (delete atomically with the annotation)
+        # so it doesn't leak into subsequent inferences in the same interp.
+        if def isa Method && def in interp.oc_methods_to_annotate
+            delete!(interp.oc_methods_to_annotate, def)
+            oc_citree = get(interp.oc_body_trees, def, nothing)
+            # `oc_citree[1]` is the body block, matching `annotate_types!`'s contract.
+            oc_citree === nothing || annotate_types!(oc_citree[1], frame)
+        end
     end
     return ret
+end
+
+# Walk `(citree, src)` and register `is_for_opaque_closure` `Method` objects
+# (the result of `resolve_definition_effects_in_ir` replacing
+# `:opaque_closure_method` Exprs in `src.code`) against the matching
+# `K"code_info"` subtree of the corresponding `K"opaque_closure_method"` syntax
+# node. Method-keyed (not CodeInfo-keyed) because `jl_method_set_source`
+# compresses the body — `frame.src` is a freshly decompressed copy and won't
+# `===` the original body `CodeInfo`.
+#
+# Recurses through each newly-registered OC's body via `Base.uncompressed_ir`
+# to register nested closures up-front. Unlike regular closures (which
+# `JL.convert_closures` hoists to top-level `:method` 3-arg statements),
+# `:opaque_closure_method` stays at the construction site, so an inner OC's
+# Method lives inside its outer OC's body — not in the thunk's top-level
+# `src.code`. Without the recursion, when CC dispatches the inner OC and
+# `finishinfer!` runs for it, the lookup against `oc_body_trees` misses.
+function register_oc_body_trees!(
+        oc_body_trees::IdDict{Method,SyntaxTreeC}, citree::SyntaxTreeC, src::CodeInfo
+    )
+    block_citree = JS.kind(citree) === JS.K"code_info" ? citree[1] : citree
+    JS.numchildren(block_citree) == length(src.code) || return oc_body_trees
+    for i = 1:length(src.code)
+        stmt = src.code[i]
+        node = block_citree[i]
+        stmt isa Method || continue
+        ocmeth = stmt
+        if ocmeth isa Method && ocmeth.is_for_opaque_closure
+            JS.kind(node) === JS.K"opaque_closure_method" || continue
+            body_citree = @something find_code_info_child(node) continue
+            haskey(oc_body_trees, ocmeth) && continue # avoid re-recursing on cycles
+            oc_body_trees[ocmeth] = body_citree
+            inner_src = Base.uncompressed_ir(ocmeth)
+            inner_src isa CodeInfo &&
+                register_oc_body_trees!(oc_body_trees, body_citree, inner_src)
+        end
+    end
+    return oc_body_trees
+end
+
+function find_code_info_child(node::SyntaxTreeC)
+    for i = 1:JS.numchildren(node)
+        c = node[i]
+        JS.kind(c) === JS.K"code_info" && return c
+    end
+    return nothing
 end
 
 # Type annotation driver
@@ -223,21 +357,21 @@ If full-analysis hasn't materialized those bindings, every user-defined name fal
 through to `Any` and method bodies are inferred against `Any` argtypes. Argument type
 instantiation simply isn't possible without the bindings being present.
 
-# Design: every chunk is an "anonymous toplevel chunk"
+# Design: "anonymous toplevel thunk" as inference unit
 
-The basic inference unit is a chunk: a `Core.CodeInfo` paired with a `SyntaxTreeC` whose
-`[1]` is the block of statements to annotate, plus a list of slot argtypes. The toplevel
-itself is such a chunk (nargs=0).
+The basic inference unit is a thunk: a `Core.CodeInfo` paired with a `SyntaxTreeC` whose
+first statement is the block of statements to annotate, plus a list of slot argtypes.
+The toplevel itself is such a thunk (nargs=0).
 
 Method definitions are handled the same way — *not* by going through `Method` /
 `MethodInstance` dispatch, but by treating each method's body `CodeInfo` as another
-anonymous chunk:
+anonymous thunk:
 
 1. We walk `inferred[1]` for `:method` 3-arg statements.
 2. For each, we statically evaluate the argtypes svec referenced from `args[2]` against
    `context_module` (`eval_to_value` follows the SSA chain in `src.code`, resolving
    `Core.apply_type`, `Core.Typeof`, `GlobalRef`, etc.).
-3. The resolved argtypes are fed to `infer_chunk!` together with the body `CodeInfo` and
+3. The resolved argtypes are fed to `infer_thunk!` together with the body `CodeInfo` and
    the corresponding `K"code_info"` subtree of `inferred`.
 
 No `Method` lookup, no dispatch, no `Base._which` — body inference needs only what's
@@ -245,7 +379,7 @@ already in `inferred` and `src.code`, plus the caller's `context_module` for res
 `GlobalRef`s in type expressions.
 
 !!! note "Why we don't let `CC.typeinf` recurse into `:method` itself"
-    The straightforward alternative would be to let inference of the toplevel chunk
+    The straightforward alternative would be to let inference of the toplevel thunk
     recurse into `:method` 3-arg statements via the usual dispatch path. That path
     doesn't reach `function f(...; kw...) end`: JuliaLowering introduces synthetic
     kwbody bindings (e.g. `var"#kw_body#f#0"`) whose names don't match the bindings
@@ -258,20 +392,19 @@ already in `inferred` and `src.code`, plus the caller's `context_module` for res
 The static-svec approach inherits a few precision losses around lowering's synthetic
 binding constructs. None of these break correctness; they only degrade types to `Any`.
 
-- **Closures.** `JL.convert_closures` hoists every closure to a toplevel `:method` 3-arg,
-  so closure body inference itself works normally — local variables, parameter types, and
-  the closure's return type are all annotated. But the closure is callable through a
-  synthetic type (`var"#closure#N"`) that isn't `getfield`-resolvable in `context_module`.
-  So:
-  - The closure's self slot resolves to `Any`, which means **captured variables**
-    (accessed via the self field) infer as `Any`.
-  - From the **enclosing function's body**, calling the closure dispatches on this
-    synthetic type, so the call site infers as `Any` and `Any`-typedness propagates
-    outward (e.g. an accumulator that sums a closure's results becomes `Any`).
+- **Closures.** Single-method local closures are rewritten to `K"_opaque_closure"` by
+  [`Closure2Opaque.rewrite_local_closures_to_opaque`](@ref) before `JL.convert_closures`,
+  so CC's native `OpaqueClosure` path handles them precisely (body, captures, and call site all infer).
+  Multi-method local closures (same name with multiple method definitions) aren't
+  representable as a single OC, so the rewrite skips them and JL's synthetic struct path
+  takes over. JL's standard runtime materializes the synthetic struct type before
+  dispatch, but `infer_toplevel_tree` deliberately avoids `Core.eval` to keep analysis
+  side-effect-free, so the synthetic type never appears in `context_module` and call
+  sites collapse to `Any`.
 
 - **Parametric methods.** TypeVars constructed via `Core.TypeVar(:T, ub)` in the argtypes
   svec are flattened to their upper bound (`val.ub`) so the slot has a usable `Type`.
-  Furthermore, the chunk's `MethodInstance` is a thunk MI (`def isa Module`); CC's
+  Furthermore, the thunk's `MethodInstance` is a thunk MI (`def isa Module`); CC's
   `sptypes_from_meth_instance` forces `EMPTY_SPTYPES` for toplevel MIs, so an
   `Expr(:static_parameter, i)` reference inside the body cannot retrieve `T` and infers
   as `Any`.
@@ -285,24 +418,30 @@ infer_toplevel_tree(args...; kwargs...) =
     (@something _infer_toplevel_tree(args...; kwargs...) return nothing).toptree
 
 function _infer_toplevel_tree(
-        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, context_module::Module;
+        ctx3::JL.VariableAnalysisContext, inferrable_tree3::SyntaxTreeC, context_module::Module;
         world::UInt = Base.get_world_counter()
     )
-    inferred = try
-        ctx4, st4 = JL.convert_closures(ctx3, st3)
+    inferrable_tree = try
+        # Route single-method local closures through `OpaqueClosure` instead of
+        # the synthetic-struct path. CC's native OC handling then resolves the
+        # closure body and call sites precisely (the synthetic-struct route
+        # collapses both to `Any` because the synthetic type isn't materialized
+        # in `context_module`).
+        st3_oc = rewrite_local_closures_to_opaque(ctx3, inferrable_tree3)
+        ctx4, st4 = JL.convert_closures(ctx3, st3_oc)
         _, st5 = JL.linearize_ir(ctx4, st4)
         st5
     catch e
         @error "infer_toplevel_tree: Lowering failed" e
         return nothing
     end |> prepare_type_attr
-    lwr = JL.to_lowered_expr(inferred)
+    lwr = JL.to_lowered_expr(inferrable_tree)
 
     Meta.isexpr(lwr, :thunk) || error("infer_toplevel_tree: Unexpected lowering result")
     src = lwr.args[1]::CodeInfo
 
-    interp = @something infer_chunk!(inferred, src, context_module, nothing, world) return nothing
-    infer_method_defs!(inferred, src, context_module, world)
+    interp = infer_thunk!(inferrable_tree, src, context_module, nothing, world)
+    infer_method_defs!(inferrable_tree, src, context_module, world)
     return interp
 end
 
@@ -314,39 +453,33 @@ end
 
 # `argtypes === nothing` keeps the `InferenceResult`'s default argtypes (intended
 # for nargs=0 thunks); a `Vector{Any}` overrides them with one entry per slot.
-function infer_chunk!(
-        tree::SyntaxTreeC, src::CodeInfo, context_module::Module,
-        argtypes::Union{Nothing, Vector{Any}}, world::UInt
-    )
+function infer_thunk!(tree::SyntaxTreeC, src::CodeInfo, context_module::Module,
+                      argtypes::Union{Nothing,Vector{Any}}, world::UInt)
     strip_latestworld!(src)
     mi = construct_toplevel_mi(src, context_module)
     interp = ASTTypeAnnotator(tree, mi; world)
+    register_oc_body_trees!(interp.oc_body_trees, tree, src)
     result = CC.InferenceResult(mi)
     if argtypes !== nothing
         # Thunk MIs have no `specTypes`-derived argtypes, so populate them
-        # explicitly to match the chunk's slot count.
+        # explicitly to match the thunk's slot count.
         empty!(result.argtypes)
         append!(result.argtypes, argtypes)
     end
-    frame = try
-        CC.InferenceState(result, src, #=cache=#:no, interp)
-    catch err
-        JETLS_DEV_MODE && @warn "infer_chunk!: InferenceState failed" err
-        return nothing
-    end
+    frame = CC.InferenceState(result, src, #=cache=#:no, interp)
     CC.typeinf(interp, frame)
     return interp
 end
 
 # `Expr(:latestworld)` syncs the current task's `world_age` to the global world counter.
-# JuliaLowering emits it after any binding-mutating op in the same chunk — `const`,
+# JuliaLowering emits it after any binding-mutating op in the same thunk — `const`,
 # `import`/`using`, method add, or the `Core.declare_global` that toplevel bare assignment
 # expands to — so subsequent stmts can see those changes at runtime. CC mirrors this by
 # flipping `currsaw_latestworld`, which makes `abstract_eval_globalref` widen every global
 # (e.g. `Main.sin`) to `Any` — a guard against mid-inference binding mutation.
 #
 # In our snapshot-typing pass that guard has no subject: full-analysis has already
-# materialized any binding changes the chunk produces into `context_module` at our fixed
+# materialized any binding changes the thunk produces into `context_module` at our fixed
 # `interp.world`, so the snapshot CC reads is already the post-mutation state, and we
 # never execute or cache the inferred result. Stripping the directive is therefore not
 # just safe but a precision win — it lets `Const` propagation survive across what would
@@ -408,7 +541,7 @@ function infer_method_defs!(
         argtypes = something(
             resolve_method_argtypes(sig_ref, src, nargs, context_module, world),
             Any[Any for _ in 1:nargs])
-        infer_chunk!(body_tree, body_codeinfo, context_module, argtypes, world)
+        infer_thunk!(body_tree, body_codeinfo, context_module, argtypes, world)
     end
     return
 end

--- a/src/analysis/closure-to-opaque.jl
+++ b/src/analysis/closure-to-opaque.jl
@@ -1,0 +1,244 @@
+module Closure2Opaque
+
+using ..JETLS: JL, JS, SyntaxTreeC
+
+export rewrite_local_closures_to_opaque
+
+"""
+    rewrite_local_closures_to_opaque(
+            ctx::JL.VariableAnalysisContext, ex::SyntaxTreeC
+        ) -> SyntaxTreeC
+
+Pre-lowering rewrite that turns single-method local closure definitions
+(`K"function_decl"` paired with a sibling `K"method_defs"`) into the equivalent
+`K"_opaque_closure"` form, so that `JL.convert_closures` routes them through its
+native `OpaqueClosure` path instead of synthesizing a struct type.
+
+This is intended for stateless static-analysis consumption: an `OpaqueClosure` is enough to
+get precise body and call-site inference without `Core.eval`'ing the synthetic closure type
+into inference context module (which the regular conversion would require).
+
+# Limitations
+
+- Multi-method bindings (a single name with multiple `K"method_defs"` anywhere in `ex`)
+  can't be represented as a single OC, so they fall through to the regular synthetic-struct
+  path. A whole-tree pre-pass (`collect_multi_method_bindings`) identifies these so the
+  per-block rewrite can skip every method definition for such bindings.
+- Bodies whose `K"method_defs"` shape doesn't match the expected
+  `(block (block (= sig_ssa svec_call) (method ...) (removable ...)))`
+  template (e.g. generated functions) are likewise left untouched.
+
+# Usage
+
+Designed to be called by `TypeAnnotation.infer_toplevel_tree` against a `K"toplevel"` /
+`K"block"` `SyntaxTreeC` produced by `JL.resolve_scopes`, before `JL.convert_closures` runs.
+The rewrite is non-destructive: nodes that don't match are returned unchanged, so the
+pipeline downstream sees an equivalent tree with only the eligible closures swapped.
+"""
+function rewrite_local_closures_to_opaque(ctx::JL.VariableAnalysisContext, ex::SyntaxTreeC)
+    multis = collect_multi_method_bindings(ex)
+    return _rewrite_local_closures_to_opaque(ctx, ex, multis)
+end
+
+function _rewrite_local_closures_to_opaque(ctx::JL.VariableAnalysisContext, ex::SyntaxTreeC, multis::Set{Int})
+    if JS.kind(ex) === JS.K"block"
+        return rewrite_closure_block(ctx, ex, multis)
+    end
+    return JS.mapchildren(c::SyntaxTreeC -> _rewrite_local_closures_to_opaque(ctx, c, multis), ctx, ex)
+end
+
+function rewrite_closure_block(
+        ctx::JL.VariableAnalysisContext, blk::SyntaxTreeC, multis::Set{Int}
+    )
+    children_old = JS.children(blk)
+    n = length(children_old)
+    new_children = JS.SyntaxList(JS.syntax_graph(ctx))
+    consumed = falses(n)
+    any_changed = false
+    for i = 1:n
+        consumed[i] && continue
+        child = children_old[i]
+        if JS.kind(child) === JS.K"function_decl" && is_local_closure_decl(ctx, child)
+            func_name = child[1]
+            md_idx = find_matching_method_defs(children_old, i, func_name.var_id, consumed)
+            if md_idx !== nothing && !(func_name.var_id in multis)
+                method_defs = children_old[md_idx]
+                oc = try_build_oc_assignment(ctx, child, method_defs)
+                if oc !== nothing
+                    push!(new_children, _rewrite_local_closures_to_opaque(ctx, oc, multis))
+                    consumed[md_idx] = true
+                    any_changed = true
+                    continue
+                end
+            end
+        end
+        push!(new_children, _rewrite_local_closures_to_opaque(ctx, child, multis))
+    end
+    any_changed || return JS.mapchildren(c::SyntaxTreeC -> _rewrite_local_closures_to_opaque(ctx, c, multis), ctx, blk)
+    return JL.@ast ctx blk [JS.K"block" new_children...]
+end
+
+# Collect `var_id`s that have more than one `K"method_defs"` anywhere in `ex`.
+# JL wraps each method definition in its own inner block, so `rewrite_closure_block`'s
+# sibling-only view can't tell a single-method binding apart from one method of a
+# multi-method binding. A whole-tree pre-pass disambiguates them. We track only the
+# "seen at least once" / "seen at least twice" distinction (no need for full counts).
+function collect_multi_method_bindings(ex::SyntaxTreeC)
+    seen = Set{Int}()
+    multis = Set{Int}()
+    stack = SyntaxTreeC[ex]
+    while !isempty(stack)
+        node = pop!(stack)
+        if JS.kind(node) === JS.K"method_defs" && JS.numchildren(node) >= 1 &&
+                JS.kind(node[1]) === JS.K"BindingId"
+            vid = node[1].var_id
+            if vid in seen
+                push!(multis, vid) # idempotent if already known multi
+            else
+                push!(seen, vid)
+            end
+        end
+        if !JS.is_leaf(node)
+            for c in JS.children(node)
+                push!(stack, c)
+            end
+        end
+    end
+    return multis
+end
+
+function is_local_closure_decl(ctx::JL.VariableAnalysisContext, fd::SyntaxTreeC)
+    JS.numchildren(fd) >= 1 || return false
+    func_name = fd[1]
+    return JS.kind(func_name) === JS.K"BindingId" &&
+        haskey(ctx.closure_bindings, func_name.var_id)
+end
+
+function find_matching_method_defs(
+        children_old, fd_idx::Int, target_var_id::Int, consumed::BitVector
+    )
+    # Search both directions; method_defs may appear before or after function_decl.
+    for j = fd_idx+1:length(children_old)
+        consumed[j] && continue
+        if is_method_defs_for(children_old[j], target_var_id)
+            return j
+        end
+    end
+    for j = 1:fd_idx-1
+        consumed[j] && continue
+        if is_method_defs_for(children_old[j], target_var_id)
+            return j
+        end
+    end
+    return nothing
+end
+
+function is_method_defs_for(c::SyntaxTreeC, target_var_id::Int)
+    return JS.kind(c) === JS.K"method_defs" && JS.numchildren(c) >= 2 &&
+        JS.kind(c[1]) === JS.K"BindingId" && c[1].var_id == target_var_id
+end
+
+# `method_defs[2]` is shaped like
+#   (block (block (= sig_ssa (call core.svec inner_argtypes_svec sparams_svec functionloc))
+#                 (method func_name sig_ssa lambda)
+#                 (removable sig_ssa)))
+# Returns `nothing` if the structure doesn't match (e.g. generated functions).
+function try_build_oc_assignment(
+        ctx::JL.VariableAnalysisContext, fd::SyntaxTreeC, method_defs::SyntaxTreeC
+    )
+    func_name = fd[1]
+    method_node, sig_call = find_method_and_sig_call(method_defs[2], func_name.var_id)
+    method_node === nothing && return nothing
+    sig_call === nothing && return nothing
+    JS.numchildren(sig_call) >= 4 || return nothing
+    inner_argtypes = sig_call[2]
+    functionloc = sig_call[4]
+    JS.kind(inner_argtypes) === JS.K"call" || return nothing
+    # `core.svec` callee + at least the function-type arg
+    JS.numchildren(inner_argtypes) >= 2 || return nothing
+
+    # The inner argtypes svec is `core.svec(function_type, user_arg_types...)`.
+    # Skip the `core.svec` callee (idx 1) and the function-type marker (idx 2);
+    # the rest are the user-visible argtypes.
+    user_argtypes = JS.SyntaxList(JS.syntax_graph(ctx))
+    for i = 3:JS.numchildren(inner_argtypes)
+        push!(user_argtypes, inner_argtypes[i])
+    end
+    nargs = length(user_argtypes)
+    isva = nargs > 0 && argtype_is_vararg(user_argtypes[end])
+
+    lambda = method_node[3]
+    JS.kind(lambda) === JS.K"lambda" || return nothing
+
+    argt = JL.@ast ctx method_defs [JS.K"call"
+        "apply_type"::JS.K"core"
+        "Tuple"::JS.K"core"
+        user_argtypes...
+    ]
+    rt_lb = JL.@ast ctx method_defs [JS.K"call" "apply_type"::JS.K"core" "Union"::JS.K"core"]
+    rt_ub = JL.@ast ctx method_defs "Any"::JS.K"core"
+
+    # `K"_opaque_closure"` children:
+    # `(binding, argt, rt_lb, rt_ub, allow_partial, nargs, isva, functionloc, lambda)`.
+    # `allow_partial = true` matches what `Base.Experimental.@opaque` emits — it tells
+    # `abstract_eval_new_opaque_closure` to keep the `PartialOpaque` lattice element rather
+    # than widening it to `OpaqueClosure{argt, T} where T`.
+    # PartialOpaque carries the body's `Method` and env, and our entire OC routing depends
+    # on call sites being able to reach the body source through it.
+    oc = JL.@ast ctx method_defs [JS.K"_opaque_closure"
+        func_name
+        argt
+        rt_lb
+        rt_ub
+        true::JS.K"Bool" # allow_partial
+        nargs::JS.K"Integer"
+        isva::JS.K"Bool"
+        functionloc
+        lambda
+    ]
+    return JL.@ast ctx method_defs [JS.K"=" func_name oc]
+end
+
+function find_method_and_sig_call(root::SyntaxTreeC, target_var_id::Int)
+    method_node = sig_call = nothing
+    stack = SyntaxTreeC[root]
+    while !isempty(stack)
+        method_node === nothing || sig_call === nothing || break
+        node = pop!(stack)
+        if JS.kind(node) === JS.K"method" && JS.numchildren(node) == 3 &&
+                JS.kind(node[1]) === JS.K"BindingId" && node[1].var_id == target_var_id
+            method_node = node
+        elseif JS.kind(node) === JS.K"=" && JS.numchildren(node) == 2 &&
+                JS.kind(node[1]) === JS.K"BindingId" &&
+                JS.kind(node[2]) === JS.K"call" && is_core_svec_call(node[2])
+            sig_call = node[2]
+        end
+        if !JS.is_leaf(node)
+            for c in JS.children(node)
+                push!(stack, c)
+            end
+        end
+    end
+    return (method_node, sig_call)
+end
+
+function is_core_svec_call(call_node::SyntaxTreeC)
+    JS.numchildren(call_node) >= 1 || return false
+    callee = call_node[1]
+    return JS.kind(callee) === JS.K"core" && JS.hasattr(callee, :name_val) &&
+        callee.name_val == "svec"
+end
+
+# Detect a vararg-typed entry in the user-argtypes svec. JL lowers both `(xs...)`
+# and `(xs::T...)` to `(call core.apply_type core.Vararg <type-arg>)`.
+function argtype_is_vararg(t::SyntaxTreeC)
+    JS.kind(t) === JS.K"call" && JS.numchildren(t) >= 2 || return false
+    callee = t[1]
+    JS.kind(callee) === JS.K"core" && JS.hasattr(callee, :name_val) &&
+        callee.name_val == "apply_type" || return false
+    inner = t[2]
+    return JS.kind(inner) === JS.K"core" && JS.hasattr(inner, :name_val) &&
+        inner.name_val == "Vararg"
+end
+
+end # module Closure2Opaque

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -7,7 +7,7 @@ using JETLS.TypeAnnotation
 using JETLS.JET: CC
 
 # Run the full pipeline a typical caller would: parse → lower → infer, then
-# wrap the chunk's inferred tree (and `st3`, used to identify user-written
+# wrap the thunk's inferred tree (and `st3`, used to identify user-written
 # return values) in an `InferredTreeContext` ready for byte-range queries.
 # Returns `(fi, ctx)` so the test can also access `fi` for `xy_to_offset` etc.
 function type_annotate(code::AbstractString, mod::Module = Main; expect_degrade::Bool=false)
@@ -74,9 +74,9 @@ end
 
 @testset "get_inferrable_tree" begin
     # `iterate_toplevel_tree` walks each top-level expression independently;
-    # `get_inferrable_tree` is invoked once per chunk. Verify it lowers all
+    # `get_inferrable_tree` is invoked once per thunk. Verify it lowers all
     # of them, not just the first.
-    @testset "valid input returns inferrable tree for each chunk" begin
+    @testset "valid input returns inferrable tree for each thunk" begin
         let code = """
             let x = 1
                 x
@@ -118,7 +118,7 @@ end
 end
 
 @testset "Inference robustness across method shapes" begin
-    # Method bodies are inferred as their own anonymous chunks: argtypes are
+    # Method bodies are inferred as their own anonymous thunks: argtypes are
     # resolved from the lowered svec, no full-analysis-defined `Method` is
     # required for the body's user-named slots.
     @testset "annotates non-kwarg method body" begin
@@ -147,8 +147,11 @@ end
         end
     end
 
-    # Closures are hoisted to toplevel `:method` 3-arg statements by
-    # `JL.convert_closures`, so the closure body itself is inferred.
+    # Single-method local closures are converted to `OpaqueClosure` form via
+    # `JL.rewrite_local_closures_to_opaque` before `convert_closures`, so CC
+    # resolves both the body and the call site precisely (synthetic-struct
+    # closures would collapse both to `Any` since their type isn't materialized
+    # in `context_module`).
     @testset "annotates closure" begin
         let code = """
             function with_closure(xs::Vector{Int})
@@ -160,21 +163,14 @@ end
             @testset "body" begin
                 @test widenconst(get_type_for_range(ctx, range_of(code, "y * 2"))) === Int
             end
-
-            # Limitation: from the enclosing function's body, calling a closure
-            # dispatches on a synthetic type that isn't in `context_module`, so the
-            # call site degrades to `Any`. Recorded as `@test_broken` to flip when
-            # the synthetic-name lookup gap is closed.
             @testset "closure call from outer body" begin
-                @test_broken widenconst(get_type_for_range(ctx, range_of(code, "inner(xs[1])"))) === Int
+                @test widenconst(get_type_for_range(ctx, range_of(code, "inner(xs[1])"))) === Int
             end
         end
 
-        # Limitation: a captured variable inside the closure body is accessed via
-        # the synthetic self type's field. Since the self slot resolves to `Any`,
-        # the captured variable infers as `Any` and `Any`-typedness propagates
-        # through any operation involving it. The reference inside the closure
-        # would otherwise be `Int` once the gap is closed.
+        # Captured variables flow through the OC's env tuple; the body's
+        # `getfield(self, i)` access (emitted by `convert_closures` in opaque
+        # mode) resolves precisely from CC's PartialOpaque env type.
         @testset "captured variable in closure body" begin
             let code = """
                 function with_capture(xs::Vector{Int})
@@ -184,7 +180,258 @@ end
                 end
                 """
                 _, ctx = type_annotate(code)
-                @test_broken widenconst(get_type_for_range(ctx, range_of(code, "y * factor"))) === Int
+                @test widenconst(get_type_for_range(ctx, range_of(code, "y * factor"))) === Int
+            end
+        end
+
+        # Multiple captures of different types — the OC's env tuple keeps each
+        # capture's type independently; integer-positional access in the body
+        # resolves each precisely.
+        @testset "multiple captures of different types" begin
+            let code = """
+                function multi_cap(xs::Vector{Int})
+                    a = 1
+                    b = 2.0
+                    inner(y::Int) = y + a + b
+                    inner(xs[1])
+                end
+                """
+                _, ctx = type_annotate(code)
+                @test widenconst(get_type_for_range(ctx, range_of(code, "y + a + b"))) === Float64
+                @test widenconst(get_type_for_range(ctx, range_of(code, "inner(xs[1])"))) === Float64
+            end
+        end
+
+        # Nested closures: the inner closure is registered eagerly via
+        # `Base.uncompressed_ir` walk of each outer OC's body, so by the time
+        # CC's depth-first inference reaches the inner OC's call site, the
+        # inner Method already has its citree mapping in `oc_body_trees`.
+        @testset "nested closures (two levels)" begin
+            let code = """
+                function nested2(xs::Vector{Int})
+                    function oc(x::Int)
+                        ic(y::Int) = x + y
+                        ic(2)
+                    end
+                    oc(xs[1])
+                end
+                """
+                _, ctx = type_annotate(code)
+                @test widenconst(get_type_for_range(ctx, range_of(code, "x + y"))) === Int
+                @test widenconst(get_type_for_range(ctx, range_of(code, "ic(2)"))) === Int
+                @test widenconst(get_type_for_range(ctx, range_of(code, "oc(xs[1])"))) === Int
+            end
+        end
+
+        # Two independent single-method closures in the same scope. The rewrite
+        # fires for both and their OCs don't interfere (each gets its own LHS
+        # binding), so each call site infers precisely.
+        @testset "sibling closures (different names)" begin
+            let code = """
+                function siblings(xs::Vector{Int})
+                    a(x::Int) = x + 1
+                    b(x::Int) = x * 2
+                    (a(xs[1]), b(xs[1]))
+                end
+                """
+                _, ctx = type_annotate(code)
+                @test widenconst(get_type_for_range(ctx, range_of(code, "a(xs[1])"))) === Int
+                @test widenconst(get_type_for_range(ctx, range_of(code, "b(xs[1])"))) === Int
+            end
+        end
+
+        # Closure A captures a variable, closure B captures closure A. CC sees
+        # B's env contain a `PartialOpaque` for A and dispatches A's call
+        # precisely.
+        @testset "closure capturing another closure" begin
+            let code = """
+                function chain(xs::Vector{Int})
+                    x = 10
+                    a(y::Int) = x + y
+                    b(z::Int) = a(z) * 2
+                    b(xs[1])
+                end
+                """
+                _, ctx = type_annotate(code)
+                @test widenconst(get_type_for_range(ctx, range_of(code, "a(z) * 2"))) === Int
+                @test widenconst(get_type_for_range(ctx, range_of(code, "b(xs[1])"))) === Int
+            end
+        end
+
+        # Body annotations are always signature-based — same model as top-level method
+        # bodies. Body inference uses the eager `most_general_argtypes(po.typ)`
+        # specialization, and per-call-site specializations only update the call site
+        # annotation (`finishinfer!`'s marker is consumed once at the eager `finishinfer!`
+        # and skipped for subsequent dispatches). The untyped multi-call shape below is the
+        # most observable demonstration: under "last-write-wins" the body would depend on
+        # which call site CC infers last; here it should be `Any`.
+        @testset "closure body annotation is signature-based" begin
+            let code = """
+                function multi_call(xs::Vector{Float64}, ys::Vector{Int})
+                    f(x) = 2x
+                    (f(xs[1]), f(ys[1]))
+                end
+                """
+                _, ctx = type_annotate(code)
+                @test widenconst(get_type_for_range(ctx, range_of(code, "2x"))) === Any
+                @test widenconst(get_type_for_range(ctx, range_of(code, "f(xs[1])"))) === Float64
+                @test widenconst(get_type_for_range(ctx, range_of(code, "f(ys[1])"))) === Int
+            end
+        end
+
+        # Reassigned captures get boxed by `convert_closures` and the body
+        # reads `Core.Box.contents::Any` — JL-side erasure that the rewrite
+        # can't lift, so we just assert the resulting `Any`.
+        @testset "reassigned captured variable boxes to Any" begin
+            let code = """
+                function box_reassign(xs::Vector{Int})
+                    counter = 0
+                    inner(y::Int) = (counter += y; counter)
+                    inner(xs[1])
+                end
+                """
+                _, ctx = type_annotate(code)
+                @test widenconst(get_type_for_range(ctx, range_of(code, "inner(xs[1])"))) === Any
+            end
+        end
+
+        # Mutation outside the closure body that targets a captured variable
+        # also forces boxing — same Box-erasure as the reassignment case.
+        @testset "captured variable mutated after closure creation" begin
+            # Take a dummy argument so the def signature and call expression
+            # are distinguishable substrings — `range_of` would otherwise
+            # match the def first.
+            let code = """
+                function box_outer_mut(xs::Vector{Int})
+                    counter = 0
+                    inner(_) = counter
+                    counter += xs[1]
+                    inner(nothing)
+                end
+                """
+                _, ctx = type_annotate(code)
+                @test widenconst(get_type_for_range(ctx, range_of(code, "inner(nothing)"))) === Any
+            end
+        end
+
+        # Closures with `::RT` annotation: the rewrite preserves the lambda's
+        # return-type assertion (we pass the entire `lambda` subtree into
+        # `K"_opaque_closure"`), so JL's `convert_closures` keeps the
+        # body-level typeassert. The call site here flows the `PartialOpaque`
+        # directly without a `widenconst` boundary, so the precise rt comes
+        # from `abstract_call_opaque_closure`'s body inference, independent of
+        # any refinement to `PartialOpaque.typ`.
+        @testset "closure with return type annotation" begin
+            let code = """
+                function with_rt_annot(xs::Vector{Float64})
+                    f(y)::Float64 = xs[1] + y
+                    f(2.0)
+                end
+                """
+                _, ctx = type_annotate(code)
+                @test widenconst(get_type_for_range(ctx, range_of(code, "f(2.0)"))) === Float64
+            end
+            let code = """
+                function with_rt_annot(xs::Vector{Float64})
+                    f(y)::Int = xs[1] + y
+                    f(2.0)
+                end
+                """
+                _, ctx = type_annotate(code)
+                @test widenconst(get_type_for_range(ctx, range_of(code, "f(2.0)"))) === Int
+            end
+            # `::typeof(captured)` resolves through the OC's env tuple, so the
+            # return type assertion still infers precisely.
+            let code = """
+                function with_computed_rt(xs::Vector{Float64})
+                    x = xs[1]
+                    f(y)::typeof(x) = x + y
+                    f(2.0)
+                end
+                """
+                _, ctx = type_annotate(code)
+                @test widenconst(get_type_for_range(ctx, range_of(code, "f(2.0)"))) === Float64
+            end
+        end
+
+        # Self-referencing closures need boxing for the self capture (the
+        # binding has no value at OC construction time), and `Box.contents`
+        # is `::Any` — same JL-side erasure as the reassigned-capture case,
+        # also present for native closures, so we just assert the `Any`.
+        @testset "self-recursive closure" begin
+            let code = """
+                function self_rec()
+                    fact(n::Int)::Int = n <= 1 ? 1 : n * fact(n - 1)
+                    fact(5)
+                end
+                """
+                _, ctx = type_annotate(code)
+                @test widenconst(get_type_for_range(ctx, range_of(code, "fact(5)"))) === Any
+            end
+        end
+
+        # Multi-method local closures fall through to JL's synthetic struct
+        # path, but `infer_toplevel_tree` skips `Core.eval`, so the synthetic
+        # type never reaches `context_module` and the call collapses. Lifting
+        # this needs sandbox-materialization on the JETLS side — broken until.
+        @testset "multi-method local closure" begin
+            let code = """
+                function with_multi_method(x::Int)
+                    f(y::Int) = y + 1
+                    f(y::String) = string(y, "!")
+                    f(x)
+                end
+                """
+                _, ctx = type_annotate(code)
+                @test_broken widenconst(get_type_for_range(ctx, range_of(code, "f(x)"))) === Int
+            end
+        end
+
+        @testset "do-block as closure argument to map" begin
+            # Typed `do x::Int`: `ASTTypeAnnotator`'s override of
+            # `abstract_eval_new_opaque_closure` refines `PartialOpaque.typ`'s
+            # rt from `OC{argt, T} where T` to `OC{argt, Int}`. The resulting
+            # `Generator{Vector{Int}, OC{argt, Int}}` is fully concrete, so
+            # the OC's rt also survives `Base._collect`'s
+            # `Compiler.return_type(first, …)` probe and sizes the result
+            # vector to `Vector{Int}`. The override is JETLS-only because the
+            # refinement is IPO-unsound for upstream Julia (`typeof(oc)`'s `R`
+            # is fixed at construction by `rt_ub`, not the body's actual
+            # return); see JuliaLang/julia#61718.
+            let code = """
+                function with_do_typed(xs::Vector{Int})
+                    map(xs) do x::Int
+                        x * 2
+                    end
+                end
+                """
+                _, ctx = type_annotate(code)
+                @test widenconst(get_type_for_range(ctx, range_of(code, "x * 2"))) === Int
+                map_call = range_of(code, "map(xs) do x::Int\n        x * 2\n    end")
+                @test widenconst(get_type_for_range(ctx, map_call)) === Vector{Int}
+            end
+
+            # Untyped `do x`: the body is annotated from the eager
+            # `most_general_argtypes(Tuple{Any})` specialization (signature view, like a
+            # top-level untyped method body), so `x * 2` is `Any`. That matches what native
+            # closure inference would expose for the method body.
+            # The call-site annotation widens to `Vector` though: the OC's rt parameter
+            # stays `T<:Any` (no concrete rt to bind from the eager body), so
+            # `Generator{Vector{Int}, F<:OC{Tuple{Any}, T}}` is non-concrete and
+            # `Base._collect` can't recover the element type. Native closures dispatch
+            # through the synthetic struct's method table and infer this as `Vector{Int}`;
+            # matching that here would need call-site-aware refinement (thus kept `@test_broken`).
+            let code = """
+                function with_do(xs::Vector{Int})
+                    map(xs) do x
+                        x * 2
+                    end
+                end
+                """
+                _, ctx = type_annotate(code)
+                @test widenconst(get_type_for_range(ctx, range_of(code, "x * 2"))) === Any
+                map_call = range_of(code, "map(xs) do x\n        x * 2\n    end")
+                @test_broken widenconst(get_type_for_range(ctx, map_call)) === Vector{Int}
             end
         end
     end
@@ -209,7 +456,7 @@ end
     end
 
     # Limitation: `Expr(:static_parameter, i)` references inside a parametric
-    # method body. The chunk's MI is a thunk MI (`def isa Module`); CC's
+    # method body. The thunk's MI is a thunk MI (`def isa Module`); CC's
     # `sptypes_from_meth_instance` forces `EMPTY_SPTYPES` for toplevel MIs,
     # so a body expression that depends on `T` can't recover its bound and
     # falls through to `Any`.
@@ -850,7 +1097,7 @@ end
         end
     end
 
-    # Top-level bare assignment `x = sin(1.0)` lowers to a chunk that
+    # Top-level bare assignment `x = sin(1.0)` lowers to a thunk that
     # prepends `Core.declare_global(Main, :x, true)` + `Expr(:latestworld)`
     # before the RHS. Without intervention the world bump would make
     # `abstract_eval_globalref` widen `Main.sin` to `Any` and the call to

--- a/test/analysis/test_closure_to_opaque.jl
+++ b/test/analysis/test_closure_to_opaque.jl
@@ -1,0 +1,244 @@
+module test_closure_to_opaque
+
+using Test
+using JETLS
+using JETLS: JL, JS, rewrite_local_closures_to_opaque
+
+# Run the rewrite + the rest of JL lowering, then `Core.eval` the resulting
+# `:thunk` so tests can assert against the runtime value the rewritten IR
+# produces. Returns `(value, st3_oc)` — `st3_oc` is the post-rewrite tree so
+# tests can assert structural facts (e.g. an OC was actually emitted).
+function rewrite_lower_eval(code::AbstractString)
+    mod = Module()
+    fi = JETLS.FileInfo(1, code, @__FILE__)
+    st0_top = JETLS.build_syntax_tree(fi)
+    last_value = Ref{Any}(nothing)
+    last_st3_oc = Ref{Union{JETLS.SyntaxTreeC,Nothing}}(nothing)
+    JETLS.iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
+        result = JETLS.TypeAnnotation.get_inferrable_tree(st0, mod)
+        result === nothing && error("get_inferrable_tree failed for: $code")
+        (; ctx3, st3) = result
+        st3_oc = rewrite_local_closures_to_opaque(ctx3, st3)
+        ctx4, st4 = JL.convert_closures(ctx3, st3_oc)
+        _, st5 = JL.linearize_ir(ctx4, st4)
+        lwr = JL.to_lowered_expr(st5)
+        last_value[] = Core.eval(mod, lwr)
+        last_st3_oc[] = st3_oc
+        return nothing
+    end
+    return (last_value[], last_st3_oc[])
+end
+
+# Variant that stops before `Core.eval`, for cases where the lowered code goes
+# through paths whose runtime requirements aren't met on the current Julia
+# (e.g. synthetic-struct closures' `declare_const` is v1.14-only). Returns the
+# post-rewrite tree only — sufficient for structural assertions like "the
+# rewrite did NOT fire for this shape".
+function rewrite_only(code::AbstractString)
+    mod = Module()
+    fi = JETLS.FileInfo(1, code, @__FILE__)
+    st0_top = JETLS.build_syntax_tree(fi)
+    last_st3_oc = Ref{Union{JETLS.SyntaxTreeC,Nothing}}(nothing)
+    JETLS.iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
+        result = JETLS.TypeAnnotation.get_inferrable_tree(st0, mod)
+        result === nothing && error("get_inferrable_tree failed for: $code")
+        (; ctx3, st3) = result
+        last_st3_oc[] = rewrite_local_closures_to_opaque(ctx3, st3)
+        return nothing
+    end
+    return last_st3_oc[]
+end
+
+# Count `K"_opaque_closure"` nodes in `tree`. Used to verify the rewrite emits
+# exactly one OC per source-level closure (no synthetic duplication).
+function count_opaque_closures(tree::JETLS.SyntaxTreeC)
+    n = JS.kind(tree) === JS.K"_opaque_closure" ? 1 : 0
+    if !JS.is_leaf(tree)
+        for c in JS.children(tree)
+            n += count_opaque_closures(c)
+        end
+    end
+    return n
+end
+
+@testset "single-method closure → OC" begin
+    let (val, tree) = rewrite_lower_eval("""
+            let f = x -> 2x
+                f(21)
+            end
+            """)
+        @test val == 42
+        @test count_opaque_closures(tree) == 1
+    end
+
+    let (val, tree) = rewrite_lower_eval("""
+            let f = (x::Int) -> x + 1
+                f(41)
+            end
+            """)
+        @test val == 42
+        @test count_opaque_closures(tree) == 1
+    end
+
+    let (val, tree) = rewrite_lower_eval("""
+            let
+                function inner(x)
+                    x * 3
+                end
+                inner(14)
+            end
+            """)
+        @test val == 42
+        @test count_opaque_closures(tree) == 1
+    end
+end
+
+@testset "captured variables" begin
+    let (val, tree) = rewrite_lower_eval("""
+            let y = 10
+                f = x -> x + y
+                f(32)
+            end
+            """)
+        @test val == 42
+        @test count_opaque_closures(tree) == 1
+    end
+
+    let (val, tree) = rewrite_lower_eval("""
+            let a = 2,
+                b = 20
+                f = x -> a*x + b
+                f(11)
+            end
+            """)
+        @test val == 42
+        @test count_opaque_closures(tree) == 1
+    end
+end
+
+@testset "return type annotation" begin
+    # Literal `::RT` on the closure: native `f(y)::T = body` lowers to
+    # `convert(T, body)::T`, and the rewrite preserves that by passing the
+    # whole `lambda` subtree into `K"_opaque_closure"` — we don't use OC's
+    # own `rt_lb`/`rt_ub` slots (which would assert without converting).
+    let (val, tree) = rewrite_lower_eval("""
+            let f(y)::Float64 = 2.0 + y
+                f(3.0)
+            end
+            """)
+        @test val === 5.0
+        @test count_opaque_closures(tree) == 1
+    end
+    # Convert-not-just-assert check: with native `convert + typeassert`
+    # semantics, `2.0 + 3.0 == 5.0` becomes `convert(Int, 5.0) === 5`.
+    # If someone later replaced this with OC's `_->Int` slot, the same
+    # body would `TypeError: expected Int, got Float64`.
+    let (val, tree) = rewrite_lower_eval("""
+            let f(y)::Int = 2.0 + y
+                f(3.0)
+            end
+            """)
+        @test val === 5
+        @test count_opaque_closures(tree) == 1
+    end
+
+    # Computed `::typeof(x)` referring to a captured variable.
+    let (val, tree) = rewrite_lower_eval("""
+            let x = 1.5
+                f(y)::typeof(x) = x + y
+                f(2.5)
+            end
+            """)
+        @test val === 4.0
+        @test count_opaque_closures(tree) == 1
+    end
+end
+
+@testset "vararg closure" begin
+    let (val, tree) = rewrite_lower_eval("""
+            let f = (xs...,) -> sum(xs)
+                f(1, 2, 3, 4, 5)
+            end
+            """)
+        @test val == 15
+        @test count_opaque_closures(tree) == 1
+    end
+end
+
+@testset "sibling closures (different names)" begin
+    # Two single-method closures in the same scope — each is independently
+    # eligible, so the rewrite fires for both and the resulting OCs don't
+    # interfere (each gets its own LHS binding).
+    let (val, tree) = rewrite_lower_eval("""
+            let
+                f = x -> 2x
+                g = x -> x + 10
+                (f(21), g(32))
+            end
+            """)
+        @test val == (42, 42)
+        @test count_opaque_closures(tree) == 2
+    end
+
+    let (val, tree) = rewrite_lower_eval("""
+            let
+                function inc(x)
+                    x + 1
+                end
+                function dbl(x)
+                    x * 2
+                end
+                (inc(41), dbl(21))
+            end
+            """)
+        @test val == (42, 42)
+        @test count_opaque_closures(tree) == 2
+    end
+end
+
+@testset "nested closures" begin
+    let (val, tree) = rewrite_lower_eval("""
+            let outer = x -> begin
+                    inner = y -> x + y
+                    inner(10)
+                end
+                outer(32)
+            end
+            """)
+        @test val == 42
+        @test count_opaque_closures(tree) == 2
+    end
+end
+
+@testset "do-block as map argument" begin
+    let (val, tree) = rewrite_lower_eval("""
+            let xs = [1, 2, 3]
+                map(xs) do x
+                    2x
+                end
+            end
+            """)
+        @test val == [2, 4, 6]
+        @test count_opaque_closures(tree) == 1
+    end
+end
+
+# Multi-method local closures aren't representable as a single OC, so the rewrite
+# must skip them and let `JL.convert_closures` produce a synthetic struct. JL wraps
+# each method definition in its own inner block, so a sibling-only count would see
+# only one `K"method_defs"` per block. The pre-pass in
+# `_collect_multi_method_bindings` walks the whole tree to count `K"method_defs"`
+# per `var_id`, which is what lets the rewrite skip both methods here.
+@testset "multi-method local closure should fall through" begin
+    let tree = rewrite_only("""
+            let
+                f(x::Int) = x + 1
+                f(x::String) = string(x, "!")
+                (f(41), f("hi"))
+            end
+            """)
+        @test count_opaque_closures(tree) == 0
+    end
+end
+
+end # module test_closure_to_opaque

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,7 @@ end
         @testset "occurrence" include("analysis/test_occurrence_analysis.jl")
         @testset "cfg" include("analysis/test_cfg_analysis.jl")
         @testset "LSAnalyzer" include("analysis/test_Analyzer.jl")
+        @testset "closure-to-opaque" include("analysis/test_closure_to_opaque.jl")
         @testset "TypeAnnotation" include("analysis/test_TypeAnnotation.jl")
     end
     @testset "types" include("test_types.jl")


### PR DESCRIPTION
The `TypeAnnotation` module (ef22f68b) routes local closures through `JL.convert_closures`'s synthetic-struct path: each closure becomes a method on a synthetic type (`var"#closure#N"`) hoisted to a toplevel `:method` 3-arg.
Because `infer_toplevel_tree` deliberately skips `Core.eval` to keep analysis side-effect-free, that synthetic type never appears in `context_module`. CC can then resolve neither `getfield(self, …)` on the closure env nor dispatch the closure's call site, so the closure body's captures and the enclosing function's call to the closure both infer as `Any`.

Fix this for the common case (single-method local closures) by routing them through CC's native `OpaqueClosure` path instead. OCs carry their `Method` directly on the value (no method-table lookup needed) and their env is a typed tuple, so CC infers both the body and the call site precisely without any `context_module` dependency.

A new pre-lowering pass `rewrite_local_closures_to_opaque` (`src/analysis/closure-to-opaque.jl`) runs before `JL.convert_closures` and turns `K"function_decl"` + `K"method_defs"` pairs for single-method local bindings into `K"_opaque_closure"` form. A whole-tree pre-pass counts `K"method_defs"` per `var_id`, so multi-method bindings (which can't fit in one OC) are skipped and fall through to the existing synthetic-struct path.

`ASTTypeAnnotator` carries an `oc_body_trees::IdDict{Method, SyntaxTreeC}` populated by `register_oc_body_trees!` after a thunk's `resolve_definition_effects_in_ir` resolves `:opaque_closure_method` Exprs to concrete `Method`s. `finishinfer!` then looks up `frame.linfo.def` to find the body's citree and annotate it.

That annotation needs to be deterministic. CC infers an OC body once at the construction site — via the eager `abstract_call_opaque_closure(check=false)` call from `abstract_eval_new_opaque_closure`, using `most_general_argtypes(po.typ)` (i.e. the signature view) — and then again at each real call site, on the per-argtypes specialization. Without coordination every `finishinfer!` for the same `Method` would overwrite the citree's `:type` attributes, leaving the body annotation dependent on which call site CC processed last. We avoid this by marking the OC's `Method` in an `oc_methods_to_annotate` `Set` from the `abstract_eval_new_opaque_closure` override before the eager inference runs; `finishinfer!` then consumes the marker atomically (annotate + delete), so only the signature-view specialization writes annotations and per-call-site specializations find the marker gone and skip. The result is the same UX rule used for top-level method bodies: body annotations reflect the signature, call-site annotations reflect actual dispatch.

That override carries one more refinement (orthogonal to the marker above): the OC's static rt parameter. It binds `PartialOpaque.typ`'s rt typevar to the eager body inference's result, so the OC type survives `widenconst` boundaries (e.g. `Base.@default_eltype`'s `Tuple{typeof(itr)}` widening inside `map`) without collapsing to `T<:rt_ub`. This refinement is IPO-unsound in general — `OpaqueClosure`'s rt parameter is fixed by `rt_ub` at construction, not by the body's actual return — and was rejected upstream (JuliaLang/julia#61718).
It's contained here because `ASTTypeAnnotator` results never feed optimization, caching, or runtime; they only drive tooling, and the closure→OC rewrite already accepts a class of incompleteness.

Tests in `test_closure_to_opaque.jl` exercise the rewrite end-to-end (parse → rewrite → lower → `Core.eval`). `test_TypeAnnotation.jl` adds closure precision tests, including a multi-call-site case that demonstrates the body annotation is deterministic (signature view) rather than tied to call site order. Box-erasure cases (reassigned/mutated captures, self-recursion) assert the documented `Any`, since they're inherent to JL's `Core.Box` strategy. The untyped `do x` `map` body asserts `Any` (signature view, matching native closure inference for the method body), but the result vector stays `@test_broken === Vector{Int}` — native closures dispatch through the synthetic struct's method table and infer it precisely; matching that here needs call-site-aware refinement on the OC's rt parameter.
Multi-method local closures stay `@test_broken` because they fall through to the synthetic-struct path and lifting them needs sandbox-materialization on the JETLS side.