### PR TITLE
notebook: Fix spurious `lowering/error` on `.ipynb` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed spurious diagnostics like `` `{ }` outside of `where` is reserved for future use `` falsely appearing on Jupyter notebook (`.ipynb`) files in VS Code. (Fixed https://github.com/aviatesk/JETLS.jl/issues/703)
+
 - Fixed `jetls check` failing with "could not find any files to analyze" on Windows when the current working directory's drive letter casing differed from the URI-normalized form (Closed https://github.com/aviatesk/JETLS.jl/issues/679).
 
 - `jetls check` no longer rejects files outside the current working directory. Previously, paths such as `jetls check ../foo.jl` were classified as out-of-scope by the LSP-style workspace boundary guard and produced "could not find any files to analyze". The CLI now analyzes any file passed on the command line regardless of where it lives relative to the cwd.

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -381,8 +381,8 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
         @goto next_request
     end
 
-    if is_abandoned_unsaved_buffer(server, request.uri)
-        JETLS_DEV_MODE && @info "Skipped analysis for closed unsaved buffer" entry=progress_title(request.entry) uri=request.uri
+    if is_abandoned_request(server, request)
+        JETLS_DEV_MODE && @info "Skipped analysis for closed editor-managed document" entry=progress_title(request.entry) uri=request.uri
         @goto next_request
     end
 
@@ -423,12 +423,13 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
     tm = round(time() - s, digits=2)
     JETLS_DEV_MODE && @info "Analysis completed in $tm seconds:" entry=progress_title(request.entry) uri=request.uri generation=get_generation(manager,request.entry)
 
-    if is_abandoned_unsaved_buffer(server, request.uri)
-        # Buffer was closed mid-analysis. `file_cache` becoming empty means didClose
-        # already ran (or is racing with us) and `cleanup_unsaved_analysis!` is taking care
-        # of `manager.cache`/generations/debounced + the OLD prev_result's methods.
+    if is_abandoned_request(server, request)
+        # Document was closed mid-analysis. `file_cache`/`notebook_cache`
+        # becoming empty means didClose already ran (or is racing with us) and
+        # `cleanup_analysis_state!` is taking care of
+        # `manager.cache`/generations/debounced + the OLD prev_result's methods.
         # We just need to drop the methods this analysis just defined and skip the cache write.
-        JETLS_DEV_MODE && @info "Discarding analysis result for closed unsaved buffer" entry=progress_title(request.entry) uri=request.uri
+        JETLS_DEV_MODE && @info "Discarding analysis result for closed editor-managed document" entry=progress_title(request.entry) uri=request.uri
         cleanup_prev_methods(analysis_result)
         @goto next_request
     end
@@ -523,26 +524,57 @@ function cleanup_prev_methods(prev_result::AnalysisResult)
     end
 end
 
-# An unsaved (`untitled:`/`buffer:`) URI is "abandoned" once `file_cache` no
-# longer holds it: didClose has already cleared the buffer and the URI is
-# unique per session, so any remaining analysis work for it would only leak.
-is_abandoned_unsaved_buffer(server::Server, uri::URI) =
-    isunsaveduri(uri) && get_file_info(server.state, uri) === nothing
+# An analysis request is "abandoned" once the document it targets is no longer
+# editor-managed: `file_cache` empty for an unsaved (`untitled:`/`buffer:`) URI,
+# or `notebook_cache` empty for a notebook entry. In either case the prior
+# analysis state was already evicted by `cleanup_analysis_state!`, so any
+# remaining work would only re-populate caches we just cleaned up.
+function is_abandoned_request(server::Server, request::AnalysisRequest)
+    state = server.state
+    uri = request.uri
+    if isunsaveduri(uri)
+        return get_file_info(state, uri) === nothing
+    end
+    entry = request.entry
+    if ((entry isa ScriptAnalysisEntry || entry isa ScriptInEnvAnalysisEntry) &&
+        entry.isnotebook)
+        return !is_notebook_uri(state, uri)
+    end
+    return false
+end
 
 """
-    cleanup_unsaved_analysis!(server::Server, uri::URI)
+    cleanup_analysis_state!(server::Server, uri::URI)
 
-Drop the analysis state for an unsaved URI when its buffer is closed.
-Untitled URIs are unique per session, so leaving state behind would leak both
-the cache and the methods registered in `Core.methodtable` by previous
-analyses (otherwise visible as ghost entries in completions/signature help).
+Drop the analysis state for `uri` when its editor-managed lifecycle ends —
+unsaved (`untitled:`/`buffer:`) buffers and notebooks. These share two
+properties that make cleanup both safe and necessary:
+
+1. The analysis unit is a single file (`analyzed_file_uris(prev_result)` is
+   `[uri]`), so removing it from `manager.cache` does not affect any sibling
+   file's analysis.
+2. Methods defined during analysis live in gensym'd virtual modules, so
+   `cleanup_prev_methods` can safely `delete_method` them; otherwise they
+   leak as ghost entries in completions/signature help.
+
+For notebooks there is the additional motivation that the on-disk `.ipynb` JSON
+is not directly analyzable as Julia source, so leaving the cache entry would
+let `workspace/diagnostic` fall through and emit spurious diagnostics for the
+raw JSON.
+
+Saved `.jl` files are intentionally NOT cleaned up here. They violate both
+properties: a `PackageSourceAnalysisEntry` covers every file in the package
+(removing one would tear out siblings' cached analysis), and Revise-based
+package analysis registers `module_range_infos` against the user's real
+modules, so `cleanup_prev_methods` would delete the user's live methods.
+Keeping the cache also lets `workspace/diagnostic` keep reporting disk-based
+diagnostics after close.
 
 This only handles state already in the caches. Any in-flight or queued analysis
-for this entry is short-circuited separately by `is_abandoned_unsaved_buffer`
-checks in `resolve_analysis_request`.
+for this entry is short-circuited separately by `is_abandoned_request` checks
+in `resolve_analysis_request`.
 """
-function cleanup_unsaved_analysis!(server::Server, uri::URI)
-    @assert isunsaveduri(uri)
+function cleanup_analysis_state!(server::Server, uri::URI)
     manager = server.state.analysis_manager
     prev_result = get_analysis_info(manager, uri)
     if prev_result isa AnalysisResult

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -127,12 +127,12 @@ function handle_DidCloseTextDocumentNotification(server::Server, msg::DidCloseTe
     clear_extra_diagnostics!(server, uri)
     # Republish textDocument/publishDiagnostics for cases with `diagnostic.all_files === false`,
     # where diagnostics for this file must be suppressed.
-    # This must run before `cleanup_unsaved_analysis!` below, since the suppression
+    # This must run before `cleanup_analysis_state!` below, since the suppression
     # branch in `notify_diagnostics!` only emits the clearing notification when the
     # analysis cache still reports non-empty diagnostics for this URI.
     notify_diagnostics!(server; ensure_cleared=uri)
     if isunsaveduri(uri)
-        cleanup_unsaved_analysis!(server, uri)
+        cleanup_analysis_state!(server, uri)
     end
     # Retrigger workspace/diagnostic to recalculate diagnostics for this closed file
     request_diagnostic_refresh!(server)

--- a/src/notebook.jl
+++ b/src/notebook.jl
@@ -230,6 +230,11 @@ function handle_DidCloseNotebookDocumentNotification(
     store!(state.saved_file_cache) do cache
         Base.delete(cache, notebook_uri), nothing
     end
+    clear_cell_push_diagnostics!(server, msg.params.cellTextDocuments)
+    # Disk content isn't analyzable as Julia, so keeping the analysis cache around
+    # would only enable the JSON-as-Julia bug guarded against in `_store_unsynced_file_info!`.
+    cleanup_analysis_state!(server, notebook_uri)
+    request_diagnostic_refresh!(server)
     nothing
 end
 
@@ -239,6 +244,9 @@ end
 is_notebook_uri(state::ServerState, uri::URI) = haskey(load(state.notebook_cache), uri)
 
 is_notebook_cell_uri(state::ServerState, uri::URI) = haskey(load(state.cell_to_notebook), uri)
+
+# URI-only check: does this URI point to a Jupyter notebook (`.ipynb`) file on disk?
+is_notebook_uri(uri::URI) = uri.scheme == "file" && endswith(uri.path, ".ipynb")
 
 function localize_notebook_diagnostics!(uri2diagnostics::URI2Diagnostics, state::ServerState)
     notebook_uris_to_delete = URI[]
@@ -354,6 +362,16 @@ function _localize_notebook_diagnostics(
         push!(result, cell_diag)
     end
     return result
+end
+
+# Push diagnostics aren't auto-cleared on close; republish empty for each cell.
+function clear_cell_push_diagnostics!(server::Server, cells::Vector{TextDocumentIdentifier})
+    for cell in cells
+        send(server, PublishDiagnosticsNotification(;
+            params = PublishDiagnosticsParams(;
+                uri = cell.uri,
+                diagnostics = empty_diagnostics)))
+    end
 end
 
 # Document symbol

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -259,6 +259,13 @@ function _store_unsynced_file_info!(state::ServerState, uri::URI; force::Bool=fa
             return cache, cache[uri]
         end
         version = time_ns() % Int
+        # Notebook URIs can reach this path during the race window in
+        # `handle_DidCloseNotebookDocumentNotification` between clearing `file_cache`
+        # and `cleanup_analysis_state!` evicting `analysis_manager.cache`, when
+        # a concurrent workspace iteration still has the URI in its `uris_to_search`.
+        # Reading the raw `.ipynb` as Julia would otherwise parse the JSON literal
+        # and emit bogus `lowering/error` diagnostics (aviatesk/JETLS.jl#703).
+        is_notebook_uri(uri) && return cache, nothing
         filename = uri2filename(uri)
         isfile(filename) || return cache, nothing
         parsed_stream = try

--- a/test/test_unsaved_buffer.jl
+++ b/test/test_unsaved_buffer.jl
@@ -71,8 +71,8 @@ const SETTINGS = Dict{String,Any}(
         # didClose must publish an empty `PublishDiagnosticsNotification` to
         # clear the previously published `unused-argument` diagnostic, and
         # then drop the per-entry analysis state. This exercises the ordering
-        # of `notify_diagnostics!` before `cleanup_unsaved_analysis!` in
-        # `handle_DidCloseTextDocumentNotification`: if `cleanup_unsaved_analysis!`
+        # of `notify_diagnostics!` before `cleanup_analysis_state!` in
+        # `handle_DidCloseTextDocumentNotification`: if `cleanup_analysis_state!`
         # ran first the clearing notification path in `notify_diagnostics!`
         # would have nothing to publish under `all_files=false`.
         let (; raw_res) = writereadmsg(make_DidCloseTextDocumentNotification(untitled_uri))


### PR DESCRIPTION
Jupyter notebooks (`.ipynb`) could surface false `lowering/error` diagnostics like `` `{ }` outside of `where` is reserved for future use ``, originating from reading the raw `.ipynb` JSON as Julia in the unsynced-file fallback path of `_store_unsynced_file_info!`.

This was hit when a notebook URI lingered in `analysis_manager.cache` after the notebook lifecycle ended, so subsequent
`workspace/diagnostic` iterations entered the disk-read fallback.

Fix in layers:

- `_store_unsynced_file_info!` skips notebook URIs unconditionally (last-line guard against the JSON-as-Julia parse).
- `is_notebook_uri(uri::URI)` (a new URI-only overload) detects `.ipynb` paths without requiring server state.
- `handle_DidCloseNotebookDocumentNotification` now evicts analysis state via `cleanup_analysis_state!` (renamed from `cleanup_unsaved_analysis!` and generalized to also handle notebooks), pushes empty diagnostics on each cell URI via `clear_cell_push_diagnostics!`, and requests a workspace pull refresh.
- `is_abandoned_request` (renamed from `is_abandoned_unsaved_buffer`) now detects closed-notebook mid-analysis races in addition to closed unsaved buffers.

A VS Code limitation remains where pull-mode diagnostics on cell URIs are not always cleared when a notebook is closed; this is client-side and out of server scope.

Closes aviatesk/JETLS.jl#703