### PR TITLE
semantic-tokens: Extend `typeParameter` to struct type heads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > The new shape adds [`inlay_hint.block_end.enabled`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/inlay_hint/block_end/enabled) for toggling block-end hints independently, and renames `inlay_hint.block_end_min_lines` to [`inlay_hint.block_end.min_lines`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/inlay_hint/block_end/min_lines).
 > Existing configs keep working for now: the legacy key is still accepted at load time and mapped onto the new key in memory (your config file is not modified automatically), with a one-shot deprecation warning. The legacy alias will be removed in releases after **June 2026**, so if you are still using `inlay_hint.block_end_min_lines`, please update your config.
 
+### Changed
+
+- `textDocument/semanticTokens` now classifies type parameters declared in `struct` / `abstract type` / `primitive type` headers (and their use sites inside the type body) as `typeParameter`. Previously these identifiers were classified as plain `variable`.
+
 ## 2026-05-08
 
 - Commit: [`72cc49c`](https://github.com/aviatesk/JETLS.jl/commit/72cc49c)

--- a/src/semantic-tokens.jl
+++ b/src/semantic-tokens.jl
@@ -132,7 +132,7 @@ function compute_semantic_tokens(
             return
         end
         occs = get_binding_occurrences!(state, uri, fi, st0)
-        collect_semantic_tokens_for_occurrences!(raw, state, uri, fi, occs)
+        collect_semantic_tokens_for_occurrences!(raw, state, uri, fi, occs, st0)
     end
     sort!(raw)
     merge_overlapping_tokens!(raw)
@@ -183,27 +183,61 @@ end
 
 function collect_semantic_tokens_for_occurrences!(
         raw::Vector{SemanticTokenTuple}, state::ServerState, uri::URI, fi::FileInfo,
-        occs::BindingOccurrencesResult,
+        occs::BindingOccurrencesResult, st0::SyntaxTreeC,
     )
-    # `:static_parameter` bindings often coexist with same-named `:local`
-    # aliases produced by `where`-clause scope blocks, sharing the same
-    # occurrence set. Emitting both classifies one identifier as both
-    # `typeParameter` and `variable`. Drop the `:local` aliases.
-    static_param_names = Set{String}()
+    # `:local` aliases for type parameters cover a superset of the corresponding
+    # `:static_parameter`'s occurrences — and for plain `struct A{T}; ...; end` are
+    # the only signal at all.
+    # Collect names from both and reclassify matching `:local`s as `typeParameter`.
+    type_param_names = Set{String}()
     for binfo_key in keys(occs)
         if binfo_key.kind === :static_parameter
-            push!(static_param_names, binfo_key.name)
+            push!(type_param_names, binfo_key.name)
         end
     end
+    collect_type_param_names_from_tree!(type_param_names, st0)
     for (binfo_key, occurrences) in occs
-        binfo_key.kind === :local && binfo_key.name in static_param_names && continue
-        ttype = classify_token_type(binfo_key.kind)
+        if binfo_key.name in type_param_names
+            ttype = SEMANTIC_TOKEN_TYPE_TYPE_PARAMETER
+        else
+            ttype = classify_token_type(binfo_key.kind)
+        end
         name_bytes = sizeof(binfo_key.name)
         for occurrence in occurrences
             push_semantic_token!(raw, state, uri, fi, occurrence, ttype, name_bytes)
         end
     end
     return raw
+end
+
+function collect_type_param_names_from_tree!(names::Set{String}, st0::SyntaxTreeC)
+    traverse(st0) do node
+        k = JS.kind(node)
+        if k === JS.K"struct" && JS.numchildren(node) >= 2
+            sig = node[2]
+        elseif k in JS.KSet"abstract primitive" && JS.numchildren(node) >= 1
+            sig = node[1]
+        else
+            return
+        end
+        if JS.kind(sig) === JS.K"<:" && JS.numchildren(sig) >= 1
+            sig = sig[1]
+        end
+        if JS.kind(sig) === JS.K"curly"
+            for i = 2:JS.numchildren(sig)
+                param = sig[i]
+                if JS.kind(param) === JS.K"<:" && JS.numchildren(param) >= 1
+                    param = param[1]
+                end
+                name = @something extract_name_val(param) continue
+                push!(names, name)
+            end
+        end
+        # Bodies host no nested type defs; inner-ctor `where` params
+        # already surface as `:static_parameter`.
+        return traversal_no_recurse
+    end
+    return names
 end
 
 function push_semantic_token!(

--- a/test/test_semantic_tokens.jl
+++ b/test/test_semantic_tokens.jl
@@ -89,6 +89,69 @@ end
         @test any(t -> t.line == 0 && t.char == 32 && t.len == 1 && t.mod == 0, type_params)
     end
 
+    @testset "struct type parameter" begin
+        # Plain `struct A{T}; ... end` doesn't introduce any `:static_parameter`;
+        # we recover `T` by walking the type header.
+        let code = """
+            struct A{T}
+                x::T
+            end
+            """
+            tokens = tokens_for(code)
+            type_params = filter(t -> t.type == TYPE_TYPE_PARAMETER, tokens)
+            @test length(type_params) == 2
+            @test any(t -> t.line == 0 && t.char == 9 && t.len == 1, type_params) # struct A{T}
+            @test any(t -> t.line == 1 && t.char == 7 && t.len == 1 && t.mod == 0, type_params) # x::T
+        end
+
+        # Constrained type params and multiple params; `Number` must stay as a regular
+        # type reference, not be lifted to `typeParameter`.
+        let code = """
+            struct B{T<:Number, S}
+                x::T
+                y::S
+            end
+            """
+            tokens = tokens_for(code)
+            type_params = filter(t -> t.type == TYPE_TYPE_PARAMETER, tokens)
+            @test any(t -> t.line == 0 && t.char == 9  && t.len == 1, type_params) # T in `B{T<:...,`
+            @test any(t -> t.line == 0 && t.char == 20 && t.len == 1, type_params) # S
+            @test any(t -> t.line == 1 && t.char == 7  && t.len == 1, type_params) # x::T
+            @test any(t -> t.line == 2 && t.char == 7  && t.len == 1, type_params) # y::S
+            @test !any(t -> t.line == 0 && t.char == 12 && t.type == TYPE_TYPE_PARAMETER, tokens) # Number
+        end
+
+        # `abstract type C{T} end`
+        let code = "abstract type C{T} end\n"
+            tokens = tokens_for(code)
+            type_params = filter(t -> t.type == TYPE_TYPE_PARAMETER, tokens)
+            @test any(t -> t.line == 0 && t.char == 16 && t.len == 1, type_params)
+        end
+
+        # Parametric inner ctor: every `T` should be `typeParameter`,
+        # including the ones reachable only through the `:local` alias
+        # (`struct A{T}` header and `x::T`, which the inner ctor's
+        # `:static_parameter` scope doesn't cover).
+        let code = """
+            struct A{T}
+                x::T
+                A{T}(x) where T = new{T}(convert(T, x))
+            end
+            """
+            tokens = tokens_for(code)
+            type_params = filter(t -> t.type == TYPE_TYPE_PARAMETER, tokens)
+            @test length(type_params) == 6
+            @test any(t -> t.line == 0 && t.char == 9  && t.len == 1 &&
+                           t.mod == (MOD_DEFINITION | MOD_DECLARATION), type_params)             # struct A{T}
+            @test any(t -> t.line == 1 && t.char == 7  && t.len == 1 && t.mod == 0, type_params) # x::T
+            @test any(t -> t.line == 2 && t.char == 6  && t.len == 1 && t.mod == 0, type_params) # A{T}(x)
+            @test any(t -> t.line == 2 && t.char == 18 && t.len == 1 &&
+                           t.mod == (MOD_DEFINITION | MOD_DECLARATION), type_params)             # where T
+            @test any(t -> t.line == 2 && t.char == 26 && t.len == 1 && t.mod == 0, type_params) # new{T}
+            @test any(t -> t.line == 2 && t.char == 37 && t.len == 1 && t.mod == 0, type_params) # convert(T, x)
+        end
+    end
+
     @testset "global use is emitted as `unspecified`" begin
         code = """
         println("hello")


### PR DESCRIPTION
Type parameters declared in `struct A{T}; x::T; end` and friends are now classified as `typeParameter` instead of `variable`. The `T` in `struct A{T}` is tracked by JuliaLowering as `:local` (no `:static_parameter` is introduced for plain struct heads), so the previous `:static_parameter`-only path missed it.

Type-parameter names are now collected from two sources — the `:static_parameter` bindings already in `occs`, plus a syntactic walk of `st0` for `struct` / `abstract type` / `primitive type` headers — and any matching binding is reclassified.

This also fixes the partial coverage in
`struct A{T}; x::T; A{T}(x) where T = new{T}(...); end`, where the inner ctor's `:static_parameter T` reached its own `where`-scope but not the outer `struct A{T}` header or the field type.