### PR TITLE
diagnostic: Recover from macro-stub errors without aborting expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `lowering/undef-global-var` now suppresses reports as soon as a sibling file in the same analysis unit defines the referenced name. Previously, adding `foo = ...` to one file left `foo` references in other files of the same unit flagged as undefined until the next full-analysis cycle (typically triggered on save) caught up.
 
+- `lowering/macro-expansion-error` no longer aborts analysis of the enclosing top-level form when an issue can be reported in place.
+  Previously, a single bad `Threads.@spawn :badname …`, `@info "msg" id=1 id=2`, `@test x skip=true broken=true`, or `Base.@assume_effects :badname …` in a function body would propagate a `MacroExpansionError` and remove the entire macrocall from analysis — every other LSP feature (hover, inlay, signature help, undef-var, references, …) for the *enclosing* function went dark, not just for the bad macrocall.
+  The error is still reported with `Error` severity (matching what Base does at expansion or runtime), but the macrocall body now flows through to scope and type analysis.
+  Additionally, `@testset` cases that Base accepts silently or only deprecates — multiple descriptions, multiple testset types, duplicate options — surface as `Warning` severity under the same diagnostic code.
+
 ### Fixed
 
 - Fixed spurious diagnostics like `` `{ }` outside of `where` is reserved for future use `` falsely appearing on Jupyter notebook (`.ipynb`) files in VS Code. (Fixed https://github.com/aviatesk/JETLS.jl/issues/703)

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -105,7 +105,7 @@ Here is a summary table of the diagnostics explained in this section:
 | ------------------------------------------------------------------------------------------------ | --------------------- | ------------- | -------------------------------------------------- |
 | [`syntax/parse-error`](@ref diagnostic/reference/syntax/parse-error)                             | `Error`               | `JETLS/live`  | Syntax parsing errors detected by JuliaSyntax.jl   |
 | [`lowering/error`](@ref diagnostic/reference/lowering/error)                                     | `Error`               | `JETLS/live`  | General lowering errors                            |
-| [`lowering/macro-expansion-error`](@ref diagnostic/reference/lowering/macro-expansion-error)     | `Error`               | `JETLS/live`  | Errors during macro expansion                      |
+| [`lowering/macro-expansion-error`](@ref diagnostic/reference/lowering/macro-expansion-error)     | `Error/Warning`       | `JETLS/live`  | Issues detected during macro expansion             |
 | [`lowering/undef-global-var`](@ref diagnostic/reference/lowering/undef-global-var)               | `Warning`             | `JETLS/live`  | References to undefined global variables           |
 | [`lowering/undef-local-var`](@ref diagnostic/reference/lowering/undef-local-var)                 | `Warning/Information` | `JETLS/live`  | References to undefined local variables            |
 | [`lowering/ambiguous-soft-scope`](@ref diagnostic/reference/lowering/ambiguous-soft-scope)       | `Warning`             | `JETLS/live`  | Assignment in soft scope shadows a global variable |
@@ -170,19 +170,16 @@ end
 
 #### [Macro expansion error (`lowering/macro-expansion-error`)](@id diagnostic/reference/lowering/macro-expansion-error)
 
-**Default severity**: `Error`
+**Default severity**: `Error` or `Warning` (see below)
 
-Errors that occur when expanding macros during the lowering phase.
-
-Example:
+Issues detected during macro expansion. The macro name being unresolved
+or a macro body throwing surfaces as `Error` severity:
 
 ```julia
 function macro_expand_error()
     @undefined_macro ex  # Macro name `@undefined_macro` not found (JETLS lowering/macro-expansion-error)
 end
 ```
-
-Errors that occur during actual macro expansion are also reported:
 
 ```julia
 macro myinline(ex)
@@ -191,6 +188,36 @@ macro myinline(ex)
 end
 @myinline callsin(x) = sin(x)  # Error expanding macro
                                # Expected long function definition (JETLS lowering/macro-expansion-error)
+```
+
+For a subset of Base macros (`@spawn`, `@test`, `@info`, `@testset`, ...),
+JETLS provides new-style stubs that validate arguments at expansion time
+and report problems via a side channel *without* aborting expansion, so
+downstream analyses (undef-var, references, hover, signature help, ...)
+keep running on the rest of the macrocall. The severity mirrors what
+Base would do — `Error` for cases Base rejects, `Warning` for cases Base
+accepts silently or only deprecates:
+
+```julia
+# Error: Base also rejects.
+Threads.@spawn :badname body   # unsupported threadpool in @spawn: badname
+                               # (JETLS lowering/macro-expansion-error)
+
+@info "msg" k=1 k=2            # @info: keyword `k` provided more than once
+                               # (JETLS lowering/macro-expansion-error)
+
+@test x skip=true broken=true  # invalid test macro call: cannot set both
+                               # `skip` and `broken` keywords
+                               # (JETLS lowering/macro-expansion-error)
+
+# Warning: Base accepts silently or only deprecates.
+@testset "a" "b" begin end     # Multiple descriptions provided to @testset.
+                               # This is deprecated and may error in the future.
+                               # (JETLS lowering/macro-expansion-error)
+
+@testset verbose=true verbose=false begin end
+                               # @testset: option `verbose` provided more than once
+                               # (JETLS lowering/macro-expansion-error)
 ```
 
 #### [Undefined global variable (`lowering/undef-global-var`)](@id diagnostic/reference/lowering/undef-global-var)

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -566,6 +566,22 @@ function stacktrace_to_related_information(stacktrace::Vector{Base.StackTraces.S
     return relatedInformation
 end
 
+function emit_macro_diagnostics!(
+        diagnostics::Vector{Diagnostic}, fi::FileInfo, macro_diags::Vector{MacroDiagnostic}
+    )
+    isempty(macro_diags) && return diagnostics
+    for d in macro_diags
+        push!(diagnostics, Diagnostic(;
+            range = jsobj_to_range(d.node, fi),
+            severity = d.severity,
+            message = d.msg,
+            source = DIAGNOSTIC_SOURCE_LIVE,
+            code = LOWERING_MACRO_EXPANSION_ERROR_CODE,
+            codeDescription = diagnostic_code_description(LOWERING_MACRO_EXPANSION_ERROR_CODE)))
+    end
+    return diagnostics
+end
+
 # TODO Use actual file cache (with proper character encoding)
 function provenances_to_related_information!(relatedInformation::Vector{DiagnosticRelatedInformation}, provs, msg)
     for prov in provs
@@ -1322,7 +1338,8 @@ function per_stmt_diagnostics!(
     analyze_unsorted_imports!(diagnostics, fi, st0)
 
     (st0, _) = desugar_main_macrocall(st0)
-    res = try
+    macro_diags = MacroDiagnostic[]
+    res = Base.ScopedValues.@with MACRO_DIAGNOSTIC_SINK => macro_diags try
         jl_lower_for_scope_resolution(context_module, st0; world,
             recover_from_macro_errors=false, convert_closures=true, soft_scope)
     catch err
@@ -1370,13 +1387,21 @@ function per_stmt_diagnostics!(
             JETLS_DEBUG_LOWERING && showerror(stderr, err)
             JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
         end
+        nothing # signal primary-attempt failure to the fallback path
+    end
+    emit_macro_diagnostics!(diagnostics, fi, macro_diags)
 
-        st0 = remove_macrocalls(trim_error_nodes(st0))
-        try
-            ctx1, st1 = JL.expand_forms_1(context_module, st0, true, world)
-            _jl_lower_for_scope_resolution(ctx1, st0, st1; convert_closures=true)
+    if res === nothing
+        # Fallback expansion runs *outside* the sink scope: `remove_macrocalls`
+        # only strips old-style macrocalls, so any new-style stub that reported via
+        # the sink during the primary attempt would push the same entry again here
+        # — emitting twice. With the sink unbound, those `push_macro_*!` calls
+        # become no-ops, and stubs that genuinely throw simply re-throw and we bail.
+        st0 = remove_macrocalls(st0)
+        res = try
+            jl_lower_for_scope_resolution(context_module, st0; world,
+                recover_from_macro_errors=false, convert_closures=true, soft_scope)
         catch
-            # The same error has probably already been handled above
             return diagnostics
         end
     end

--- a/src/utils/jl-syntax-macros.jl
+++ b/src/utils/jl-syntax-macros.jl
@@ -18,8 +18,96 @@ function mapchildren(f, ctx, ex::SyntaxTreeC, indices::UnitRange{<:Integer})
     end
 end
 
+const macro_issue_contract = """
+# Macro issue contract
+
+When a stub detects a problem, pick the helper that minimizes loss of downstream
+analysis while still surfacing the issue with the severity Base would assign:
+
+| helper                        | when                                                                                     | examples                                                                                 |
+|:------------------------------|:-----------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------|
+| [`throw_macro_error`](@ref)   | Base rejects, **and** the stub cannot produce a valid recovery expansion                 | `@assert` with zero args, `@invoke` whose argument is not a call, `@kwdef` on non-struct |
+| [`push_macro_error!`](@ref)   | Base rejects, **but** the stub can recover (typically: keep the body, drop the bad part) | `@spawn :badname body`, `@info` with dup kwargs, `@test` with `skip` + `broken`          |
+| [`push_macro_warning!`](@ref) | Base accepts silently or only emits `depwarn`                                            | `@testset` with multiple descriptions/types or duplicate options                         |
+
+The push helpers feed [`MACRO_DIAGNOSTIC_SINK`](@ref); see its docstring for the
+producer/consumer contract.
+"""
+
+"""
+    throw_macro_error(node::SyntaxTreeC, msg::AbstractString)
+
+Throw a `JL.MacroExpansionError` anchored on `node`, aborting the current macro
+expansion. In the LSP analysis pipeline this triggers a fallback through
+`remove_macrocalls` for the *whole* enclosing top-level form, so identifier-level
+analysis (undef-var, references, [`TypeAnnotation`](@ref) for hover / inlay /
+signature-help, …) is lost across that form, not just at the bad macrocall.
+
+$macro_issue_contract
+"""
 @noinline throw_macro_error(node::SyntaxTreeC, msg::AbstractString) =
     throw(JL.MacroExpansionError(node, msg))
+
+"""
+    MACRO_DIAGNOSTIC_SINK :: ScopedValue{Union{Nothing,Vector{MacroDiagnostic}}}
+
+Side channel that lets macro stubs surface issues as LSP diagnostics without
+aborting expansion — the producer/consumer contract for [`push_macro_error!`](@ref)
+and [`push_macro_warning!`](@ref).
+
+Consumers bind this to a vector via `Base.ScopedValues.@with` around their lowering
+call and drain it afterwards. Currently only `per_stmt_diagnostics!` does that; the
+other lowering consumers (`get_inferrable_tree`, `cursor_bindings`,
+`occurrence-analysis`, `document-symbol`) leave the sink unbound, so the push helpers
+become no-ops and those consumers simply see the recovered expansion without emitting
+diagnostics — which is exactly what makes `TypeAnnotation` etc. keep working across
+recoverable macro errors.
+
+Concurrency-safe by construction: `ScopedValue` binds per task and propagates to
+child tasks, so the concurrent `per_stmt_diagnostics!` workers spawned under
+workspace diagnostic each get their own sink without cross-talk or locking.
+
+See also: [`throw_macro_error`](@ref), [`push_macro_error!`], [`push_macro_warning!`]
+"""
+struct MacroDiagnostic
+    node::SyntaxTreeC
+    msg::String
+    severity::DiagnosticSeverity.Ty
+end
+
+const MACRO_DIAGNOSTIC_SINK =
+    Base.ScopedValues.ScopedValue{Union{Nothing,Vector{MacroDiagnostic}}}(nothing)
+
+@noinline function push_macro_diagnostic!(
+        node::SyntaxTreeC, msg::AbstractString, severity::DiagnosticSeverity.Ty
+    )
+    sink = MACRO_DIAGNOSTIC_SINK[]
+    sink === nothing && return
+    push!(sink, MacroDiagnostic(node, String(msg), severity))
+    return
+end
+
+"""
+    push_macro_warning!(node::SyntaxTreeC, msg::AbstractString)
+
+Push a `DiagnosticSeverity.Warning` entry anchored on `node` into
+[`MACRO_DIAGNOSTIC_SINK`](@ref) (no-op if the sink is unbound).
+
+$macro_issue_contract
+"""
+push_macro_warning!(node::SyntaxTreeC, msg::AbstractString) =
+    push_macro_diagnostic!(node, msg, DiagnosticSeverity.Warning)
+
+"""
+    push_macro_error!(node::SyntaxTreeC, msg::AbstractString)
+
+Push a `DiagnosticSeverity.Error` entry anchored on `node` into
+[`MACRO_DIAGNOSTIC_SINK`](@ref) (no-op if the sink is unbound).
+
+$macro_issue_contract
+"""
+push_macro_error!(node::SyntaxTreeC, msg::AbstractString) =
+    push_macro_diagnostic!(node, msg, DiagnosticSeverity.Error)
 
 # Simple (non-qualified) macro names whose new-style implementations in this file and
 # `JuliaLowering/src/syntax_macros.jl` preserve fine-grained source provenance during
@@ -177,12 +265,17 @@ function _validate_spawn_threadpool(threadpool::SyntaxTreeC)
             name = inner.name_val
             if name isa AbstractString
                 name in _SPAWN_THREADPOOLS && return
-                throw_macro_error(threadpool, "unsupported threadpool in @spawn: $name")
+                # Base defers the threadpool check to runtime; flag it statically as an
+                # error but keep expanding so the body (and threadpool identifier, if any)
+                # still reaches scope analysis.
+                push_macro_error!(threadpool, "unsupported threadpool in @spawn: $name")
+                return
             end
         end
     end
-    throw_macro_error(threadpool,
+    push_macro_error!(threadpool,
         "threadpool argument in @spawn must be `:default`, `:interactive`, `:samepool`, or a bare variable")
+    nothing
 end
 
 function Base.Threads.var"@spawn"(__context__::JL.MacroContext, ::SyntaxTreeC...)
@@ -375,9 +468,14 @@ function _logmsg_stub(
         if k === JS.K"="
             kwname = _validate_logmsg_kw(ex, name)
             if kwname !== nothing
-                kwname in seen_kws && throw_macro_error(ex,
-                    "$name: keyword `$kwname` provided more than once")
-                push!(seen_kws, kwname)
+                if kwname in seen_kws
+                    # Base would let the synthesized `(; k=…, k=…)` named tuple fail
+                    # lowering; flag the dup here but keep the RHS in `children` so
+                    # any identifier inside still gets scope-resolved.
+                    push_macro_error!(ex, "$name: keyword `$kwname` provided more than once")
+                else
+                    push!(seen_kws, kwname)
+                end
             end
             push!(children, ex[2])
         elseif k === JS.K"..."
@@ -701,25 +799,28 @@ function Test.var"@test"(__context__::JL.MacroContext, ex::SyntaxTreeC, kws::Syn
     mc = __context__.macrocall::SyntaxTreeC
     seen_broken = seen_skip = seen_context = nothing
     rhss = SyntaxTreeC[]
+    # Base `extract_broken_skip_kws` hard-errors on dup or `skip`+`broken`; we report
+    # as Error but keep every RHS in the block so identifiers inside (e.g. dup values)
+    # still reach scope analysis.
     for kw in kws
         name = _validate_test_kw(kw)
         push!(rhss, kw[2])
         if name == "broken"
-            seen_broken === nothing || throw_macro_error(kw,
+            seen_broken === nothing || push_macro_error!(kw,
                 "invalid test macro call: cannot set `broken` keyword multiple times")
             seen_broken = kw
         elseif name == "skip"
-            seen_skip === nothing || throw_macro_error(kw,
+            seen_skip === nothing || push_macro_error!(kw,
                 "invalid test macro call: cannot set `skip` keyword multiple times")
             seen_skip = kw
         elseif name == "context"
-            seen_context === nothing || throw_macro_error(kw,
+            seen_context === nothing || push_macro_error!(kw,
                 "invalid test macro call: cannot set `context` keyword multiple times")
             seen_context = kw
         end
     end
     if seen_skip !== nothing && seen_broken !== nothing
-        throw_macro_error(mc,
+        push_macro_error!(mc,
             "invalid test macro call: cannot set both `skip` and `broken` keywords")
     end
     isempty(rhss) && return JL.@ast(__context__, mc, ex)
@@ -852,18 +953,24 @@ function Test.var"@testset"(__context__::JL.MacroContext, args::SyntaxTreeC...)
         arg = args[i]
         k = JS.kind(arg)
         if k === JS.K"Identifier" || k === JS.K"."
-            testsettype === nothing ||
-                throw_macro_error(arg, "@testset: multiple testset types provided")
+            # Mirror `Base.@testset`'s `depwarn` on extra testset types — the last one wins.
+            testsettype === nothing || push_macro_warning!(arg,
+                "Multiple testset types provided to @testset. This is deprecated and may error in the future.")
             testsettype = arg
         elseif k === JS.K"String" || k === JS.K"string"
-            desc === nothing ||
-                throw_macro_error(arg, "@testset: multiple descriptions provided")
+            desc === nothing || push_macro_warning!(arg,
+                "Multiple descriptions provided to @testset. This is deprecated and may error in the future.")
             desc = arg
         elseif k === JS.K"="
+            # Base's `parse_testset_args` silently appends duplicate options to the
+            # `Dict` literal and lets last-wins absorb them; warn instead of erroring
+            # so we still flag the redundancy without aborting expansion.
             name = _validate_testset_option(arg)
-            name in seen_options &&
-                throw_macro_error(arg, "@testset: option `$name` already provided")
-            push!(seen_options, name)
+            if name in seen_options
+                push_macro_warning!(arg, "@testset: option `$name` provided more than once")
+            else
+                push!(seen_options, name)
+            end
         else
             throw_macro_error(arg, "@testset: unexpected argument")
         end
@@ -928,12 +1035,15 @@ function Base.var"@assume_effects"(
 end
 
 function _validate_assume_effect_setting(setting::SyntaxTreeC)
+    # Base hard-errors on either of these via `compute_assumed_setting`; we report as
+    # Error but let the body still flow through, since the setting only affects effect
+    # metadata which the LSP analyses don't consume.
     name = _extract_assume_effect_setting_name(setting)
     if name === nothing
-        throw_macro_error(setting,
+        push_macro_error!(setting,
             "@assume_effects: expected an effect setting (e.g. `:consistent`, `!:nothrow`)")
     elseif name ∉ _ASSUME_EFFECTS_SETTINGS
-        throw_macro_error(setting,
+        push_macro_error!(setting,
             "@assume_effects: unrecognized effect setting `:$name`")
     end
     return nothing

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -1546,6 +1546,29 @@ end
             @test widenconst(get_type_for_range(ctx, range_of(code, "sin(1.0)"))) === Float64
         end
     end
+
+    # `get_inferrable_tree` does not bind `MACRO_DIAGNOSTIC_SINK`, so stubs that call
+    # `push_macro_error!` (e.g. `Threads.@spawn` on an unsupported threadpool literal)
+    # become no-ops and the macrocall still expands. Without this, a single such invalid
+    # macrocall in a function body would propagate a `MacroExpansionError` out of
+    # `expand_forms_1`, `get_inferrable_tree` would return `nothing`, and every
+    # `hover` / `inlay` / `signature-help` in the enclosing toplevel would go dark.
+    @testset "recoverable macro stub error keeps enclosing toplevel inferrable" begin
+        let code = """
+            function f(xs::Vector{Float64})
+                s = sum(xs)
+                t = Threads.@spawn :badname sin(s)
+                fetch(t)
+            end
+            """
+            fi, ctx = type_annotate(code)
+            # Surface lookup for the macro body's `sin(s)` returns `Float64`.
+            @test widenconst(get_type_for_range(ctx, range_of(code, "sin(s)"))) === Float64
+            # Every `s` reference is annotated as `Float64`.
+            s_types = query_all_types(fi, ctx, "s")
+            @test count(t -> widenconst(t) === Float64, s_types) == 2
+        end
+    end
 end
 
 @testset HierarchicalTestSet "get_matches_for_range" begin

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -823,6 +823,47 @@ end
         @test diagnostic.range.start.line == 2
         @test diagnostic.range.var"end".line == 2
     end
+
+    @testset "macro expansion warning diagnostics" begin
+        # `@testset` with multiple descriptions should surface as a Warning
+        # diagnostic (mirroring Base's `depwarn`), not abort the expansion.
+        # Reuses the macro-expansion-error code with `Warning` severity.
+        # Use `Test` as the context so `@testset` resolves.
+        diagnostics = get_lowering_diagnostics(
+            """@testset "a" "b" begin end""";
+            context_module = Test,
+            code = JETLS.LOWERING_MACRO_EXPANSION_ERROR_CODE)
+        @test length(diagnostics) == 1
+        diagnostic = only(diagnostics)
+        @test diagnostic.severity == LSP.DiagnosticSeverity.Warning
+        @test diagnostic.source == JETLS.DIAGNOSTIC_SOURCE_LIVE
+        @test occursin("Multiple descriptions provided to @testset", diagnostic.message)
+        # The diagnostic anchors on the redundant `"b"` argument (the `K"String"`
+        # node's byte range covers just the inner content).
+        @test diagnostic.range.start.character == sizeof("""@testset "a" \"""")
+        @test diagnostic.range.var"end".character == sizeof("""@testset "a" "b""")
+    end
+
+    # A macro-expansion-error reported via the sink (here: `Threads.@spawn` with an
+    # unsupported threadpool literal) must not suppress other lowering diagnostics in
+    # the same top-level form.
+    @testset "macro expansion error does not suppress sibling lowering diagnostics" begin
+        diagnostics = get_lowering_diagnostics("""
+            function f()
+                Threads.@spawn :badname undef_a
+                undef_b
+            end
+            """; context_module = @__MODULE__)
+        @test count(diagnostics) do d
+            d.code == JETLS.LOWERING_MACRO_EXPANSION_ERROR_CODE &&
+                d.severity == LSP.DiagnosticSeverity.Error
+        end == 1
+        undef_msgs = String[d.message for d in diagnostics
+                            if d.code == JETLS.LOWERING_UNDEF_GLOBAL_VAR_CODE]
+        @test length(undef_msgs) == 2
+        @test any(m -> occursin("undef_a", m), undef_msgs)
+        @test any(m -> occursin("undef_b", m), undef_msgs)
+    end
 end
 
 module TestLoweringUndefGlobalBinding

--- a/test/utils/test_jl_syntax_macros.jl
+++ b/test/utils/test_jl_syntax_macros.jl
@@ -64,6 +64,17 @@ function assert_no_binding(res, kind::Symbol, name::AbstractString)
     @test !found
 end
 
+# Run `f()` (typically a macro-expand call) with `MACRO_DIAGNOSTIC_SINK` bound to
+# a fresh vector, then return that vector so tests can inspect the collected
+# `MacroDiagnostic` entries.
+function collect_macro_diagnostics(f)
+    sink = JETLS.MacroDiagnostic[]
+    Base.ScopedValues.@with JETLS.MACRO_DIAGNOSTIC_SINK => sink begin
+        f()
+    end
+    return sink
+end
+
 @testset "@kwdef" begin
     @testset "macro expansion" begin
         # parametric with defaults
@@ -230,19 +241,20 @@ end
     end
 
     @testset "error cases" begin
-        # Unsupported literal threadpool is rejected at expansion time, with the
-        # same message as the runtime `Base.Threads.@spawn` check.
-        let err = try
+        # Unsupported literal threadpool surfaces as an Error diagnostic via the
+        # sink — Base defers this check to runtime, but we flag it statically.
+        # Expansion still succeeds.
+        let diags = collect_macro_diagnostics() do
                 jlexpand("Threads.@spawn :foo 1+1")
-                nothing
-            catch err
-                err
             end
-            @test err isa JL.MacroExpansionError
-            @test occursin("unsupported threadpool in @spawn: foo", err.msg)
+            @test length(diags) == 1
+            d = only(diags)
+            @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+            @test occursin("unsupported threadpool in @spawn: foo", d.msg)
         end
 
-        # Zero arguments and 3+ arguments both fall through to the variadic fallback method.
+        # Zero arguments and 3+ arguments both fall through to the variadic fallback
+        # method (truly unrecoverable, so this stays a hard `MacroExpansionError`).
         for code in ("Threads.@spawn", "Threads.@spawn :default :foo 1+1")
             let err = try
                     jlexpand(code)
@@ -256,9 +268,8 @@ end
         end
 
         # Anything other than `:default`/`:interactive`/`:samepool` literals or
-        # a bare identifier is rejected. The original macro defers most of
-        # these to a runtime `_spawn_set_thrpool(::Symbol)` MethodError; we
-        # catch them at expansion time so the user gets immediate feedback.
+        # a bare identifier is flagged via the sink (Error severity). Expansion
+        # still completes so the body reaches scope analysis.
         for code in (
                 "Threads.@spawn 42 body",          # numeric literal
                 "Threads.@spawn 1.0 body",         # float literal
@@ -269,14 +280,13 @@ end
                 "Threads.@spawn M.pool body",      # qualified access
                 "Threads.@spawn :(foo()) body",    # quoted non-symbol expression
             )
-            let err = try
+            let diags = collect_macro_diagnostics() do
                     jlexpand(code)
-                    nothing
-                catch err
-                    err
                 end
-                @test err isa JL.MacroExpansionError
-                @test occursin("threadpool argument in @spawn must be", err.msg)
+                @test length(diags) == 1
+                d = only(diags)
+                @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+                @test occursin("threadpool argument in @spawn must be", d.msg)
             end
         end
     end
@@ -494,22 +504,21 @@ logging_resolve(code::AbstractString) = jlresolve(logging_module, code)
             end
         end
 
-        # Duplicate kwarg names are flagged at expansion time; without this,
-        # they'd surface only as a generic `syntax: field name "k" repeated`
-        # error from lowering the synthesized `(; k=1, k=2)` named tuple.
-        # Metadata keys (`_module`, `_group`, ...) are checked the same way,
-        # even though Base silently overwrites them.
+        # Duplicate kwarg names are flagged via the sink at expansion time; without
+        # this, they'd surface only as a generic `syntax: field name "k" repeated`
+        # error from lowering the synthesized `(; k=1, k=2)` named tuple. Metadata
+        # keys (`_module`, `_group`, ...) are checked the same way. Expansion still
+        # completes so the kwarg RHS reaches scope analysis.
         for name in ("@debug", "@info", "@warn", "@error")
             for code in ("$name \"msg\" k=1 k=2",
                          "$name \"msg\" _module=a _module=b")
-                let err = try
+                let diags = collect_macro_diagnostics() do
                         logging_expand(code)
-                        nothing
-                    catch err
-                        err
                     end
-                    @test err isa JL.MacroExpansionError
-                    @test occursin("provided more than once", err.msg)
+                    @test length(diags) == 1
+                    d = only(diags)
+                    @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+                    @test occursin("provided more than once", d.msg)
                 end
             end
         end
@@ -560,15 +569,14 @@ end
         end
 
         # Duplicate kwargs are flagged the same way as for the level-implicit
-        # logging macros.
-        let err = try
+        # logging macros: Error severity via sink, expansion still completes.
+        let diags = collect_macro_diagnostics() do
                 logging_expand("@logmsg lvl \"msg\" foo=1 foo=2")
-                nothing
-            catch err
-                err
             end
-            @test err isa JL.MacroExpansionError
-            @test occursin("provided more than once", err.msg)
+            @test length(diags) == 1
+            d = only(diags)
+            @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+            @test occursin("provided more than once", d.msg)
         end
     end
 
@@ -753,31 +761,32 @@ test_macro_lower(code::AbstractString) = jlresolve(test_lowering_module, code)
     end
 
     @testset "validation" begin
-        # `broken`/`skip`/`context` may each appear at most once.
+        # `broken`/`skip`/`context` may each appear at most once. Base hard-errors;
+        # we report as Error severity via the sink but keep expansion going so the
+        # RHS values still reach scope analysis.
         for kw in ("broken", "skip", "context")
-            let err = try
+            let diags = collect_macro_diagnostics() do
                     test_macro_expand("@test x $(kw)=true $(kw)=false")
-                    nothing
-                catch err
-                    err
                 end
-                @test err isa JL.MacroExpansionError
-                @test occursin("cannot set `$kw` keyword multiple times", err.msg)
+                @test length(diags) == 1
+                d = only(diags)
+                @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+                @test occursin("cannot set `$kw` keyword multiple times", d.msg)
             end
         end
 
-        # `skip` and `broken` are mutually exclusive.
-        let err = try
+        # `skip` and `broken` are mutually exclusive — Error severity, recovery
+        # keeps both RHS in the block.
+        let diags = collect_macro_diagnostics() do
                 test_macro_expand("@test x skip=true broken=true")
-                nothing
-            catch err
-                err
             end
-            @test err isa JL.MacroExpansionError
-            @test occursin("cannot set both `skip` and `broken`", err.msg)
+            @test length(diags) == 1
+            d = only(diags)
+            @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+            @test occursin("cannot set both `skip` and `broken`", d.msg)
         end
 
-        # Non-`key=value` positional arguments are rejected.
+        # Non-`key=value` positional arguments are rejected (unrecoverable AST shape).
         let err = try
                 test_macro_expand("@test x foo")
                 nothing
@@ -868,35 +877,38 @@ end
             end
         end
 
-        # Multiple descriptions / testset types are rejected.
-        let err = try
+        # Multiple descriptions / testset types are surfaced via the macro-diagnostic
+        # sink (mirroring `Base.@testset`'s `depwarn`); expansion still succeeds with
+        # the last value winning.
+        let diags = collect_macro_diagnostics() do
                 test_macro_expand("@testset \"a\" \"b\" begin end")
-                nothing
-            catch err
-                err
             end
-            @test err isa JL.MacroExpansionError
-            @test occursin("multiple descriptions", err.msg)
+            @test length(diags) == 1
+            d = only(diags)
+            @test d.severity == JETLS.LSP.DiagnosticSeverity.Warning
+            @test occursin("Multiple descriptions provided to @testset", d.msg)
+            @test JS.sourcetext(d.node) == "b"
         end
-        let err = try
+        let diags = collect_macro_diagnostics() do
                 test_macro_expand("@testset Foo Bar begin end")
-                nothing
-            catch err
-                err
             end
-            @test err isa JL.MacroExpansionError
-            @test occursin("multiple testset types", err.msg)
+            @test length(diags) == 1
+            d = only(diags)
+            @test d.severity == JETLS.LSP.DiagnosticSeverity.Warning
+            @test occursin("Multiple testset types provided to @testset", d.msg)
+            @test JS.sourcetext(d.node) == "Bar"
         end
 
-        # Duplicate options are rejected.
-        let err = try
+        # Duplicate options surface as warnings (Base accepts them silently); expansion
+        # still succeeds with the last value winning, mirroring Base's `Dict` semantics.
+        let diags = collect_macro_diagnostics() do
                 test_macro_expand("@testset verbose=true verbose=false begin end")
-                nothing
-            catch err
-                err
             end
-            @test err isa JL.MacroExpansionError
-            @test occursin("option `verbose` already provided", err.msg)
+            @test length(diags) == 1
+            d = only(diags)
+            @test d.severity == JETLS.LSP.DiagnosticSeverity.Warning
+            @test occursin("option `verbose` provided more than once", d.msg)
+            @test strip(JS.sourcetext(d.node)) == "verbose=false"
         end
 
         # Unexpected leading arguments (e.g. integer literals) are rejected.
@@ -1181,41 +1193,40 @@ end
             @test occursin("at least one argument is required", err.msg)
         end
 
-        # Unknown setting name (in non-final position) is rejected.
-        let err = try
+        # Unknown setting name (in non-final position) surfaces as Error severity
+        # via the sink. Effects metadata doesn't affect LSP analyses, so the body
+        # still expands normally.
+        let diags = collect_macro_diagnostics() do
                 jlexpand("Base.@assume_effects :badname foo()")
-                nothing
-            catch err
-                err
             end
-            @test err isa JL.MacroExpansionError
-            @test occursin("unrecognized effect setting `:badname`", err.msg)
+            @test length(diags) == 1
+            d = only(diags)
+            @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+            @test occursin("unrecognized effect setting `:badname`", d.msg)
         end
 
-        # Setting in non-final position must look like a setting form.
+        # Setting in non-final position must look like a setting form — Error via sink.
         for bad in ("42", "\"foldable\"", "foo()")
-            let err = try
+            let diags = collect_macro_diagnostics() do
                     jlexpand("Base.@assume_effects $bad foo()")
-                    nothing
-                catch err
-                    err
                 end
-                @test err isa JL.MacroExpansionError
-                @test occursin("expected an effect setting", err.msg)
+                @test length(diags) == 1
+                d = only(diags)
+                @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+                @test occursin("expected an effect setting", d.msg)
             end
         end
 
         # `:nortcall` and `:consistent_overlay` are not accepted as standalone
         # inputs — they're internal-only (set via shortcuts).
         for setting in (":nortcall", ":consistent_overlay")
-            let err = try
+            let diags = collect_macro_diagnostics() do
                     jlexpand("Base.@assume_effects $setting foo()")
-                    nothing
-                catch err
-                    err
                 end
-                @test err isa JL.MacroExpansionError
-                @test occursin("unrecognized effect setting", err.msg)
+                @test length(diags) == 1
+                d = only(diags)
+                @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+                @test occursin("unrecognized effect setting", d.msg)
             end
         end
 


### PR DESCRIPTION
Adds a `ScopedValue`-based side channel (`MACRO_DIAGNOSTIC_SINK`) that lets new-style macro stubs in `src/utils/jl-syntax-macros.jl` report problems as LSP diagnostics without throwing `MacroExpansionError`. Two helpers feed it:
`push_macro_error!` for cases Base itself rejects but where the stub can produce a valid recovery expansion, and
`push_macro_warning!` for cases Base accepts silently or only emits `depwarn`. The existing `throw_macro_error` is kept for genuinely unrecoverable AST shapes.

`per_stmt_diagnostics!` binds the sink around its lowering call and emits each entry as a `lowering/macro-expansion-error` diagnostic (`Error` or `Warning` severity per the stub's choice). Other lowering consumers (`get_inferrable_tree`, `cursor_bindings`, `occurrence-analysis`, `document-symbol`) leave the sink unbound, so the helpers become no-ops and those consumers transparently benefit from the recovered expansion.

On the failure path, `per_stmt_diagnostics!` invokes the `remove_macrocalls`-based fallback *outside* the sink binding so any stub re-invoked during the retry can't push duplicates of what the primary attempt already emitted. `soft_scope` is forwarded to that retry, fixing a pre-existing case where REPL / notebook scope semantics were silently dropped on the recovery path.

Converted call sites:

- `Threads.@spawn`: unsupported / invalid threadpool literal
- logging macros (`@debug`/`@info`/`@warn`/`@error`/`@logmsg`): duplicate kwarg names
- `@test`: duplicate `broken`/`skip`/`context` kwarg, and the `skip` + `broken` mutual exclusion
- `Base.@assume_effects`: unrecognized or malformed setting
- `@testset`: multiple descriptions, multiple testset types, duplicate options (these emit `Warning`, matching Base)

User-visible impact: a single bad `Threads.@spawn :badname …` or `@info "msg" id=1 id=2` in a function body no longer kills every LSP feature (hover, inlay, signature help, undef-var, references, …) for the enclosing top-level form. The diagnostic still surfaces with the appropriate severity, anchored on the offending node.

Documents the producer/consumer contract via a shared `macro_issue_contract` doc snippet on `throw_macro_error` / `push_macro_error!` / `push_macro_warning!`, plus an updated `lowering/macro-expansion-error` section in `docs/src/diagnostic.md`.