### PR TITLE
server: Drop deprecated `mod` field from `get_context_info`

### DIFF
--- a/src/analysis/occurrence-analysis.jl
+++ b/src/analysis/occurrence-analysis.jl
@@ -383,7 +383,7 @@ function compute_full_binding_occurrences(
         # unit using `collect_search_uris`, the notebook URI is used instead, and its
         # lowering requires `soft_scope`.
         is_notebook_uri(state, uri)
-    (; mod) = get_context_info(state, uri, offset_to_xy(fi, JS.first_byte(st0)); lookup_func)
+    (; context_module) = get_context_info(state, uri, offset_to_xy(fi, JS.first_byte(st0)); lookup_func)
 
     # Lowering `export`/`public`/`import`/`using` statements collapses their listed
     # identifiers into opaque `K"Value"` nodes and records no `BindingInfo` for them,
@@ -395,11 +395,11 @@ function compute_full_binding_occurrences(
     k0 = JS.kind(st0)
     if k0 in JS.KSet"export public"
         binding_occurrences = Dict{JL.BindingInfo,Set{BindingOccurrence}}()
-        collect_export_public_occurrences!(binding_occurrences, st0, mod)
+        collect_export_public_occurrences!(binding_occurrences, st0, context_module)
         return binding_occurrences
     elseif k0 in JS.KSet"import using"
         binding_occurrences = Dict{JL.BindingInfo,Set{BindingOccurrence}}()
-        collect_import_using_occurrences!(binding_occurrences, st0, mod)
+        collect_import_using_occurrences!(binding_occurrences, st0, context_module)
         return binding_occurrences
     end
 
@@ -407,7 +407,7 @@ function compute_full_binding_occurrences(
         # Remove macros to preserve precise source locations.
         # TODO: This won't be necessary once JuliaLowering can preserve precise
         # source locations for old macro-expanded code.
-        jl_lower_for_scope_resolution(mod, remove_macrocalls(st0); soft_scope)
+        jl_lower_for_scope_resolution(context_module, remove_macrocalls(st0); soft_scope)
     catch
         return nothing
     end
@@ -415,19 +415,19 @@ function compute_full_binding_occurrences(
     binding_occurrences = compute_binding_occurrences(ctx3, st3, is_generated;
         include_global_bindings = true)
 
-    collect_macrocall_occurrences!(binding_occurrences, mod, st0; soft_scope)
+    collect_macrocall_occurrences!(binding_occurrences, context_module, st0; soft_scope)
     # Global bindings used inside inert nodes (quoted expressions) are not
     # resolved by scope analysis. This applies to `@generated` functions,
     # macro definitions, and any function that constructs quoted expressions.
     # Run independent scope resolution on inert content to collect them.
-    collect_inert_global_occurrences!(binding_occurrences, ctx3, st3, mod; soft_scope)
+    collect_inert_global_occurrences!(binding_occurrences, ctx3, st3, context_module; soft_scope)
 
     return binding_occurrences
 end
 
 function collect_export_public_occurrences!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
-        st0::SyntaxTreeC, mod::Module
+        st0::SyntaxTreeC, context_module::Module
     )
     JS.kind(st0) in JS.KSet"export public" || return occurrences
     for i = 1:JS.numchildren(st0)
@@ -435,7 +435,7 @@ function collect_export_public_occurrences!(
         JS.kind(child) === JS.K"Identifier" || continue
         name = get(child, :name_val, nothing)
         name isa AbstractString || continue
-        binfo = JL.BindingInfo(0, name, :global, 0; mod)
+        binfo = JL.BindingInfo(0, name, :global, 0; mod=context_module)
         target_set = get!(Set{BindingOccurrence}, occurrences, binfo)
         push!(target_set, BindingOccurrence(child, :use))
     end
@@ -444,12 +444,12 @@ end
 
 function collect_import_using_occurrences!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
-        st0::SyntaxTreeC, mod::Module
+        st0::SyntaxTreeC, context_module::Module
     )
     foreach_local_import_identifier(st0) do id_st::SyntaxTreeC
         name = get(id_st, :name_val, nothing)
         name isa AbstractString || return
-        binfo = JL.BindingInfo(0, name, :global, 0; mod)
+        binfo = JL.BindingInfo(0, name, :global, 0; mod=context_module)
         target_set = get!(Set{BindingOccurrence}, occurrences, binfo)
         push!(target_set, BindingOccurrence(id_st, :decl))
         return
@@ -459,7 +459,7 @@ end
 
 function collect_macrocall_occurrences!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
-        mod::Module, st0::SyntaxTreeC;
+        context_module::Module, st0::SyntaxTreeC;
         soft_scope::Bool = false
     )
     traverse(st0) do st::SyntaxTreeC
@@ -467,7 +467,7 @@ function collect_macrocall_occurrences!(
         JS.numchildren(st) ≥ 1 || return nothing
         macrocall_name = st[1]
         (; ctx3) = try
-            jl_lower_for_scope_resolution(mod, macrocall_name; soft_scope)
+            jl_lower_for_scope_resolution(context_module, macrocall_name; soft_scope)
         catch
             return traversal_no_recurse
         end
@@ -488,7 +488,7 @@ end
 Collect global bindings used inside `K"inert"` nodes by running independent
 scope resolution on each inert subtree and recording any non-internal
 `:global` bindings it finds as `:use` occurrences. The inert subtree is
-lowered with `mod` — the enclosing module at the inert's position — as
+lowered with `context_module` — the enclosing module at the inert's position — as
 the resolution module.
 
 # Approximation
@@ -505,15 +505,13 @@ there:
   inside thus resolve in that module.
 
 The approximation breaks down whenever the inert content is ultimately
-evaluated somewhere other than `mod`. Detecting these cases would
+evaluated somewhere other than `context_module`. Detecting these cases would
 require cross-function / whole-program analysis that we don't currently
 perform:
 
-- The inert content is spliced into another quote that introduces a
-  new local scope — e.g. a builder that returns
-  `quote function f(x); \$body; end end`, where identifiers inside
-  `body` are meant to resolve against `f`'s arguments, not globals in
-  `mod`.
+- The inert content is spliced into another quote that introduces a new local scope —  e.g.
+  a builder that returns `quote function f(x); \$body; end end`, where identifiers inside
+  `body` are meant to resolve against `f`'s arguments, not globals in `context_module`.
 - The resulting `Expr`/`SyntaxTree` is handed off to `Core.eval` in a
   different module — e.g. `g() = :(foo())` later called as
   `Core.eval(SomeOtherModule, g())`, so `foo` resolves in
@@ -545,7 +543,7 @@ function/macro argument name are filtered out to avoid false
 """
 function collect_inert_global_occurrences!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
-        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, mod::Module;
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, context_module::Module;
         soft_scope::Bool = false
     )
     arg_names = Set{String}()
@@ -565,14 +563,14 @@ function collect_inert_global_occurrences!(
             # Unwrap `$` nodes (replace with their content) instead of removing
             # them, so that parent nodes like dot expressions (`x.$name`)
             # remain well-formed and non-interpolated identifiers are resolved.
-            jl_lower_for_scope_resolution(mod, unwrap_interpolations(st3′[1]); soft_scope)
+            jl_lower_for_scope_resolution(context_module, unwrap_interpolations(st3′[1]); soft_scope)
         catch
             return nothing
         end
         for binfo in ires.ctx3.bindings.info
             if binfo.kind === :global && !binfo.is_internal && !(binfo.name in arg_names)
                 # Use the inert ctx's BindingInfo as key; when cached via
-                # BindingInfoKey(mod, name, :global) it matches the import.
+                # BindingInfoKey(context_module, name, :global) it matches the import.
                 occ_set = get!(Set{BindingOccurrence}, occurrences, binfo)
                 push!(occ_set, BindingOccurrence(
                     JL.binding_ex(ires.ctx3, binfo.id), :use))

--- a/src/declaration.jl
+++ b/src/declaration.jl
@@ -73,9 +73,9 @@ function find_declaration(
     state = server.state
     st0 = build_syntax_tree(fi)
     offset = xy_to_offset(fi, pos)
-    (; mod) = get_context_info(state, uri, pos)
+    (; context_module) = get_context_info(state, uri, pos)
 
-    binding_result = select_target_binding(st0, offset, mod; caller="find_declaration", soft_scope)
+    binding_result = select_target_binding(st0, offset, context_module; caller="find_declaration", soft_scope)
     if !isnothing(binding_result)
         (; ctx3, st3, st0, binding) = binding_result
         binfo = JL.get_binding(ctx3, binding)

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -785,11 +785,11 @@ function analyze_undefined_global_bindings!(
         binfo.is_internal && continue
         startswith(binfo.name, '#') && continue
         any(o->o.kind===:def, occurrences) && continue
-        mod = binfo.mod
-        isnothing(mod) && continue
-        Base.invoke_in_world(world, isdefinedglobal, mod, Symbol(binfo.name))::Bool && continue
+        bmod = binfo.mod
+        isnothing(bmod) && continue
+        Base.invoke_in_world(world, isdefinedglobal, bmod, Symbol(binfo.name))::Bool && continue
         if !isnothing(analyzer)
-            bp = Base.lookup_binding_partition(world, GlobalRef(mod, Symbol(binfo.name)))
+            bp = Base.lookup_binding_partition(world, GlobalRef(bmod, Symbol(binfo.name)))
             haskey(JET.AnalyzerState(analyzer).binding_states, bp) && continue
         end
         bn = binfo.name
@@ -802,7 +802,7 @@ function analyze_undefined_global_bindings!(
         push!(diagnostics, Diagnostic(;
             range,
             severity = DiagnosticSeverity.Warning,
-            message = postprocessor("`$(mod).$(binfo.name)` is not defined"),
+            message = postprocessor("`$(bmod).$(binfo.name)` is not defined"),
             source = DIAGNOSTIC_SOURCE_LIVE,
             code,
             codeDescription = diagnostic_code_description(code)))
@@ -1407,11 +1407,11 @@ function compute_unit_used_names(
         iterate_toplevel_tree(search_st0_top) do st0::SyntaxTreeC
             binding_occurrences = @something get_binding_occurrences!(
                 state, search_uri, search_fi, st0) return
-            mod = get_context_module(state, search_uri, offset_to_xy(search_fi, JS.first_byte(st0)))
+            context_module = get_context_module(state, search_uri, offset_to_xy(search_fi, JS.first_byte(st0)))
             for (binfo_key, occurrences) in binding_occurrences
                 binfo_key.kind === :global || continue
                 if any(o -> o.kind === :use, occurrences)
-                    push!(get!(Set{String}, mod_used_names, mod), binfo_key.name)
+                    push!(get!(Set{String}, mod_used_names, context_module), binfo_key.name)
                 end
             end
         end
@@ -1438,9 +1438,9 @@ function analyze_unused_imports!(
     mod_imported_names = Dict{Module,Dict{String,Vector{ImportInfo}}}()
     traverse(st0_top) do st0::SyntaxTreeC
         JS.kind(st0) ∈ JS.KSet"import using" || return nothing
-        mod = get_context_module(state, uri, offset_to_xy(fi, JS.first_byte(st0)))
+        context_module = get_context_module(state, uri, offset_to_xy(fi, JS.first_byte(st0)))
         for (name, name_range, delete_range) in collect_explicit_import_names(st0, fi)
-            imported_names = get!(Dict{String,Vector{ImportInfo}}, mod_imported_names, mod)
+            imported_names = get!(Dict{String,Vector{ImportInfo}}, mod_imported_names, context_module)
             push!(get!(Vector{ImportInfo}, imported_names, name), ImportInfo(uri, name_range, delete_range))
         end
         return TraversalNoRecurse()
@@ -1452,8 +1452,8 @@ function analyze_unused_imports!(
         compute_unit_used_names(server, search_uris; skip_context_check)
     end
 
-    for (mod, imported_names) in mod_imported_names
-        used_names = get(mod_used_names, mod, nothing)
+    for (context_module, imported_names) in mod_imported_names
+        used_names = get(mod_used_names, context_module, nothing)
         for (name, infos) in imported_names
             used_names !== nothing && name in used_names && continue
             for info in infos
@@ -1578,9 +1578,9 @@ function compute_lowering_diagnostics(
     iterate_toplevel_tree(st0_top) do st0::SyntaxTreeC
         is_cancelled(cancel_flag) && return traversal_terminator
         pos = offset_to_xy(file_info, JS.first_byte(st0))
-        (; mod, world, analyzer, postprocessor) = get_context_info(server.state, uri, pos; lookup_func)
+        (; context_module, world, analyzer, postprocessor) = get_context_info(server.state, uri, pos; lookup_func)
         lowering_diagnostics!(diagnostics, uri, file_info, st0,
-            mod, world, analyzer, postprocessor;
+            context_module, world, analyzer, postprocessor;
             skip_analysis_requiring_context, allow_unused_underscore, soft_scope)
     end
     return diagnostics

--- a/src/document-highlight.jl
+++ b/src/document-highlight.jl
@@ -51,11 +51,11 @@ function document_highlights!(
     )
     st0_top = build_syntax_tree(fi)
     offset = xy_to_offset(fi, pos)
-    (; mod) = get_context_info(state, uri, pos)
+    (; context_module) = get_context_info(state, uri, pos)
     soft_scope = is_notebook_cell_uri(state, uri)
 
     (; ctx3, st3, st0, binding) = @something begin
-        select_target_binding(st0_top, offset, mod; caller="document_highlights!", soft_scope)
+        select_target_binding(st0_top, offset, context_module; caller="document_highlights!", soft_scope)
     end return highlights
 
     binfo = JL.get_binding(ctx3, binding)

--- a/src/document-symbol.jl
+++ b/src/document-symbol.jl
@@ -74,8 +74,8 @@ function get_document_symbols!(state::ServerState, uri::URI, fi::FileInfo)
         end
         st0 = build_syntax_tree(fi)
         pos = Position(; line=0, character=0)
-        (; mod) = get_context_info(state, uri, pos)
-        symbols = extract_document_symbols(st0, fi, mod)
+        (; context_module) = get_context_info(state, uri, pos)
+        symbols = extract_document_symbols(st0, fi, context_module)
         return DocumentSymbolCacheData(cache, cache_uri => symbols), symbols
     end
 end
@@ -91,75 +91,80 @@ function invalidate_document_symbol_cache!(state::ServerState, uri::URI)
     end
 end
 
-function extract_document_symbols(st0_top::SyntaxTreeC, fi::FileInfo, mod::Module=Main)
+function extract_document_symbols(st0_top::SyntaxTreeC, fi::FileInfo, context_module::Module=Main)
     @assert JS.kind(st0_top) === JS.K"toplevel"
     symbols = DocumentSymbol[]
-    extract_toplevel_symbols!(symbols, st0_top, fi, mod)
+    extract_toplevel_symbols!(symbols, st0_top, fi, context_module)
     sort!(symbols; by = s::DocumentSymbol -> (s.range.start.line, s.range.start.character))
     return symbols
 end
 
 function extract_toplevel_symbols!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        context_module::Module
     )
     for i = 1:JS.numchildren(st0)
-        extract_toplevel_symbol!(symbols, st0[i], fi, mod)
+        extract_toplevel_symbol!(symbols, st0[i], fi, context_module)
     end
 end
 
-function extract_toplevel_symbol!(symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module)
+function extract_toplevel_symbol!(
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        context_module::Module
+    )
     k = JS.kind(st0)
     if k === JS.K"module"
-        extract_module_symbol!(symbols, st0, fi, mod)
+        extract_module_symbol!(symbols, st0, fi, context_module)
     elseif k === JS.K"function"
-        extract_function_symbol!(symbols, st0, fi, mod)
+        extract_function_symbol!(symbols, st0, fi, context_module)
     elseif k === JS.K"macro"
-        extract_macro_symbol!(symbols, st0, fi, mod)
+        extract_macro_symbol!(symbols, st0, fi, context_module)
     elseif k === JS.K"struct"
-        extract_struct_symbol!(symbols, st0, fi, mod)
+        extract_struct_symbol!(symbols, st0, fi, context_module)
     elseif k === JS.K"abstract"
         extract_abstract_type_symbol!(symbols, st0, fi)
     elseif k === JS.K"primitive"
         extract_primitive_type_symbol!(symbols, st0, fi)
     elseif k === JS.K"const"
-        extract_const_symbols!(symbols, st0, fi, mod)
+        extract_const_symbols!(symbols, st0, fi, context_module)
     elseif k === JS.K"global"
-        extract_global_symbols!(symbols, st0, fi, mod)
+        extract_global_symbols!(symbols, st0, fi, context_module)
     elseif k === JS.K"="
-        extract_toplevel_assignment_symbols!(symbols, st0, fi, mod)
+        extract_toplevel_assignment_symbols!(symbols, st0, fi, context_module)
     elseif k === JS.K"let"
-        extract_let_symbol!(symbols, st0, fi, mod)
+        extract_let_symbol!(symbols, st0, fi, context_module)
     elseif k === JS.K"while"
-        extract_while_symbol!(symbols, st0, fi, mod)
+        extract_while_symbol!(symbols, st0, fi, context_module)
     elseif k === JS.K"for"
-        extract_for_symbol!(symbols, st0, fi, mod)
+        extract_for_symbol!(symbols, st0, fi, context_module)
     elseif k === JS.K"if"
-        extract_if_symbol!(symbols, st0, fi, mod)
+        extract_if_symbol!(symbols, st0, fi, context_module)
     elseif k === JS.K"toplevel" || k === JS.K"block"
-        extract_toplevel_symbols!(symbols, st0, fi, mod)
+        extract_toplevel_symbols!(symbols, st0, fi, context_module)
     elseif k === JS.K"macrocall"
-        extract_macrocall_symbol!(symbols, st0, fi, mod)
+        extract_macrocall_symbol!(symbols, st0, fi, context_module)
     end
     return nothing
 end
 
 function extract_module_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, parent_mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        parent_context_module::Module
     )
     JS.numchildren(st0) ≥ 3 || return nothing
     name_node = st0[2]
     name = @something extract_name_val(name_node) return nothing
-    mod = parent_mod
-    if invokelatest(isdefinedglobal, parent_mod, Symbol(name))
-        childmod = invokelatest(getglobal, parent_mod, Symbol(name))
+    context_module = parent_context_module
+    if invokelatest(isdefinedglobal, parent_context_module, Symbol(name))
+        childmod = invokelatest(getglobal, parent_context_module, Symbol(name))
         if childmod isa Module
-            mod = childmod
+            context_module = childmod
         end
     end
     children = DocumentSymbol[]
     body = st0[end]
     if JS.kind(body) === JS.K"block"
-        extract_toplevel_symbols!(children, body, fi, mod)
+        extract_toplevel_symbols!(children, body, fi, context_module)
     end
     is_baremodule = JS.has_flags(JS.flags(st0), JS.BARE_MODULE_FLAG)
     detail = (is_baremodule ? "baremodule " : "module ") * name
@@ -174,12 +179,13 @@ function extract_module_symbol!(
 end
 
 function extract_function_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        context_module::Module
     )
     JS.numchildren(st0) ≥ 1 || return nothing
     sig = st0[1]
     name, name_node = @something extract_function_name(sig) return nothing
-    children = @something extract_scoped_children(st0, fi, mod) Some(nothing)
+    children = @something extract_scoped_children(st0, fi, context_module) Some(nothing)
     is_short_form = JS.has_flags(JS.flags(st0), JS.SHORT_FORM_FUNCTION_FLAG)
     detail = is_short_form ? JS.sourcetext(sig) * " =" : "function " * JS.sourcetext(sig)
     push!(symbols, DocumentSymbol(;
@@ -244,7 +250,8 @@ function extract_dotted_name(node::SyntaxTreeC)
 end
 
 function extract_macro_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        context_module::Module
     )
     JS.numchildren(st0) ≥ 1 || return nothing
     sig_orig = st0[1]
@@ -262,7 +269,7 @@ function extract_macro_symbol!(
     end
     name = "@" * name
     detail = "macro " * JS.sourcetext(sig_orig)
-    children = @something extract_scoped_children(st0, fi, mod) Some(nothing)
+    children = @something extract_scoped_children(st0, fi, context_module) Some(nothing)
     push!(symbols, DocumentSymbol(;
         name,
         detail,
@@ -274,7 +281,8 @@ function extract_macro_symbol!(
 end
 
 function extract_struct_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        context_module::Module
     )
     JS.numchildren(st0) ≥ 2 || return nothing
     sig_node = st0[2]
@@ -297,9 +305,9 @@ function extract_struct_symbol!(
             child = body[i]
             child_k = JS.kind(child)
             if child_k === JS.K"function"
-                extract_function_symbol!(children, child, fi, mod)
+                extract_function_symbol!(children, child, fi, context_module)
             elseif child_k === JS.K"="
-                extract_toplevel_assignment_symbols!(children, child, fi, mod)
+                extract_toplevel_assignment_symbols!(children, child, fi, context_module)
             else
                 extract_struct_field!(children, child, fi)
             end
@@ -386,7 +394,8 @@ function extract_primitive_type_symbol!(
 end
 
 function extract_const_symbols!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        context_module::Module
     )
     JS.numchildren(st0) ≥ 1 || return nothing
     assign = st0[1]
@@ -396,12 +405,13 @@ function extract_const_symbols!(
     rhs = assign[2]
     range = jsobj_to_range(st0, fi)
     detail = lstrip(JS.sourcetext(st0))
-    extract_assignment_symbols!(symbols, lhs, rhs, range, SymbolKind.Constant, detail, fi, mod)
+    extract_assignment_symbols!(symbols, lhs, rhs, range, SymbolKind.Constant, detail, fi, context_module)
     return nothing
 end
 
 function extract_global_symbols!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        context_module::Module
     )
     JS.numchildren(st0) ≥ 1 || return nothing
     inner = st0[1]
@@ -411,20 +421,21 @@ function extract_global_symbols!(
         JS.numchildren(inner) ≥ 2 || return nothing
         lhs = inner[1]
         rhs = inner[2]
-        extract_assignment_symbols!(symbols, lhs, rhs, range, SymbolKind.Variable, detail, fi, mod)
+        extract_assignment_symbols!(symbols, lhs, rhs, range, SymbolKind.Variable, detail, fi, context_module)
     else
-        extract_assignment_symbols!(symbols, inner, nothing, range, SymbolKind.Variable, detail, fi, mod)
+        extract_assignment_symbols!(symbols, inner, nothing, range, SymbolKind.Variable, detail, fi, context_module)
     end
     return nothing
 end
 
 function extract_assignment_symbols!(
         symbols::Vector{DocumentSymbol}, lhs::SyntaxTreeC, rhs::Union{SyntaxTreeC,Nothing},
-        range::Range, kind::SymbolKind.Ty, detail::AbstractString, fi::FileInfo, mod::Module
+        range::Range, kind::SymbolKind.Ty, detail::AbstractString, fi::FileInfo,
+        context_module::Module
     )
     children = if rhs !== nothing && JS.kind(rhs) === JS.K"let"
         let_children = DocumentSymbol[]
-        extract_let_symbol!(let_children, rhs, fi, mod)
+        extract_let_symbol!(let_children, rhs, fi, context_module)
         @somereal let_children Some(nothing)
     else
         nothing
@@ -479,38 +490,40 @@ function extract_assignment_symbols!(
             children))
     end
     if rhs !== nothing && JS.kind(rhs) === JS.K"block"
-        extract_toplevel_symbols!(symbols, rhs, fi, mod)
+        extract_toplevel_symbols!(symbols, rhs, fi, context_module)
     end
     return nothing
 end
 
 function extract_toplevel_assignment_symbols!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        context_module::Module
     )
     JS.numchildren(st0) ≥ 2 || return nothing
     lhs = st0[1]
     JS.kind(lhs) in JS.KSet". ref" && return nothing # Skip property assignment like obj.field = value
     lhs_unwrapped = unwrap_funcdef_sig(lhs)
     if JS.kind(lhs_unwrapped) === JS.K"call" || is_mainfunc0(lhs_unwrapped)
-        extract_short_function_symbol!(symbols, st0, fi, mod)
+        extract_short_function_symbol!(symbols, st0, fi, context_module)
         return nothing
     end
     rhs = st0[2]
     range = jsobj_to_range(st0, fi)
     detail = lstrip(JS.sourcetext(st0))
     kind = is_anonymous_function_rhs(rhs) ? SymbolKind.Function : SymbolKind.Variable
-    extract_assignment_symbols!(symbols, lhs, rhs, range, kind, detail, fi, mod)
+    extract_assignment_symbols!(symbols, lhs, rhs, range, kind, detail, fi, context_module)
     return nothing
 end
 
 # Short-form function definition: `f(x) = x` or `f(x) where T = x`
 function extract_short_function_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        context_module::Module
     )
     JS.numchildren(st0) ≥ 2 || return nothing
     sig = st0[1]
     name, name_node = @something extract_function_name(sig) return nothing
-    children = @something extract_scoped_children(st0, fi, mod) Some(nothing)
+    children = @something extract_scoped_children(st0, fi, context_module) Some(nothing)
     detail = JS.sourcetext(sig) * " ="
     push!(symbols, DocumentSymbol(;
         name,
@@ -529,14 +542,14 @@ extract_while_symbol!(args...) = extract_namespace_symbol!(args..., "while ")
 extract_for_symbol!(args...) = extract_namespace_symbol!(args..., "for ")
 
 function extract_namespace_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module,
-        prefix::AbstractString
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        context_module::Module, prefix::AbstractString
     )
     JS.numchildren(st0) ≥ 2 || return nothing
-    children = @something extract_scoped_children(st0, fi, mod) return nothing
+    children = @something extract_scoped_children(st0, fi, context_module) return nothing
     body = st0[end]
     if JS.kind(body) === JS.K"block"
-        extract_macrocalls_from_block!(children, body, fi, mod)
+        extract_macrocalls_from_block!(children, body, fi, context_module)
     end
     push!(symbols, DocumentSymbol(;
         name = " ",
@@ -549,13 +562,14 @@ function extract_namespace_symbol!(
 end
 
 function extract_if_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module;
-        prefix::AbstractString="if ",
-        range_node::SyntaxTreeC=st0
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        context_module::Module;
+        prefix::AbstractString = "if ",
+        range_node::SyntaxTreeC = st0
     )
     JS.numchildren(st0) ≥ 2 || return nothing
     children = DocumentSymbol[]
-    extract_if_children!(children, st0, fi, mod)
+    extract_if_children!(children, st0, fi, context_module)
     isempty(children) && return nothing
     push!(symbols, DocumentSymbol(;
         name = " ",
@@ -568,57 +582,59 @@ function extract_if_symbol!(
 end
 
 function extract_if_children!(
-        children::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
+        children::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        context_module::Module
     )
     for i in 2:JS.numchildren(st0)
         child = st0[i]
         k = JS.kind(child)
         if k === JS.K"block"
-            extract_toplevel_symbols!(children, child, fi, mod)
+            extract_toplevel_symbols!(children, child, fi, context_module)
         elseif k === JS.K"elseif" || k === JS.K"if"
-            extract_if_children!(children, child, fi, mod)
+            extract_if_children!(children, child, fi, context_module)
         end
     end
     return nothing
 end
 
 function extract_macrocalls_from_block!(
-        symbols::Vector{DocumentSymbol}, st::SyntaxTreeC, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st::SyntaxTreeC, fi::FileInfo, context_module::Module
     )
     for i = 1:JS.numchildren(st)
         child = st[i]
         if JS.kind(child) === JS.K"macrocall"
-            extract_macrocall_symbol!(symbols, child, fi, mod)
+            extract_macrocall_symbol!(symbols, child, fi, context_module)
         end
     end
     return nothing
 end
 
 function extract_macrocall_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, context_module::Module
     )
     macro_name = get_macrocall_name(st0)
     if macro_name == "@enum"
         extract_enum_symbol!(symbols, st0, fi)
     elseif macro_name == "@static"
-        extract_static_if_symbol!(symbols, st0, fi, mod)
+        extract_static_if_symbol!(symbols, st0, fi, context_module)
     elseif macro_name == "@testset"
-        extract_testset_symbol!(symbols, st0, fi, mod)
+        extract_testset_symbol!(symbols, st0, fi, context_module)
     elseif macro_name == "@test"
         extract_test_symbol!(symbols, st0, fi)
     else
-        extract_toplevel_symbols!(symbols, st0, fi, mod)
+        extract_toplevel_symbols!(symbols, st0, fi, context_module)
     end
     return nothing
 end
 
 function extract_static_if_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        context_module::Module
     )
     JS.numchildren(st0) ≥ 3 || return nothing
     if_node = st0[3]
     JS.kind(if_node) === JS.K"if" || return nothing
-    extract_if_symbol!(symbols, if_node, fi, mod; prefix="@static if ", range_node=st0)
+    extract_if_symbol!(symbols, if_node, fi, context_module; prefix="@static if ", range_node=st0)
     return nothing
 end
 
@@ -639,7 +655,8 @@ function get_macrocall_name(st0::SyntaxTreeC)
 end
 
 function extract_testset_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, mod::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        context_module::Module
     )
     JS.numchildren(st0) ≥ 3 || return nothing
 
@@ -665,18 +682,18 @@ function extract_testset_symbol!(
     body_kind = JS.kind(body)
     children = DocumentSymbol[]
     if body_kind === JS.K"block"
-        extract_toplevel_symbols!(children, body, fi, mod)
+        extract_toplevel_symbols!(children, body, fi, context_module)
     elseif body_kind === JS.K"for" || body_kind === JS.K"let"
         JS.numchildren(body) ≥ 2 || return nothing
         body_block = body[end]
         if JS.kind(body_block) === JS.K"block"
-            extract_toplevel_symbols!(children, body_block, fi, mod)
+            extract_toplevel_symbols!(children, body_block, fi, context_module)
         end
     elseif body_kind === JS.K"call"
         # Function call: @testset "desc" test_func()
         # No children to extract, the test function itself is the body
     else
-        extract_toplevel_symbol!(children, body, fi, mod)
+        extract_toplevel_symbol!(children, body, fi, context_module)
     end
 
     # For @testset let, use bindings node as selection range since there's no description
@@ -769,11 +786,11 @@ end
 
 # Binding-based extraction for scoped children (function body, let block, etc.)
 function extract_scoped_children(
-        st0::SyntaxTreeC, fi::FileInfo, mod::Module;
+        st0::SyntaxTreeC, fi::FileInfo, context_module::Module;
         soft_scope::Bool = false
     )
     (; ctx3) = try
-        jl_lower_for_scope_resolution(mod, st0; soft_scope)
+        jl_lower_for_scope_resolution(context_module, st0; soft_scope)
     catch
         return nothing
     end

--- a/src/references.jl
+++ b/src/references.jl
@@ -84,12 +84,12 @@ function find_references(
     )
     st0_top = build_syntax_tree(fi)
     offset = xy_to_offset(fi, pos)
-    (; mod) = get_context_info(server.state, uri, pos)
+    (; context_module) = get_context_info(server.state, uri, pos)
     soft_scope = is_notebook_cell_uri(server.state, uri)
     locations = Location[]
 
     (; ctx3, st3, st0, binding) = @something begin
-        select_target_binding(st0_top, offset, mod; caller="find_references", soft_scope)
+        select_target_binding(st0_top, offset, context_module; caller="find_references", soft_scope)
     end return locations
 
     binfo = JL.get_binding(ctx3, binding)

--- a/src/rename.jl
+++ b/src/rename.jl
@@ -53,27 +53,27 @@ function handle_PrepareRenameRequest(
     end
     fi = result
 
-    (; mod) = get_context_info(state, uri, pos)
+    (; context_module) = get_context_info(state, uri, pos)
     soft_scope = is_notebook_cell_uri(state, uri)
     return send(server,
         PrepareRenameResponse(;
             id = msg.id,
             result = @something(
-                local_binding_rename_preparation(state, uri, fi, pos, mod; soft_scope),
-                global_binding_rename_preparation(state, uri, fi, pos, mod; soft_scope),
+                local_binding_rename_preparation(state, uri, fi, pos, context_module; soft_scope),
+                global_binding_rename_preparation(state, uri, fi, pos, context_module; soft_scope),
                 file_rename_preparation(state, uri, fi, pos),
                 null)))
 end
 
 function local_binding_rename_preparation(
-        state::ServerState, uri::URI, fi::FileInfo, pos::Position, mod::Module;
+        state::ServerState, uri::URI, fi::FileInfo, pos::Position, context_module::Module;
         soft_scope::Bool = false
     )
     st0_top = build_syntax_tree(fi)
     offset = xy_to_offset(fi, pos)
 
     (; ctx3, binding) = @something begin
-        select_target_binding(st0_top, offset, mod; caller="local_binding_rename_preparation", soft_scope)
+        select_target_binding(st0_top, offset, context_module; caller="local_binding_rename_preparation", soft_scope)
     end return nothing
 
     binfo = JL.get_binding(ctx3, binding)
@@ -86,14 +86,14 @@ function local_binding_rename_preparation(
 end
 
 function global_binding_rename_preparation(
-        state::ServerState, uri::URI, fi::FileInfo, pos::Position, mod::Module;
+        state::ServerState, uri::URI, fi::FileInfo, pos::Position, context_module::Module;
         soft_scope::Bool = false
     )
     st0_top = build_syntax_tree(fi)
     offset = xy_to_offset(fi, pos)
 
     (; ctx3, binding) = @something begin
-        select_target_binding(st0_top, offset, mod; caller="global_binding_rename_preparation", soft_scope)
+        select_target_binding(st0_top, offset, context_module; caller="global_binding_rename_preparation", soft_scope)
     end return nothing
 
     binfo = JL.get_binding(ctx3, binding)
@@ -180,17 +180,17 @@ function rename(
         server::Server, uri::URI, fi::FileInfo, pos::Position, newName::String;
         token::Union{Nothing,ProgressToken} = nothing,
         cancel_flag::AbstractCancelFlag = DUMMY_CANCEL_FLAG)
-    (; mod) = get_context_info(server.state, uri, pos)
+    (; context_module) = get_context_info(server.state, uri, pos)
     soft_scope = is_notebook_cell_uri(server.state, uri)
     return @something(
-        local_binding_rename(server, uri, fi, pos, mod, newName; soft_scope),
-        global_binding_rename(server, uri, fi, pos, mod, newName; token, cancel_flag, soft_scope),
+        local_binding_rename(server, uri, fi, pos, context_module, newName; soft_scope),
+        global_binding_rename(server, uri, fi, pos, context_module, newName; token, cancel_flag, soft_scope),
         file_rename(server, uri, fi, pos, newName),
         (; result = null, error = nothing))
 end
 
 function local_binding_rename(
-        server::Server, uri::URI, fi::FileInfo, pos::Position, mod::Module, newName::String;
+        server::Server, uri::URI, fi::FileInfo, pos::Position, context_module::Module, newName::String;
         soft_scope::Bool = false
     )
     state = server.state
@@ -198,7 +198,7 @@ function local_binding_rename(
     offset = xy_to_offset(fi, pos)
 
     (; ctx3, st3, st0, binding) = @something begin
-        select_target_binding(st0_top, offset, mod; caller="local_binding_rename", soft_scope)
+        select_target_binding(st0_top, offset, context_module; caller="local_binding_rename", soft_scope)
     end return nothing
 
     binfo = JL.get_binding(ctx3, binding)
@@ -249,7 +249,7 @@ function local_binding_rename(
 end
 
 function global_binding_rename(
-        server::Server, uri::URI, fi::FileInfo, pos::Position, mod::Module, newName::String;
+        server::Server, uri::URI, fi::FileInfo, pos::Position, context_module::Module, newName::String;
         token::Union{Nothing,ProgressToken} = nothing,
         cancel_flag::AbstractCancelFlag = DUMMY_CANCEL_FLAG,
         soft_scope::Bool = false
@@ -258,7 +258,7 @@ function global_binding_rename(
     offset = xy_to_offset(fi, pos)
 
     (; ctx3, binding) = @something begin
-        select_target_binding(st0_top, offset, mod; caller="global_binding_rename", soft_scope)
+        select_target_binding(st0_top, offset, context_module; caller="global_binding_rename", soft_scope)
     end return nothing
 
     binfo = JL.get_binding(ctx3, binding)

--- a/src/type-definition.jl
+++ b/src/type-definition.jl
@@ -69,8 +69,8 @@ function find_type_definition(server::Server, uri::URI, fi::FileInfo, pos::Posit
     node = @something select_target_for_type_query(st0_top, offset) return nothing
 
     rng = JS.byte_range(node)
-    (; mod, world) = get_context_info(state, uri, pos)
-    typ = @something infer_type_at_range(st0_top, mod, rng; world) return nothing
+    (; context_module, world) = get_context_info(state, uri, pos)
+    typ = @something infer_type_at_range(st0_top, context_module, rng; world) return nothing
 
     target_type = @something extract_target_type(typ) return nothing
     return type_locations(state, uri, target_type, world), node

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -31,7 +31,7 @@ end
 
 """
     jl_lower_for_scope_resolution(
-            mod::Module, st0::SyntaxTreeC;
+            context_module::Module, st0::SyntaxTreeC;
             world::UInt = Base.get_world_counter(),
             trim_error_nodes::Bool = true,
             recover_from_macro_errors::Bool = true,
@@ -56,7 +56,7 @@ Throw if lowering fails otherwise.
 Note that ctx objects share mutable information, so we only return `ctx3`
 """
 function jl_lower_for_scope_resolution(
-        mod::Module, st0::SyntaxTreeC;
+        context_module::Module, st0::SyntaxTreeC;
         world::UInt = Base.get_world_counter(),
         trim_error_nodes::Bool = true,
         recover_from_macro_errors::Bool = true,
@@ -67,14 +67,14 @@ function jl_lower_for_scope_resolution(
         st0 = without_kinds(st0, JS.KSet"error")
     end
     ctx1, st1 = try
-        JL.expand_forms_1(mod, st0, true, world)
+        JL.expand_forms_1(context_module, st0, true, world)
     catch err
         recover_from_macro_errors || rethrow(err)
         JETLS_DEBUG_LOWERING && @warn "Error in macro expansion; trimming and retrying"
         JETLS_DEBUG_LOWERING && showerror(stderr, err)
         JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
         st0 = remove_macrocalls(st0)
-        JL.expand_forms_1(mod, st0, true, world)
+        JL.expand_forms_1(context_module, st0, true, world)
     end
     return _jl_lower_for_scope_resolution(ctx1, st0, st1; convert_closures, soft_scope)
 end
@@ -100,13 +100,13 @@ as an ephemeral stack.)  We work around this by taking all available bindings
 and filtering out any that aren't declared in a scope containing the cursor.
 """
 function cursor_bindings(
-        st0_top::SyntaxTreeC, offset::Int, mod::Module;
+        st0_top::SyntaxTreeC, offset::Int, context_module::Module;
         soft_scope::Bool = false
     )
     st0 = @something greatest_local(st0_top, offset) return nothing # nothing we can lower
     (st0, _) = desugar_main_macrocall(st0)
     (; ctx3, st2) = try
-        jl_lower_for_scope_resolution(mod, st0; soft_scope)
+        jl_lower_for_scope_resolution(context_module, st0; soft_scope)
     catch err
         JETLS_DEBUG_LOWERING && @warn "Error in lowering" err
         JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
@@ -230,7 +230,10 @@ function _select_target_binding(
 end
 
 """
-    select_target_binding(st0_top, offset, mod) -> Union{Nothing, NamedTuple}
+    select_target_binding(
+            st0_top::SyntaxTreeC, offset::Int, context_module::Module;
+            soft_scope::Bool = false
+        ) -> Union{Nothing, NamedTuple}
 
 Return the binding closest to the cursor at `offset` within `st0_top`,
 or `nothing` if no binding is found. On success the returned named tuple
@@ -238,24 +241,24 @@ contains `(; ctx3, st3, st0, binding)` where `binding` satisfies
 `JS.kind(binding) === JS.K"BindingId"`.
 """
 function select_target_binding(
-        st0_top::SyntaxTreeC, offset::Int, mod::Module;
+        st0_top::SyntaxTreeC, offset::Int, context_module::Module;
         caller::AbstractString = "select_target_binding",
         soft_scope::Bool = false
     )
     st0 = @something greatest_local(st0_top, offset) return nothing # nothing we can lower
 
-    macrocall_result = select_macrocall_binding(st0, offset, mod, caller; soft_scope)
+    macrocall_result = select_macrocall_binding(st0, offset, context_module, caller; soft_scope)
     macrocall_result !== nothing && return macrocall_result
 
-    export_public_result = select_export_public_binding(st0, offset, mod, caller; soft_scope)
+    export_public_result = select_export_public_binding(st0, offset, context_module, caller; soft_scope)
     export_public_result !== nothing && return export_public_result
 
-    import_using_result = select_import_using_binding(st0, offset, mod, caller; soft_scope)
+    import_using_result = select_import_using_binding(st0, offset, context_module, caller; soft_scope)
     import_using_result !== nothing && return import_using_result
 
     (; ctx3, st3) = try
         # Remove macros to preserve precise source locations
-        jl_lower_for_scope_resolution(mod, remove_macrocalls(st0); soft_scope)
+        jl_lower_for_scope_resolution(context_module, remove_macrocalls(st0); soft_scope)
     catch err
         JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
         JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
@@ -271,7 +274,7 @@ function select_target_binding(
     # Inert contents aren't scope-resolved, so no `BindingId` exists for
     # `find_target_binding` to pick up — we run a fresh resolution on just
     # the inert subtree.
-    return find_inert_global_target_binding(st0, st3, offset, mod; soft_scope)
+    return find_inert_global_target_binding(st0, st3, offset, context_module; soft_scope)
 end
 
 function find_inert_target_binding(
@@ -286,23 +289,24 @@ function find_inert_target_binding(
 end
 
 find_inert_global_target_binding(
-    st0::SyntaxTreeC, st3::SyntaxTreeC, offset::Int, mod::Module;
+    st0::SyntaxTreeC, st3::SyntaxTreeC, offset::Int, context_module::Module;
     soft_scope::Bool = false
 ) = @something(
-    _find_inert_global_target_binding(st0, st3, offset, mod; soft_scope),
+    _find_inert_global_target_binding(st0, st3, offset, context_module; soft_scope),
     # Handle `var│` at end-of-token (same retry as `_select_target_binding`).
-    _find_inert_global_target_binding(st0, st3, offset-1, mod; soft_scope),
+    _find_inert_global_target_binding(st0, st3, offset-1, context_module; soft_scope),
     return nothing)
 
 function _find_inert_global_target_binding(
-        st0::SyntaxTreeC, st3::SyntaxTreeC, offset::Int, mod::Module;
+        st0::SyntaxTreeC, st3::SyntaxTreeC, offset::Int, context_module::Module;
         soft_scope::Bool = false
     )
     name = @something find_inert_identifier_name(st3, offset) return nothing
     inert_tree = @something enclosing_inert_tree(st3, offset) return nothing
     JS.numchildren(inert_tree) ≥ 1 || return nothing
     ires = try
-        jl_lower_for_scope_resolution(mod, unwrap_interpolations(inert_tree[1]); soft_scope)
+        jl_lower_for_scope_resolution(
+            context_module, unwrap_interpolations(inert_tree[1]); soft_scope)
     catch
         return nothing
     end
@@ -353,7 +357,7 @@ function normalize_local_alias_to_global(
 end
 
 function select_macrocall_binding(
-        st0::SyntaxTreeC, offset::Int, mod::Module, caller::AbstractString;
+        st0::SyntaxTreeC, offset::Int, context_module::Module, caller::AbstractString;
         soft_scope::Bool = false
     )
     is_macrocall_name = (offset::Int) -> (st0′::SyntaxTreeC) ->
@@ -368,7 +372,7 @@ function select_macrocall_binding(
     isempty(bas) && return nothing
     macrocall_name = bas[1][1]
     (; ctx3, st3) = try
-        jl_lower_for_scope_resolution(mod, macrocall_name; soft_scope)
+        jl_lower_for_scope_resolution(context_module, macrocall_name; soft_scope)
     catch err
         JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
         JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
@@ -388,7 +392,7 @@ end
 # Detect that case directly and lower just the single identifier under the
 # cursor so callers receive a normal `(ctx3, st3, st0, binding)` tuple.
 function select_export_public_binding(
-        st0::SyntaxTreeC, offset::Int, mod::Module, caller::AbstractString;
+        st0::SyntaxTreeC, offset::Int, context_module::Module, caller::AbstractString;
         soft_scope::Bool = false
     )
     find_name_node = (offset::Int) -> (st0′::SyntaxTreeC) -> begin
@@ -413,7 +417,7 @@ function select_export_public_binding(
             1:JS.numchildren(parent)) return nothing; end
     name_node = parent[i]
     (; ctx3, st3) = try
-        jl_lower_for_scope_resolution(mod, name_node; soft_scope)
+        jl_lower_for_scope_resolution(context_module, name_node; soft_scope)
     catch err
         JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
         JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
@@ -433,7 +437,7 @@ end
 # detect the cursor against `foreach_local_import_identifier` and lower the
 # single matching identifier to synthesize a normal binding tuple.
 function select_import_using_binding(
-        st0::SyntaxTreeC, offset::Int, mod::Module, caller::AbstractString;
+        st0::SyntaxTreeC, offset::Int, context_module::Module, caller::AbstractString;
         soft_scope::Bool = false
     )
     find_name_node_at = function (offset::Int, st0′::SyntaxTreeC)
@@ -457,7 +461,7 @@ function select_import_using_binding(
     isempty(bas) && return nothing
     name_node = @something find_name_node_at(offset, bas[1]) return nothing
     (; ctx3, st3) = try
-        jl_lower_for_scope_resolution(mod, name_node; soft_scope)
+        jl_lower_for_scope_resolution(context_module, name_node; soft_scope)
     catch err
         JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
         JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
@@ -473,8 +477,9 @@ function select_import_using_binding(
 end
 
 """
-    select_target_binding_definitions(st0_top::SyntaxTreeC, offset::Int, mod::Module) ->
-        nothing or (binding::SyntaxTreeC, definitions::SyntaxListC)
+    select_target_binding_definitions(
+            st0_top::SyntaxTreeC, offset::Int, context_module::Module
+        ) -> nothing or (binding::SyntaxTreeC, definitions::SyntaxListC)
 
 Find the binding at the cursor position and return all of its definition sites.
 
@@ -484,10 +489,11 @@ has no definitions. Otherwise returns a tuple of `(binding, definitions)` where:
 - `definitions` is a `SyntaxListC` containing all definition sites for that binding
 """
 function select_target_binding_definitions(
-        st0_top::SyntaxTreeC, offset::Int, mod::Module;
+        st0_top::SyntaxTreeC, offset::Int, context_module::Module;
         soft_scope::Bool = false, skip_global::Bool = false
     )
-    (; ctx3, st3, binding) = @something select_target_binding(st0_top, offset, mod; soft_scope) return nothing
+    (; ctx3, st3, binding) = @something select_target_binding(
+        st0_top, offset, context_module; soft_scope) return nothing
     binfo = JL.get_binding(ctx3, binding)
     skip_global && binfo.kind === :global && return nothing
     definitions = @somereal lookup_binding_definitions(st3, binfo) return nothing

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -313,7 +313,7 @@ function get_context_info(state::ServerState, uri::URI, pos::Position; lookup_fu
     world = get_context_world(analysis_info)
     analyzer = get_context_analyzer(analysis_info, lookup_uri)
     postprocessor = get_post_processor(analysis_info)
-    return (; context_module, world, analyzer, postprocessor, mod=context_module) # `mod` is temporarily preserved
+    return (; context_module, world, analyzer, postprocessor)
 end
 
 get_context_module(::Nothing, ::URI, ::Position) = Main

--- a/test/analysis/test_cfg_analysis.jl
+++ b/test/analysis/test_cfg_analysis.jl
@@ -11,9 +11,13 @@ module lowering_module end
 
 # --- Undefined binding analysis ---
 
-function get_undef_status(text::AbstractString; mod::Module=lowering_module, allow_noreturn_optimization::Vector{Symbol}=Symbol[])
+function get_undef_status(
+        text::AbstractString;
+        context_module::Module = lowering_module,
+        allow_noreturn_optimization::Vector{Symbol} = Symbol[]
+    )
     st0 = jlparse(text; rule=:statement, filename=@__FILE__)
-    (; ctx3, st3) = JETLS.jl_lower_for_scope_resolution(mod, st0; trim_error_nodes=false, recover_from_macro_errors=false)
+    (; ctx3, st3) = JETLS.jl_lower_for_scope_resolution(context_module, st0; trim_error_nodes=false, recover_from_macro_errors=false)
     (; undef_info) = JETLS.analyze_all_lambdas(ctx3, st3; allow_noreturn_optimization)
     result = Dict{String, Union{Nothing,Bool}}()
     for (binfo, info) in undef_info
@@ -1093,11 +1097,13 @@ end # @testset "undef analysis" begin
 
 # --- Dead store (unused assignment) analysis ---
 
-function get_dead_stores(text::AbstractString;
-        mod::Module=lowering_module,
-        allow_noreturn_optimization::Vector{Symbol}=Symbol[])
+function get_dead_stores(
+        text::AbstractString;
+        context_module::Module = lowering_module,
+        allow_noreturn_optimization::Vector{Symbol} = Symbol[]
+    )
     st0 = jlparse(text; rule=:statement, filename=@__FILE__)
-    (; ctx3, st3) = JETLS.jl_lower_for_scope_resolution(mod, st0;
+    (; ctx3, st3) = JETLS.jl_lower_for_scope_resolution(context_module, st0;
         trim_error_nodes=false, recover_from_macro_errors=false)
     (; dead_store_info) = JETLS.analyze_all_lambdas(ctx3, st3;
         allow_noreturn_optimization)
@@ -1531,11 +1537,13 @@ end # @testset "dead store analysis" begin
 # (e.g. the iterate-step assignment of a `for` loop) whose provenance
 # points back to a syntactically reachable location; the diagnostic layer
 # filters those out, the CFG layer does not.
-function get_unreachable_statements(text::AbstractString;
-        mod::Module=lowering_module,
-        allow_noreturn_optimization::Vector{Symbol}=Symbol[])
+function get_unreachable_statements(
+        text::AbstractString;
+        context_module::Module = lowering_module,
+        allow_noreturn_optimization::Vector{Symbol} = Symbol[]
+    )
     st0 = jlparse(text; rule=:statement, filename=@__FILE__)
-    (; ctx3, st3) = JETLS.jl_lower_for_scope_resolution(mod, st0;
+    (; ctx3, st3) = JETLS.jl_lower_for_scope_resolution(context_module, st0;
         trim_error_nodes=false, recover_from_macro_errors=false)
     (; unreachable_statements) = JETLS.analyze_all_lambdas(ctx3, st3;
         allow_noreturn_optimization)

--- a/test/analysis/test_closure_to_opaque.jl
+++ b/test/analysis/test_closure_to_opaque.jl
@@ -4,25 +4,27 @@ using Test
 using JETLS
 using JETLS: JL, JS, rewrite_local_closures_to_opaque
 
+module lowering_module end
+
 # Run the rewrite + the rest of JL lowering, then `Core.eval` the resulting
 # `:thunk` so tests can assert against the runtime value the rewritten IR
 # produces. Returns `(value, st3_oc)` — `st3_oc` is the post-rewrite tree so
 # tests can assert structural facts (e.g. an OC was actually emitted).
 function rewrite_lower_eval(code::AbstractString)
-    mod = Module()
+    context_module = lowering_module
     fi = JETLS.FileInfo(1, code, @__FILE__)
     st0_top = JETLS.build_syntax_tree(fi)
     last_value = Ref{Any}(nothing)
     last_st3_oc = Ref{Union{JETLS.SyntaxTreeC,Nothing}}(nothing)
     JETLS.iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
-        result = JETLS.TypeAnnotation.get_inferrable_tree(st0, mod)
+        result = JETLS.TypeAnnotation.get_inferrable_tree(st0, context_module)
         result === nothing && error("get_inferrable_tree failed for: $code")
         (; ctx3, st3) = result
         st3_oc = rewrite_local_closures_to_opaque(ctx3, st3)
         ctx4, st4 = JL.convert_closures(ctx3, st3_oc)
         _, st5 = JL.linearize_ir(ctx4, st4)
         lwr = JL.to_lowered_expr(st5)
-        last_value[] = Core.eval(mod, lwr)
+        last_value[] = Core.eval(context_module, lwr)
         last_st3_oc[] = st3_oc
         return nothing
     end
@@ -35,12 +37,12 @@ end
 # post-rewrite tree only — sufficient for structural assertions like "the
 # rewrite did NOT fire for this shape".
 function rewrite_only(code::AbstractString)
-    mod = Module()
+    context_module = lowering_module
     fi = JETLS.FileInfo(1, code, @__FILE__)
     st0_top = JETLS.build_syntax_tree(fi)
     last_st3_oc = Ref{Union{JETLS.SyntaxTreeC,Nothing}}(nothing)
     JETLS.iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
-        result = JETLS.TypeAnnotation.get_inferrable_tree(st0, mod)
+        result = JETLS.TypeAnnotation.get_inferrable_tree(st0, context_module)
         result === nothing && error("get_inferrable_tree failed for: $code")
         (; ctx3, st3) = result
         last_st3_oc[] = rewrite_local_closures_to_opaque(ctx3, st3)

--- a/test/analysis/test_occurrence_analysis.jl
+++ b/test/analysis/test_occurrence_analysis.jl
@@ -11,14 +11,16 @@ module lowering_module end
 
 with_binding_occurrences(callback, code::AbstractString; kwargs...) =
     with_binding_occurrences(callback, lowering_module, code; kwargs...)
-function with_binding_occurrences(callback, mod::Module, code::AbstractString;
-                                  remove_macrocalls::Bool = false,
-                                  is_generated::Bool = false)
+function with_binding_occurrences(
+        callback, context_module::Module, code::AbstractString;
+        remove_macrocalls::Bool = false,
+        is_generated::Bool = false
+    )
     st0 = jlparse(code; rule=:statement)
     if remove_macrocalls
         st0 = JETLS.remove_macrocalls(st0)
     end
-    (; ctx3, st3) = JETLS.jl_lower_for_scope_resolution(mod, st0)
+    (; ctx3, st3) = JETLS.jl_lower_for_scope_resolution(context_module, st0)
     binding_occurrences = JETLS.compute_binding_occurrences(ctx3, st3, is_generated)
     callback(binding_occurrences)
 end

--- a/test/jsjl-utils.jl
+++ b/test/jsjl-utils.jl
@@ -34,19 +34,20 @@ end
 
 # dump all intermediate ctx and st into the global scope for inspection
 # use `stop` if some lowering pass mutates ctx in a way you don't want
-function jldebug(mod::Module, st0_in::JS.SyntaxTree, stop::Int=5)
+function jldebug(context_module::Module, st0_in::JS.SyntaxTree, stop::Int=5)
     global st0 = st0_in
     global st1, st2, st3, st4, st5
     global ctx1, ctx2, ctx3, ctx4, ctx5
     ctx0 = nothing
-    (stop -= 1) < 0 && return ctx0, st0; ctx1, st1 = JL.expand_forms_1(mod, st0_in, true, Base.get_world_counter())
+    (stop -= 1) < 0 && return ctx0, st0; ctx1, st1 = JL.expand_forms_1(context_module, st0_in, true, Base.get_world_counter())
     (stop -= 1) < 0 && return ctx1, st1; ctx2, st2 = JL.expand_forms_2(ctx1, st1)
     (stop -= 1) < 0 && return ctx2, st2; ctx3, st3 = JL.resolve_scopes(ctx2, st2)
     (stop -= 1) < 0 && return ctx3, st3; ctx4, st4 = JL.convert_closures(ctx3, st3)
     (stop -= 1) < 0 && return ctx4, st4; ctx5, st5 = JL.linearize_ir(ctx4, st4)
     return ctx5, st5
 end
-jldebug(mod::Module, s::AbstractString, stop::Int=5) = jldebug(mod, jlparse(s; rule=:statement), stop)
+jldebug(context_module::Module, s::AbstractString, stop::Int=5) =
+    jldebug(context_module, jlparse(s; rule=:statement), stop)
 jldebug(args...) = jldebug(@__MODULE__, args...)
 
 # Select a node by ID from a tree (its underlying graph), graph, or ctx

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -13,11 +13,11 @@ module lowering_module end
 
 function get_cursor_bindings(
         fi::JETLS.FileInfo, b::Int;
-        mod::Module = lowering_module,
+        context_module::Module = lowering_module,
         soft_scope::Bool = false
     )
     st0 = JETLS.build_syntax_tree(fi)
-    cb = JETLS.cursor_bindings(st0, b, mod; soft_scope)
+    cb = JETLS.cursor_bindings(st0, b, context_module; soft_scope)
     return isnothing(cb) ? [] : cb
 end
 function get_cursor_bindings(marked_text::AbstractString; kwargs...)
@@ -321,7 +321,7 @@ end
 
 # Lightweight version of `with_completion_request` for cases where full module
 # context (populated by `request_analysis!`) isn't needed.
-# The `mod` context falls back to `Main`, so this works for tests against names defined in
+# The `context_module` context falls back to `Main`, so this works for tests against names defined in
 # `Main`/`Base`/`Core` and for purely local/keyword/latex/emoji completions.
 function with_completion_items(
         tester, text::AbstractString;
@@ -1311,14 +1311,14 @@ end
         """
         # Without soft_scope: `x` is a new local (ambiguous local)
         cbs_hard = get_cursor_bindings(marked_text;
-            mod=soft_scope_completions_module, soft_scope=false)
+            context_module=soft_scope_completions_module, soft_scope=false)
         xs_hard = filter(((bi, _, _),) -> bi.name == "x", cbs_hard)
         @test length(xs_hard) == 1
         @test xs_hard[1][1].kind === :local
 
         # With soft_scope: `x` assigns to the existing global
         cbs_soft = get_cursor_bindings(marked_text;
-            mod=soft_scope_completions_module, soft_scope=true)
+            context_module=soft_scope_completions_module, soft_scope=true)
         xs_soft = filter(((bi, _, _),) -> bi.name == "x", cbs_soft)
         @test length(xs_soft) == 1
         @test xs_soft[1][1].kind === :global

--- a/test/test_signature_help.jl
+++ b/test/test_signature_help.jl
@@ -214,12 +214,11 @@ f(a0, a1, a2, va3...; kw4=0, kw5=0, kws6...) = 0
 f1(x, xs...) = 0
 kwfunc(; kw0, kw1, kws2...) = nothing
 end
+function active_parameter(context_module::Module, code::AbstractString; kwargs...)
+    si = siginfos(context_module, code; kwargs...)
+    Int(@something only(si).activeParameter return nothing)
+end
 @testset "Active param highlighting" begin
-    function active_parameter(mod::Module, code::AbstractString; kwargs...)
-        si = siginfos(mod, code; kwargs...)
-        Int(@something only(si).activeParameter return nothing)
-    end
-
     @test 0 == active_parameter(M_highlight, "f(│)")
     @test 0 == active_parameter(M_highlight, "f(0│)")
     @test 1 == active_parameter(M_highlight, "f(0,│)")

--- a/test/utils/test_jl_syntax_macros.jl
+++ b/test/utils/test_jl_syntax_macros.jl
@@ -7,22 +7,23 @@ include(normpath(pkgdir(JETLS), "test", "jsjl-utils.jl"))
 
 module lowering_module end
 
-function jlexpand(mod::Module, code::AbstractString)
+function jlexpand(context_module::Module, code::AbstractString)
     st0 = jlparse(code; rule=:statement)
     world = Base.get_world_counter()
-    _, st1 = JL.expand_forms_1(mod, st0, true, world)
+    _, st1 = JL.expand_forms_1(context_module, st0, true, world)
     return st1
 end
 jlexpand(code::AbstractString) = jlexpand(lowering_module, code)
 
-function jlresolve(mod::Module, code::AbstractString)
+function jlresolve(context_module::Module, code::AbstractString)
     st0 = jlparse(code; rule=:statement)
-    return JETLS.jl_lower_for_scope_resolution(mod, st0;
+    return JETLS.jl_lower_for_scope_resolution(context_module, st0;
         recover_from_macro_errors=false, convert_closures=true)
 end
 jlresolve(code::AbstractString) = jlresolve(lowering_module, code)
 
-jleval(mod::Module, code::AbstractString) = JL.eval(mod, jlparse(code; rule=:statement))
+jleval(context_module::Module, code::AbstractString) =
+    JL.eval(context_module, jlparse(code; rule=:statement))
 jleval(code::AbstractString) = jleval(lowering_module, code)
 
 children_kinds(st::JS.SyntaxTree) = JS.Kind[JS.kind(c) for c in JS.children(st)]


### PR DESCRIPTION
Remove the temporarily preserved `mod` alias from the named tuple returned by `get_context_info`, and complete the migration to `context_module` across handlers, helper functions, and test helpers. This sweeps the rename through `src/utils/binding.jl`, `src/document-symbol.jl`, `src/diagnostic.jl`, and the related test helpers under `test/` for consistency.

In `src/diagnostic.jl` the local that holds `binfo.mod` is also renamed to `bmod` to avoid colliding with the surrounding `context_module` vocabulary. `test/analysis/test_closure_to_opaque.jl` additionally switches from a per-call anonymous `Module()` to the shared `lowering_module` convention used elsewhere in the test suite.