### PR TITLE
testrunner: Run tests against the live editor buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `textDocument/diagnostic` now returns an unchanged report when neither the document nor its analysis-unit siblings have changed since the previous pull, skipping diagnostic recomputation. This reduces redundant work on clients that aggressively re-pull diagnostics across all open files on each edit (e.g., Zed).
 
+- Test runner code lens / code action now runs against the current editor buffer rather than the saved file. JETLS pipes the live buffer to the `testrunner` subprocess over stdin, so unsaved edits (including brand-new `@testset` / `@test` cases) execute as-is and the previous "Save the file first to run tests" error no longer occurs.
+  This requires upgrading the `testrunner` CLI to a version that understands the `--read-stdin` flag. Reinstall the latest release with:
+  ```bash
+  julia -e 'using Pkg; Pkg.Apps.add(; url="https://github.com/aviatesk/TestRunner.jl", rev="release")'
+  ```
+  and confirm the upgrade by running `testrunner --help` and checking that `--read-stdin` appears under `Options:`.
+
 ## 2026-05-05
 
 - Commit: [`563fd7e`](https://github.com/aviatesk/JETLS.jl/commit/563fd7e)
@@ -710,7 +717,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated TestRunner.jl installation instructions to use the `#release` branch
   for vendored dependencies. TestRunner.jl should now be installed via
   ```bash
-  julia -e 'using Pkg; Pkg.Apps.add(url="https://github.com/aviatesk/TestRunner.jl#release")'
+  julia -e 'using Pkg; Pkg.Apps.add(; url="https://github.com/aviatesk/TestRunner.jl", rev="release")'
   ```
   (aviatesk/TestRunner.jl#14).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `textDocument/diagnostic` now returns an unchanged report when neither the document nor its analysis-unit siblings have changed since the previous pull, skipping diagnostic recomputation. This reduces redundant work on clients that aggressively re-pull diagnostics across all open files on each edit (e.g., Zed).
 
 - Test runner code lens / code action now runs against the current editor buffer rather than the saved file. JETLS pipes the live buffer to the `testrunner` subprocess over stdin, so unsaved edits (including brand-new `@testset` / `@test` cases) execute as-is and the previous "Save the file first to run tests" error no longer occurs.
+  The integration also works for buffers (`untitled:` for VSCode / `buffer:` for Sublime Text) that have never been saved to disk: relative `include` calls in the buffer resolve from the workspace root.
   This requires upgrading the `testrunner` CLI to a version that understands the `--read-stdin` flag. Reinstall the latest release with:
   ```bash
   julia -e 'using Pkg; Pkg.Apps.add(; url="https://github.com/aviatesk/TestRunner.jl", rev="release")'

--- a/docs/src/testrunner.md
+++ b/docs/src/testrunner.md
@@ -184,9 +184,13 @@ If you see an error about `testrunner` not being found:
    `which testrunner`: otherwise you may need to add `~/.julia/bin` to `PATH`
 3. Restart your editor to ensure it picks up the updated `PATH`
 
-Test execution streams the current editor buffer to `testrunner` over stdin,
-so saving the file is not required and unsaved edits run as-is. This needs a
-`testrunner` CLI new enough to recognize the `--read-stdin` flag — if tests
-fail to start with an "Unknown option" error, reinstall `testrunner` (see
-[Prerequisites](@ref testrunner/prerequisites)) and confirm that
-`testrunner --help` lists `--read-stdin` under `Options:`.
+Starting with releases on or after 2026-05-06, test execution streams the
+current editor buffer to `testrunner` over stdin, so saving the file is not
+required and unsaved edits run as-is — including buffers (`untitled:` for
+VSCode / `buffer:` for Sublime Text) that have never been saved to disk,
+where relative `include` calls resolve from the workspace root.
+
+This needs a `testrunner` CLI new enough to recognize the `--read-stdin`
+flag — if tests fail to start with an "Unknown option" error, reinstall
+`testrunner` (see [Prerequisites](@ref testrunner/prerequisites)) and confirm
+that `testrunner --help` lists `--read-stdin` under `Options:`.

--- a/docs/src/testrunner.md
+++ b/docs/src/testrunner.md
@@ -9,7 +9,7 @@ development environment.
 
 To use this feature, you need to install the `testrunner` executable:
 ```bash
-julia -e 'using Pkg; Pkg.Apps.add(url="https://github.com/aviatesk/TestRunner.jl#release")'
+julia -e 'using Pkg; Pkg.Apps.add(; url="https://github.com/aviatesk/TestRunner.jl", rev="release")'
 ```
 
 Note that you need to manually make `~/.julia/bin` available on the `PATH`
@@ -184,6 +184,9 @@ If you see an error about `testrunner` not being found:
    `which testrunner`: otherwise you may need to add `~/.julia/bin` to `PATH`
 3. Restart your editor to ensure it picks up the updated `PATH`
 
-Test execution requires that your file is saved and matches the on-disk version.
-If you see a message asking you to save the file first, make sure to save your
-changes before running tests.
+Test execution streams the current editor buffer to `testrunner` over stdin,
+so saving the file is not required and unsaved edits run as-is. This needs a
+`testrunner` CLI new enough to recognize the `--read-stdin` flag — if tests
+fail to start with an "Unknown option" error, reinstall `testrunner` (see
+[Prerequisites](@ref testrunner/prerequisites)) and confirm that
+`testrunner --help` lists `--read-stdin` under `Options:`.

--- a/src/testrunner/testrunner.jl
+++ b/src/testrunner/testrunner.jl
@@ -297,25 +297,38 @@ function testrunner_testcase_code_actions!(
     return code_actions
 end
 
+# Returns the workspace root to feed `testrunner` as `--root-path`, but only
+# when needed: for unsaved (`untitled:`/`buffer:`) URIs the `filepath` we send
+# has no `dirname`, so the runner needs an explicit base for relative
+# `include` calls. Saved files have a real `dirname` and should rely on it.
+function testrunner_root_path(state::ServerState, uri::URI)
+    isunsaveduri(uri) || return nothing
+    return isdefined(state, :root_path) ? state.root_path : nothing
+end
+
 # `@testset` execution
-function testrunner_cmd(executable::String, filepath::String, tsn::String, tsl::Int, test_env_path::Union{Nothing,String})
+function testrunner_cmd(executable::String, filepath::String, tsn::String, tsl::Int,
+                        test_env_path::Union{Nothing,String},
+                        root_path::Union{Nothing,String})
     tsn = rlstrip(tsn, '"')
     testrunner_exe = Sys.which(executable)
-    if isnothing(test_env_path)
-        return `$testrunner_exe --verbose --json --read-stdin $filepath $tsn --filter-lines=$tsl`
-    else
-        return `$testrunner_exe --verbose --project=$test_env_path --json --read-stdin $filepath $tsn --filter-lines=$tsl`
-    end
+    project_args = isnothing(test_env_path) ? `` : `--project=$test_env_path`
+    # `--root-path` only matters when `filepath` is a virtual identifier
+    # (no `dirname`); for saved files we omit it to avoid implying a
+    # workspace-relative include base that doesn't apply.
+    root_args = isnothing(root_path) ? `` : `--root-path=$root_path`
+    return `$testrunner_exe --verbose $project_args $root_args --json --read-stdin $filepath $tsn --filter-lines=$tsl`
 end
 
 # `@test` execution
-function testrunner_cmd(executable::String, filepath::String, tcl::Int, test_env_path::Union{Nothing,String})
+function testrunner_cmd(executable::String, filepath::String, tcl::Int,
+                        test_env_path::Union{Nothing,String},
+                        root_path::Union{Nothing,String})
     testrunner_exe = Sys.which(executable)
-    if isnothing(test_env_path)
-        return `$testrunner_exe --verbose --json --read-stdin $filepath L$tcl`
-    else
-        return `$testrunner_exe --verbose --project=$test_env_path --json --read-stdin $filepath L$tcl`
-    end
+    project_args = isnothing(test_env_path) ? `` : `--project=$test_env_path`
+    # See the `@testset` overload for the rationale behind `--root-path`.
+    root_args = isnothing(root_path) ? `` : `--root-path=$root_path`
+    return `$testrunner_exe --verbose $project_args $root_args --json --read-stdin $filepath L$tcl`
 end
 
 function testrunner_diagnostic_to_related_information(diagnostic::TestRunnerDiagnostic)
@@ -520,7 +533,8 @@ function _testrunner_run_testset(
 
     tsl = testset_line(fi.testsetinfos[idx])
     test_env_path = find_uri_env_path(server.state, uri)
-    cmd = testrunner_cmd(executable, filepath, tsn, tsl, test_env_path)
+    root_path = testrunner_root_path(server.state, uri)
+    cmd = testrunner_cmd(executable, filepath, tsn, tsl, test_env_path, root_path)
     source = JS.sourcetext(fi.parsed_stream)
     testrunnerproc = open(pipeline(cmd; stdin=IOBuffer(source)); read=true)
 
@@ -650,7 +664,8 @@ function _testrunner_run_testcase(
         cancellable_token::Union{Nothing,CancellableToken} = nothing
     )
     test_env_path = find_uri_env_path(server.state, uri)
-    cmd = testrunner_cmd(executable, filepath, tcl, test_env_path)
+    root_path = testrunner_root_path(server.state, uri)
+    cmd = testrunner_cmd(executable, filepath, tcl, test_env_path, root_path)
     testrunnerproc = open(pipeline(cmd; stdin=IOBuffer(source)); read=true)
 
     result = try

--- a/src/testrunner/testrunner.jl
+++ b/src/testrunner/testrunner.jl
@@ -302,9 +302,9 @@ function testrunner_cmd(executable::String, filepath::String, tsn::String, tsl::
     tsn = rlstrip(tsn, '"')
     testrunner_exe = Sys.which(executable)
     if isnothing(test_env_path)
-        return `$testrunner_exe --verbose --json $filepath $tsn --filter-lines=$tsl`
+        return `$testrunner_exe --verbose --json --read-stdin $filepath $tsn --filter-lines=$tsl`
     else
-        return `$testrunner_exe --verbose --project=$test_env_path --json $filepath $tsn --filter-lines=$tsl`
+        return `$testrunner_exe --verbose --project=$test_env_path --json --read-stdin $filepath $tsn --filter-lines=$tsl`
     end
 end
 
@@ -312,9 +312,9 @@ end
 function testrunner_cmd(executable::String, filepath::String, tcl::Int, test_env_path::Union{Nothing,String})
     testrunner_exe = Sys.which(executable)
     if isnothing(test_env_path)
-        return `$testrunner_exe --verbose --json $filepath L$tcl`
+        return `$testrunner_exe --verbose --json --read-stdin $filepath L$tcl`
     else
-        return `$testrunner_exe --verbose --project=$test_env_path --json $filepath L$tcl`
+        return `$testrunner_exe --verbose --project=$test_env_path --json --read-stdin $filepath L$tcl`
     end
 end
 
@@ -322,7 +322,7 @@ function testrunner_diagnostic_to_related_information(diagnostic::TestRunnerDiag
     relatedInformation = DiagnosticRelatedInformation[]
     for info in @something diagnostic.relatedInformation return nothing
         info.filename == "none" && continue
-        uri = filepath2uri(to_full_path(info.filename))
+        uri = to_valid_uri(info.filename)
         range = line_range(info.line)
         location = Location(; uri, range)
         message = info.message
@@ -334,7 +334,7 @@ end
 function testrunner_result_to_diagnostics(result::TestRunnerResult)
     uri2diagnostics = URI2Diagnostics()
     for diag in result.diagnostics
-        uri = filename2uri(to_full_path(diag.filename))
+        uri = to_valid_uri(diag.filename)
         relatedInformation = testrunner_diagnostic_to_related_information(diag)
         diagnostic = Diagnostic(;
             range = line_range(diag.line),
@@ -521,7 +521,8 @@ function _testrunner_run_testset(
     tsl = testset_line(fi.testsetinfos[idx])
     test_env_path = find_uri_env_path(server.state, uri)
     cmd = testrunner_cmd(executable, filepath, tsn, tsl, test_env_path)
-    testrunnerproc = open(cmd; read=true)
+    source = JS.sourcetext(fi.parsed_stream)
+    testrunnerproc = open(pipeline(cmd; stdin=IOBuffer(source)); read=true)
 
     result = try
         # Wait for the process with cancellation support
@@ -599,7 +600,7 @@ function _testrunner_run_testset(
 end
 
 function testrunner_run_testcase(
-        server::Server, uri::URI, tcl::Int, tct::String, filepath::String;
+        server::Server, uri::URI, tcl::Int, tct::String, filepath::String, source::String;
         cancellable_token::Union{Nothing,CancellableToken} = nothing
     )
     setting_path = (:testrunner, :executable)
@@ -627,7 +628,7 @@ function testrunner_run_testcase(
 
     local result::String
     try
-        result = _testrunner_run_testcase(server, executable, uri, tcl, tct, filepath; cancellable_token)
+        result = _testrunner_run_testcase(server, executable, uri, tcl, tct, filepath, source; cancellable_token)
     catch err
         result = sprint(Base.showerror, err, catch_backtrace())
         @error "Error from testrunner executor" err
@@ -644,12 +645,13 @@ function testrunner_run_testcase(
 end
 
 function _testrunner_run_testcase(
-        server::Server, executable::AbstractString, uri::URI, tcl::Int, tct::String, filepath::String;
+        server::Server, executable::AbstractString, uri::URI, tcl::Int, tct::String,
+        filepath::String, source::String;
         cancellable_token::Union{Nothing,CancellableToken} = nothing
     )
     test_env_path = find_uri_env_path(server.state, uri)
     cmd = testrunner_cmd(executable, filepath, tcl, test_env_path)
-    testrunnerproc = open(cmd; read=true)
+    testrunnerproc = open(pipeline(cmd; stdin=IOBuffer(source)); read=true)
 
     result = try
         # Wait for the process with cancellation support
@@ -768,20 +770,14 @@ cancellable_token(rc::TestRunnerTestsetProgressCaller) = rc.token
     testrunner_run_testset_from_uri(server::Server, uri::URI, idx::Int) -> Union{Nothing, String}
 
 Run tests for the testset at the given index in the file specified by URI.
-Validates that the file exists, is saved, and matches the on-disk version.
+The current editor buffer is piped to TestRunner via stdin, so the file does not need to be saved.
 Returns `nothing` if the test was started successfully, or an error message string otherwise.
 """
 function testrunner_run_testset_from_uri(server::Server, uri::URI, idx::Int, tsn::String)
     fi = @something get_file_info(server.state, uri) begin
         return "File is no longer available in the editor"
     end
-    sfi = @something get_saved_file_info(server.state, uri) begin
-        return "The file appears not to exist on disk. Save the file first to run tests."
-    end
-    if JS.sourcetext(fi.parsed_stream) ≠ JS.sourcetext(sfi.parsed_stream)
-        return "The editor state differs from the saved file. Save the file first to run tests."
-    end
-    filepath = @something uri2filepath(uri) return "Cannot determine file path for the URI"
+    filepath = uri2filename(uri)
 
     if supports(server, :window, :workDoneProgress)
         id = String(gensym(:WorkDoneProgressCreateRequest_testrunner))
@@ -812,6 +808,7 @@ struct TestRunnerTestcaseProgressCaller <: RequestCaller
     testcase_line::Int
     testcase_text::String
     filepath::String
+    source::String
     token::ProgressToken
 end
 cancellable_token(rc::TestRunnerTestcaseProgressCaller) = rc.token
@@ -820,22 +817,17 @@ function testrunner_run_testcase_from_uri(server::Server, uri::URI, tcl::Int, tc
     fi = @something get_file_info(server.state, uri) begin
         return "File is no longer available in the editor"
     end
-    sfi = @something get_saved_file_info(server.state, uri) begin
-        return "The file appears not to exist on disk. Save the file first to run tests."
-    end
-    if JS.sourcetext(fi.parsed_stream) ≠ JS.sourcetext(sfi.parsed_stream)
-        return "The editor state differs from the saved file. Save the file first to run tests."
-    end
-    filepath = @something uri2filepath(uri) return "Cannot determine file path for the URI"
+    filepath = uri2filename(uri)
+    source = JS.sourcetext(fi.parsed_stream)
 
     if supports(server, :window, :workDoneProgress)
         id = String(gensym(:WorkDoneProgressCreateRequest_testrunner))
         token = String(gensym(:TestRunnerProgress))
-        addrequest!(server, id=>TestRunnerTestcaseProgressCaller(uri, tcl, tct, filepath, token))
+        addrequest!(server, id=>TestRunnerTestcaseProgressCaller(uri, tcl, tct, filepath, source, token))
         params = WorkDoneProgressCreateParams(; token)
         send(server, WorkDoneProgressCreateRequest(; id, params))
     else
-        testrunner_run_testcase(server, uri, tcl, tct, filepath)
+        testrunner_run_testcase(server, uri, tcl, tct, filepath, String(source))
     end
     return nothing
 end
@@ -847,9 +839,9 @@ function handle_testrunner_testcase_progress_response(
     if handle_response_error(server, msg, "create work done progress")
         return
     end
-    (; uri, testcase_line, testcase_text, filepath, token) = request_caller
+    (; uri, testcase_line, testcase_text, filepath, source, token) = request_caller
     cancellable_token = CancellableToken(token, cancel_flag)
-    testrunner_run_testcase(server, uri, testcase_line, testcase_text, filepath; cancellable_token)
+    testrunner_run_testcase(server, uri, testcase_line, testcase_text, filepath, source; cancellable_token)
 end
 
 """


### PR DESCRIPTION
Summary

Run TestRunner integration against the live editor buffer instead of the on-disk file. The buffer source is piped to the `testrunner` subprocess via stdin (`--read-stdin`), and the workspace root is passed as `--root-path` so relative `include` calls in unsaved buffers can find workspace files.

Effects:

- Saving is no longer required before running tests; unsaved edits and brand-new `@testset` / `@test` cases execute as-is.
- Untitled buffers (`untitled:` for VSCode / `buffer:` for Sublime Text) work too — relative `include`s resolve from the workspace root, and failure diagnostics are reported back against the same URI.

## Requirement

Needs a `testrunner` CLI built from a TestRunner.jl revision that understands `--read-stdin` and `--root-path`. Upgrade with:

```bash
julia -e 'using Pkg; Pkg.Apps.add(; url="https://github.com/aviatesk/TestRunner.jl", rev="release")'
```