### PR TITLE
config: Drop Configurations.jl dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed pull-model diagnostics (`textDocument/diagnostic` and `workspace/diagnostic`) to refresh after `[diagnostic]` configuration changes. Previously, changing settings such as `diagnostic.enabled`, `diagnostic.allow_unused_underscore`, or `diagnostic.patterns` did not invalidate the client's cached results, so stale diagnostics remained until the file was edited.
 
+### Changed
+
+- Configuration parse errors now point at the offending key with its full dotted path, e.g. ```Invalid value at `diagnostic.allow_unused_underscore`: expected Bool, got String``` for type mismatches and ```Configuration file at … contains an unknown key: \`diagnostic.unknown_field\` ``` for unrecognized keys. Previously these messages either omitted the location entirely or referenced only the immediate key.
+
+- Dropped the dependency on Configurations.jl. Configuration parsing and validation are now handled in-tree, so JETLS pulls in fewer transitive packages on first install and load.
+
 ## 2026-05-06
 
 - Commit: [`732c537`](https://github.com/aviatesk/JETLS.jl/commit/732c537)

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,6 @@ projects = ["docs", "test", "scripts"]
 
 [deps]
 Compiler = "807dbc54-b67e-4c79-8afb-eafe4df6f2e1"
-Configurations = "5218b696-f38b-4ac9-8b61-a12ec717816d"
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 JuliaLowering = "f3c80556-a63f-4383-b822-37d64f81a311"
@@ -34,7 +33,6 @@ LSP = {path = "LSP"}
 
 [compat]
 Compiler = "0.1.1"
-Configurations = "0.17.6"
 Glob = "1.4"
 JET = "0.10.6"
 JuliaLowering = "1"

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -50,7 +50,6 @@ using Markdown: Markdown
 using TOML: TOML
 using Test: Test # used to define new-style implementations of `@test`/`@testset`
 
-using Configurations: @option, Configurations, Maybe
 using Glob: Glob
 
 abstract type AnalysisEntry end # used by `Analyzer.LSAnalyzer`

--- a/src/config.jl
+++ b/src/config.jl
@@ -124,21 +124,144 @@ If a field in `overlay` is `nothing`, the corresponding field from `base` is ret
 merge_settings(base::JETLSConfig, overlay::JETLSConfig) =
     merge_and_track(Returns(nothing), base, overlay, ())
 
-# TODO: Remove this. Now this is used for `collect_unmatched_keys` only. See the comment there.
-function parse_config_dict(config_dict::AbstractDict{String}, filepath::Union{Nothing,AbstractString} = nothing)
+"""
+    InvalidKeyError(path, expected_keys)
+
+Thrown by [`parse_config_from_dict`](@ref) when a config dict contains a key that does not
+match any field of the target [`ConfigSection`](@ref). `path` is the dotted key path to the
+offending entry (e.g. `["diagnostic", "patterns"]`); `expected_keys` is the list of
+field names of the target type at that path.
+"""
+struct InvalidKeyError <: Exception
+    path::Vector{String}
+    expected_keys::Vector{String}
+end
+function Base.showerror(io::IO, e::InvalidKeyError)
+    print(io, "InvalidKeyError: invalid key `", join(e.path, "."), "`",
+          ", expected one of: ", join((string('`', k, '`') for k in e.expected_keys), ", "))
+end
+
+"""
+    parse_config_from_dict(::Type{T}, d::AbstractDict{String}, path=String[])
+        where T<:ConfigSection -> T
+
+Recursively populate a [`ConfigSection`](@ref) struct from a config dict (typically
+parsed from `.JETLSConfig.toml` or `workspace/configuration`). Throws
+[`InvalidKeyError`](@ref) — carrying the full dotted path — on unknown keys; missing
+fields keep the struct's `@kwdef` defaults. `path` is threaded through nested calls
+so any error surfaced downstream knows where in the dict it originated; callers
+typically leave it at the default.
+"""
+function parse_config_from_dict(
+        ::Type{T}, d::AbstractDict{String}, path::Vector{String} = String[]
+    ) where T<:ConfigSection
+    valid_keys = String[String(name) for name in fieldnames(T)]
+    for key::String in keys(d)
+        key in valid_keys || throw(InvalidKeyError(String[path; key], valid_keys))
+    end
+    kwargs = Pair{Symbol,Any}[]
+    for fname in fieldnames(T)
+        sname = String(fname)
+        haskey(d, sname) || continue
+        v = parse_config_dict_value(fieldtype(T, fname), d[sname], String[path; sname])
+        push!(kwargs, fname => v)
+    end
+    return T(; kwargs...)
+end
+
+# Format an error message rooted at `path` (or unrooted at the top level). Messages
+# share the capital-prefix convention with `DiagnosticConfigError` thrown from
+# `parse_diagnostic_pattern` / `parse_analysis_override`.
+function parse_dict_error(path::Vector{String}, msg::AbstractString)
+    if isempty(path)
+        error(uppercasefirst(msg))
+    else
+        error("Invalid value at `", join(path, "."), "`: ", msg)
+    end
+end
+
+# Drives `parse_config_from_dict`'s field-by-field hydration: turns the raw dict value `x`
+# into the field's declared type `T`. Handles the small type tree we actually use — Maybe,
+# nested `ConfigSection`, vectors of `ConfigSection`, the formatter union, and plain
+# `convert`-able leaves. `DiagnosticPattern` / `AnalysisOverride` need bespoke validation
+# and are inlined here for the same reason `Maybe{FormatterConfig}` is — the set of special
+# cases is small and closed, so a dispatch hook would be over-built.
+function parse_config_dict_value(
+        T::Type, @nospecialize(x), path::Vector{String} = String[]
+    )
+    x === nothing && Nothing <: T && return nothing
+    if T isa Union
+        non_nothing = Type[U for U in Base.uniontypes(T) if U !== Nothing]
+        if length(non_nothing) == 1
+            # `Maybe{T}` for a single concrete `T` — dispatch directly so inner errors
+            # (e.g. `DiagnosticConfigError`, `InvalidKeyError`) bubble up unswallowed.
+            return parse_config_dict_value(non_nothing[1], x, path)
+        end
+        # `Maybe{FormatterConfig}` is the only union we parse from a dict that mixes a plain
+        # string and an alias-tagged option type. Hard-code it rather than building a
+        # general alias dispatch.
+        if String <: T && CustomFormatterConfig <: T
+            if x isa AbstractString
+                return convert(String, x)
+            elseif x isa AbstractDict{String}
+                haskey(x, CUSTOM_FORMATTER_ALIAS) ||
+                    parse_dict_error(path, "expected formatter table key `$(CUSTOM_FORMATTER_ALIAS)`, got keys $(collect(keys(x)))")
+                return parse_config_from_dict(
+                    CustomFormatterConfig, x[CUSTOM_FORMATTER_ALIAS], String[path; CUSTOM_FORMATTER_ALIAS])
+            else
+                parse_dict_error(path, "expected formatter string or table, got $(typeof(x))")
+            end
+        end
+        # Generic multi-type union (e.g. `Maybe{Union{Missing,Bool}}`): try each
+        # non-`Nothing` branch in order; the first one that converts wins.
+        for U in non_nothing
+            try
+                return parse_config_dict_value(U, x, path)
+            catch
+                continue
+            end
+        end
+        parse_dict_error(path, "expected $T, got $(typeof(x))")
+    end
+    if T <: ConfigSection
+        x isa AbstractDict{String} || parse_dict_error(path, "expected a table for $T, got $(typeof(x))")
+        T === DiagnosticPattern && return parse_diagnostic_pattern(x)
+        T === AnalysisOverride && return parse_analysis_override(x)
+        return parse_config_from_dict(T, x, path)
+    end
+    if T <: AbstractVector
+        x isa AbstractVector || parse_dict_error(path, "expected an array for $T, got $(typeof(x))")
+        E = eltype(T)
+        return E[parse_config_dict_value(E, e, path) for e in x]
+    end
     try
-        return Configurations.from_dict(JETLSConfig, config_dict)
+        return convert(T, x)
     catch e
-        # TODO: remove this when Configurations.jl support to report
-        #       full path of unknown key.
-        if e isa Configurations.InvalidKeyError
-            unknown_keys = collect_unmatched_keys(to_untyped_config_dict(config_dict))
-            if !isempty(unknown_keys)
-                if isnothing(filepath)
-                    return unmatched_keys_in_lsp_config_msg(unknown_keys)
-                else
-                    return unmatched_keys_in_config_file_msg(filepath, unknown_keys)
-                end
+        e isa MethodError || rethrow(e)
+        parse_dict_error(path, "expected $T, got $(typeof(x))")
+    end
+end
+
+"""
+    parse_config_dict(config_dict::AbstractDict{String}, filepath=nothing)
+        -> Union{JETLSConfig,String}
+
+Parse a raw `JETLSConfig` dict from `workspace/configuration` (`filepath=nothing`)
+or `.JETLSConfig.toml` (`filepath` set). Returns the parsed config on success, or a
+user-facing error message string on failure — covering unknown keys (with the full
+dotted path), invalid `[diagnostic]` patterns, and any other parse error.
+"""
+function parse_config_dict(
+        config_dict::AbstractDict{String}, filepath::Union{Nothing,AbstractString} = nothing
+    )
+    try
+        return parse_config_from_dict(JETLSConfig, config_dict)
+    catch e
+        if e isa InvalidKeyError
+            if isnothing(filepath)
+                return unmatched_key_in_lsp_config_msg(e.path)
+            else
+                return unmatched_key_in_config_file_msg(filepath, e.path)
             end
         elseif e isa DiagnosticConfigError
             if isnothing(filepath)
@@ -157,70 +280,6 @@ function parse_config_dict(config_dict::AbstractDict{String}, filepath::Union{No
             Failed to load configuration file at $filepath:
             $(e)
             """
-        end
-    end
-end
-
-const UntypedConfigDict = Base.PersistentDict{String, Any}
-to_untyped_config_dict(dict::AbstractDict) =
-    UntypedConfigDict((k => (v isa AbstractDict ? to_untyped_config_dict(v) : v) for (k, v) in dict)...)
-
-const DEFAULT_UNTYPED_CONFIG_DICT = to_untyped_config_dict(Configurations.to_dict(DEFAULT_CONFIG))
-
-"""
-    collect_unmatched_keys(this::UntypedConfigDict, ref::UntypedConfigDict) -> Vector{Vector{String}}
-
-Traverses the keys of `this` and returns a list of key paths that are not present in `ref`.
-Note that this function does *not* perform deep structural comparison for keys whose values are dictionaries.
-
-# Examples
-```julia-repl
-julia> collect_unmatched_keys(
-            UntypedConfigDict("key1" => UntypedConfigDict("key2" => 0, "key3"  => 0, "key4"  => 0)),
-            UntypedConfigDict("key1" => UntypedConfigDict("key2" => 0, "diff1" => 0, "diff2" => 0))
-        )
-2-element Vector{Vector{String}}:
- ["key1", "key3"]
- ["key1", "key4"]
-
-julia> collect_unmatched_keys(
-            UntypedConfigDict("key1" => 0, "key2" => 0),
-            UntypedConfigDict("key1" => 1, "key2" => 1)
-        )
-Vector{String}[]
-
-julia> collect_unmatched_keys(
-           UntypedConfigDict("key1" => UntypedConfigDict("key2" => 0, "key3" => 0)),
-           UntypedConfigDict("diff" => UntypedConfigDict("diff" => 0, "key3" => 0))
-        )
-1-element Vector{Vector{String}}:
- ["key1"]
-```
-
-TODO: Remove this. This is a temporary workaround to report unknown keys in the config file
-      until Configurations.jl supports reporting full path of unknown keys.
-"""
-function collect_unmatched_keys(this::UntypedConfigDict, ref::UntypedConfigDict=DEFAULT_UNTYPED_CONFIG_DICT)
-    unknown_keys = Vector{String}[]
-    collect_unmatched_keys!(unknown_keys, this, ref, String[])
-    return unknown_keys
-end
-
-function collect_unmatched_keys!(
-        unknown_keys::Vector{Vector{String}},
-        this::UntypedConfigDict, ref::UntypedConfigDict, key_path::Vector{String}
-    )
-    for (k, v) in this
-        current_path = [key_path; k]
-        b = get(ref, k, nothing)
-        if b === nothing
-            push!(unknown_keys, current_path)
-        elseif v isa AbstractDict
-            if b isa AbstractDict
-                collect_unmatched_keys!(unknown_keys, v, b, current_path)
-            else
-                push!(unknown_keys, current_path)
-            end
         end
     end
 end
@@ -308,11 +367,11 @@ function notify_config_changes(
     end
 end
 
-unmatched_keys_msg(header_msg::AbstractString, unmatched_keys) =
-    header_msg * "\n" * join(map(x -> string('`', join(x, "."), '`'), unmatched_keys), ", ")
+unmatched_key_msg(header_msg::AbstractString, path::Vector{String}) =
+    string(header_msg, "\n`", join(path, "."), "`")
 
 # Rewrite raw user config dicts so deprecated key paths land at their new
-# location before `Configurations.from_dict` sees them. Returns a list of
+# location before `parse_config_from_dict` sees them. Returns a list of
 # user-facing warnings — one per deprecation actually present.
 #
 # The struct schema only knows the current key paths, so callers must invoke

--- a/src/did-change-watched-files.jl
+++ b/src/did-change-watched-files.jl
@@ -102,8 +102,8 @@ function load_file_config!(on_difference, server::Server, filepath::AbstractStri
     end
 end
 
-unmatched_keys_in_config_file_msg(filepath::AbstractString, unmatched_keys) =
-    unmatched_keys_msg("Configuration file at $filepath contains unknown keys:", unmatched_keys)
+unmatched_key_in_config_file_msg(filepath::AbstractString, path::Vector{String}) =
+    unmatched_key_msg("Configuration file at $filepath contains an unknown key:", path)
 
 function delete_file_config!(on_difference, manager::ConfigManager, filepath::AbstractString)
     store!(manager) do old_data::ConfigManagerData

--- a/src/init-options.jl
+++ b/src/init-options.jl
@@ -16,7 +16,7 @@ function parse_init_options(server::Server, @nospecialize init_options)
     init_options === nothing && return DEFAULT_INIT_OPTIONS
     init_options isa AbstractDict || return DEFAULT_INIT_OPTIONS
     parsed = try
-        validate_init_options(server, Configurations.from_dict(InitOptions, init_options))
+        validate_init_options(server, parse_config_from_dict(InitOptions, init_options))
     catch err
         show_warning_message(server,
             "Failed to parse initializationOptions, using defaults: $err")
@@ -47,7 +47,7 @@ function load_file_init_options(server::Server, filepath::AbstractString)
         return nothing
     end
     try
-        return validate_init_options(server, Configurations.from_dict(InitOptions, init_options_dict))
+        return validate_init_options(server, parse_config_from_dict(InitOptions, init_options_dict))
     catch err
         show_error_message(server,
             "Failed to parse `[initialization_options]` in $filepath: $err")

--- a/src/types.jl
+++ b/src/types.jl
@@ -356,12 +356,13 @@ function Base.iterate(extra_diagnostics::ExtraDiagnosticsData, keysiter=(keys(ex
 end
 
 """
-To extend configuration options, define new `@option struct`s here:
+To extend configuration options, define new config structs here:
 
-    @option struct NewConfig <: ConfigSection
-        field1::Maybe{Type1}  # Maybe{T} from Configurations.jl allows optional fields
-        field2::Maybe{Type2}
+    @kwdef struct NewConfig <: ConfigSection
+        field1::Maybe{Type1} = nothing
+        field2::Maybe{Type2} = nothing
     end
+    @define_eq_overloads NewConfig
 
 All fields must be wrapped in `Maybe{}` to distinguish between cases of
 "no configuration set" and those of "user has set some configuration",
@@ -378,21 +379,32 @@ Finally, add the new config section to `JETLSConfig` struct below.
 """
 abstract type ConfigSection end
 
+const Maybe{T} = Union{Nothing,T}
+
 function merge_key_value end
 
-@option struct FullAnalysisConfig <: ConfigSection
-    debounce::Maybe{Float64}
-    auto_instantiate::Maybe{Bool}
+@kwdef struct FullAnalysisConfig <: ConfigSection
+    debounce::Maybe{Float64} = nothing
+    auto_instantiate::Maybe{Bool} = nothing
 end
+@define_eq_overloads FullAnalysisConfig
 
-@option struct TestRunnerConfig <: ConfigSection
-    executable::Maybe{String}
+@kwdef struct TestRunnerConfig <: ConfigSection
+    executable::Maybe{String} = nothing
 end
+@define_eq_overloads TestRunnerConfig
 
-@option "custom" struct CustomFormatterConfig
-    executable::Maybe{String}
-    executable_range::Maybe{String}
+@kwdef struct CustomFormatterConfig <: ConfigSection
+    executable::Maybe{String} = nothing
+    executable_range::Maybe{String} = nothing
 end
+@define_eq_overloads CustomFormatterConfig
+
+# Tag used to distinguish `CustomFormatterConfig` from a plain string in the formatter
+# field when serializing to / parsing from a config dict. With Configurations.jl this
+# was provided by `@option "custom"`, but JETLS's hand-rolled `parse_config_from_dict` needs the tag
+# stored explicitly.
+const CUSTOM_FORMATTER_ALIAS = "custom"
 
 const FormatterConfig = Union{String,CustomFormatterConfig}
 
@@ -471,36 +483,16 @@ struct DiagnosticPattern <: ConfigSection
     __pattern_value__::String # used for updated setting tracking
 end
 @define_eq_overloads DiagnosticPattern
-
-# Overload to inject custom validations for parsing `DiagnosticPattern` from
-# `Configuration.to_dict(::DiagnosticConfig, config::AbstractDict{String})`
-Base.convert(::Type{DiagnosticPattern}, x::AbstractDict{String}) =
-    parse_diagnostic_pattern(x)
-
 merge_key_value(pattern::DiagnosticPattern) =
     (pattern.match_by, pattern.match_type, pattern.path, pattern.__pattern_value__)
 
-# N.B. `@option` automatically adds `Base.:(==)` overloads for annotated types,
-# whose behavior is similar to those added by`@define_eq_overloads`
-
-@option struct DiagnosticConfig <: ConfigSection
-    enabled::Maybe{Bool}
-    all_files::Maybe{Bool}
-    allow_unused_underscore::Maybe{Bool}
-    patterns::Maybe{Vector{DiagnosticPattern}}
+@kwdef struct DiagnosticConfig <: ConfigSection
+    enabled::Maybe{Bool} = nothing
+    all_files::Maybe{Bool} = nothing
+    allow_unused_underscore::Maybe{Bool} = nothing
+    patterns::Maybe{Vector{DiagnosticPattern}} = nothing
 end
-# `@option` only generates content-based `==`, not `hash`, so the default `hash` falls
-# back to `objectid` and breaks the `==`/`hash` contract for `DiagnosticConfig` (its
-# `patterns::Vector` makes the parent's identity-based hash unstable across equal-valued
-# instances). `compute_diagnostic_result_id` folds this hash into pull-diagnostic
-# resultIds, so a content-based definition is required to avoid spurious invalidations.
-function Base.hash(config::DiagnosticConfig, h::UInt)
-    h = hash(config.enabled, h)
-    h = hash(config.all_files, h)
-    h = hash(config.allow_unused_underscore, h)
-    h = hash(config.patterns, h)
-    return h
-end
+@define_eq_overloads DiagnosticConfig
 
 # Internal, undocumented configuration for full-analysis module overrides.
 struct AnalysisOverride <: ConfigSection
@@ -508,15 +500,15 @@ struct AnalysisOverride <: ConfigSection
     module_name::Maybe{String}
 end
 @define_eq_overloads AnalysisOverride
-Base.convert(::Type{AnalysisOverride}, x::AbstractDict{String}) = parse_analysis_override(x)
 merge_key_value(analysis_override::AnalysisOverride) = analysis_override.path
 
 # Static initialization options from `InitializeParams.initializationOptions`.
 # These are set once during the initialize request and remain constant.
-@option struct InitOptions <: ConfigSection
-    n_analysis_workers::Maybe{Int}
-    analysis_overrides::Maybe{Vector{AnalysisOverride}}
+@kwdef struct InitOptions <: ConfigSection
+    n_analysis_workers::Maybe{Int} = nothing
+    analysis_overrides::Maybe{Vector{AnalysisOverride}} = nothing
 end
+@define_eq_overloads InitOptions
 function Base.show(io::IO, init_options::InitOptions)
     print(io, "InitOptions(;")
     n_analysis_workers = init_options.n_analysis_workers
@@ -527,47 +519,54 @@ function Base.show(io::IO, init_options::InitOptions)
 end
 const DEFAULT_INIT_OPTIONS = InitOptions(; n_analysis_workers=1, analysis_overrides=AnalysisOverride[])
 
-@option struct LaTeXEmojiConfig <: ConfigSection
-    strip_prefix::Maybe{Union{Missing,Bool}} # missing is used as sentinel for default setting value
+@kwdef struct LaTeXEmojiConfig <: ConfigSection
+    strip_prefix::Maybe{Union{Missing,Bool}} = nothing # missing is used as sentinel for default setting value
 end
+@define_eq_overloads LaTeXEmojiConfig
 
-@option struct MethodSignatureConfig <: ConfigSection
-    prepend_inference_result::Maybe{Union{Missing,Bool}} # missing is used as sentinel for default setting value
+@kwdef struct MethodSignatureConfig <: ConfigSection
+    prepend_inference_result::Maybe{Union{Missing,Bool}} = nothing # missing is used as sentinel for default setting value
 end
+@define_eq_overloads MethodSignatureConfig
 
-@option struct CompletionConfig <: ConfigSection
-    latex_emoji::Maybe{LaTeXEmojiConfig}
-    method_signature::Maybe{MethodSignatureConfig}
+@kwdef struct CompletionConfig <: ConfigSection
+    latex_emoji::Maybe{LaTeXEmojiConfig} = nothing
+    method_signature::Maybe{MethodSignatureConfig} = nothing
 end
+@define_eq_overloads CompletionConfig
 
-@option struct CodeLensConfig <: ConfigSection
-    references::Maybe{Bool}
-    testrunner::Maybe{Bool}
+@kwdef struct CodeLensConfig <: ConfigSection
+    references::Maybe{Bool} = nothing
+    testrunner::Maybe{Bool} = nothing
 end
+@define_eq_overloads CodeLensConfig
 
-@option struct InlayHintBlockEndConfig <: ConfigSection
-    enabled::Maybe{Bool}
-    min_lines::Maybe{Int}
+@kwdef struct InlayHintBlockEndConfig <: ConfigSection
+    enabled::Maybe{Bool} = nothing
+    min_lines::Maybe{Int} = nothing
 end
+@define_eq_overloads InlayHintBlockEndConfig
 
-@option struct InlayHintConfig <: ConfigSection
-    block_end::Maybe{InlayHintBlockEndConfig}
+@kwdef struct InlayHintConfig <: ConfigSection
+    block_end::Maybe{InlayHintBlockEndConfig} = nothing
 end
+@define_eq_overloads InlayHintConfig
 
-@option struct JETLSConfig <: ConfigSection
-    diagnostic::Maybe{DiagnosticConfig}
-    full_analysis::Maybe{FullAnalysisConfig}
-    testrunner::Maybe{TestRunnerConfig}
-    formatter::Maybe{FormatterConfig}
-    completion::Maybe{CompletionConfig}
-    code_lens::Maybe{CodeLensConfig}
-    inlay_hint::Maybe{InlayHintConfig}
+@kwdef struct JETLSConfig <: ConfigSection
+    diagnostic::Maybe{DiagnosticConfig} = nothing
+    full_analysis::Maybe{FullAnalysisConfig} = nothing
+    testrunner::Maybe{TestRunnerConfig} = nothing
+    formatter::Maybe{FormatterConfig} = nothing
+    completion::Maybe{CompletionConfig} = nothing
+    code_lens::Maybe{CodeLensConfig} = nothing
+    inlay_hint::Maybe{InlayHintConfig} = nothing
     # This initialization options are read once at the server initialization and held in
     # `server.state.init_options`, so it might seem strange to hold them here also,
     # but they need to be set here for cases where initialization options are set in
     # .JETLSConfig.toml.
-    initialization_options::Maybe{InitOptions}
+    initialization_options::Maybe{InitOptions} = nothing
 end
+@define_eq_overloads JETLSConfig
 
 const DEFAULT_CONFIG = JETLSConfig(;
     diagnostic = DiagnosticConfig(true, true, true, DiagnosticPattern[]),

--- a/src/workspace-configuration.jl
+++ b/src/workspace-configuration.jl
@@ -56,8 +56,8 @@ function load_lsp_config!(server::Server, source::AbstractString; on_init::Bool=
     nothing
 end
 
-unmatched_keys_in_lsp_config_msg(unmatched_keys) =
-    unmatched_keys_msg("LSP configuration contains unknown keys:", unmatched_keys)
+unmatched_key_in_lsp_config_msg(path::Vector{String}) =
+    unmatched_key_msg("LSP configuration contains an unknown key:", path)
 
 function store_lsp_config!(tracker::ConfigChangeTracker, server::Server, @nospecialize(config_value), source::AbstractString)
     if !(config_value isa AbstractDict{String})

--- a/test/test_config.jl
+++ b/test/test_config.jl
@@ -144,42 +144,88 @@ using JETLS
     end
 end
 
-@testset "UntypedConfigDict utilities" begin
-    TEST_DICT = JETLS.UntypedConfigDict(
-        "test_key1" => "test_value1",
-        "test_key2" => JETLS.UntypedConfigDict(
-            "nested_key1" => "nested_value1",
-            "nested_key2" => JETLS.UntypedConfigDict(
-                "deep_nested_key1" => "deep_nested_value1",
-                "deep_nested_key2" => "deep_nested_value2"
-            )
-        )
-    )
+@testset "`parse_config_from_dict` reports full key paths in `InvalidKeyError`" begin
+    let err = try
+            JETLS.parse_config_from_dict(JETLS.JETLSConfig, Dict{String,Any}("___unknown___" => 1))
+            nothing
+        catch e; e; end
+        @test err isa JETLS.InvalidKeyError
+        @test err.path == ["___unknown___"]
+    end
+    let err = try
+            JETLS.parse_config_from_dict(JETLS.JETLSConfig, Dict{String,Any}(
+                "diagnostic" => Dict{String,Any}("___unknown___" => 1)))
+            nothing
+        catch e; e; end
+        @test err isa JETLS.InvalidKeyError
+        @test err.path == ["diagnostic", "___unknown___"]
+    end
+end
 
-    TEST_DICT_DIFFERENT_KEY = JETLS.UntypedConfigDict(
-        "diffname_1" => "test_value1",
-        "test_key2" => JETLS.UntypedConfigDict(
-            "nested_key1" => "nested_value1",
-            "diffname_2" => JETLS.UntypedConfigDict(
-                "deep_nested_key1" => "deep_nested_value1",
-                "diffname_3" => "deep_nested_value2"
-            )
-        ),
-    )
+@testset "`parse_dict_value` error messages include the dotted path" begin
+    # Wrong leaf type at top level (single-segment path).
+    let err = try
+            JETLS.parse_config_from_dict(JETLS.DiagnosticConfig, Dict{String,Any}("enabled" => "yes"))
+            nothing
+        catch e; e; end
+        @test err isa ErrorException
+        @test occursin("Invalid value at `enabled`", err.msg)
+        @test occursin("expected Bool", err.msg)
+        @test occursin("got String", err.msg)
+    end
 
-    @testset "collect_unmatched_keys" begin
-        # It is correct that `test_key2.diffname_2.diffname_3` is not included,
-        # because `collect_unmatched_keys` does not track deeper nested differences in key names.
-        @test Set(JETLS.collect_unmatched_keys(TEST_DICT_DIFFERENT_KEY, TEST_DICT)) == Set([
-            ["diffname_1"],
-            ["test_key2", "diffname_2"],
-        ])
+    # Wrong leaf type at a nested location (multi-segment path).
+    let err = try
+            JETLS.parse_config_from_dict(JETLS.JETLSConfig, Dict{String,Any}(
+                "diagnostic" => Dict{String,Any}("allow_unused_underscore" => "yes")))
+            nothing
+        catch e; e; end
+        @test err isa ErrorException
+        @test occursin("Invalid value at `diagnostic.allow_unused_underscore`", err.msg)
+        @test occursin("expected Bool", err.msg)
+        @test occursin("got String", err.msg)
+    end
 
-        @test isempty(JETLS.collect_unmatched_keys(TEST_DICT, TEST_DICT))
+    # `ConfigSection` field that should be a table.
+    let err = try
+            JETLS.parse_config_from_dict(JETLS.JETLSConfig, Dict{String,Any}("diagnostic" => "nope"))
+            nothing
+        catch e; e; end
+        @test err isa ErrorException
+        @test occursin("Invalid value at `diagnostic`", err.msg)
+        @test occursin("expected a table for", err.msg)
+    end
 
-        # single-arg version should use DEFAULT_UNTYPED_CONFIG_DICT
-        @test JETLS.collect_unmatched_keys(TEST_DICT_DIFFERENT_KEY) ==
-              JETLS.collect_unmatched_keys(TEST_DICT_DIFFERENT_KEY, JETLS.DEFAULT_UNTYPED_CONFIG_DICT)
+    # Vector field that should be an array.
+    let err = try
+            JETLS.parse_config_from_dict(JETLS.JETLSConfig, Dict{String,Any}(
+                "diagnostic" => Dict{String,Any}("patterns" => "not an array")))
+            nothing
+        catch e; e; end
+        @test err isa ErrorException
+        @test occursin("Invalid value at `diagnostic.patterns`", err.msg)
+        @test occursin("expected an array", err.msg)
+    end
+
+    # Formatter field expects a string or `{custom = ...}` table.
+    let err = try
+            JETLS.parse_config_from_dict(JETLS.JETLSConfig, Dict{String,Any}("formatter" => 123))
+            nothing
+        catch e; e; end
+        @test err isa ErrorException
+        @test occursin("Invalid value at `formatter`", err.msg)
+        @test occursin("expected formatter string or table", err.msg)
+    end
+
+    # Formatter table missing the `custom` key.
+    let err = try
+            JETLS.parse_config_from_dict(JETLS.JETLSConfig, Dict{String,Any}(
+                "formatter" => Dict{String,Any}("not_custom" => Dict{String,Any}())))
+            nothing
+        catch e; e; end
+        @test err isa ErrorException
+        @test occursin("Invalid value at `formatter`", err.msg)
+        @test occursin("expected formatter table key `custom`", err.msg)
     end
 end
 

--- a/test/test_diagnostic.jl
+++ b/test/test_diagnostic.jl
@@ -587,8 +587,6 @@ end
     end
 end
 
-using JETLS.Configurations: Configurations
-
 function make_test_diagnostic(;
         code::String,
         severity::DiagnosticSeverity.Ty,
@@ -606,7 +604,7 @@ function make_test_diagnostic(;
 end
 
 function make_test_manager(config_dict::Dict{String,Any})
-    lsp_config = JETLS.Configurations.from_dict(JETLS.JETLSConfig, config_dict)
+    lsp_config = JETLS.parse_config_from_dict(JETLS.JETLSConfig, config_dict)
     data = JETLS.ConfigManagerData(JETLS.EMPTY_CONFIG, lsp_config, nothing, true)
     return JETLS.ConfigManager(data)
 end
@@ -615,12 +613,12 @@ end
     @testset "DiagnosticConfig parsing/validation" begin
         @testset "valid patterns" begin
             let config_raw = Dict{String,Any}()
-                config = Configurations.from_dict(JETLS.DiagnosticConfig, config_raw)
+                config = JETLS.parse_config_from_dict(JETLS.DiagnosticConfig, config_raw)
                 @test config.enabled === nothing
                 @test config.patterns === nothing
             end
             let config_raw = Dict{String,Any}("enabled" => false)
-                config = Configurations.from_dict(JETLS.DiagnosticConfig, config_raw)
+                config = JETLS.parse_config_from_dict(JETLS.DiagnosticConfig, config_raw)
                 @test config.enabled === false
                 @test config.patterns === nothing
             end
@@ -633,7 +631,7 @@ end
                             "match_type" => "literal",
                             "severity" => "hint")
                     ])
-                config = Configurations.from_dict(JETLS.DiagnosticConfig, config_raw)
+                config = JETLS.parse_config_from_dict(JETLS.DiagnosticConfig, config_raw)
                 @test config.enabled === nothing
                 @test config.patterns !== nothing
                 @test length(config.patterns) == 1
@@ -652,7 +650,7 @@ end
                             "match_type" => "literal",
                             "severity" => 4)
                     ])
-                config = Configurations.from_dict(JETLS.DiagnosticConfig, config_raw)
+                config = JETLS.parse_config_from_dict(JETLS.DiagnosticConfig, config_raw)
                 pattern = only(config.patterns)
                 @test pattern.severity == DiagnosticSeverity.Hint
             end
@@ -665,7 +663,7 @@ end
                             "match_type" => "regex",
                             "severity" => "off")
                     ])
-                config = Configurations.from_dict(JETLS.DiagnosticConfig, config_raw)
+                config = JETLS.parse_config_from_dict(JETLS.DiagnosticConfig, config_raw)
                 pattern = only(config.patterns)
                 @test pattern.match_type == "regex"
                 @test pattern.pattern isa Regex
@@ -681,7 +679,7 @@ end
                             "match_type" => "literal",
                             "severity" => "info")
                     ])
-                config = Configurations.from_dict(JETLS.DiagnosticConfig, config_raw)
+                config = JETLS.parse_config_from_dict(JETLS.DiagnosticConfig, config_raw)
                 pattern = only(config.patterns)
                 @test pattern.match_by == "message"
                 @test pattern.pattern == "Macro name `@namespace` not found"
@@ -696,7 +694,7 @@ end
                             "match_type" => "regex",
                             "severity" => "hint")
                     ])
-                config = Configurations.from_dict(JETLS.DiagnosticConfig, config_raw)
+                config = JETLS.parse_config_from_dict(JETLS.DiagnosticConfig, config_raw)
                 pattern = only(config.patterns)
                 @test pattern.match_by == "message"
                 @test pattern.pattern isa Regex
@@ -719,7 +717,7 @@ end
                             "match_type" => "literal",
                             "severity" => "hint")
                     ])
-                config = Configurations.from_dict(JETLS.DiagnosticConfig, config_raw)
+                config = JETLS.parse_config_from_dict(JETLS.DiagnosticConfig, config_raw)
                 @test config.enabled === true
                 @test config.patterns !== nothing
                 @test length(config.patterns) == 2
@@ -734,7 +732,7 @@ end
                             "severity" => "hint",
                             "path" => "test/**/*.jl")
                     ])
-                config = Configurations.from_dict(JETLS.DiagnosticConfig, config_raw)
+                config = JETLS.parse_config_from_dict(JETLS.DiagnosticConfig, config_raw)
                 pattern = only(config.patterns)
                 @test pattern.path !== nothing
                 @test pattern.path isa Glob.FilenameMatch
@@ -749,7 +747,7 @@ end
         @testset "invalid patterns" begin
             let config_raw = Dict{String,Any}(
                     "invalid" => [])
-                @test_throws Configurations.InvalidKeyError Configurations.from_dict(
+                @test_throws JETLS.InvalidKeyError JETLS.parse_config_from_dict(
                     JETLS.DiagnosticConfig, config_raw)
             end
             let config_raw = Dict{String,Any}(
@@ -759,7 +757,7 @@ end
                             "match_type" => "literal",
                             "severity" => "info")
                     ])
-                @test_throws JETLS.DiagnosticConfigError Configurations.from_dict(
+                @test_throws JETLS.DiagnosticConfigError JETLS.parse_config_from_dict(
                     JETLS.DiagnosticConfig, config_raw)
             end
             let config_raw = Dict{String,Any}(
@@ -769,7 +767,7 @@ end
                             "match_type" => "literal",
                             "severity" => "info")
                     ])
-                @test_throws JETLS.DiagnosticConfigError Configurations.from_dict(
+                @test_throws JETLS.DiagnosticConfigError JETLS.parse_config_from_dict(
                     JETLS.DiagnosticConfig, config_raw)
             end
             let config_raw = Dict{String,Any}(
@@ -779,7 +777,7 @@ end
                             "match_by" => "code",
                             "severity" => "info")
                     ])
-                @test_throws JETLS.DiagnosticConfigError Configurations.from_dict(
+                @test_throws JETLS.DiagnosticConfigError JETLS.parse_config_from_dict(
                     JETLS.DiagnosticConfig, config_raw)
             end
             let config_raw = Dict{String,Any}(
@@ -789,7 +787,7 @@ end
                             "match_by" => "code",
                             "match_type" => "literal",)
                     ])
-                @test_throws JETLS.DiagnosticConfigError Configurations.from_dict(
+                @test_throws JETLS.DiagnosticConfigError JETLS.parse_config_from_dict(
                     JETLS.DiagnosticConfig, config_raw)
             end
             let config_raw = Dict{String,Any}(
@@ -800,7 +798,7 @@ end
                             "severity" => "info",
                             "match_type" => "literal")
                     ])
-                @test_throws JETLS.DiagnosticConfigError Configurations.from_dict(
+                @test_throws JETLS.DiagnosticConfigError JETLS.parse_config_from_dict(
                     JETLS.DiagnosticConfig, config_raw)
             end
             let config_raw = Dict{String,Any}(
@@ -811,7 +809,7 @@ end
                             "severity" => "info",
                             "match_type" => "literal")
                     ])
-                @test_throws JETLS.DiagnosticConfigError Configurations.from_dict(
+                @test_throws JETLS.DiagnosticConfigError JETLS.parse_config_from_dict(
                     JETLS.DiagnosticConfig, config_raw)
             end
             let config_raw = Dict{String,Any}(
@@ -822,7 +820,7 @@ end
                             "severity" => "invalid",
                             "match_type" => "literal")
                     ])
-                @test_throws JETLS.DiagnosticConfigError Configurations.from_dict(
+                @test_throws JETLS.DiagnosticConfigError JETLS.parse_config_from_dict(
                     JETLS.DiagnosticConfig, config_raw)
             end
             let config_raw = Dict{String,Any}(
@@ -833,7 +831,7 @@ end
                             "severity" => 5,
                             "match_type" => "literal")
                     ])
-                @test_throws JETLS.DiagnosticConfigError Configurations.from_dict(
+                @test_throws JETLS.DiagnosticConfigError JETLS.parse_config_from_dict(
                     JETLS.DiagnosticConfig, config_raw)
             end
             let config_raw = Dict{String,Any}(
@@ -844,7 +842,7 @@ end
                             "severity" => Dict{String,Any}(),
                             "match_type" => "literal")
                     ])
-                @test_throws JETLS.DiagnosticConfigError Configurations.from_dict(
+                @test_throws JETLS.DiagnosticConfigError JETLS.parse_config_from_dict(
                     JETLS.DiagnosticConfig, config_raw)
             end
             let config_raw = Dict{String,Any}(
@@ -855,7 +853,7 @@ end
                             "match_type" => "invalid",
                             "severity" => "info")
                     ])
-                @test_throws JETLS.DiagnosticConfigError Configurations.from_dict(
+                @test_throws JETLS.DiagnosticConfigError JETLS.parse_config_from_dict(
                     JETLS.DiagnosticConfig, config_raw)
             end
             let config_raw = Dict{String,Any}(
@@ -866,7 +864,7 @@ end
                             "match_type" => Dict{String,Any}(),
                             "severity" => "info")
                     ])
-                @test_throws JETLS.DiagnosticConfigError Configurations.from_dict(
+                @test_throws JETLS.DiagnosticConfigError JETLS.parse_config_from_dict(
                     JETLS.DiagnosticConfig, config_raw)
             end
             let config_raw = Dict{String,Any}(
@@ -877,7 +875,7 @@ end
                             "match_type" => "regex",
                             "severity" => "info")
                     ])
-                @test_throws JETLS.DiagnosticConfigError Configurations.from_dict(
+                @test_throws JETLS.DiagnosticConfigError JETLS.parse_config_from_dict(
                     JETLS.DiagnosticConfig, config_raw)
             end
             let config_raw = Dict{String,Any}(
@@ -889,7 +887,7 @@ end
                             "severity" => "info",
                             "invalid_key" => "value")
                     ])
-                @test_throws JETLS.DiagnosticConfigError Configurations.from_dict(
+                @test_throws JETLS.DiagnosticConfigError JETLS.parse_config_from_dict(
                     JETLS.DiagnosticConfig, config_raw)
             end
             let config_raw = Dict{String,Any}(
@@ -901,7 +899,7 @@ end
                             "severity" => "hint",
                             "path" => 123)
                     ])
-                @test_throws JETLS.DiagnosticConfigError Configurations.from_dict(
+                @test_throws JETLS.DiagnosticConfigError JETLS.parse_config_from_dict(
                     JETLS.DiagnosticConfig, config_raw)
             end
         end

--- a/test/test_did_change_watched_files.jl
+++ b/test/test_did_change_watched_files.jl
@@ -105,7 +105,7 @@ const TESTRUNNER_DEFAULT = JETLS.get_config(JETLS.ConfigManager(JETLS.ConfigMana
                 (; raw_res) = writereadmsg(msg)
                 @test raw_res isa ShowMessageNotification
                 @test raw_res.params.type == MessageType.Error
-                expected_error_msg = JETLS.unmatched_keys_in_config_file_msg(config_path, [["full_analysis", "___unknown_key___"]])
+                expected_error_msg = JETLS.unmatched_key_in_config_file_msg(config_path, ["full_analysis", "___unknown_key___"])
                 @test occursin(expected_error_msg, raw_res.params.message)
             end
 


### PR DESCRIPTION
Replace the `@option` macro from Configurations.jl with `@kwdef` plus `@define_eq_overloads` for the eleven config structs in `src/types.jl`, and hand-roll the dict-to-struct hydration that the package needs.

`parse_config_from_dict` (was `Configurations.from_dict`) recursively populates a `ConfigSection` from a config dict, threading a dotted key path through nested calls. `InvalidKeyError` now carries that full path directly, which lets `parse_config_dict` report the offending key without re-walking the user's dict against a canonical default — eliminating `collect_unmatched_keys`,
`UntypedConfigDict`, `DEFAULT_UNTYPED_CONFIG_DICT`, and the `Configurations.to_dict`-based scaffolding.

`parse_config_dict_value` handles the small type tree we actually use: `Maybe{T}`, nested `ConfigSection`, vectors, the formatter union, and plain `convert`-able leaves. Errors at every level are formatted via `parse_dict_error` so users get
`Invalid value at \`a.b.c\`: expected X, got Y` regardless of where in the type tree the mismatch occurred. The bespoke `DiagnosticPattern` / `AnalysisOverride` validators are inlined in `parse_config_dict_value` rather than dispatched through a hook, matching how `Maybe{FormatterConfig}` is handled — the set of special cases is small and closed.

`Maybe{T} = Union{Nothing,T}` is now defined locally. Tests that poked into `Configurations.from_dict` / `Configurations.InvalidKeyError` are updated to use the JETLS-side equivalents, and new tests cover `InvalidKeyError.path` and `parse_config_dict_value`'s path-aware error messages.