### PR TITLE
diagnostic: Invalidate pull-diagnostic resultId on config changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - JETLS now performs correct scope resolution on identifiers used inside Test.jl macro calls (i.e., `@testset`, `@test`, `@test_throws`, `@test_broken`, `@test_skip`, `@test_warn`, `@test_nowarn`, `@test_logs`, `@test_deprecated`, and `@inferred`), which previously could yield incorrect results in edge cases.
 
+- Fixed pull-model diagnostics (`textDocument/diagnostic` and `workspace/diagnostic`) to refresh after `[diagnostic]` configuration changes. Previously, changing settings such as `diagnostic.enabled`, `diagnostic.allow_unused_underscore`, or `diagnostic.patterns` did not invalidate the client's cached results, so stale diagnostics remained until the file was edited.
+
 ## 2026-05-06
 
 - Commit: [`732c537`](https://github.com/aviatesk/JETLS.jl/commit/732c537)

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -1852,21 +1852,26 @@ end
 # When the file has explicit imports it folds every unit member's version into the key so a
 # sibling edit invalidates this file's cached diagnostics and `analyze_unused_imports!` reruns.
 # Files without explicit imports stay keyed on their own version alone.
+# `ConfigManagerData.diagnostic_settings_hash` is folded in so the resultId flips when
+# `[diagnostic]` config changes — otherwise the equality check below would still match the
+# client's `previousResultId` and the `request_diagnostic_refresh!` from
+# `handle_lsp_config_change!` would be a no-op.
 function compute_diagnostic_result_id(server::Server, uri::URI, fi::FileInfo)
     state = server.state
+    config_hash = hash(get_config(state, :diagnostic)::DiagnosticConfig)
     if !file_has_explicit_imports(build_syntax_tree(fi))
-        return string(fi.version)
+        return string(hash((fi.version, config_hash)))
     end
-    result_id_hash = zero(UInt)
+    file_hash = zero(UInt)
     for search_uri in collect_search_uris(server, uri)
         search_fi = @something begin
             get_file_info(state, search_uri)
         end begin
             get_unsynced_file_info!(state, search_uri)
         end continue
-        result_id_hash ⊻= hash((search_uri, search_fi.version))
+        file_hash ⊻= hash((search_uri, search_fi.version))
     end
-    return string(result_id_hash)
+    return string(hash((file_hash, config_hash)))
 end
 
 # Computes raw per-file diagnostics for both `textDocument/diagnostic` and

--- a/src/types.jl
+++ b/src/types.jl
@@ -489,6 +489,18 @@ merge_key_value(pattern::DiagnosticPattern) =
     allow_unused_underscore::Maybe{Bool}
     patterns::Maybe{Vector{DiagnosticPattern}}
 end
+# `@option` only generates content-based `==`, not `hash`, so the default `hash` falls
+# back to `objectid` and breaks the `==`/`hash` contract for `DiagnosticConfig` (its
+# `patterns::Vector` makes the parent's identity-based hash unstable across equal-valued
+# instances). `compute_diagnostic_result_id` folds this hash into pull-diagnostic
+# resultIds, so a content-based definition is required to avoid spurious invalidations.
+function Base.hash(config::DiagnosticConfig, h::UInt)
+    h = hash(config.enabled, h)
+    h = hash(config.all_files, h)
+    h = hash(config.allow_unused_underscore, h)
+    h = hash(config.patterns, h)
+    return h
+end
 
 # Internal, undocumented configuration for full-analysis module overrides.
 struct AnalysisOverride <: ConfigSection

--- a/test/test_diagnostic.jl
+++ b/test/test_diagnostic.jl
@@ -419,6 +419,41 @@ end
                 @test raw_res.result isa RelatedFullDocumentDiagnosticReport
                 @test raw_res.result.resultId == second_result_id
             end
+
+            # `:diagnostic` config change → `resultId` changes so the client-side cached
+            # `Unchanged` response is invalidated when the server's `request_diagnostic_refresh!`
+            # prompts the client to re-pull.
+            let settings = Dict{String,Any}(
+                    "diagnostic" => Dict{String,Any}("allow_unused_underscore" => false))
+                (; raw_res) = writereadmsg(DidChangeConfigurationNotification(;
+                        params = DidChangeConfigurationParams(; settings));
+                    read = 2)
+                @test count(msg -> msg isa ShowMessageNotification, raw_res) == 1
+                @test count(msg -> msg isa PublishDiagnosticsNotification, raw_res) == 1
+            end
+
+            local third_result_id::String
+            let id = id_counter[] += 1
+                (; raw_res) = writereadmsg(DocumentDiagnosticRequest(;
+                    id,
+                    params = DocumentDiagnosticParams(;
+                        textDocument = TextDocumentIdentifier(; uri),
+                        previousResultId = second_result_id)))
+                @test raw_res isa DocumentDiagnosticResponse
+                @test raw_res.result isa RelatedFullDocumentDiagnosticReport
+                @test raw_res.result.resultId != second_result_id
+                third_result_id = raw_res.result.resultId
+            end
+            let id = id_counter[] += 1
+                (; raw_res) = writereadmsg(DocumentDiagnosticRequest(;
+                    id,
+                    params = DocumentDiagnosticParams(;
+                        textDocument = TextDocumentIdentifier(; uri),
+                        previousResultId = third_result_id)))
+                @test raw_res isa DocumentDiagnosticResponse
+                @test raw_res.result isa RelatedUnchangedDocumentDiagnosticReport
+                @test raw_res.result.resultId == third_result_id
+            end
         end
     end
 end


### PR DESCRIPTION
`compute_diagnostic_result_id` previously keyed the resultId only on the file version (and dependency versions for files with explicit imports). When `[diagnostic]` config changed,
`handle_lsp_config_change!`
sent `workspace/diagnostic/refresh`, but the client's re-request with the previous `previousResultId` matched the freshly-computed resultId and the server returned `Unchanged`, so the refresh was effectively a no-op and stale diagnostics persisted on the client.

Fold the current `DiagnosticConfig` value into the resultId so any `[diagnostic]` config mutation flips the resultId and the refresh takes effect.

Also defines `Base.hash(::DiagnosticConfig, ::UInt)` content-based. `@option` from Configurations.jl generates `==` but not `hash`, so the default `hash` fell back to `objectid` and broke the `==`/`hash` contract — equal-valued `DiagnosticConfig` instances hashed differently because of the embedded `patterns::Vector`. Without this, the resultId fold above would spuriously invalidate the client cache whenever `ConfigManagerData` was rebuilt with the same values.