### PR TITLE
TypeAnnotation: Filter OC construction scaffolding at yield byte ranges

### DIFF
--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -695,6 +695,13 @@ struct InferredTreeContext
     # `K"return"` is part of the queried branching's value and isn't
     # filtered.
     user_return_value_ranges::Dict{UnitRange{Int}, UnitRange{Int}}
+    # For each lowered node inside the body of some OC, the byte range of that OC's
+    # `K"opaque_closure_method"`. Used by `tmerge_at_range` to filter OC construction
+    # scaffolding sharing a byte range with the user's yield expression: a node is kept
+    # only when the OC whose body it's in has the queried byte range — so inner-OC noise
+    # inside an outer OC body (e.g. multi-`for` comprehension, closure-of-closure) is
+    # filtered when querying at the inner OC's range.
+    oc_body_scope::Dict{Int,UnitRange{Int}}
 end
 
 function InferredTreeContext(inferred_tree::SyntaxTreeC, st3::SyntaxTreeC)
@@ -745,10 +752,39 @@ function InferredTreeContext(inferred_tree::SyntaxTreeC, st3::SyntaxTreeC)
     user_return_value_ranges = Dict{UnitRange{Int}, UnitRange{Int}}()
     collect_user_return_value_ranges!(user_return_value_ranges, st3)
 
+    oc_body_scope = Dict{Int,UnitRange{Int}}()
+    populate_oc_body_scope!(oc_body_scope, inferred_tree, nothing)
+
     return InferredTreeContext(
         inferred_tree, surface_kind_index, by_byte_range,
         macrocall_typed_calls, return_first_bytes, return_nodes,
-        user_return_value_ranges)
+        user_return_value_ranges, oc_body_scope)
+end
+
+# `K"code_info"` only marks an OC body when it's the body slot of a
+# `K"opaque_closure_method"` — the top-level thunk is also wrapped in `K"code_info"` and
+# would otherwise mark the entire tree. Each `K"opaque_closure_method"` opens its own
+# scope; entering its `K"code_info"` child overrides the inherited scope so an inner OC's
+# body is attributed to the inner method, not the outer.
+function populate_oc_body_scope!(
+        scope::Dict{Int,UnitRange{Int}},
+        node::SyntaxTreeC,
+        current::Union{Nothing,UnitRange{Int}},
+    )
+    current === nothing || (scope[node._id] = current)
+    JS.is_leaf(node) && return
+    if JS.kind(node) === JS.K"opaque_closure_method"
+        method_range = JS.byte_range(node)
+        for c in JS.children(node)
+            child_scope = JS.kind(c) === JS.K"code_info" ? method_range : current
+            populate_oc_body_scope!(scope, c, child_scope)
+        end
+    else
+        for c in JS.children(node)
+            populate_oc_body_scope!(scope, c, current)
+        end
+    end
+    return
 end
 
 # Walk `st`, find every `K"return"` node, and record the byte ranges of all
@@ -989,9 +1025,20 @@ function type_for_funcdef(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
 end
 
 function tmerge_at_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
+    nodes = get(ctx.by_byte_range, rng, ())
+    # When `OpaqueClosure` construction occurs at `rng` (most often a comprehension/
+    # `map`/`filter` auto-generated lambda whose source bytes coincide with the user's
+    # yield expression), the construction scaffolding — OC method object, argt/rt_lb svec,
+    # OC binding — would otherwise `tmerge` into the user-visible value and surface as
+    # `Union{T, Method, OpaqueClosure, Type}`. Keep only nodes attributed to the body of
+    # the OC at `rng`; outside that scope is scaffolding.
+    is_oc_site = any(s -> JS.kind(s) === JS.K"new_opaque_closure", nodes)
     typ = nothing
-    for st in get(ctx.by_byte_range, rng, ())
+    for st in nodes
         hasproperty(st, :type) || continue
+        if is_oc_site && get(ctx.oc_body_scope, st._id, nothing) !== rng
+            continue
+        end
         ntyp = st.type
         typ = typ === nothing ? ntyp : CC.tmerge(ntyp, typ)
     end

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -499,6 +499,74 @@ end
         end
     end
 
+    # OC construction scaffolding shares its byte range with the user's yield expression
+    # for comprehension/`map` lambdas; queries at that range should surface only the body's
+    # value type. See `tmerge_at_range`.
+    @testset "OC construction noise at user expression byte range" begin
+        @testset "comprehension with typed iterator yield" begin
+            let code = "let xs = rand(3); [yld for yld::Float64 in xs]; end"
+                _, ctx = type_annotate(code)
+                # First `yld` in source order is the yield expression.
+                @test widenconst(get_type_for_range(ctx, range_of(code, "yld"))) === Float64
+            end
+        end
+        @testset "typed comprehension with typed iterator yield" begin
+            let code = "let xs = rand(3); Float64[yld for yld::Float64 in xs]; end"
+                _, ctx = type_annotate(code)
+                # First `yld` in source order is the yield expression.
+                @test widenconst(get_type_for_range(ctx, range_of(code, "yld"))) === Float64
+            end
+        end
+
+        @testset "comprehension with typed iterator with filter on iterator" begin
+            let code = "let xs = rand(3); [yld for yld::Float64 in xs if yld > 0]; end"
+                _, ctx = type_annotate(code)
+                # First `yld` in source order is the yield expression.
+                @test widenconst(get_type_for_range(ctx, range_of(code, "yld"))) === Float64
+            end
+        end
+
+        @testset "comprehension with typed tuple yield" begin
+            let code = """
+                let xs = rand(3), ys = rand(3)
+                    [(x, y) for (x, y)::Tuple{Float64,Float64} in zip(xs, ys)]
+                end
+                """
+                _, ctx = type_annotate(code)
+                # First `(x, y)` in source order is the yield expression.
+                @test widenconst(get_type_for_range(ctx, range_of(code, "(x, y)"))) ===
+                    Tuple{Float64,Float64}
+            end
+        end
+
+        # Multi-`for` lowers to nested OCs whose construction sites overlap source-wise;
+        # the inner-body slot must still resolve precisely. See `populate_oc_body_scope!`.
+        @testset "nested OC scopes (multi-for comprehension)" begin
+            let code = """
+                let xs = [1, 2, 3], ys = [1.0]
+                    [x + y for x::Int in xs for y::Float64 in ys]
+                end
+                """
+                _, ctx = type_annotate(code)
+                rng = range_of(code, "x + y")
+                @test widenconst(get_type_for_range(ctx, rng)) === Float64
+            end
+        end
+
+        # An explicit closure binding's reference surfaces `OpaqueClosure{…}` legitimately
+        # — the filter must not strip it.
+        @testset "explicit closure binding reference still surfaces the OC type" begin
+            let code = "let f = (x::Int) -> x + 1; f; end"
+                _, ctx = type_annotate(code)
+                # Reference `f` is the second occurrence (`; f;` near the end).
+                ref_rng = let i = findlast("f", code)
+                    first(i):last(i)
+                end
+                @test widenconst(get_type_for_range(ctx, ref_rng)) <: Core.OpaqueClosure
+            end
+        end
+    end
+
     @testset "regular call dispatches to the user's call result" begin
         let code = "let v = [1.0, 2.0]; sum(v); end"
             _, ctx = type_annotate(code)


### PR DESCRIPTION
When a comprehension / `map` / `filter` auto-generated lambda's source bytes coincide with the user's yield expression, the lowered tree puts `K"new_opaque_closure"`, `K"opaque_closure_method"`, the argt/rt_lb svec helpers, and the OC binding `K"="` / `K"slot"` all at that same byte range. `tmerge_at_range` would otherwise surface `Union{T, Method, OpaqueClosure, Type}` instead of the body's actual value type. Note that comprehension with untyped iterator masked this currently — `Any` from `most_general_argtypes` absorbed everything — but typed forms (`for x::T in xs`) make it visible.

Filter structurally rather than filtering by matching against inferred lattice element: track which `K"opaque_closure_method"`'s body each lowered node belongs to (the new `oc_body_scope` index in `InferredTreeContext`) and at query time keep only the nodes whose body matches the queried range. Inner-OC construction noise sitting inside an outer OC body — multi-`for` comprehension, closure-of-closure — is filtered when querying at the inner OC's byte range, while a reference to an explicit closure binding (no OC construction at the byte range) still surfaces its `OpaqueClosure{…}` type unchanged.