### PR TITLE
TypeAnnotation: Annotate literal positional args of `:call`

### DIFF
--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -387,6 +387,16 @@ function is_synthetic_destructure_stmt(filter::SyntheticFilter, stmttree::Syntax
     return false
 end
 
+# JL inserts synthetic nodes (`Base.X` / `Core.X` call-head refs for
+# array literals / kwarg / parametric-ctor scaffolding, lowering-introduced
+# literals in destructure / generator scaffolding, …) with no natural
+# user-source position; JL attaches their `treeref` to the parent surface
+# form so they share the surrounding stmt's full byte range. Flagging by
+# that range equality skips annotating scaffolding leaves at ranges meant
+# for user-facing queries.
+is_synthetic_arg_leaf(stmttree::SyntaxTreeC, leaf::SyntaxTreeC) =
+    JS.byte_range(leaf) == JS.byte_range(stmttree)
+
 function annotate_types!(
         citree::SyntaxTreeC, frame::CC.InferenceState, filter::SyntheticFilter
     )
@@ -406,8 +416,8 @@ function annotate_types!(
         # Synthetic destructure K"="s share the user's RHS byte range, so
         # annotating them (or their inner K"call" / args, below) would shadow
         # source-range queries.
-        is_synthesized = is_synthetic_destructure_stmt(filter, stmttree)
-        is_synthesized || JS.setattr!(stmttree, :type, stmttype)
+        is_synthesized_stmt = is_synthetic_destructure_stmt(filter, stmttree)
+        is_synthesized_stmt || JS.setattr!(stmttree, :type, stmttype)
         if stmt isa Expr
             stmt.head === :meta && continue
             # TODO: properly annotate static-parameter references once CC supports
@@ -431,10 +441,10 @@ function annotate_types!(
                 stmt = stmt.args[2]
                 stmt isa Expr || continue
                 treeref = treeref[2]
-                is_synthesized || JS.setattr!(treeref, :type, stmttype)
+                is_synthesized_stmt || JS.setattr!(treeref, :type, stmttype)
             end
             is_call = stmt.head === :call
-            if is_call && !is_synthesized
+            if is_call && !is_synthesized_stmt
                 matches = extract_call_matches(frame.stmt_info[i])
                 matches === nothing || JS.setattr!(treeref, :matches, matches)
             end
@@ -442,6 +452,18 @@ function annotate_types!(
                 arg = stmt.args[j]
                 if arg isa SlotNumber && !is_internal_binding_leaf(filter, treeref[j])
                     argtyp = slot_type_at(arg, i, frame)
+                    JS.setattr!(treeref[j], :type, argtyp)
+                elseif (!is_synthesized_stmt && is_call && !(arg isa SSAValue) &&
+                        !is_synthetic_arg_leaf(treeref, treeref[j]))
+                    # `is_synthetic_arg_leaf` filters lowering-inserted leaves
+                    # (synthetic call heads like `Base.vect` for `[1,2,3]` /
+                    # `Core.apply_type` / `Core.kwcall` for kwarg calls, and
+                    # lowering-introduced literals in comprehension scaffolding).
+                    # Their `argextype` otherwise leaks through `tmerge_at_range`-dispatched
+                    # queries (`K"vect"`, `K"typed_vcat"`, …) as a union with the real type.
+                    # SSAValue args are skipped separately since the producing stmt already
+                    # annotates the value.
+                    argtyp = CC.argextype(arg, frame.src, frame.sptypes)
                     JS.setattr!(treeref[j], :type, argtyp)
                 end
             end

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -503,6 +503,90 @@ end
     end
 end
 
+@testset HierarchicalTestSet "Call positional arg annotation" begin
+    # At a `:call` site, both the callee identifier and each literal /
+    # `GlobalRef` arg should resolve to `Core.Const(value)` so consumers
+    # (hover, signature help, completion) can read precise types by
+    # querying at the corresponding byte range.
+
+    @testset "annotates literal args" begin
+        @testset "integer" begin
+            code = "sin(42)"
+            _, ctx = type_annotate(code)
+            @test get_type_for_range(ctx, range_of(code, "sin")) === Core.Const(sin)
+            @test get_type_for_range(ctx, range_of(code, "42")) === Core.Const(42)
+        end
+        @testset "float" begin
+            code = "sin(1.5)"
+            _, ctx = type_annotate(code)
+            @test get_type_for_range(ctx, range_of(code, "sin")) === Core.Const(sin)
+            @test get_type_for_range(ctx, range_of(code, "1.5")) === Core.Const(1.5)
+        end
+        @testset "bool" begin
+            code = "xor(true, false)"
+            _, ctx = type_annotate(code)
+            @test get_type_for_range(ctx, range_of(code, "xor")) === Core.Const(xor)
+            @test get_type_for_range(ctx, range_of(code, "true")) === Core.Const(true)
+            @test get_type_for_range(ctx, range_of(code, "false")) === Core.Const(false)
+        end
+        @testset "nothing" begin
+            code = "sin(nothing)"
+            _, ctx = type_annotate(code)
+            @test get_type_for_range(ctx, range_of(code, "sin")) === Core.Const(sin)
+            @test get_type_for_range(ctx, range_of(code, "nothing")) === Core.Const(nothing)
+        end
+        # String / Symbol / Char literals expose the value at the inner
+        # content node, not at the surrounding surface form that includes
+        # the quotes / colon.
+        @testset "string" begin
+            code = "println(\"hi\")"
+            _, ctx = type_annotate(code)
+            @test get_type_for_range(ctx, range_of(code, "println")) === Core.Const(println)
+            @test get_type_for_range(ctx, range_of(code, "hi")) === Core.Const("hi")
+        end
+        @testset "symbol" begin
+            code = "sin(:foo)"
+            _, ctx = type_annotate(code)
+            @test get_type_for_range(ctx, range_of(code, "sin")) === Core.Const(sin)
+            @test get_type_for_range(ctx, range_of(code, "foo")) === Core.Const(:foo)
+        end
+        @testset "char" begin
+            code = "sin('a')"
+            _, ctx = type_annotate(code)
+            @test get_type_for_range(ctx, range_of(code, "sin")) === Core.Const(sin)
+            @test get_type_for_range(ctx, range_of(code, "a")) === Core.Const('a')
+        end
+    end
+
+    # User-written `GlobalRef` args carry the resolved value at the
+    # identifier's narrow range — `is_synthetic_arg_leaf` filters only the
+    # *broad* synthetic refs lowering plants for scaffolding callees.
+    @testset "annotates GlobalRef args at narrow source position" begin
+        code = "convert(Int, 3.0)"
+        _, ctx = type_annotate(code)
+        @test get_type_for_range(ctx, range_of(code, "convert")) === Core.Const(convert)
+        @test get_type_for_range(ctx, range_of(code, "Int")) === Core.Const(Int)
+        @test get_type_for_range(ctx, range_of(code, "3.0")) === Core.Const(3.0)
+    end
+
+    @testset "annotates literal args in nested calls" begin
+        code = "sin(cos(0.5))"
+        _, ctx = type_annotate(code)
+        @test get_type_for_range(ctx, range_of(code, "sin")) === Core.Const(sin)
+        @test get_type_for_range(ctx, range_of(code, "cos")) === Core.Const(cos)
+        @test get_type_for_range(ctx, range_of(code, "0.5")) === Core.Const(0.5)
+    end
+
+    @testset "annotates each positional arg independently" begin
+        code = "clamp(5, 1, 10)"
+        _, ctx = type_annotate(code)
+        @test get_type_for_range(ctx, range_of(code, "clamp")) === Core.Const(clamp)
+        @test get_type_for_range(ctx, range_of(code, "5")) === Core.Const(5)
+        @test get_type_for_range(ctx, range_of(code, "1")) === Core.Const(1)
+        @test get_type_for_range(ctx, range_of(code, "10")) === Core.Const(10)
+    end
+end
+
 module myfunc_module
 myfunc(x::Int) = x + 1
 end
@@ -606,6 +690,22 @@ end
                 end
                 @test widenconst(get_type_for_range(ctx, ref_rng)) <: Core.OpaqueClosure
             end
+        end
+    end
+
+    # `[xs...]` / `T[xs...]` should surface the constructed `Vector{T}` type,
+    # not widen to a union with the synthetic `Base.vect` / `Base.getindex`
+    # callees that lowering plants at the literal's byte range.
+    @testset "array literal leaf scaffolding doesn't pollute tmerge range" begin
+        let code = "[1, 2, 3]"
+            _, ctx = type_annotate(code)
+            @test widenconst(get_type_for_range(ctx, range_of(code, "[1, 2, 3]"))) ===
+                Vector{Int}
+        end
+        let code = "Any[1, 2, 3]"
+            _, ctx = type_annotate(code)
+            @test widenconst(get_type_for_range(ctx, range_of(code, "Any[1, 2, 3]"))) ===
+                Vector{Any}
         end
     end
 


### PR DESCRIPTION
Extend `annotate_types!` to set `:type` on non-`Expr`, non-`SSAValue` positional args of `:call` statements, so that literal arguments like `f(1.0)` carry `Core.Const(1.0)` at the literal's byte range. This lets hover, signature help, and completion read precise argument types from a call site by querying at the argument's source position.

Introduce `is_synthetic_arg_leaf(stmttree, leaf)` to filter lowering-inserted scaffolding leaves whose `treeref` byte range equals the parent stmt's range — synthetic call heads (`Base.vect` for `[1,2,3]`, `Core.apply_type` / `Core.kwcall` for kwarg calls) and lowering-introduced literals in comprehension scaffolding. Without this filter, their `argextype` would leak through `tmerge_at_range`-dispatched queries (`K"vect"`, `K"typed_vcat"`, …) as a union with the real type.

SSAValue args are skipped separately since the producing stmt already annotates the value.

Add a "Call positional arg annotation" testset documenting the feature across literal types, `GlobalRef` args, nested calls, and multi-arg calls. Add an "array literal leaf scaffolding" regression test guarding the synthetic-leaf invariant.