### PR TITLE
diagnostic: Add realtime cross-file undef-global suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `textDocument/semanticTokens` now classifies type parameters declared in `struct` / `abstract type` / `primitive type` headers (and their use sites inside the type body) as `typeParameter`. Previously these identifiers were classified as plain `variable`.
 
+- `lowering/undef-global-var` now suppresses reports as soon as a sibling file in the same analysis unit defines the referenced name. Previously, adding `foo = ...` to one file left `foo` references in other files of the same unit flagged as undefined until the next full-analysis cycle (typically triggered on save) caught up.
+
 ### Fixed
 
 - Identifiers inside keyword arguments of `@test`, `@test_broken`, and `@test_skip` (e.g. `flag` in `@test x broken=flag`) are now picked up by scope resolution, so undef-var diagnostics and find-references work for them. Previously the keyword arguments were dropped during macro expansion.

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -607,7 +607,7 @@ function update_analysis_cache!(state::ServerState, analysis_result::AnalysisRes
             continue
         end
         invalidate_binding_occurrences_cache!(state, uri)
-        invalidate_lowering_diagnostics_cache!(state, uri)
+        invalidate_per_file_diagnostics_cache!(state, uri)
     end
 end
 

--- a/src/app/cli-check.jl
+++ b/src/app/cli-check.jl
@@ -420,6 +420,7 @@ function run_per_file_diagnostics!(
     )
     total_uris = length(analyzed_uris)
     uri2diagnostics_lock = ReentrantLock()
+    def_used_names_cache = DefUsedNamesCache()
     with_progress(progress_ctx, "Lowering analysis", "[$total_uris files]") do cancellable_token
         if cancellable_token !== nothing
             send_progress(server, cancellable_token.token, WorkDoneProgressBegin(; title="Analyzing", message="Started lowering analysis"))
@@ -432,7 +433,7 @@ function run_per_file_diagnostics!(
             end return
             # Mirrors `compute_pull_diagnostics`: parse errors short-circuit lowering.
             diagnostics = if isempty(fi.parsed_stream.diagnostics)
-                toplevel_lowering_diagnostics(server, uri, fi; lookup_func)
+                toplevel_lowering_diagnostics!(def_used_names_cache, server, uri, fi; lookup_func)
             else
                 parsed_stream_to_diagnostics(fi)
             end

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -344,7 +344,7 @@ function jet_result_to_diagnostics!(
     )
     for report in result.res.toplevel_error_reports
         if report isa JET.LoweringErrorReport || report isa JET.MacroExpansionErrorReport
-            # the equivalent report should have been reported by `lowering_diagnostics!`
+            # the equivalent report should have been reported by `per_stmt_diagnostics!`
             # with more precise location information
             continue
         end
@@ -593,12 +593,6 @@ function provenances_to_related_information!(relatedInformation::Vector{Diagnost
     return relatedInformation
 end
 
-struct LoweringDiagnosticKey
-    range::Range
-    kind::Symbol
-    name::String
-end
-
 # Compute a mapping from source locations to the set of identifier names found in keyword
 # argument type annotations.
 # `K"kw"` nodes are produced by JuliaSyntax for both true keyword arguments
@@ -762,6 +756,14 @@ function analyze_unused_assignments!(
     end
 end
 
+struct DefUsedNames
+    def::Set{String}
+    used::Set{String}
+    DefUsedNames() = new(Set{String}(), Set{String}())
+end
+const DefUsedNamesCacheData = Base.PersistentDict{UInt,Dict{Module,DefUsedNames}}
+const DefUsedNamesCache = LWContainer{DefUsedNamesCacheData, LWStats}
+
 # This analysis reports `lowering/undef-global-var` on a change basis, utilizing an already
 # analyzed analysis context. Full-analysis also reports similar diagnostics as
 # `inference/undef-global-var`. These two diagnostics have the following differences:
@@ -772,11 +774,14 @@ end
 #   faster. Since it's based on JuliaLowering, position information is accurate. However, it
 #   cannot analyze cases like `Base.undefvar`, so it basically detects a subset of what
 #   full-analysis reports.
-function analyze_undefined_global_bindings!(
-        diagnostics::Vector{Diagnostic}, fi::FileInfo, world::UInt,
-        analyzer::Union{Nothing,LSAnalyzer}, postprocessor::LSPostProcessor,
-        ctx3::JL.VariableAnalysisContext,
+# Per-file phase: collect undef-global candidates while `ctx3` is alive. Filters
+# against `world`/`analyzer` here so the cached candidates need no link back to
+# the lowering context. The cross-file phase consumes these via
+# `emit_undef_global_diagnostics!` with a unit-wide def-name set.
+function collect_undef_global_candidates!(
+        candidates::Vector{UndefGlobalCandidate}, fi::FileInfo, ctx3::JL.VariableAnalysisContext,
         binding_occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
+        world::UInt, analyzer::Union{Nothing,LSAnalyzer}, postprocessor::LSPostProcessor,
         reported::Set{LoweringDiagnosticKey}
     )
     for (binfo, occurrences) in binding_occurrences
@@ -798,14 +803,31 @@ function analyze_undefined_global_bindings!(
         range = jsobj_to_range(last(provs), fi)
         key = LoweringDiagnosticKey(range, bk, bn)
         key in reported ? continue : push!(reported, key)
-        code = LOWERING_UNDEF_GLOBAL_VAR_CODE
+        message = postprocessor("`$(bmod).$(bn)` is not defined")
+        push!(candidates, UndefGlobalCandidate(bmod, bn, range, message))
+    end
+end
+
+# Cross-file phase: emit a `Diagnostic` for each candidate whose name isn't defined
+# elsewhere in the analysis unit. Pure Set lookup — no re-lowering.
+function emit_undef_global_diagnostics!(
+        diagnostics::Vector{Diagnostic}, candidates::Vector{UndefGlobalCandidate},
+        mod_def_used_names::Dict{Module,DefUsedNames},
+    )
+    code = LOWERING_UNDEF_GLOBAL_VAR_CODE
+    cdesc = diagnostic_code_description(code)
+    for c in candidates
+        def_used_names = get(mod_def_used_names, c.bmod, nothing)
+        if def_used_names !== nothing && c.name in def_used_names.def
+            continue
+        end
         push!(diagnostics, Diagnostic(;
-            range,
+            range = c.range,
             severity = DiagnosticSeverity.Warning,
-            message = postprocessor("`$(bmod).$(binfo.name)` is not defined"),
+            message = c.message,
             source = DIAGNOSTIC_SOURCE_LIVE,
             code,
-            codeDescription = diagnostic_code_description(code)))
+            codeDescription = cdesc))
     end
 end
 
@@ -862,11 +884,7 @@ function analyze_undefined_local_bindings!(
     end
 end
 
-function compute_unused_variable_data(
-        st0::SyntaxTreeC,
-        prov::SyntaxTreeC,
-        fi::FileInfo
-    )
+function compute_unused_variable_data(st0::SyntaxTreeC, prov::SyntaxTreeC, fi::FileInfo)
     # Find parent K"=" node using byte_ancestors
     ancestors = byte_ancestors(st::SyntaxTreeC->JS.kind(st)===JS.K"=", st0, JS.byte_range(prov))
     isempty(ancestors) && return nothing
@@ -1253,8 +1271,9 @@ function collect_gotos_labels!(
 end
 
 function analyze_lowered_code!(
-        diagnostics::Vector{Diagnostic}, uri::URI, fi::FileInfo, res::NamedTuple,
-        world::UInt, analyzer::Union{Nothing,LSAnalyzer}, postprocessor::LSPostProcessor;
+        diagnostics::Vector{Diagnostic}, candidates::Vector{UndefGlobalCandidate},
+        uri::URI, fi::FileInfo, res::NamedTuple, world::UInt,
+        analyzer::Union{Nothing,LSAnalyzer}, postprocessor::LSPostProcessor;
         skip_analysis_requiring_context::Bool = false,
         allow_unused_underscore::Bool = true,
         allow_noreturn_optimization::Vector{Symbol} = Symbol[]
@@ -1282,18 +1301,18 @@ function analyze_lowered_code!(
     analyze_unresolved_gotos!(diagnostics, fi, st3)
 
     if !skip_analysis_requiring_context
-        analyze_undefined_global_bindings!(
-            diagnostics, fi, world, analyzer, postprocessor,
-            ctx3, binding_occurrences, reported)
+        collect_undef_global_candidates!(candidates, fi, ctx3, binding_occurrences,
+            world, analyzer, postprocessor, reported)
         analyze_ambiguous_soft_scope!(diagnostics, fi, ctx3, reported)
     end
 
     return diagnostics
 end
 
-function lowering_diagnostics!(
-        diagnostics::Vector{Diagnostic}, uri::URI, fi::FileInfo, st0::SyntaxTreeC,
-        context_module::Module, world::UInt, analyzer::Union{Nothing,LSAnalyzer}, postprocessor::LSPostProcessor;
+function per_stmt_diagnostics!(
+        diagnostics::Vector{Diagnostic}, candidates::Vector{UndefGlobalCandidate},
+        uri::URI, fi::FileInfo, st0::SyntaxTreeC, context_module::Module, world::UInt,
+        analyzer::Union{Nothing,LSAnalyzer}, postprocessor::LSPostProcessor;
         skip_analysis_requiring_context::Bool = false,
         allow_unused_underscore::Bool = true,
         soft_scope::Bool = false
@@ -1377,7 +1396,7 @@ function lowering_diagnostics!(
     end
 
     return analyze_lowered_code!(
-        diagnostics, uri, fi, res, world, analyzer, postprocessor;
+        diagnostics, candidates, uri, fi, res, world, analyzer, postprocessor;
         skip_analysis_requiring_context, allow_unused_underscore, allow_noreturn_optimization)
 end
 
@@ -1387,14 +1406,11 @@ struct ImportInfo
     delete_range::Range
 end
 
-const UsedNamesByUnit = Dict{Set{URI},Dict{Module,Set{String}}}
-
-function compute_unit_used_names(
-        server::Server, search_uris::Set{URI};
-        skip_context_check::Bool = false
+function compute_unit_def_used_names(
+        server::Server, search_uris::Set{URI}; skip_context_check::Bool = false
     )
     state = server.state
-    mod_used_names = Dict{Module,Set{String}}()
+    mod_def_used_names = Dict{Module,DefUsedNames}()
     for search_uri in search_uris
         skip_context_check || has_analyzed_context(state, search_uri) || continue
         search_fi = @something begin
@@ -1411,12 +1427,36 @@ function compute_unit_used_names(
             for (binfo_key, occurrences) in binding_occurrences
                 binfo_key.kind === :global || continue
                 if any(o -> o.kind === :use, occurrences)
-                    push!(get!(Set{String}, mod_used_names, context_module), binfo_key.name)
+                    def_used_names = get!(DefUsedNames, mod_def_used_names, context_module)
+                    push!(def_used_names.used, binfo_key.name)
+                elseif any(o -> o.kind === :def, occurrences)
+                    def_used_names = get!(DefUsedNames, mod_def_used_names, context_module)
+                    push!(def_used_names.def, binfo_key.name)
                 end
             end
         end
     end
-    return mod_used_names
+    return mod_def_used_names
+end
+
+# Memoizes `compute_unit_def_used_names` per analysis-unit key. Lock-serialized writes
+# from `LWContainer` make the cache safe to share across worker threads (e.g.
+# `run_per_file_diagnostics!` in cli-check).
+function compute_def_used_names!(
+        cache::DefUsedNamesCache, server::Server, search_uris::Set{URI};
+        skip_context_check::Bool = false
+    )
+    # `Base.PersistentDict` uses `===` to compare keys (HAMT looks up via object identity),
+    # so a `Set{URI}` key would never hit the cache across calls even when the elements
+    # match. Hash the URI set up-front to get an immutable key that `===`-equates by value.
+    key = hash(search_uris)
+    return store!(cache) do data::DefUsedNamesCacheData
+        if haskey(data, key)
+            return data, data[key]
+        end
+        result = compute_unit_def_used_names(server, search_uris; skip_context_check)
+        return DefUsedNamesCacheData(data, key => result), result
+    end
 end
 
 # Detects unused imports by scanning all workspace files for usages of imported names.
@@ -1429,10 +1469,9 @@ end
 #   across every import-bearing file in the same analysis unit
 # - Unchanged file skipping in workspace/diagnostic
 function analyze_unused_imports!(
-        diagnostics::Vector{Diagnostic}, server::Server, uri::URI,
-        fi::FileInfo, st0_top::SyntaxTreeC;
-        skip_context_check::Bool = false,
-        used_names_cache::UsedNamesByUnit = UsedNamesByUnit()
+        diagnostics::Vector{Diagnostic}, def_used_names_cache::DefUsedNamesCache,
+        server::Server, uri::URI, fi::FileInfo, st0_top::SyntaxTreeC;
+        skip_context_check::Bool = false # used by test only
     )
     state = server.state
     mod_imported_names = Dict{Module,Dict{String,Vector{ImportInfo}}}()
@@ -1448,14 +1487,13 @@ function analyze_unused_imports!(
     isempty(mod_imported_names) && return diagnostics
 
     search_uris = collect_search_uris(server, uri)
-    mod_used_names = get!(used_names_cache, search_uris) do
-        compute_unit_used_names(server, search_uris; skip_context_check)
-    end
+    mod_def_used_names = compute_def_used_names!(def_used_names_cache, server,
+        search_uris; skip_context_check)
 
     for (context_module, imported_names) in mod_imported_names
-        used_names = get(mod_used_names, context_module, nothing)
+        def_used_names = get(mod_def_used_names, context_module, nothing)
         for (name, infos) in imported_names
-            used_names !== nothing && name in used_names && continue
+            def_used_names !== nothing && name in def_used_names.used && continue
             for info in infos
                 push!(diagnostics, Diagnostic(;
                     range = info.name_range,
@@ -1474,30 +1512,7 @@ function analyze_unused_imports!(
 end
 
 analyze_unused_imports(args...; kwargs...) = # used by tests
-    analyze_unused_imports!(Diagnostic[], args...; kwargs...)
-
-# Returns true if `st0_top` contains an `import`/`using` with explicit names
-# (the only shape `analyze_unused_imports!` can flag). Gates whether the
-# workspace/diagnostic `result_id` must fold in the analysis unit's state.
-function file_has_explicit_imports(st0_top::SyntaxTreeC)
-    found = traverse(st0_top) do st0::SyntaxTreeC
-        k = JS.kind(st0)
-        if k ∈ JS.KSet"import using"
-            if JS.numchildren(st0) == 1
-                child = st0[1]
-                ck = JS.kind(child)
-                if ck === JS.K":"
-                    return TraversalReturn(true; terminate=true)
-                elseif ck === JS.K"." && k === JS.K"import" && JS.numchildren(child) >= 2
-                    return TraversalReturn(true; terminate=true)
-                end
-            end
-            return TraversalNoRecurse()
-        end
-        return nothing
-    end
-    return found === true
-end
+    analyze_unused_imports!(Diagnostic[], DefUsedNamesCache(), args...; kwargs...)
 
 # Returns tuples of (name, name_range, delete_range).
 # For single imports like `using M: x`, delete_range covers the entire import statement.
@@ -1562,56 +1577,60 @@ function collect_explicit_import_names(st0::SyntaxTreeC, fi::FileInfo)
     return names
 end
 
-# Runs `lowering_diagnostics!` over every top-level statement of `file_info`,
-# returning the per-file diagnostics that depend solely on this file's content
-# and analysis context. `analyze_unused_imports!` is not included because its
-# result depends on sibling files in the analysis unit.
-function compute_lowering_diagnostics(
+# Runs `per_stmt_diagnostics!` over every top-level statement of `file_info`, returning
+# the per-file diagnostics together with the undef-global candidates collected while
+# `ctx3` is alive. `analyze_unused_imports!` and the cross-file emit step run later in
+# `toplevel_lowering_diagnostics!` because they depend on sibling files in the unit.
+function compute_per_file_diagnostics(
         server::Server, uri::URI, file_info::FileInfo, st0_top::SyntaxTreeC,
         cancel_flag::CancelFlag;
         lookup_func = nothing
     )
     diagnostics = Diagnostic[]
+    candidates = UndefGlobalCandidate[]
     skip_analysis_requiring_context = !has_analyzed_context(server.state, uri; lookup_func)
     allow_unused_underscore = get_config(server, :diagnostic, :allow_unused_underscore)
     soft_scope = is_notebook_cell_uri(server.state, uri)
     iterate_toplevel_tree(st0_top) do st0::SyntaxTreeC
         is_cancelled(cancel_flag) && return traversal_terminator
         pos = offset_to_xy(file_info, JS.first_byte(st0))
-        (; context_module, world, analyzer, postprocessor) = get_context_info(server.state, uri, pos; lookup_func)
-        lowering_diagnostics!(diagnostics, uri, file_info, st0,
+        (; context_module, world, analyzer, postprocessor) =
+            get_context_info(server.state, uri, pos; lookup_func)
+        per_stmt_diagnostics!(diagnostics, candidates, uri, file_info, st0,
             context_module, world, analyzer, postprocessor;
             skip_analysis_requiring_context, allow_unused_underscore, soft_scope)
     end
-    return diagnostics
+    return PerFileDiagnosticsResult(diagnostics, candidates)
 end
 
-# Cached accessor for the per-file lowering diagnostics. The cached `Vector` is
-# treated as read-only; callers must copy before mutating (e.g. before appending
-# `analyze_unused_imports!` results). Cache misses and cancelled computations
+# Cached accessor for the per-file `PerFileDiagnosticsResult`. The cached `diagnostics`
+# vector is treated as read-only; callers must copy before mutating (e.g. before appending
+# cross-file diagnostics). The cached `undef_global_candidates` are pre-filtered against
+# the lowering-time world + analyzer state, so the cross-file phase only needs to filter
+# them against the unit's `DefUsedNames` set. Cache misses and cancelled computations
 # both return without caching; only a fully computed result is stored.
-function get_lowering_diagnostics!(
+function get_per_file_diagnostics!(
         server::Server, uri::URI, file_info::FileInfo, st0_top::SyntaxTreeC,
         cancel_flag::CancelFlag;
         lookup_func = nothing
     )
     cache_uri = canonical_cache_uri(server.state, uri)
-    return store!(server.state.lowering_diagnostics_cache) do cache::LoweringDiagnosticsCacheData
+    return store!(server.state.per_file_diagnostics_cache) do cache::PerFileDiagnosticsCacheData
         if haskey(cache, cache_uri)
             return cache, cache[cache_uri]
         end
-        result = compute_lowering_diagnostics(server, uri, file_info, st0_top, cancel_flag;
-                                              lookup_func)
+        result = compute_per_file_diagnostics(
+            server, uri, file_info, st0_top, cancel_flag; lookup_func)
         if is_cancelled(cancel_flag)
             return cache, result
         end
-        return LoweringDiagnosticsCacheData(cache, cache_uri => result), result
+        return PerFileDiagnosticsCacheData(cache, cache_uri => result), result
     end
 end
 
-function invalidate_lowering_diagnostics_cache!(state::ServerState, uri::URI)
+function invalidate_per_file_diagnostics_cache!(state::ServerState, uri::URI)
     cache_uri = canonical_cache_uri(state, uri)
-    store!(state.lowering_diagnostics_cache) do cache::LoweringDiagnosticsCacheData
+    store!(state.per_file_diagnostics_cache) do cache::PerFileDiagnosticsCacheData
         if haskey(cache, cache_uri)
             Base.delete(cache, cache_uri), nothing
         else
@@ -1620,23 +1639,39 @@ function invalidate_lowering_diagnostics_cache!(state::ServerState, uri::URI)
     end
 end
 
-function clear_lowering_diagnostics_cache!(state::ServerState)
-    store!(state.lowering_diagnostics_cache) do _::LoweringDiagnosticsCacheData
-        LoweringDiagnosticsCacheData(), nothing
+function clear_per_file_diagnostics_cache!(state::ServerState)
+    store!(state.per_file_diagnostics_cache) do _::PerFileDiagnosticsCacheData
+        PerFileDiagnosticsCacheData(), nothing
     end
 end
 
-function toplevel_lowering_diagnostics(
-        server::Server, uri::URI, file_info::FileInfo, cancel_flag::CancelFlag=DUMMY_CANCEL_FLAG;
-        lookup_func = nothing,
-        used_names_cache::UsedNamesByUnit = UsedNamesByUnit(),
+# Runs the cross-file phase of lowering diagnostics: emits undef-global diagnostics
+# from cached candidates filtered against the unit's def names, and detects unused
+# imports against the unit's used names. Both consult `compute_def_used_names!`
+# which is memoized per-unit on `def_used_names_cache`.
+function cross_file_diagnostics!(
+        diagnostics::Vector{Diagnostic}, def_used_names_cache::DefUsedNamesCache,
+        server::Server, uri::URI, file_info::FileInfo, st0_top::SyntaxTreeC,
+        per_file::PerFileDiagnosticsResult,
+    )
+    search_uris = collect_search_uris(server, uri)
+    mod_def_used_names = compute_def_used_names!(def_used_names_cache, server, search_uris)
+    emit_undef_global_diagnostics!(diagnostics, per_file.undef_global_candidates, mod_def_used_names)
+    analyze_unused_imports!(diagnostics, def_used_names_cache, server, uri, file_info, st0_top)
+    return diagnostics
+end
+
+function toplevel_lowering_diagnostics!(
+        def_used_names_cache::DefUsedNamesCache, server::Server, uri::URI,
+        file_info::FileInfo, cancel_flag::CancelFlag=DUMMY_CANCEL_FLAG;
+        lookup_func = nothing
     )
     st0_top = build_syntax_tree(file_info)
-    cached = get_lowering_diagnostics!(server, uri, file_info, st0_top, cancel_flag; lookup_func)
-    is_cancelled(cancel_flag) && return cached
-    diagnostics = copy(cached)
+    cached = get_per_file_diagnostics!(server, uri, file_info, st0_top, cancel_flag; lookup_func)
+    is_cancelled(cancel_flag) && return cached.diagnostics
+    diagnostics = copy(cached.diagnostics)
     if has_analyzed_context(server.state, uri; lookup_func)
-        analyze_unused_imports!(diagnostics, server, uri, file_info, st0_top; used_names_cache)
+        cross_file_diagnostics!(diagnostics, def_used_names_cache, server, uri, file_info, st0_top, cached)
     end
     return diagnostics
 end
@@ -1809,14 +1844,15 @@ function handle_DocumentDiagnosticRequest(
         return send(server, DocumentDiagnosticResponse(; id = msg.id, result = nothing, error = result))
     end
     file_info = result
-    resultId = compute_diagnostic_result_id(server, uri, file_info)
+    resultId = compute_diagnostic_result_id(server, uri)
     if msg.params.previousResultId == resultId
         return send(server,
             DocumentDiagnosticResponse(;
                 id = msg.id,
                 result = RelatedUnchangedDocumentDiagnosticReport(; resultId)))
     end
-    diagnostics = compute_pull_diagnostics(server, uri, file_info, cancel_flag)
+    def_used_names_cache = DefUsedNamesCache()
+    diagnostics = compute_pull_diagnostics!(def_used_names_cache, server, uri, file_info, cancel_flag)
     if is_cancelled(cancel_flag)
         return send(server, DocumentDiagnosticResponse(; id = msg.id, result = nothing, error = request_cancelled_error()))
     end
@@ -1857,19 +1893,16 @@ function handle_WorkspaceDiagnosticRequest(
 end
 
 # Derives the `resultId` sent back for `textDocument/diagnostic` and `workspace/diagnostic`.
-# When the file has explicit imports it folds every unit member's version into the key so a
-# sibling edit invalidates this file's cached diagnostics and `analyze_unused_imports!` reruns.
-# Files without explicit imports stay keyed on their own version alone.
+# Every unit member's version is folded into the key so a sibling edit invalidates this
+# file's cached diagnostics and the cross-file analyses (`analyze_undefined_global_uses_for_file!`,
+# `analyze_unused_imports!`) rerun.
 # `ConfigManagerData.diagnostic_settings_hash` is folded in so the resultId flips when
 # `[diagnostic]` config changes — otherwise the equality check below would still match the
 # client's `previousResultId` and the `request_diagnostic_refresh!` from
 # `handle_lsp_config_change!` would be a no-op.
-function compute_diagnostic_result_id(server::Server, uri::URI, fi::FileInfo)
+function compute_diagnostic_result_id(server::Server, uri::URI)
     state = server.state
     config_hash = hash(get_config(state, :diagnostic))
-    if !file_has_explicit_imports(build_syntax_tree(fi))
-        return string(hash((fi.version, config_hash)))
-    end
     file_hash = zero(UInt)
     for search_uri in collect_search_uris(server, uri)
         search_fi = @something begin
@@ -1885,12 +1918,12 @@ end
 # Computes raw per-file diagnostics for both `textDocument/diagnostic` and
 # `workspace/diagnostic`. Falls back to parsed-stream diagnostics when the file does
 # not parse cleanly, otherwise runs the lowering-based analyses.
-function compute_pull_diagnostics(
-        server::Server, uri::URI, fi::FileInfo, cancel_flag::CancelFlag = DUMMY_CANCEL_FLAG;
-        used_names_cache::UsedNamesByUnit = UsedNamesByUnit(),
+function compute_pull_diagnostics!(
+        def_used_names_cache::DefUsedNamesCache, server::Server, uri::URI, fi::FileInfo,
+        cancel_flag::CancelFlag = DUMMY_CANCEL_FLAG;
     )
     if isempty(fi.parsed_stream.diagnostics)
-        return toplevel_lowering_diagnostics(server, uri, fi, cancel_flag; used_names_cache)
+        return toplevel_lowering_diagnostics!(def_used_names_cache, server, uri, fi, cancel_flag)
     else
         return parsed_stream_to_diagnostics(fi)
     end
@@ -1928,7 +1961,7 @@ function send_workspace_diagnostics(
     root_path = isdefined(state, :root_path) ? state.root_path : nothing
     debuginfo = nothing
     # debuginfo = (; synced = URI[], analyzed = URI[], skipped = URI[], failed = URI[])
-    used_names_cache = UsedNamesByUnit()
+    def_used_names_cache = DefUsedNamesCache()
     for uri in uris_to_search
         is_cancelled(cancel_flag) && return send(server,
             WorkspaceDiagnosticResponse(;
@@ -1946,7 +1979,7 @@ function send_workspace_diagnostics(
             continue
         end
 
-        result_id = compute_diagnostic_result_id(server, uri, fi)
+        result_id = compute_diagnostic_result_id(server, uri)
         prev_result_id = get(previous_result_ids, uri, nothing)
         if prev_result_id !== nothing && prev_result_id == result_id
             item = WorkspaceUnchangedDocumentDiagnosticReport(;
@@ -1963,7 +1996,7 @@ function send_workspace_diagnostics(
             continue
         end
 
-        diagnostics = compute_pull_diagnostics(server, uri, fi, cancel_flag; used_names_cache)
+        diagnostics = compute_pull_diagnostics!(def_used_names_cache, server, uri, fi, cancel_flag)
         is_cancelled(cancel_flag) && return send(server,
             WorkspaceDiagnosticResponse(;
                 id = msg.id,

--- a/src/did-change-watched-files.jl
+++ b/src/did-change-watched-files.jl
@@ -61,7 +61,7 @@ function handle_config_file_change!(
     source = "[.JETLSConfig.toml] $(dirname(changed_path)) ($kind)"
     notify_config_changes(server, tracker, source)
     if tracker.diagnostic_setting_changed
-        clear_lowering_diagnostics_cache!(server.state)
+        clear_per_file_diagnostics_cache!(server.state)
         notify_diagnostics!(server; ensure_cleared = true)
         request_diagnostic_refresh!(server)
     end

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -12,7 +12,7 @@ end
 function invalidate_per_file_caches!(state::ServerState, uri::URI)
     invalidate_document_symbol_cache!(state, uri)
     invalidate_binding_occurrences_cache!(state, uri)
-    invalidate_lowering_diagnostics_cache!(state, uri)
+    invalidate_per_file_diagnostics_cache!(state, uri)
 end
 
 """

--- a/src/notebook.jl
+++ b/src/notebook.jl
@@ -8,7 +8,7 @@ get_notebook_uri_for_cell(state::ServerState, cell_uri::URI, default=nothing) =
     get(load(state.cell_to_notebook), cell_uri, default)
 
 # Per-file caches (`document_symbol_cache`, `binding_occurrences_cache`,
-# `lowering_diagnostics_cache`) key on a single canonical URI per logical file.
+# `per_file_diagnostics_cache`) key on a single canonical URI per logical file.
 # For notebooks, every cell URI shares the same concat-source `FileInfo`, so the
 # canonical key is the notebook URI. Cache accessors and their invalidations
 # both run input through this helper so reads, writes, and invalidations always

--- a/src/types.jl
+++ b/src/types.jl
@@ -723,8 +723,27 @@ const DocumentSymbolCacheData = Base.PersistentDict{URI,Vector{DocumentSymbol}}
 const DocumentSymbolCache = LWContainer{DocumentSymbolCacheData, LWStats}
 const BindingOccurrencesCacheData = Base.PersistentDict{URI,BindingOccurrencesCacheEntry}
 const BindingOccurrencesCache = LWContainer{BindingOccurrencesCacheData, LWStats}
-const LoweringDiagnosticsCacheData = Base.PersistentDict{URI,Vector{Diagnostic}}
-const LoweringDiagnosticsCache = LWContainer{LoweringDiagnosticsCacheData, LWStats}
+struct LoweringDiagnosticKey
+    range::Range
+    kind::Symbol
+    name::String
+end
+# Undef-global candidate emitted by the per-file phase (with fresh `ctx3`),
+# consumed by the cross-file phase (which only does a cheap def-name lookup).
+# Everything needed for the final `Diagnostic` is pre-computed so the cache
+# carries no reference to lowering contexts.
+struct UndefGlobalCandidate
+    bmod::Module
+    name::String
+    range::Range
+    message::String
+end
+struct PerFileDiagnosticsResult
+    diagnostics::Vector{Diagnostic}
+    undef_global_candidates::Vector{UndefGlobalCandidate}
+end
+const PerFileDiagnosticsCacheData = Base.PersistentDict{URI,PerFileDiagnosticsResult}
+const PerFileDiagnosticsCache = LWContainer{PerFileDiagnosticsCacheData, LWStats}
 const ConfigManager = LWContainer{ConfigManagerData, LWStats}
 const UnsyncedFileCacheData = Base.PersistentDict{URI,FileInfo}
 const UnsyncedFileCache = LWContainer{UnsyncedFileCacheData, LWStats}
@@ -747,13 +766,13 @@ mutable struct ServerState
     # Per-file caches keyed on the canonical (notebook-aware) URI of a logical file.
     # All three are dropped together via `invalidate_per_file_caches!` on content change
     # (didChange/didOpen, notebook cell edits, watched-file events).
-    # `binding_occurrences_cache` and `lowering_diagnostics_cache` are additionally
+    # `binding_occurrences_cache` and `per_file_diagnostics_cache` are additionally
     # invalidated by `update_analysis_cache!` when full-analysis changes module context,
-    # since both embed `binfo.mod`. `lowering_diagnostics_cache` is also cleared wholesale
-    # on diagnostic-affecting config changes via `clear_lowering_diagnostics_cache!`.
+    # since both embed `binfo.mod`. `per_file_diagnostics_cache` is also cleared wholesale
+    # on diagnostic-affecting config changes via `clear_per_file_diagnostics_cache!`.
     const document_symbol_cache::DocumentSymbolCache
     const binding_occurrences_cache::BindingOccurrencesCache
-    const lowering_diagnostics_cache::LoweringDiagnosticsCache
+    const per_file_diagnostics_cache::PerFileDiagnosticsCache
     const analysis_manager::AnalysisManager
     const extra_diagnostics::ExtraDiagnostics
     const currently_handled::CurrentlyHandled
@@ -785,7 +804,7 @@ mutable struct ServerState
             #=unsynced_file_cache=# UnsyncedFileCache(),
             #=document_symbol_cache=# DocumentSymbolCache(),
             #=binding_occurrences_cache=# BindingOccurrencesCache(),
-            #=lowering_diagnostics_cache=# LoweringDiagnosticsCache(),
+            #=per_file_diagnostics_cache=# PerFileDiagnosticsCache(),
             #=analysis_manager=# AnalysisManager(),
             #=extra_diagnostics=# ExtraDiagnostics(),
             #=currently_handled=# CurrentlyHandled(),

--- a/src/workspace-configuration.jl
+++ b/src/workspace-configuration.jl
@@ -113,7 +113,7 @@ function handle_lsp_config_change!(server::Server, tracker::ConfigChangeTracker,
         notify_config_changes(server, tracker, source)
     end
     if tracker.diagnostic_setting_changed
-        clear_lowering_diagnostics_cache!(server.state)
+        clear_per_file_diagnostics_cache!(server.state)
         notify_diagnostics!(server; ensure_cleared = true)
         request_diagnostic_refresh!(server)
     end

--- a/test/test_code_action.jl
+++ b/test/test_code_action.jl
@@ -22,9 +22,11 @@ function get_lowering_diagnostics(
     uri = filepath2uri(filename)
     st0_top = JETLS.build_syntax_tree(fi)
     diagnostics = LSP.Diagnostic[]
+    candidates = JETLS.UndefGlobalCandidate[]
     JETLS.iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
-        JETLS.lowering_diagnostics!(diagnostics, uri, fi,
-            st0, context_module, world, #=analyzer=#nothing, JETLS.LSPostProcessor();
+        JETLS.per_stmt_diagnostics!(diagnostics, candidates, uri, fi,
+            st0, context_module, world,
+            #=analyzer=#nothing, JETLS.LSPostProcessor();
             kwargs...)
     end
     if code !== nothing

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -22,11 +22,15 @@ function get_lowered_diagnostics(
     st0_top = JETLS.build_syntax_tree(fi)
     @assert JS.kind(st0_top) === JS.K"toplevel"
     diagnostics = LSP.Diagnostic[]
+    candidates = JETLS.UndefGlobalCandidate[]
     JETLS.iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
-        JETLS.lowering_diagnostics!(diagnostics, uri, fi,
+        JETLS.per_stmt_diagnostics!(diagnostics, candidates, uri, fi,
             st0, context_module, world, #=analyzer=#nothing, JETLS.LSPostProcessor();
             kwargs...)
     end
+    # Mirror the cross-file phase. The test runs in isolation so there are no sibling
+    # defs to consult; emit every collected candidate.
+    JETLS.emit_undef_global_diagnostics!(diagnostics, candidates, Dict{Module,JETLS.DefUsedNames}())
     return diagnostics
 end
 
@@ -42,6 +46,8 @@ macro just_return(x)
 end
 
 length_utf16(s::AbstractString) = sum(c::Char -> codepoint(c) < 0x10000 ? 1 : 2, collect(s); init=0)
+
+module EmptyModule end
 
 @testset HierarchicalTestSet "unused binding detection" begin
     let diagnostics = get_lowered_diagnostics("""
@@ -663,20 +669,19 @@ length_utf16(s::AbstractString) = sum(c::Char -> codepoint(c) < 0x10000 ? 1 : 2,
             @test only(diagnostics).message == "Unused argument `unused`"
         end
     end
-end
 
-module EmptyModule end
-@testset "unused binding detection (before full-analysis, without macro expansion)" begin
-    # `@sprintf` is not available yet for EmptyModule (simulating the lowering analysis behavior before full-analysis complete)
-    # https://github.com/aviatesk/JETLS.jl/issues/522
-    diagnostics = get_lowered_diagnostics("""
-        let
-            OLR = SW_in = 0.0
-            @info @sprintf("OLR: %.1f W/m², SW_in: %.1f W/m², net: %.1f W/m²",
-                            OLR, SW_in, SW_in - OLR)
-        end
-        """; context_module=EmptyModule, skip_analysis_requiring_context=true)
-    @test isempty(diagnostics)
+    @testset "before full-analysis, without macro expansion" begin
+        # `@sprintf` is not available yet for EmptyModule (simulating the lowering analysis behavior before full-analysis complete)
+        # https://github.com/aviatesk/JETLS.jl/issues/522
+        diagnostics = get_lowered_diagnostics("""
+            let
+                OLR = SW_in = 0.0
+                @info @sprintf("OLR: %.1f W/m², SW_in: %.1f W/m², net: %.1f W/m²",
+                                OLR, SW_in, SW_in - OLR)
+            end
+            """; context_module=EmptyModule, skip_analysis_requiring_context=true)
+        @test isempty(diagnostics)
+    end
 end
 
 macro m_throw(_)


### PR DESCRIPTION
Suppress `lowering/undef-global-var` candidates whose name is defined in any sibling file of the same analysis unit, closing the gap between a definition being added in one file and full-analysis catching up. The cached per-file result now carries both the file's diagnostics and its pre-filtered undef-global candidates, and the cross-file phase emits diagnostics only for candidates whose names aren't defined elsewhere in the unit.

The implementation splits into three phases named consistently so future inference-diagnostic pull-mode work can mirror the shape:

- Per-statement (`per_stmt_diagnostics!`, formerly `lowering_diagnostics!`): lowers one top-level statement and drives `analyze_lowered_code!`. The latter now also runs `collect_undef_global_candidates!` (formerly `analyze_undefined_global_bindings!`), which pre-filters against `world` + `analyzer.binding_states` and pushes survivors as `UndefGlobalCandidate` values. The cross-file phase needs no re-lowering as a result.

- Per-file (`compute_per_file_diagnostics`, `get_per_file_diagnostics!`; formerly `compute_lowering_diagnostics` / `get_lowering_diagnostics!`): iterates statements, fills a `PerFileDiagnosticsResult` (diagnostics + candidates), and caches it in `PerFileDiagnosticsCache` (formerly `LoweringDiagnosticsCache`).

- Cross-file (new `cross_file_diagnostics!`): resolves the unit's `Dict{Module,DefUsedNames}` once via `compute_def_used_names!` on `DefUsedNamesCache`, then runs `emit_undef_global_diagnostics!` (a Set lookup over candidates) and `analyze_unused_imports!`.

`compute_unit_def_used_names` (formerly `compute_unit_used_names`, now tracking `:def` occurrences alongside `:use`) is memoized per analysis-unit key through `compute_def_used_names!`. The cache key is `hash(search_uris)::UInt` rather than the `Set{URI}` itself because `Base.PersistentDict` compares keys with `===` (its docstring notes "It behaves like an `IdDict`."), so a freshly built `Set` from each call would never hit. The cache is an `LWContainer` so cli-check's parallel `run_per_file_diagnostics!` can share it safely across worker threads.

`compute_diagnostic_result_id` drops the `file_has_explicit_imports` gate. Every unit member's version is now folded into the key unconditionally, so a sibling edit flips this file's `resultId` and re-triggers the cross-file analyses; the previous gate only folded sibling versions in for files with explicit `import`/`using`, which missed undef-global suppression updates entirely.

`toplevel_lowering_diagnostics!` keeps the `lowering` qualifier as the feature-level entry, anticipating a sibling
`toplevel_inference_diagnostics!` when inference diagnostics migrate to a pull model. Other internal names drop `lowering` since the implementation already makes the lowering basis obvious.