### PR TITLE
test: Add `HierarchicalTestSet` for full-path failure messages

### DIFF
--- a/test/AtomicContainers/test_AtomicContainers.jl
+++ b/test/AtomicContainers/test_AtomicContainers.jl
@@ -4,6 +4,8 @@ using Test
 using JETLS.AtomicContainers
 using JETLS.AtomicContainers: CASStats, LWStats, SWStats
 
+include("../HierarchicalTestSet.jl")
+
 struct PairSnap
     a::Int
     b::Int
@@ -207,7 +209,7 @@ function stress_test_mwmr2(ContainerType;
     resetstats!(box)
 end
 
-@testset "Atomic container stress test" begin
+@testset HierarchicalTestSet "Atomic container stress test" begin
     @testset "SWMR1 SWContainer"               stress_test_swmr1(SWContainer)
     @testset "SWMR1 SWContainer (with stats)"  stress_test_swmr1(SWContainer; StatsType=SWStats)
     @testset "SWMR1 LWContainer"               stress_test_swmr1(LWContainer)

--- a/test/FixedSizeQueues/test_FixedSizeQueues.jl
+++ b/test/FixedSizeQueues/test_FixedSizeQueues.jl
@@ -3,6 +3,8 @@ module test_FixedSizeQueues
 using Test
 using JETLS.FixedSizeQueues
 
+include("../HierarchicalTestSet.jl")
+
 struct TestType
     x::Int
 end
@@ -12,149 +14,151 @@ mutable struct MutableTestType
     data::Vector{Int}
 end
 
-@testset "FixedSizeQueue basic operations" begin
-    let q = FixedSizeQueue{Int}(3)
-        @test isempty(q)
-        @test !isfull(q)
-        @test length(q) == 0
-        @test q.capacity == 3
+@testset HierarchicalTestSet "FixedSizeQueue" begin
+    @testset "basic operations" begin
+        let q = FixedSizeQueue{Int}(3)
+            @test isempty(q)
+            @test !isfull(q)
+            @test length(q) == 0
+            @test q.capacity == 3
 
-        push!(q, 1)
-        @test !isempty(q)
-        @test length(q) == 1
-        @test 1 in q
-        @test !(2 in q)
+            push!(q, 1)
+            @test !isempty(q)
+            @test length(q) == 1
+            @test 1 in q
+            @test !(2 in q)
 
-        push!(q, 2)
-        push!(q, 3)
-        @test isfull(q)
-        @test length(q) == 3
-        @test 1 in q && 2 in q && 3 in q
-    end
-
-    let q = FixedSizeQueue{Int}(3)
-        push!(q, 1)
-        push!(q, 2)
-        push!(q, 3)
-        push!(q, 4)  # Should overwrite 1
-        @test isfull(q)
-        @test length(q) == 3
-        @test !(1 in q)
-        @test 2 in q && 3 in q && 4 in q
-
-        push!(q, 5)  # Should overwrite 2
-        @test !(2 in q)
-        @test 3 in q && 4 in q && 5 in q
-    end
-end
-
-@testset "FixedSizeQueue type flexibility" begin
-    let q = FixedSizeQueue(2)
-        push!(q, "hello")
-        push!(q, 42)
-        @test "hello" in q
-        @test 42 in q
-
-        push!(q, :symbol)
-        @test !("hello" in q)
-        @test 42 in q
-        @test :symbol in q
-    end
-
-    let q = FixedSizeQueue{TestType}(2)
-        t1 = TestType(1)
-        t2 = TestType(2)
-        t3 = TestType(3)
-
-        push!(q, t1)
-        push!(q, t2)
-        @test t1 in q
-        @test t2 in q
-
-        push!(q, t3)
-        @test !(t1 in q)
-        @test t2 in q
-        @test t3 in q
-    end
-end
-
-@testset "FixedSizeQueue edge cases" begin
-    let q = FixedSizeQueue{String}(1)
-        push!(q, "a")
-        @test "a" in q
-        push!(q, "b")
-        @test !("a" in q)
-        @test "b" in q
-    end
-
-    @test_throws ArgumentError FixedSizeQueue{Int}(0)
-    @test_throws ArgumentError FixedSizeQueue{Int}(-1)
-end
-
-@testset "FixedSizeQueue collect and display" begin
-    let q = FixedSizeQueue{Int}(3)
-        push!(q, 1)
-        push!(q, 2)
-        push!(q, 3)
-
-        items = collect(q)
-        @test items == [1, 2, 3]
-
-        push!(q, 4)  # Overwrites 1
-        items = collect(q)
-        @test items == [2, 3, 4]
-
-        str = string(q)
-        @test occursin("FixedSizeQueue{Int", str)
-        @test occursin("capacity=3", str)
-        @test occursin("[2, 3, 4]", str)
-    end
-end
-
-@testset "FixedSizeQueue large capacity" begin
-    let q = FixedSizeQueue{Union{Int,String}}(1000)
-        for i in 1:500
-            push!(q, i)
-        end
-        for i in 501:1000
-            push!(q, "id-$i")
+            push!(q, 2)
+            push!(q, 3)
+            @test isfull(q)
+            @test length(q) == 3
+            @test 1 in q && 2 in q && 3 in q
         end
 
-        @test isfull(q)
-        @test 1 in q
-        @test 500 in q
-        @test "id-501" in q
-        @test "id-1000" in q
+        let q = FixedSizeQueue{Int}(3)
+            push!(q, 1)
+            push!(q, 2)
+            push!(q, 3)
+            push!(q, 4)  # Should overwrite 1
+            @test isfull(q)
+            @test length(q) == 3
+            @test !(1 in q)
+            @test 2 in q && 3 in q && 4 in q
 
-        push!(q, "extra-1")
-        @test !(1 in q)  # First element should be evicted
-        @test 2 in q      # Second element should still be there
-        @test "extra-1" in q
+            push!(q, 5)  # Should overwrite 2
+            @test !(2 in q)
+            @test 3 in q && 4 in q && 5 in q
+        end
+    end
 
-        for i in 1:100
-            push!(q, "new-$i")
+    @testset "type flexibility" begin
+        let q = FixedSizeQueue(2)
+            push!(q, "hello")
+            push!(q, 42)
+            @test "hello" in q
+            @test 42 in q
+
+            push!(q, :symbol)
+            @test !("hello" in q)
+            @test 42 in q
+            @test :symbol in q
         end
 
-        @test !(2 in q)
-        @test !(100 in q)
-        @test "new-100" in q
+        let q = FixedSizeQueue{TestType}(2)
+            t1 = TestType(1)
+            t2 = TestType(2)
+            t3 = TestType(3)
+
+            push!(q, t1)
+            push!(q, t2)
+            @test t1 in q
+            @test t2 in q
+
+            push!(q, t3)
+            @test !(t1 in q)
+            @test t2 in q
+            @test t3 in q
+        end
     end
-end
 
-@testset "FixedSizeQueue garbage collection" begin
-    let q = FixedSizeQueue{MutableTestType}(2)
-        obj1 = MutableTestType(1, [1,2,3])
-        obj2 = MutableTestType(2, [4,5,6])
-        obj3 = MutableTestType(3, [7,8,9])
+    @testset "edge cases" begin
+        let q = FixedSizeQueue{String}(1)
+            push!(q, "a")
+            @test "a" in q
+            push!(q, "b")
+            @test !("a" in q)
+            @test "b" in q
+        end
 
-        push!(q, obj1)
-        push!(q, obj2)
-        push!(q, obj3)
+        @test_throws ArgumentError FixedSizeQueue{Int}(0)
+        @test_throws ArgumentError FixedSizeQueue{Int}(-1)
+    end
 
-        @test obj2 in q
-        @test obj3 in q
-        @test !(obj1 in q.data)
-        @test !(obj1 in q.items)
+    @testset "collect and display" begin
+        let q = FixedSizeQueue{Int}(3)
+            push!(q, 1)
+            push!(q, 2)
+            push!(q, 3)
+
+            items = collect(q)
+            @test items == [1, 2, 3]
+
+            push!(q, 4)  # Overwrites 1
+            items = collect(q)
+            @test items == [2, 3, 4]
+
+            str = string(q)
+            @test occursin("FixedSizeQueue{Int", str)
+            @test occursin("capacity=3", str)
+            @test occursin("[2, 3, 4]", str)
+        end
+    end
+
+    @testset "large capacity" begin
+        let q = FixedSizeQueue{Union{Int,String}}(1000)
+            for i in 1:500
+                push!(q, i)
+            end
+            for i in 501:1000
+                push!(q, "id-$i")
+            end
+
+            @test isfull(q)
+            @test 1 in q
+            @test 500 in q
+            @test "id-501" in q
+            @test "id-1000" in q
+
+            push!(q, "extra-1")
+            @test !(1 in q)  # First element should be evicted
+            @test 2 in q      # Second element should still be there
+            @test "extra-1" in q
+
+            for i in 1:100
+                push!(q, "new-$i")
+            end
+
+            @test !(2 in q)
+            @test !(100 in q)
+            @test "new-100" in q
+        end
+    end
+
+    @testset "garbage collection" begin
+        let q = FixedSizeQueue{MutableTestType}(2)
+            obj1 = MutableTestType(1, [1,2,3])
+            obj2 = MutableTestType(2, [4,5,6])
+            obj3 = MutableTestType(3, [7,8,9])
+
+            push!(q, obj1)
+            push!(q, obj2)
+            push!(q, obj3)
+
+            @test obj2 in q
+            @test obj3 in q
+            @test !(obj1 in q.data)
+            @test !(obj1 in q.items)
+        end
     end
 end
 

--- a/test/HierarchicalTestSet.jl
+++ b/test/HierarchicalTestSet.jl
@@ -1,0 +1,61 @@
+using Test
+
+# Custom test set that prints the full testset path on failure (e.g. `outer > middle > leaf:`)
+# instead of just the innermost description that `DefaultTestSet` prints. Specify on the
+# outermost `@testset` only; nested `@testset` invocations inherit the type via Test.jl's
+# `testsettype` propagation.
+struct HierarchicalTestSet <: Test.AbstractTestSet
+    __hierarchical_testset_inner__::Test.DefaultTestSet
+end
+HierarchicalTestSet(desc::AbstractString; kws...) =
+    HierarchicalTestSet(Test.DefaultTestSet(desc; kws...))
+
+# Duck-typed description lookup for the failure path renderer.
+# `Test.AbstractTestSet`'s public protocol is just `record` / `finish` —
+# `description` is an internal detail of `DefaultTestSet`, so we can't assume it on
+# arbitrary testsets (e.g. `TestRunner.TestRunnerTestSet`).
+#
+# `HierarchicalTestSet` is detected by the `:__hierarchical_testset_inner__` field name
+# rather than by type, because `setup.jl` is included by both `runtests.jl` (in `Main`) and
+# each `test_XXX.jl` (inside `module test_XXX`), so `HierarchicalTestSet` ends up defined as
+# distinct types per each test module and a single dispatch wouldn't cover both.
+# Anything else falls back to the type name so the renderer never crashes on an
+# unrecognized wrapping testset.
+function ts_description(ts::Test.AbstractTestSet)
+    if hasfield(typeof(ts), :__hierarchical_testset_inner__) && isdefined(ts, :__hierarchical_testset_inner__)
+        inner = ts.__hierarchical_testset_inner__
+        inner isa Test.DefaultTestSet && return inner.description
+    end
+    ts isa Test.DefaultTestSet && return ts.description
+    return string(typeof(ts))
+end
+
+function Test.record(ts::HierarchicalTestSet, t::Union{Test.Fail, Test.Error};
+                     print_result::Bool = Test.TESTSET_PRINT_ENABLE[])
+    if print_result
+        stack = get(task_local_storage(), :__BASETESTNEXT__, Test.AbstractTestSet[])::Vector{Test.AbstractTestSet}
+        printstyled(stdout, "[Testset Path] "; bold=true, color=:light_black)
+        n = length(stack)
+        for (i,s) in enumerate(stack)
+            printstyled(stdout, ts_description(s); bold=true)
+            i == n || printstyled(stdout, " > "; color=:light_black)
+        end
+        println(stdout)
+        if !(t isa Test.Error) || t.test_type !== :test_interrupted
+            s = sprint(; context=IOContext(stdout)) do io
+                print(io, t)
+                t isa Test.Error || Base.show_backtrace(io,
+                    Test.scrub_backtrace(backtrace(), ts.__hierarchical_testset_inner__.file, Test.extract_file(t.source)))
+                println(io)
+            end
+            for l in split(s, '\n')
+                println(stdout, "  ", l)
+            end
+        end
+    end
+    push!(ts.__hierarchical_testset_inner__.results, t)
+    (Test.FAIL_FAST[] || ts.__hierarchical_testset_inner__.failfast) && throw(Test.FailFastError())
+    return t
+end
+Test.record(ts::HierarchicalTestSet, t) = Test.record(ts.__hierarchical_testset_inner__, t)
+Test.finish(ts::HierarchicalTestSet) = Test.finish(ts.__hierarchical_testset_inner__)

--- a/test/analysis/test_cfg_analysis.jl
+++ b/test/analysis/test_cfg_analysis.jl
@@ -28,7 +28,7 @@ function get_undef_status(text::AbstractString; mod::Module=lowering_module, all
     return result
 end
 
-@testset "undef analysis" begin
+@testset HierarchicalTestSet "undef analysis" begin
 
 @testset "sequential assignment then use" begin
     # Variable is assigned before use - definitely defined
@@ -1110,7 +1110,7 @@ function get_dead_stores(text::AbstractString;
     return result
 end
 
-@testset "dead store analysis" begin
+@testset HierarchicalTestSet "dead store analysis" begin
 
 @testset "simple use, no dead stores" begin
     ds = get_dead_stores("""
@@ -1451,7 +1451,7 @@ function get_unreachable_statements(text::AbstractString;
     return [JS.sourcetext(p) for p in provs]
 end
 
-@testset "unreachable statement analysis" begin
+@testset HierarchicalTestSet "unreachable statement analysis" begin
 
 @testset "unreachable after return" begin
     let urs = get_unreachable_statements("""

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ end
 @testset "AtomicContainers" include("AtomicContainers/test_AtomicContainers.jl")
 @testset "FixedSizeQueues" include("FixedSizeQueues/test_FixedSizeQueues.jl")
 
-@testset "JETLS" verbose=true begin
+@testset HierarchicalTestSet "JETLS" verbose=true begin
     @testset "utils" verbose=true begin
         @testset "general" include("utils/test_general.jl")
         @testset "ast" include("utils/test_ast.jl")

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -6,6 +6,8 @@ using JETLS.URIs2
 
 using JETLS: get_text_and_positions
 
+include("HierarchicalTestSet.jl")
+
 """
     wait_for_file_cache_version(state::JETLS.ServerState, uri::URI, version::Int; timeout::Float64=10.0)
 

--- a/test/test_definition.jl
+++ b/test/test_definition.jl
@@ -3,6 +3,8 @@ module test_definition
 using Test
 using JETLS
 
+include("setup.jl")
+
 @testset "method location" begin
     linenum = @__LINE__; method_for_test_method_definition_range() = 1
     @assert length(methods(method_for_test_method_definition_range)) == 1
@@ -24,8 +26,6 @@ const LINE_TestModuleDefinitionRange = (@__LINE__) - 3
     @test JETLS.URIs2.uri2filepath(loc.uri) == @__FILE__
     @test loc.range.start.line == LINE_TestModuleDefinitionRange-1
 end
-
-include("setup.jl")
 
 # Full-analysis helper — use this only for tests that exercise the
 # reflection-based fallback (`Base` symbols, module `moduleloc`, etc.).
@@ -74,7 +74,7 @@ function with_find_definition(tester, text::AbstractString; kwargs...)
     return cnt
 end
 
-@testset "'Definition' for modules and methods" begin
+@testset HierarchicalTestSet "'Definition' for modules and methods" begin
     @testset "function definition" begin
         @test with_find_definition("""
             func(x) = 1
@@ -225,7 +225,7 @@ end
 
 end
 
-@testset "'Definition' for local bindings" begin
+@testset HierarchicalTestSet "'Definition' for local bindings" begin
     @testset "local definition" begin
         @test with_find_definition("""
             function func(x, y)

--- a/test/test_diagnostic.jl
+++ b/test/test_diagnostic.jl
@@ -576,7 +576,7 @@ function make_test_manager(config_dict::Dict{String,Any})
     return JETLS.ConfigManager(data)
 end
 
-@testset "diagnostic configuration" begin
+@testset HierarchicalTestSet "diagnostic configuration" begin
     @testset "DiagnosticConfig parsing/validation" begin
         @testset "valid patterns" begin
             let config_raw = Dict{String,Any}()

--- a/test/test_document_highlight.jl
+++ b/test/test_document_highlight.jl
@@ -23,7 +23,7 @@ function highlight_testcase(code::AbstractString, n::Int)
     return fi, positions
 end
 
-@testset "document_highlights!" begin
+@testset HierarchicalTestSet "document_highlights!" begin
     @testset "local binding highlights" begin
         let code = """
             function func(│xx│x│, yyy)

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -38,7 +38,7 @@ end
 
 length_utf16(s::AbstractString) = sum(c::Char -> codepoint(c) < 0x10000 ? 1 : 2, collect(s); init=0)
 
-@testset "unused binding detection" begin
+@testset HierarchicalTestSet "unused binding detection" begin
     let diagnostics = get_lowered_diagnostics("""
         y = let x = 42
             sin(42)
@@ -686,7 +686,7 @@ let filename = normpath(pkgdir(JETLS), "test", "fixtures", "macros-JL.jl")
     JL.include_string(@__MODULE__, read(filename,String), filename)
 end
 
-@testset "JuliaLowering error diagnostics" begin
+@testset HierarchicalTestSet "JuliaLowering error diagnostics" begin
     @testset "lowering error diagnostics" begin
         diagnostics = get_lowered_diagnostics(@__MODULE__, "macro foo(x, y) \$(x) end")
         @test length(diagnostics) == 1
@@ -810,7 +810,7 @@ module TestLoweringUndefGlobalBinding
 const myfunc = (x) -> x
 end
 
-@testset "Undefined global binding report" begin
+@testset HierarchicalTestSet "Undefined global binding report" begin
     @test isempty(get_lowered_diagnostics(@__MODULE__, "let x = 42; println(sin(x)); end"))
     let diagnostics = get_lowered_diagnostics(@__MODULE__, """let x = 42
             undeffunc(x)
@@ -851,7 +851,7 @@ end
     """))
 end
 
-@testset "Undefined local binding report" begin
+@testset HierarchicalTestSet "Undefined local binding report" begin
     @testset "sequential assignment then use - no diagnostic" begin
         @test isempty(get_lowered_diagnostics("""
             function f()
@@ -1073,7 +1073,7 @@ end
     end
 end
 
-@testset "dead store detection" begin
+@testset HierarchicalTestSet "dead store detection" begin
     @testset "assignment at end of function is dead" begin
         let diagnostics = get_lowered_diagnostics("""
             function foo(x::Bool)
@@ -1204,7 +1204,7 @@ end
     end
 end
 
-@testset "captured boxed variable detection" begin
+@testset HierarchicalTestSet "captured boxed variable detection" begin
     # Variable modified after capture -> boxed
     let diagnostics = get_lowered_diagnostics("""
         function foo()
@@ -1489,7 +1489,7 @@ function get_unused_import_diagnostics(text::AbstractString)
     return JETLS.analyze_unused_imports(server, uri, fi, st0_top; skip_context_check=true)
 end
 
-@testset "unused imports detection" begin
+@testset HierarchicalTestSet "unused imports detection" begin
     let diagnostics = get_unused_import_diagnostics("""
         using Base: sin, cos
         sin(1.0)
@@ -1627,7 +1627,7 @@ end
     end
 end
 
-@testset "unreachable code detection" begin
+@testset HierarchicalTestSet "unreachable code detection" begin
     let diagnostics = get_lowered_diagnostics("""
         function foo()
             return 1
@@ -2123,7 +2123,7 @@ module soft_scope_module
     global x = 1
 end
 
-@testset "ambiguous soft scope detection" begin
+@testset HierarchicalTestSet "ambiguous soft scope detection" begin
     let diagnostics = get_lowered_diagnostics(soft_scope_module, """
         for _ = 1:10
             x = 2
@@ -2209,7 +2209,7 @@ end
     end
 end
 
-@testset "unresolved goto detection" begin
+@testset HierarchicalTestSet "unresolved goto detection" begin
     # forward goto with matching label — no diagnostic
     let diagnostics = get_lowered_diagnostics("""
         begin
@@ -2281,7 +2281,7 @@ end
     end
 end
 
-@testset "unused label detection" begin
+@testset HierarchicalTestSet "unused label detection" begin
     let diagnostics = get_lowered_diagnostics("""
         function f()
             @label unused

--- a/test/test_references.jl
+++ b/test/test_references.jl
@@ -17,7 +17,7 @@ function find_references(code::AbstractString, pos::Position; include_declaratio
     return locations
 end
 
-@testset "find_references" begin
+@testset HierarchicalTestSet "find_references" begin
     @testset "local binding references" begin
         let code = """
             function func(│xx│x│, yyy)


### PR DESCRIPTION
Introduce `HierarchicalTestSet` (in `test/HierarchicalTestSet.jl`), an `AbstractTestSet` that wraps a `DefaultTestSet` and overrides `record` to print the full testset path
(`outer > middle > leaf`) on failure, instead of just the innermost description that `DefaultTestSet` shows. Specify on the outermost `@testset` only; nested ones inherit the type via Test.jl's `testsettype` propagation.

The path renderer (`ts_description`) detects sibling `HierarchicalTestSet` instances by the unique
`:__hierarchical_testset_inner__` field name rather than by type, because `HierarchicalTestSet.jl` is included by both `runtests.jl` (in `Main`) and each `test_XXX.jl` (inside `module test_XXX`), so the type ends up defined separately per module and a single dispatch wouldn't cover both. Other testsets are matched only via `Test.DefaultTestSet`'s public `description`; anything else (e.g. `TestRunner.TestRunnerTestSet`) falls back to the type name to keep the renderer crash-free without assuming non-public internals.