### PR TITLE
ast: Dispatch `@doc` children separately in `iterate_toplevel_tree`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,10 +94,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Identifiers inside keyword arguments of `@test`, `@test_broken`, and `@test_skip` (e.g. `flag` in `@test x broken=flag`) are now picked up by scope resolution, so undef-var diagnostics and find-references work for them. Previously the keyword arguments were dropped during macro expansion.
-
-- Identifiers inside `@show`, `@debug`, `@info`, `@warn`, `@error`, and `@logmsg` calls — including kwarg values (e.g. `flag` in `@info "msg" extra=flag`) and splatted operands (e.g. `kws` in `@info "msg" kws...`) — are now picked up by scope resolution, so undef-var diagnostics and find-references work for them. Previously the identifiers in these macros were silently ignored. For the logging macros, duplicate kwarg names also surface as `lowering/macro-expansion-error` anchored at the call site.
-
 - Fixed `jetls check` failing with "could not find any files to analyze" on Windows when the current working directory's drive letter casing differed from the URI-normalized form (Closed https://github.com/aviatesk/JETLS.jl/issues/679).
 
 - `jetls check` no longer rejects files outside the current working directory. Previously, paths such as `jetls check ../foo.jl` were classified as out-of-scope by the LSP-style workspace boundary guard and produced "could not find any files to analyze". The CLI now analyzes any file passed on the command line regardless of where it lives relative to the cwd.
@@ -105,6 +101,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `jetls check` now reports parse errors. Previously, files with syntax errors (e.g. an unclosed parenthesis like `f(x) = println(x`) silently produced "No diagnostics found".
 
 - Fixed spurious `WARNING: Detected access to binding ... in a world prior to its definition world` messages emitted by `jetls check` and other server analyses.
+
+- Identifiers interpolated into docstrings (e.g. `$(TYPEDEF)` / `$(TYPEDSIGNATURES)` from [DocStringExtensions.jl](https://github.com/JuliaDocs/DocStringExtensions.jl)) are now treated as real references during scope resolution. As a result, `lowering/unused-import` no longer falsely reports imports that are only used through docstring interpolations, and `lowering/undef-global-var` flags interpolations of names that aren't actually in scope. Other LSP features (hover, go-to-definition, find-references, …) also work on identifiers inside docstring interpolations. (Fixed https://github.com/aviatesk/JETLS.jl/issues/699)
+
+- Identifiers inside keyword arguments of `@test`, `@test_broken`, and `@test_skip` (e.g. `flag` in `@test x broken=flag`) are now picked up by scope resolution, so undef-var diagnostics and find-references work for them. Previously the keyword arguments were dropped during macro expansion.
+
+- Identifiers inside `@show`, `@debug`, `@info`, `@warn`, `@error`, and `@logmsg` calls — including kwarg values (e.g. `flag` in `@info "msg" extra=flag`) and splatted operands (e.g. `kws` in `@info "msg" kws...`) — are now picked up by scope resolution, so undef-var diagnostics and find-references work for them. Previously the identifiers in these macros were silently ignored. For the logging macros, duplicate kwarg names also surface as `lowering/macro-expansion-error` anchored at the call site.
 
 ## 2026-05-08
 

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -318,8 +318,6 @@ function _remove_macrocalls(st0::SyntaxTreeC)
             # `@main` functions are desugared by `desugar_main_macrocall` below,
             # so there's no need to remove them here
             return st0, false
-        elseif is_doc0(st0)
-            return _remove_macrocalls(st0[end])[1], true
         elseif is_cmd0(st0)
             # `` `foo` `` parses to `Core.@cmd(LineNumberNode, CmdString)` where
             # `CmdString` is an opaque leaf JuliaLowering has no rule for at
@@ -638,8 +636,21 @@ function iterate_toplevel_tree(callback, st0_top::SyntaxTreeC)
                 push!(sl, stblk[i])
             end
         elseif is_doc0_any(st0)
-            # Analyze only the code to which docstrings are attached.
-            push!(sl, st0[end])
+            # Dispatch the macro arguments of a `@doc` macrocall as their own
+            # lowerable trees:
+            # - the documented expression is reached directly, so cursor-based features and
+            #   per-statement diagnostics keep accurate source positions, which otherwise
+            #   could be lost during the expansion of `@doc` (an old-style macro)
+            # - the docstring node (a `K"string"` with interpolations as children) is
+            #   lowered too, so identifier interpolations like `$(SIGNATURES)` from
+            #   `DocStringExtensions` resolve as global `:use` occurrences
+            for i = JS.numchildren(st0):-1:3 # reversed since we use `pop!`
+                # The first two children of any macrocall are the macro name and the line
+                # node, both of which carry the macrocall's full byte range as provenance
+                # and would otherwise capture cursor-based lookups for any offset inside
+                # the doc-wrapped form; start at `i = 3` to skip them.
+                push!(sl, st0[i])
+            end
         else # st0 is lowerable tree
             ret = callback(st0)
             if ret isa TraversalReturn

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -868,6 +868,23 @@ end
             end
         end
     """; context_module=@__MODULE__))
+
+    # Undefined identifiers used as docstring interpolations should be reported
+    let diagnostics = get_lowering_diagnostics("""
+        \"\"\"
+        \$(undef_doc_interp)
+        \"\"\"
+        issue699_undef(x) = x
+        """; context_module=@__MODULE__)
+        @test length(diagnostics) == 1
+        diagnostic = only(diagnostics)
+        @test diagnostic.code == JETLS.LOWERING_UNDEF_GLOBAL_VAR_CODE
+        @test diagnostic.message == "`$(@__MODULE__).undef_doc_interp` is not defined"
+        @test diagnostic.range.start.line == 1
+        @test diagnostic.range.start.character == 2
+        @test diagnostic.range.var"end".line == 1
+        @test diagnostic.range.var"end".character == 2 + length("undef_doc_interp")
+    end
 end
 
 @testset HierarchicalTestSet "Undefined local binding report" begin
@@ -1607,6 +1624,22 @@ end
         export sin
         issue586(x) = sin(x)
         end
+        """)
+        @test isempty(diagnostics)
+    end
+
+    # Imports used only as identifier interpolations inside docstrings should
+    # not be reported as unused (aviatesk/JETLS.jl#699)
+    let diagnostics = get_unused_import_diagnostics("""
+        using DocStringExtensions: TYPEDEF, TYPEDSIGNATURES
+        \"\"\"
+        \$(TYPEDEF)
+        \"\"\"
+        struct Issue699 end
+        \"\"\"
+        \$(TYPEDSIGNATURES)
+        \"\"\"
+        issue699(x) = x
         """)
         @test isempty(diagnostics)
     end

--- a/test/utils/test_ast.jl
+++ b/test/utils/test_ast.jl
@@ -865,29 +865,48 @@ end
         @test func1[] && struct1[]
     end
 
-    let cnt = Ref(0), func1 = Ref(false), struct1 = Ref(false)
+    # Doc-wrapped forms should yield the docstring and the documented expression
+    # as separate lowerable trees, with interpolated identifiers inside the
+    # docstring reachable for downstream analyses (e.g. `analyze_unused_imports!`).
+    let cnt = Ref(0), func1 = Ref(false), struct1 = Ref(false),
+        outer_doc = Ref{Union{Nothing,JS.SyntaxTree}}(nothing),
+        inner_doc = Ref{Union{Nothing,JS.SyntaxTree}}(nothing)
         JETLS.iterate_toplevel_tree(jlparse("""
             \"\"\"
             Docstring for `module Module1`
             \"\"\"
             module Module1
             \"\"\"
-            Docstring for `func1`
+            \$(SIGNATURES)
             \"\"\"
             func1(x) = x
             struct Struct1 end
             end
             """)) do st0
             cnt[] += 1
-            s = JS.sourcetext(st0)
-            if s == "func1(x) = x"
-                func1[] = true
-            elseif s == "struct Struct1 end"
-                struct1[] = true
+            k = JS.kind(st0)
+            if k === JS.K"string"
+                inner_doc[] = st0
+            elseif k === JS.K"String"
+                outer_doc[] = st0
+            else
+                s = JS.sourcetext(st0)
+                if s == "func1(x) = x"
+                    func1[] = true
+                elseif s == "struct Struct1 end"
+                    struct1[] = true
+                end
             end
         end
-        @test cnt[] == 2
+        @test cnt[] == 4
         @test func1[] && struct1[]
+        @test outer_doc[] !== nothing
+        doc = inner_doc[]
+        @test doc !== nothing
+        @test any(JS.children(doc)) do c
+            JS.kind(c) === JS.K"Identifier" &&
+                JS.hasattr(c, :name_val) && c.name_val == "SIGNATURES"
+        end
     end
 end
 


### PR DESCRIPTION
`iterate_toplevel_tree` now pushes the docstring and the documented expression of a `Core.@doc` macrocall as their own lowerable trees (skipping the macro name and line-number children). Previously only the documented expression was visited.

The previous behavior caused `analyze_unused_imports!` to miss references that only appear as identifier interpolations inside docstrings, falsely flagging imports like
`using DocStringExtensions: TYPEDEF` as unused when only used via `$(TYPEDEF)` interpolation. Dispatching the docstring node as a separate lowerable tree lets downstream scope resolution see those interpolations as real `:use` occurrences, and as a side benefit opens identifiers inside docstring interpolations up to other LSP features (hover, go-to-definition, find-references) and `lowering/undef-global-var`.

For the same reason, the `@doc` special case in `remove_macrocalls` is also removed. The fallback handling will strip `@doc` either way, but there is no need to also drop the string node.

Closes aviatesk/JETLS.jl#699