### PR TITLE
cfg-analysis: Route `return` inside `try` through enclosing `finally`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - `lowering/unused-assignment` no longer flags an assignment in a `try` (or `catch`) body as dead when the assigned variable is read in the enclosing `finally`, even if the assignment is followed by `return`. The `finally` block runs before the return takes effect, so the value is live.
+  ```julia
+  function f()
+      local x::Float64
+      try
+          y = sin(rand((rand(), Inf)))
+          x = y               # previously: dead store
+          return 0
+      catch
+          x = 0.0             # previously: dead store
+          return 1
+      finally
+          push!(xs, x)
+      end
+  end
+  ```
+
+- `lowering/unused-assignment` no longer flags intermediate assignments in a `try` body when a later statement might throw.
+  Common state-tracking idioms like the following now keep `state = "step1 starting"` and `state = "step2 starting"` live with respect to `log(state)`:
+  ```julia
+  function process()
+      state = "init"
+      try
+          state = "step1 starting"  # previously: dead store
+          step1()
+          state = "step2 starting"  # previously: dead store
+          step2()
+          state = "done"
+      finally
+          log(state)
+      end
+  end
+  ```
 
 ## 2026-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   ```
   and confirm the upgrade by running `testrunner --help` and checking that `--read-stdin` appears under `Options:`.
 
+### Fixed
+
+- `lowering/unused-assignment` no longer flags an assignment in a `try` (or `catch`) body as dead when the assigned variable is read in the enclosing `finally`, even if the assignment is followed by `return`. The `finally` block runs before the return takes effect, so the value is live.
+
 ## 2026-05-05
 
 - Commit: [`563fd7e`](https://github.com/aviatesk/JETLS.jl/commit/563fd7e)

--- a/src/analysis/cfg-analysis.jl
+++ b/src/analysis/cfg-analysis.jl
@@ -104,12 +104,19 @@ mutable struct EventLinearizer
     # resolved at finalization, even when the preceding fall-through (before_block) is
     # unreachable.
     const statement_blocks::Vector{StatementRecord}
+    # Stack of enclosing `K"tryfinally"` finally-block label IDs. Pushed before linearizing
+    # the try body and popped before the finally body (so it is empty inside the finally
+    # body itself). Consulted by `K"return"` so that a return inside `try` routes through
+    # the innermost enclosing finally — modeling the runtime semantics of "finally runs
+    # before the return takes effect" — and an assignment in the try body can correctly
+    # reach a use in the finally body.
+    const active_finally_labels::Vector{Int}
     function EventLinearizer()
         blocks = EventBlock[EventBlock(1)]
         new(blocks, 1, Dict{Int,Int}(), Tuple{Int,Int}[], 0,
             Dict{String,Int}(), Dict{String,Int}(),
             Dict{Set{JL.IdTag},Set{JL.IdTag}}(), Set{JL.IdTag}[],
-            StatementRecord[])
+            StatementRecord[], Int[])
     end
 end
 
@@ -582,14 +589,23 @@ function linearize_cfg_events!(
         end_label = cfg_make_label!(lin)
 
         cfg_emit_gotoifnot!(lin, finally_label)
+        # `active_finally_labels` is consulted by `K"return"` (and only spans the try body
+        # — `pop!` happens before linearizing the finally body so a `return` inside
+        # `finally` is not redirected back to itself).
+        push!(lin.active_finally_labels, finally_label)
         let saved = undef_save_cond_implied(lin)
             linearize_cfg_events!(lin, ctx3, ex3[1], candidates, allow_noreturn_optimization)
             undef_restore_cond_implied!(lin, saved)
         end
+        pop!(lin.active_finally_labels)
 
-        # If the try body terminated, post-try is unreachable; the finally
-        # body still runs (modeled via the gotoifnot bypass) but its
-        # completion does not flow into post-try.
+        # If the try body terminated, post-try is unreachable; the finally body still
+        # runs (modeled via the entry-bypass `gotoifnot` and any `K"return"`-routed
+        # pending gotos from inside the try body) but its completion does not flow
+        # into post-try. This check is correct even after returns add pending gotos
+        # to `finally_label` because `is_block_reachable_from_entry` only follows
+        # pending gotos to already-resolved labels, and `finally_label` is registered
+        # below by `cfg_emit_label!`.
         try_body_terminated = !is_block_reachable_from_entry(lin, lin.current_block)
 
         cfg_emit_label!(lin, finally_label)
@@ -607,14 +623,16 @@ function linearize_cfg_events!(
         if JS.numchildren(ex3) >= 1
             linearize_cfg_events!(lin, ctx3, ex3[1], candidates, allow_noreturn_optimization)
         end
-        # Switch to a fresh "phantom" block — no edge from the
-        # return-emitting block — so the linearizer keeps a valid
-        # `current_block` for whatever syntactically follows the return.
-        # The phantom has no incoming edges, so subsequent events recorded
-        # against it are correctly treated as unreachable. Same pattern:
-        # `cfg_emit_goto!`, no-target `K"break"`, noreturn-call branch.
-        unreachable = cfg_new_block!(lin)
-        cfg_switch_to_block!(lin, unreachable)
+        if isempty(lin.active_finally_labels)
+            # Same pattern as `cfg_emit_goto!`, no-target `K"break"`, noreturn-call branch:
+            # phantom has no incoming edges, so post-return code is unreachable.
+            unreachable = cfg_new_block!(lin)
+            cfg_switch_to_block!(lin, unreachable)
+        else
+            # `return` inside `try` runs the enclosing `finally` first, so route the edge
+            # through it — otherwise an assignment preceding the return looks dead.
+            cfg_emit_goto!(lin, last(lin.active_finally_labels))
+        end
 
     elseif k == JS.K"block"
         # Record each direct child as a "statement" tagged with both the

--- a/src/analysis/cfg-analysis.jl
+++ b/src/analysis/cfg-analysis.jl
@@ -648,6 +648,13 @@ function linearize_cfg_events!(
             linearize_cfg_events!(lin, ctx3, child, candidates, allow_noreturn_optimization)
             after_block = lin.current_block
             push!(lin.statement_blocks, StatementRecord(before_block, after_block, child))
+            # Inside a `try` body, model "exception thrown between statements escapes
+            # to the enclosing finally" by branching to the innermost active finally
+            # at every statement boundary. Combined with `K"tryfinally"`'s entry-bypass
+            # `gotoifnot`, this covers exception escape at every point in the try body.
+            if !isempty(lin.active_finally_labels)
+                cfg_emit_gotoifnot!(lin, last(lin.active_finally_labels))
+            end
         end
 
     else # Default: process all children

--- a/test/analysis/test_cfg_analysis.jl
+++ b/test/analysis/test_cfg_analysis.jl
@@ -1481,6 +1481,46 @@ end
     end
 end
 
+@testset "tryfinally: mid-try exception keeps intermediate assignments live" begin
+    # Classic state-tracking pattern: each step records progress before
+    # calling a possibly-throwing helper, and `finally` logs the latest
+    # progress reached. Every intermediate assignment can be the live
+    # value seen by `log(state)` if the next call throws, so none is dead.
+    let ds = get_dead_stores("""
+        function process()
+            state = "init"
+            try
+                state = "step1 starting"
+                step1()
+                state = "step2 starting"
+                step2()
+                state = "done"
+            finally
+                log(state)
+            end
+        end
+        """)
+        @test !haskey(ds, "state")
+    end
+
+    # Statements inside the finally body itself should NOT branch to the
+    # same finally label (the active stack is popped before linearizing
+    # the finally body): a clobbered local with no later use is still dead.
+    let ds = get_dead_stores("""
+        function f()
+            try
+                step()
+            finally
+                x = 1
+                x = 2
+                println(x)
+            end
+        end
+        """)
+        @test ds["x"] == 1
+    end
+end
+
 end # @testset "dead store analysis" begin
 
 # --- Unreachable-statement analysis ---

--- a/test/analysis/test_cfg_analysis.jl
+++ b/test/analysis/test_cfg_analysis.jl
@@ -1428,6 +1428,59 @@ end
     end
 end
 
+@testset "tryfinally: assignment before return reaches finally use" begin
+    # `return` inside `try` runs `finally` before the function exits, so
+    # an assignment preceding the return is live with respect to a use in
+    # the finally body. Without modeling the return → finally edge, both
+    # try-body and catch-body assignments here looked dead because they
+    # only fall through to the unreachable post-return phantom.
+    let ds = get_dead_stores("""
+        function f()
+            local x::Float64
+            try
+                y = sin(rand((rand(), Inf)))
+                x = y
+                return 0
+            catch
+                x = 0.0
+                return 1
+            finally
+                push!(xs, x)
+            end
+        end
+        """)
+        @test !haskey(ds, "x")
+    end
+
+    # Single-branch variant without catch: same liveness through finally.
+    let ds = get_dead_stores("""
+        function f()
+            local x
+            try
+                x = compute()
+                return 0
+            finally
+                cleanup(x)
+            end
+        end
+        """)
+        @test !haskey(ds, "x")
+    end
+
+    # Sanity: a `return` outside any tryfinally still kills the
+    # preceding assignment (no finally to flow through). The use after
+    # `return` is unreachable, so the assignment cannot reach it.
+    let ds = get_dead_stores("""
+        function f()
+            x = 1
+            return 0
+            println(x)
+        end
+        """)
+        @test ds["x"] == 1
+    end
+end
+
 end # @testset "dead store analysis" begin
 
 # --- Unreachable-statement analysis ---


### PR DESCRIPTION
Add an `active_finally_labels` stack to `EventLinearizer`, pushed before linearizing a `K"tryfinally"` try body and popped before its finally body. When `K"return"` is processed inside the try, it now routes through the innermost active finally label instead of switching directly to an unreachable phantom block. This matches the runtime semantics — `finally` runs before the return takes effect — so an assignment preceding the return is live with respect to a use in the finally body.

Previously, `lowering/unused-assignment` flagged such assignments as dead stores, since CFG paths from the assignment block could not reach the finally use without going through the "other assignments" avoid set.

```julia
function f()
    local x::Float64
    try
        y = sin(rand((rand(), Inf)))
        x = y               # Value assigned to `x` is never used
        return 0
    catch
        x = 0.0             # Value assigned to `x` is never used
        return 1
    finally
        push!(xs, x)
    end
end
```

`K"tryfinally"`'s `try_body_terminated` check is unaffected: `is_block_reachable_from_entry` ignores pending gotos to as-yet -unemitted labels, so the new pending `(_, finally_label)` edges from returns are not seen during the check.