### PR TITLE
ast: Replace `greatest_local` with `lowerable_toplevel_at`

### DIFF
--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -125,6 +125,7 @@ is_new_style_macrocall0(st0::SyntaxTreeC) =
     is_macrocall_st0(st0, NEW_STYLE_MACROCALL_NAMES...)
 
 is_doc0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@doc"; from=Core)
+is_doc0_any(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@doc") # Explicit `@doc` can have any module set.
 
 is_cmd0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@cmd"; from=Core)
 
@@ -628,13 +629,16 @@ function iterate_toplevel_tree(callback, st0_top::SyntaxTreeC)
                 push!(sl, st0[i])
             end
         elseif JS.kind(st0) === JS.K"module"
-            stblk = st0[end]
-            JS.kind(stblk) === JS.K"block" || continue
+            # The body `K"block"` is typically the last child, but trailing
+            # `K"error"` nodes from incomplete code can push it earlier.
+            stblk_idx = @something findlast(i::Int -> JS.kind(st0[i]) === JS.K"block",
+                1:JS.numchildren(st0)) continue
+            stblk = st0[stblk_idx]
             for i = JS.numchildren(stblk):-1:1 # reversed since we use `pop!`
                 push!(sl, stblk[i])
             end
-        elseif is_doc0(st0)
-            # Analyze only the code to which docstrings are attached
+        elseif is_doc0_any(st0)
+            # Analyze only the code to which docstrings are attached.
             push!(sl, st0[end])
         else # st0 is lowerable tree
             ret = callback(st0)
@@ -684,52 +688,24 @@ end
 byte_ancestors(flt, st::SyntaxTreeC, byte::Integer) = byte_ancestors(flt, st, byte:byte)
 
 """
-    greatest_local(st0::SyntaxTreeC, offset::Integer) -> st::Union{SyntaxTreeC, Nothing}
+    lowerable_toplevel_at(st0_top::SyntaxTreeC, offset::Integer) -> st::Union{SyntaxTreeC, Nothing}
 
-Return the largest tree that can introduce local bindings that are visible to the cursor
-(if any such tree exists).
+Return the lowerable top-level subtree of `st0_top` whose byte range contains `offset`, or
+`nothing` if no such subtree exists. Equivalent to running [`iterate_toplevel_tree`](@ref)
+and picking the first hit whose byte range contains `offset`, with an `offset - 1` retry
+for cursor positions just past the last token of a statement (e.g. `export foo│\\n`).
 """
-function greatest_local(st0::SyntaxTreeC, offset::Integer)
-    result = _find_greatest_local(st0, offset)
+function lowerable_toplevel_at(st0_top::SyntaxTreeC, offset::Integer)
+    result = _lowerable_toplevel_at(st0_top, offset)
     result !== nothing && return result
-    # When the cursor sits just past the last token of a line (e.g. `export
-    # foo│\n`), `offset` points at a byte owned only by `toplevel`, so the
-    # initial lookup yields nothing. Retry with `offset - 1` to select the
-    # node just to the left of the cursor, mirroring the offset-1 fallbacks
-    # in `_select_target_binding` / `select_macrocall_binding`.
-    return offset > 1 ? _find_greatest_local(st0, offset - 1) : nothing
+    return offset > 1 ? _lowerable_toplevel_at(st0_top, offset - 1) : nothing
 end
 
-function _find_greatest_local(st0::SyntaxTreeC, offset::Integer)
-    bas = byte_ancestors(st0, offset)
-    first_global = @something begin
-        findfirst(st::SyntaxTreeC -> JS.kind(st) in JS.KSet"toplevel module", bas)
-    end return nothing
-    if first_global == 1
-        return nothing
+function _lowerable_toplevel_at(st0_top::SyntaxTreeC, offset::Integer)
+    return iterate_toplevel_tree(st0_top) do st0::SyntaxTreeC
+        offset in JS.byte_range(st0) || return nothing
+        return TraversalReturn(st0; terminate=true)
     end
-    idx = Ref(first_global - 1)
-    # `@doc`-wrapped definitions don't introduce locals themselves, and macro
-    # expansion replaces the wrapper with synthetic nodes that have no source
-    # positions — leaving the macrocall as the chosen tree would exclude the
-    # cursor from every scope after lowering. Unwrap to the decorated form.
-    if is_macrocall_st0(bas[idx[]], "@doc")
-        decorated = bas[idx[]][end]
-        offset in JS.byte_range(decorated) || return nothing
-        return decorated
-    end
-    while JS.kind(bas[idx[]]) === JS.K"block"
-        if any(j::Int -> JS.kind(bas[idx[]][j]) === JS.K"local", 1:JS.numchildren(bas[idx[]]))
-            # If this `block` contains `local`, it may introduce local bindings.
-            # For correct scope analysis, we need to analyze this entire block
-            break
-        end
-        # `bas[i]` is a block within a global scope, so can't introduce local bindings.
-        # Shrink the tree (mostly for performance).
-        idx[] -= 1
-        idx[] < 1 && return nothing
-    end
-    return bas[idx[]]
 end
 
 """

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -103,7 +103,7 @@ function cursor_bindings(
         st0_top::SyntaxTreeC, offset::Int, context_module::Module;
         soft_scope::Bool = false
     )
-    st0 = @something greatest_local(st0_top, offset) return nothing # nothing we can lower
+    st0 = @something lowerable_toplevel_at(st0_top, offset) return nothing
     (st0, _) = desugar_main_macrocall(st0)
     (; ctx3, st2) = try
         jl_lower_for_scope_resolution(context_module, st0; soft_scope)
@@ -245,7 +245,7 @@ function select_target_binding(
         caller::AbstractString = "select_target_binding",
         soft_scope::Bool = false
     )
-    st0 = @something greatest_local(st0_top, offset) return nothing # nothing we can lower
+    st0 = @something lowerable_toplevel_at(st0_top, offset) return nothing
 
     macrocall_result = select_macrocall_binding(st0, offset, context_module, caller; soft_scope)
     macrocall_result !== nothing && return macrocall_result

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -246,8 +246,8 @@ end
     end
 end
 
-# completion for code including macros
-let code = """
+@testset "completion for code including macros" begin
+    code = """
     function foo(x)
         │
         return @inline typeof(x)
@@ -300,19 +300,20 @@ end
     @test cnt[] == 1
 end
 
-# local completion for incomplete code shouldn't crash
-let code = """
-    function fo│
-    """
-    @expect_jl_err test_single_cv(code, String[])
-end
-let # XXX somehow wrapping within `module A ... end` is necessary to get `xx` completion for this incomplete code
-    code = """
-    module A
-    function foo(xx, y=x│)
+@testset "local completion for incomplete code shouldn't crash" begin
+    let code = """
+        function fo│
+        """
+        @expect_jl_err test_single_cv(code, String[])
     end
-    """
-    test_single_cv(code, ["xx"], kind=:local)
+    let # XXX somehow wrapping within `module A ... end` is necessary to get `xx` completion for this incomplete code
+        code = """
+        module A
+        function foo(xx, y=x│)
+        end
+        """
+        test_single_cv(code, ["xx"], kind=:local)
+    end
 end
 
 # get_completion_items

--- a/test/utils/test_ast.jl
+++ b/test/utils/test_ast.jl
@@ -120,8 +120,8 @@ include(normpath(pkgdir(JETLS), "test", "jsjl-utils.jl"))
     end
 end
 
-@testset "greatest_local" begin
-    # Return the innermost non-toplevel/non-module node containing the cursor.
+@testset "lowerable_toplevel_at" begin
+    # Return the top-level subtree whose byte range contains the cursor.
     let code = """
         function foo(│x│)
             return │x│ + 1
@@ -131,13 +131,13 @@ end
         st = jlparse(clean_code)
         for pos in positions
             offset = JETLS.xy_to_offset(clean_code, pos, @__FILE__)
-            local_tree = JETLS.greatest_local(st, offset)
+            local_tree = JETLS.lowerable_toplevel_at(st, offset)
             @test !isnothing(local_tree)
             @test JS.kind(local_tree) === JS.K"function"
         end
     end
 
-    # Cursor inside a module but not any contained statement: no local scope.
+    # Cursor inside a module but not any contained statement: no top-level subtree to lower.
     let code = """
         module M
         │
@@ -146,19 +146,18 @@ end
         clean_code, positions = JETLS.get_text_and_positions(code)
         offset = JETLS.xy_to_offset(clean_code, only(positions), @__FILE__)
         st = jlparse(clean_code)
-        @test isnothing(JETLS.greatest_local(st, offset))
+        @test isnothing(JETLS.lowerable_toplevel_at(st, offset))
     end
 
     # Offset past the end of the source.
     let code = "x = 1\n"
         st = jlparse(code)
-        @test isnothing(JETLS.greatest_local(st, 1000))
+        @test isnothing(JETLS.lowerable_toplevel_at(st, 1000))
     end
 
-    # Fallback: when the cursor is just past the last token on a line (e.g.
-    # `export foo│\n`), the raw offset lands on whitespace owned only by
-    # `toplevel`. `greatest_local` should retry with `offset - 1` and return
-    # the enclosing statement.
+    # Fallback: when the cursor is just past the last token on a line (e.g. `export foo│\n`),
+    # the raw offset lands on whitespace owned only by `toplevel`.
+    # `lowerable_toplevel_at` should retry with `offset - 1` and return the enclosing statement.
     let code = """
         export foo
         foo(1)
@@ -167,7 +166,7 @@ end
         st = jlparse(clean_code)
         # Offset at the newline after `foo` (i.e. one past the identifier's last byte).
         offset = sizeof("export foo") + 1
-        local_tree = JETLS.greatest_local(st, offset)
+        local_tree = JETLS.lowerable_toplevel_at(st, offset)
         @test !isnothing(local_tree)
         @test JS.kind(local_tree) === JS.K"export"
     end
@@ -176,7 +175,7 @@ end
     let code = "x = 1\ny\n"
         st = jlparse(code)
         offset = sizeof("x = 1\ny") + 1  # just past `y`, on the newline
-        local_tree = JETLS.greatest_local(st, offset)
+        local_tree = JETLS.lowerable_toplevel_at(st, offset)
         @test !isnothing(local_tree)
         @test JS.kind(local_tree) === JS.K"Identifier"
         @test JS.sourcetext(local_tree) == "y"
@@ -847,28 +846,26 @@ end
 end
 
 @testset "iterate_toplevel_tree" begin
-    let cnt = 0,
-        func1 = struct1 = false
+    let cnt = Ref(0), func1 = Ref(false), struct1 = Ref(false)
         JETLS.iterate_toplevel_tree(jlparse("""
             module Module1
             func1(x) = x
             struct Struct1 end
             end
             """)) do st0
-            cnt += 1
+            cnt[] += 1
             s = JS.sourcetext(st0)
             if s == "func1(x) = x"
-                func1 = true
+                func1[] = true
             elseif s == "struct Struct1 end"
-                struct1 = true
+                struct1[] = true
             end
         end
-        @test cnt == 2
-        @test func1 && struct1
+        @test cnt[] == 2
+        @test func1[] && struct1[]
     end
 
-    let cnt = 0,
-        func1 = struct1 = false
+    let cnt = Ref(0), func1 = Ref(false), struct1 = Ref(false)
         JETLS.iterate_toplevel_tree(jlparse("""
             \"\"\"
             Docstring for `module Module1`
@@ -881,16 +878,16 @@ end
             struct Struct1 end
             end
             """)) do st0
-            cnt += 1
+            cnt[] += 1
             s = JS.sourcetext(st0)
             if s == "func1(x) = x"
-                func1 = true
+                func1[] = true
             elseif s == "struct Struct1 end"
-                struct1 = true
+                struct1[] = true
             end
         end
-        @test cnt == 2
-        @test func1 && struct1
+        @test cnt[] == 2
+        @test func1[] && struct1[]
     end
 end
 


### PR DESCRIPTION
Drop the bottom-up `byte_ancestors`-based `greatest_local` and introduce `lowerable_toplevel_at`, a thin wrapper around `iterate_toplevel_tree` that returns the top-level subtree whose byte range contains the cursor. The new helper preserves the `offset - 1` retry for cursor positions just past the last token of a statement.

The two existing call sites — `cursor_bindings` and `select_target_binding` — are migrated. This unifies subtree selection with `build_inferred_context_at` (which already drives inference via `iterate_toplevel_tree`), so a future refactor can share the underlying `jl_lower_for_scope_resolution` work across local completion, global completion, and call completion.

Two `iterate_toplevel_tree` corrections fall out of this migration:

- `K"module"` body lookup now searches children via `findlast` instead of taking `st0[end]` directly. Incomplete code that parses with a trailing `K"error"` child of the module would otherwise hide the body block and silently drop every subtree inside.

- `@doc` unwrapping switches to the permissive `is_doc0_any` (no `from=Core` constraint). User-written explicit forms like `@doc "..." function ...` have no `:mod` attribute set until name resolution, so the previous strict `is_doc0` check missed them — matching the fix already applied to `greatest_local` in 3cc54b2e.