### PR TITLE
completions: Remove `prepend_inference_result` config gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > The new shape adds [`inlay_hint.block_end.enabled`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/inlay_hint/block_end/enabled) for toggling block-end hints independently, and renames `inlay_hint.block_end_min_lines` to [`inlay_hint.block_end.min_lines`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/inlay_hint/block_end/min_lines).
 > Existing configs keep working for now: the legacy key is still accepted at load time and mapped onto the new key in memory (your config file is not modified automatically), with a one-shot deprecation warning. The legacy alias will be removed in releases after **June 2026**, so if you are still using `inlay_hint.block_end_min_lines`, please update your config.
 
+> [!warning]
+> The `completion.method_signature.prepend_inference_result` configuration option was removed. Inferred return types are now always shown both as `CompletionItem.detail` (` -> T` typically shown next to the candidate label) and as a leading `signature -> T` code fence at the top of the method signature completion documentation, so the previous client-specific opt-in is no longer needed.
+> Existing configs keep working for now: the removed key is still accepted at load time and silently dropped, with a one-shot deprecation warning. The legacy key will be rejected outright in releases after **June 2026**, so if you are still setting `completion.method_signature.prepend_inference_result`, please remove it from your config.
+
 ### Added
 
 - Added support for "Go to Type Definition" (`textDocument/typeDefinition`).

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -33,9 +33,6 @@ path = ""                          # string (optional), glob pattern for file pa
 [completion.latex_emoji]
 strip_prefix = false               # boolean, default: (unset) auto-detect
 
-[completion.method_signature]
-prepend_inference_result = false   # boolean, default: (unset) auto-detect
-
 [code_lens]
 references = false                 # boolean, default: false
 testrunner = true                  # boolean, default: true
@@ -61,7 +58,6 @@ executable = "testrunner"          # string, default: "testrunner" (or "testrunn
   - [`[[diagnostic.patterns]]`](@ref config/diagnostic/patterns)
 - [`[completion]`](@ref config/completion)
   - [`[completion.latex_emoji] strip_prefix`](@ref config/completion/latex_emoji/strip_prefix)
-  - [`[completion.method_signature] prepend_inference_result`](@ref config/completion/method_signature/prepend_inference_result)
 - [`[code_lens]`](@ref config/code_lens)
   - [`[code_lens] references`](@ref config/code_lens/references)
   - [`[code_lens] testrunner`](@ref config/code_lens/testrunner)
@@ -402,38 +398,6 @@ option.
 ```toml
 [completion.latex_emoji]
 strip_prefix = true  # Force prefix stripping for clients with sortText issues
-```
-
-!!! tip "Help improve auto-detection"
-    If explicitly setting this option clearly improves behavior for your client,
-    consider submitting a PR to add your client to the [auto-detection](https://github.com/aviatesk/JETLS.jl/blob/14fdc847252579c27e41cd50820aee509f8fd7bd/src/completions.jl#L386) logic.
-
-#### [`[completion.method_signature] prepend_inference_result`](@id config/completion/method_signature/prepend_inference_result)
-
-- **Type**: boolean
-- **Default**: (unset) auto-detect based on client
-
-Controls whether to prepend inferred return type information to the documentation
-of method signature completion items.
-
-In some editors (e.g., Zed), additional information like inferred return type
-displayed when an item is selected may be cut off in the UI when the method
-signature text is long.
-
-When set to `true`, JETLS prepends the return type as a code block to the
-documentation, ensuring it is always visible.
-
-When set to `false`, the return type is only shown alongside the completion item
-(as `CompletionItem.detail` in LSP terms, which may be cut off in some editors).
-
-When not set (default), JETLS auto-detects based on the client name and applies
-the appropriate behavior. Note that the auto-detection only covers a limited set
-of known clients, so if you experience issues with return type visibility, try
-explicitly setting this option.
-
-```toml
-[completion.method_signature]
-prepend_inference_result = true  # Show return type in documentation
 ```
 
 !!! tip "Help improve auto-detection"

--- a/docs/src/features.md
+++ b/docs/src/features.md
@@ -158,10 +158,6 @@ Selecting a candidate inserts remaining positional arguments as snippet
 placeholders with type annotations. Inferred return type and documentation
 are resolved lazily.
 
-See [`[completion.method_signature] prepend_inference_result`](@ref
-config/completion/method_signature/prepend_inference_result) for the
-configuration option that shows the inferred return type inline.
-
 > ```@raw html
 > <div class="display-light-only">
 > ```

--- a/jetls-client/CHANGELOG.md
+++ b/jetls-client/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
 - Diff: [`916a7a84...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/916a7a84...HEAD)
 
+### Removed
+
+- The `completion.method_signature.prepend_inference_result` setting was removed. Inferred return types are now always shown both as `CompletionItem.detail` (` -> T` next to the candidate label) and as a leading `signature -> T` code fence at the top of the method signature completion documentation, so the previous client-specific opt-in is no longer needed.
+  Existing configs keep working for now: the removed key is still accepted at load time and silently dropped, with a one-shot deprecation warning. The legacy key will be rejected outright in releases after June 2026, so if you are still setting `completion.method_signature.prepend_inference_result`, please remove it from your config.
+
 ## v0.4.0
 
 - Commit: [`916a7a84`](https://github.com/aviatesk/JETLS.jl/commit/916a7a84)

--- a/jetls-client/package.json
+++ b/jetls-client/package.json
@@ -187,18 +187,6 @@
                   },
                   "required": [],
                   "type": "object"
-                },
-                "method_signature": {
-                  "additionalProperties": false,
-                  "markdownDescription": "Method signature completion configuration. See [documentation](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/completion/method_signature/prepend_inference_result).",
-                  "properties": {
-                    "prepend_inference_result": {
-                      "markdownDescription": "When true, prepends inferred return type to completion documentation, ensuring visibility in editors where `CompletionItem.detail` may be cut off (e.g., Zed). Auto-detected by default based on client name; set explicitly if return types are not visible.",
-                      "type": "boolean"
-                    }
-                  },
-                  "required": [],
-                  "type": "object"
                 }
               },
               "required": [],

--- a/schemas/config-toml.schema.json
+++ b/schemas/config-toml.schema.json
@@ -35,18 +35,6 @@
           },
           "required": [],
           "type": "object"
-        },
-        "method_signature": {
-          "additionalProperties": false,
-          "description": "Method signature completion configuration. See [documentation](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/completion/method_signature/prepend_inference_result).",
-          "properties": {
-            "prepend_inference_result": {
-              "description": "When true, prepends inferred return type to completion documentation, ensuring visibility in editors where `CompletionItem.detail` may be cut off (e.g., Zed). Auto-detected by default based on client name; set explicitly if return types are not visible.",
-              "type": "boolean"
-            }
-          },
-          "required": [],
-          "type": "object"
         }
       },
       "required": [],

--- a/schemas/description.toml
+++ b/schemas/description.toml
@@ -42,13 +42,9 @@ module_name = "Optional module name to associate with the matched files. When sp
 
 [CompletionConfig]
 latex_emoji = "LaTeX and emoji completion configuration. See [documentation](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/completion/latex_emoji/strip_prefix)."
-method_signature = "Method signature completion configuration. See [documentation](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/completion/method_signature/prepend_inference_result)."
 
 [LaTeXEmojiConfig]
 strip_prefix = "Controls whether to strip `\\` or `:` prefix from LaTeX/emoji completion labels. Some editors (e.g., Zed) have sorting issues with backslash in `sortText`. Auto-detected by default; set explicitly if completions appear in wrong order."
-
-[MethodSignatureConfig]
-prepend_inference_result = "When true, prepends inferred return type to completion documentation, ensuring visibility in editors where `CompletionItem.detail` may be cut off (e.g., Zed). Auto-detected by default based on client name; set explicitly if return types are not visible."
 
 [CodeLensConfig]
 references = "Show reference counts above top-level symbols (functions, structs, constants, etc.). Click to open references panel."

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -46,17 +46,6 @@
                 }
               },
               "type": "object"
-            },
-            "method_signature": {
-              "additionalProperties": false,
-              "description": "Method signature completion configuration. See [documentation](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/completion/method_signature/prepend_inference_result).",
-              "properties": {
-                "prepend_inference_result": {
-                  "$ref": "#/$defs/Core.Bool",
-                  "description": "When true, prepends inferred return type to completion documentation, ensuring visibility in editors where `CompletionItem.detail` may be cut off (e.g., Zed). Auto-detected by default based on client name; set explicitly if return types are not visible."
-                }
-              },
-              "type": "object"
             }
           },
           "type": "object"

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -7,11 +7,14 @@ const JETLS_VERSION = let
     isfile(version_file) ? strip(read(version_file, String)) : "unknown"
 end
 
-# Append `old_path => new_path` pairs to register a key migration.
+# Append `old_path => new_path` pairs to register a key migration, or
+# `old_path => nothing` to deprecate a key without a replacement.
 # Each path is a list of nested keys; `migrate_deprecated_config_keys!` consults this
 # table and rewrites raw user config dicts before parsing.
-const deprecated_configurations = Pair{Vector{String},Vector{String}}[
+const deprecated_configurations = Pair{Vector{String},Union{Nothing,Vector{String}}}[
+    # 2026 June
     ["inlay_hint", "block_end_min_lines"] => ["inlay_hint", "block_end", "min_lines"],
+    ["completion", "method_signature", "prepend_inference_result"] => nothing,
 ]
 
 const __init__hooks__ = Any[]

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -893,7 +893,7 @@ function resolve_completion_item(state::ServerState, item::CompletionItem)
     elseif (data isa MethodSignatureCompletionData &&
             completion_resolver_info isa MethodSignatureCompletionResolverInfo &&
             data.resolver_id == completion_resolver_info.id)
-        return resolve_method_signature_completion_item(state, item, data, completion_resolver_info)
+        return resolve_method_signature_completion_item(item, data, completion_resolver_info)
     elseif (data isa PropertyCompletionData &&
             completion_resolver_info isa PropertyCompletionResolverInfo &&
             data.resolver_id == completion_resolver_info.id)
@@ -988,37 +988,34 @@ function resolve_global_completion_item(
 end
 
 function resolve_method_signature_completion_item(
-        state::ServerState, item::CompletionItem, data::MethodSignatureCompletionData,
+        item::CompletionItem, data::MethodSignatureCompletionData,
         completion_resolver_info::MethodSignatureCompletionResolverInfo
     )
     (; world, matches, postprocessor) = completion_resolver_info
     1 ≤ data.match_idx ≤ length(matches) || return item # just to make sure
     match = matches[data.match_idx]
     doc = @something lookup_method_documentation(match, world) return item
-    documentation = postprocessor(string(doc))
+    docstr = postprocessor(string(doc))
     _, result = infer_match!(world, match)
     resulttyp = @something result.result return item
     rettyp = CC.widenconst(resulttyp)
     # TODO Show effects and exception type?
-    typstr = postprocessor(string(rettyp))
-    detail = " ::" * typstr
-    prepend_inference_result = @somereal(
-        get_config(state, :completion, :method_signature, :prepend_inference_result),
-        # auto-detect based on client
-        getobjpath(state, :init_params, :clientInfo, :name) ∈ ("Zed", "Zed Dev"))
-    if prepend_inference_result
-        documentation = """
-        ```julia
-        ::$(typstr)
-        ```
-        """ * documentation
-    end
+    typstr = truncate_typstr(
+        postprocessor(sprint(show, rettyp; context = :compact => true)),
+        #=maxdepth=#3, #=maxwidth=#20)
+    detail = " -> " * typstr
+    full_typstr = postprocessor(string(rettyp))
+    value = """
+    ```julia
+    $(item.label) -> $(full_typstr)
+    ```
+    ---
+    """ * docstr
+    documentation = MarkupContent(; kind = MarkupKind.Markdown, value)
     return CompletionItem(item;
         labelDetails = CompletionItemLabelDetails(; detail, description = "method"),
         detail,
-        documentation = MarkupContent(;
-            kind = MarkupKind.Markdown,
-            value = documentation))
+        documentation)
 end
 
 # request handler

--- a/src/config.jl
+++ b/src/config.jl
@@ -378,23 +378,25 @@ unmatched_key_msg(header_msg::AbstractString, path::Vector{String}) =
 # this *before* parsing. Already-migrated values win over the legacy alias.
 function migrate_deprecated_config_keys!(
         config_dict::AbstractDict,
-        deprecated_configs::Vector{Pair{Vector{String},Vector{String}}} = deprecated_configurations
+        deprecated_configs::Vector{Pair{Vector{String},Union{Nothing,Vector{String}}}} = deprecated_configurations
     )
     warnings = String[]
     for (old_path, new_path) in deprecated_configs
-        old_parent = walk_nested_dict(config_dict, @view old_path[1:end-1])
-        old_parent === nothing && continue
-        haskey(old_parent, old_path[end]) || continue
-        old_value = pop!(old_parent, old_path[end])
-
-        new_parent = ensure_nested_dict!(config_dict, @view new_path[1:end-1])
-        if new_parent !== nothing && !haskey(new_parent, new_path[end])
-            new_parent[new_path[end]] = old_value
+        popped = @something pop_nested!(config_dict, old_path) continue
+        old_value = something(popped)
+        if new_path === nothing
+            push!(warnings,
+                "`" * join(old_path, ".") * "` is deprecated and no longer has " *
+                "any effect; please remove it from your config.")
+        else
+            new_parent = ensure_nested_dict!(config_dict, @view new_path[1:end-1])
+            if new_parent !== nothing && !haskey(new_parent, new_path[end])
+                new_parent[new_path[end]] = old_value
+            end
+            push!(warnings,
+                "`" * join(old_path, ".") * "` is deprecated; " *
+                "use `" * join(new_path, ".") * "` instead.")
         end
-
-        push!(warnings,
-            "`" * join(old_path, ".") * "` is deprecated; " *
-            "use `" * join(new_path, ".") * "` instead.")
     end
     return warnings
 end
@@ -407,6 +409,22 @@ function walk_nested_dict(d::AbstractDict, path)
         d isa AbstractDict || return nothing
     end
     return d
+end
+
+# Pop `path[end]` from the nested location in `d`. Empty parent dicts along the
+# walk are pruned bottom-up so the schema doesn't reject leftover table headers
+# (e.g. an empty `[completion.method_signature]` after removing its only key).
+# Returns `Some(value)` on success, or `nothing` if any step is missing.
+function pop_nested!(d::AbstractDict, path)
+    isempty(path) && return nothing
+    if length(path) == 1
+        return haskey(d, path[1]) ? Some(pop!(d, path[1])) : nothing
+    end
+    child = get(d, path[1], nothing)
+    child isa AbstractDict || return nothing
+    result = pop_nested!(child, @view path[2:end])
+    isempty(child) && pop!(d, path[1])
+    return result
 end
 
 # Like `walk_nested_dict` but creates missing intermediate dicts.

--- a/src/types.jl
+++ b/src/types.jl
@@ -525,14 +525,8 @@ const DEFAULT_INIT_OPTIONS = InitOptions(; n_analysis_workers=1, analysis_overri
 end
 @define_eq_overloads LaTeXEmojiConfig
 
-@kwdef struct MethodSignatureConfig <: ConfigSection
-    prepend_inference_result::Maybe{Union{Missing,Bool}} = nothing # missing is used as sentinel for default setting value
-end
-@define_eq_overloads MethodSignatureConfig
-
 @kwdef struct CompletionConfig <: ConfigSection
     latex_emoji::Maybe{LaTeXEmojiConfig} = nothing
-    method_signature::Maybe{MethodSignatureConfig} = nothing
 end
 @define_eq_overloads CompletionConfig
 
@@ -574,7 +568,7 @@ const DEFAULT_CONFIG = JETLSConfig(;
     full_analysis = FullAnalysisConfig(@static(JETLS_TEST_MODE ? 0.0 : 1.0), true),
     testrunner = TestRunnerConfig(@static Sys.iswindows() ? "testrunner.bat" : "testrunner"),
     formatter = "Runic",
-    completion = CompletionConfig(LaTeXEmojiConfig(missing), MethodSignatureConfig(missing)),
+    completion = CompletionConfig(LaTeXEmojiConfig(missing)),
     code_lens = CodeLensConfig(false, true),
     inlay_hint = InlayHintConfig(
         InlayHintBlockEndConfig(true, 25)),

--- a/test/test_config.jl
+++ b/test/test_config.jl
@@ -360,16 +360,34 @@ end
 end
 
 @testset "parse_config_dict accepts legacy `block_end_min_lines`" begin
-    deprecations = [
+    deprecations = Pair{Vector{String},Union{Nothing,Vector{String}}}[
         ["inlay_hint", "block_end_min_lines"] => ["inlay_hint", "block_end", "min_lines"]
     ]
     d = Dict{String,Any}(
         "inlay_hint" => Dict{String,Any}(
             "block_end_min_lines" => 7))
-    JETLS.migrate_deprecated_config_keys!(d, deprecations)
+    warnings = JETLS.migrate_deprecated_config_keys!(d, deprecations)
+    @test length(warnings) == 1
+    @test occursin("`inlay_hint.block_end_min_lines` is deprecated", warnings[1])
     config = JETLS.parse_config_dict(d)
     @test config isa JETLS.JETLSConfig
     @test config.inlay_hint.block_end.min_lines == 7
+end
+
+@testset "parse_config_dict drops removed `prepend_inference_result`" begin
+    deprecations = Pair{Vector{String},Union{Nothing,Vector{String}}}[
+        ["completion", "method_signature", "prepend_inference_result"] => nothing
+    ]
+    d = Dict{String,Any}(
+        "completion" => Dict{String,Any}(
+            "method_signature" => Dict{String,Any}(
+                "prepend_inference_result" => true)))
+    warnings = JETLS.migrate_deprecated_config_keys!(d, deprecations)
+    @test length(warnings) == 1
+    @test occursin("`completion.method_signature.prepend_inference_result` is deprecated", warnings[1])
+    @test !haskey(d, "completion")
+    config = JETLS.parse_config_dict(d)
+    @test config isa JETLS.JETLSConfig
 end
 
 end # test_config


### PR DESCRIPTION
Simplify `resolve_method_signature_completion_item` to mirror property completion's resolve shape: a short ` -> T` in `labelDetails.detail`, plus a leading `signature -> T` code fence prepended to the docstring (separated by `---`). The inferred return type is now always rendered, so the per-client opt-in is no longer needed.

Remove `completion.method_signature.prepend_inference_result` and the now-empty `MethodSignatureConfig` from `src/types.jl`, regenerate the schemas and `jetls-client/package.json`, and drop the corresponding docs entries.

Configs still referencing the removed key continue to load: extend `migrate_deprecated_config_keys!` to accept `new_path === nothing` as a removal-only deprecation that drops the value (and prunes any empty parent tables) with a one-shot warning. Register the new alias in `deprecated_configurations`. The two scan-from-root passes — leaf pop and parent prune — collapse into a single `pop_nested!` helper that walks down once and prunes empties bottom-up.