### PR TITLE
closure-to-opaque: Fix sig_call mismatch for nested closures

### DIFF
--- a/src/analysis/closure-to-opaque.jl
+++ b/src/analysis/closure-to-opaque.jl
@@ -1,6 +1,6 @@
 module Closure2Opaque
 
-using ..JETLS: JL, JS, SyntaxTreeC
+using ..JETLS: JL, JS, SyntaxTreeC, TraversalReturn, traverse
 
 export rewrite_local_closures_to_opaque
 
@@ -196,27 +196,37 @@ function try_build_oc_assignment(
     return JL.@ast ctx method_defs [JS.K"=" func_name oc]
 end
 
+# `sig_call` must be matched by `var_id` (not "first svec_call DFS finds"):
+# nested closures embed the inner OC's `method_defs` inside the outer OC's lambda body,
+# so an unconstrained DFS attributes the inner's user-argtypes to the outer OC.
 function find_method_and_sig_call(root::SyntaxTreeC, target_var_id::Int)
-    method_node = sig_call = nothing
-    stack = SyntaxTreeC[root]
-    while !isempty(stack)
-        method_node === nothing || sig_call === nothing || break
-        node = pop!(stack)
-        if JS.kind(node) === JS.K"method" && JS.numchildren(node) == 3 &&
-                JS.kind(node[1]) === JS.K"BindingId" && node[1].var_id == target_var_id
-            method_node = node
-        elseif JS.kind(node) === JS.K"=" && JS.numchildren(node) == 2 &&
-                JS.kind(node[1]) === JS.K"BindingId" &&
-                JS.kind(node[2]) === JS.K"call" && is_core_svec_call(node[2])
-            sig_call = node[2]
-        end
-        if !JS.is_leaf(node)
-            for c in JS.children(node)
-                push!(stack, c)
-            end
-        end
-    end
+    method_node = @something find_method_node(root, target_var_id) return (nothing, nothing)
+    JS.numchildren(method_node) >= 2 || return (method_node, nothing)
+    sig_ref = method_node[2]
+    JS.kind(sig_ref) === JS.K"BindingId" || return (method_node, nothing)
+    sig_call = find_sig_call_for(root, sig_ref.var_id)
     return (method_node, sig_call)
+end
+
+function find_method_node(root::SyntaxTreeC, target_var_id::Int)
+    return traverse(root) do node::SyntaxTreeC
+        if (JS.kind(node) === JS.K"method" && JS.numchildren(node) == 3 &&
+            JS.kind(node[1]) === JS.K"BindingId" && node[1].var_id == target_var_id)
+            return TraversalReturn(node; terminate=true)
+        end
+        nothing
+    end
+end
+
+function find_sig_call_for(root::SyntaxTreeC, sig_var_id::Int)
+    return traverse(root) do node::SyntaxTreeC
+        if (JS.kind(node) === JS.K"=" && JS.numchildren(node) == 2 &&
+            JS.kind(node[1]) === JS.K"BindingId" && node[1].var_id == sig_var_id &&
+            JS.kind(node[2]) === JS.K"call" && is_core_svec_call(node[2]))
+            return TraversalReturn(node[2]; terminate=true)
+        end
+        nothing
+    end
 end
 
 function is_core_svec_call(call_node::SyntaxTreeC)

--- a/test/analysis/test_closure_to_opaque.jl
+++ b/test/analysis/test_closure_to_opaque.jl
@@ -208,6 +208,30 @@ end
         @test val == 42
         @test count_opaque_closures(tree) == 2
     end
+
+    # Regression: nested typed closures must each get their own user-argtypes
+    # (no cross-attribution from inner to outer).
+    let (val, tree) = rewrite_lower_eval("""
+            let outer = (x::Int) -> begin
+                    inner = (y::Float64) -> x + y
+                    inner(2.5)
+                end
+                outer(3)
+            end
+            """)
+        @test val === 5.5
+        @test count_opaque_closures(tree) == 2
+    end
+
+    # Same shape via cartesian comprehension lowering.
+    let (val, tree) = rewrite_lower_eval("""
+            let xs = [1, 2, 3], ys = [10.0, 20.0]
+                [x + y for x::Int in xs for y::Float64 in ys]
+            end
+            """)
+        @test val == [11.0, 21.0, 12.0, 22.0, 13.0, 23.0]
+        @test count_opaque_closures(tree) == 2
+    end
 end
 
 @testset "do-block as map argument" begin


### PR DESCRIPTION
`find_method_and_sig_call` matched `sig_call` by "first svec_call DFS finds", which mis-attributed the inner OC's user-argtypes to the outer OC when nested closures embedded the inner's `method_defs` inside the outer's lambda body (cartesian comprehensions, manually nested typed closures, etc.). The outer OC was then built with the inner's argt (`Tuple{Float64}` instead of `Tuple{Int}`), surfacing as a `TypeError` at the OC call site at runtime, and as a wrongly-typed captured parameter (`x::Float64` for `for x::Int in ...`) in inlay hints.

Split the lookup into `find_method_node` / `find_sig_call_for` and match the sig_call by `var_id` against `method_node[2]`.