### PR TITLE
jl-syntax-macros: Convert all throw sites to recovery-based reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,10 +92,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `lowering/undef-global-var` now suppresses reports as soon as a sibling file in the same analysis unit defines the referenced name. Previously, adding `foo = ...` to one file left `foo` references in other files of the same unit flagged as undefined until the next full-analysis cycle (typically triggered on save) caught up.
 
-- `lowering/macro-expansion-error` no longer aborts analysis of the enclosing top-level form when an issue can be reported in place.
-  Previously, a single bad `Threads.@spawn :badname …`, `@info "msg" id=1 id=2`, `@test x skip=true broken=true`, or `Base.@assume_effects :badname …` in a function body would propagate a `MacroExpansionError` and remove the entire macrocall from analysis — every other LSP feature (hover, inlay, signature help, undef-var, references, …) for the *enclosing* function went dark, not just for the bad macrocall.
-  The error is still reported with `Error` severity (matching what Base does at expansion or runtime), but the macrocall body now flows through to scope and type analysis.
-  Additionally, `@testset` cases that Base accepts silently or only deprecates — multiple descriptions, multiple testset types, duplicate options — surface as `Warning` severity under the same diagnostic code.
+- `lowering/macro-expansion-error` no longer aborts analysis of the enclosing top-level form. Any misuse JETLS's stubs for `Base` macros detect — invalid threadpool literal in `Threads.@spawn`, duplicate kwarg in `@info`/`@warn`/…, `@test` with `skip` + `broken`, wrong argument count in `@assert`/`@invoke`/`@kwdef`/`@assume_effects`/…, non-call shape passed to `@invoke`, malformed `@testset` body, and so on — is now reported in place while the macrocall body still flows through to scope and type analysis.
+  Previously any of these would propagate a `MacroExpansionError`, remove the entire macrocall from analysis, and take every other LSP feature requiring full lowering of the enclosing function (hover, inlay, signature help, undef-var, references, …) down with it.
+  Reports come with `Error` severity when Base would reject the misuse and `Warning` severity when Base accepts it silently or only deprecates.
 
 ### Fixed
 

--- a/src/utils/jl-syntax-macros.jl
+++ b/src/utils/jl-syntax-macros.jl
@@ -21,32 +21,31 @@ end
 const macro_issue_contract = """
 # Macro issue contract
 
-When a stub detects a problem, pick the helper that minimizes loss of downstream
-analysis while still surfacing the issue with the severity Base would assign:
+When a stub detects a problem, *never throw* — produce a valid recovery expansion so
+lowering of the enclosing top-level form (function body, let, etc.) keeps succeeding,
+and surface the issue via the sink with the severity Base would assign. A throw would
+abort that lowering and take every lowering-based analysis (undef-var, references,
+[`TypeAnnotation`](@ref) for hover / inlay / signature-help, …) for the whole
+enclosing form down with it.
 
-| helper                        | when                                                                                     | examples                                                                                 |
-|:------------------------------|:-----------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------|
-| [`throw_macro_error`](@ref)   | Base rejects, **and** the stub cannot produce a valid recovery expansion                 | `@assert` with zero args, `@invoke` whose argument is not a call, `@kwdef` on non-struct |
-| [`push_macro_error!`](@ref)   | Base rejects, **but** the stub can recover (typically: keep the body, drop the bad part) | `@spawn :badname body`, `@info` with dup kwargs, `@test` with `skip` + `broken`          |
-| [`push_macro_warning!`](@ref) | Base accepts silently or only emits `depwarn`                                            | `@testset` with multiple descriptions/types or duplicate options                         |
+| helper                        | when                                                  |
+|:------------------------------|:------------------------------------------------------|
+| [`push_macro_error!`](@ref)   | Base also rejects                                     |
+| [`push_macro_warning!`](@ref) | Base accepts silently or only emits `depwarn`         |
 
-The push helpers feed [`MACRO_DIAGNOSTIC_SINK`](@ref); see its docstring for the
-producer/consumer contract.
+Common recovery shapes:
+
+- 0-arg / unrecoverable single arg → `nothing::K"Value"`
+- variadic with potentially analyzable args → `[block args...]` (with a trailing
+  `nothing::K"Value"` if the original macro returned `nothing`)
+- single-arg shape error → flow the arg through unchanged
+
+The helpers feed [`MACRO_DIAGNOSTIC_SINK`](@ref); see its docstring for the
+producer/consumer contract. By contrast, when `JL.MacroExpansionError` is thrown directly
+(which JuliaLowering itself does on e.g. macro-not-found), `per_stmt_diagnostics!` falls
+back to re-lowering the enclosing form with macrocalls stripped — a much coarser recovery
+than the sink path.
 """
-
-"""
-    throw_macro_error(node::SyntaxTreeC, msg::AbstractString)
-
-Throw a `JL.MacroExpansionError` anchored on `node`, aborting the current macro
-expansion. In the LSP analysis pipeline this triggers a fallback through
-`remove_macrocalls` for the *whole* enclosing top-level form, so identifier-level
-analysis (undef-var, references, [`TypeAnnotation`](@ref) for hover / inlay /
-signature-help, …) is lost across that form, not just at the bad macrocall.
-
-$macro_issue_contract
-"""
-@noinline throw_macro_error(node::SyntaxTreeC, msg::AbstractString) =
-    throw(JL.MacroExpansionError(node, msg))
 
 """
     MACRO_DIAGNOSTIC_SINK :: ScopedValue{Union{Nothing,Vector{MacroDiagnostic}}}
@@ -67,7 +66,7 @@ Concurrency-safe by construction: `ScopedValue` binds per task and propagates to
 child tasks, so the concurrent `per_stmt_diagnostics!` workers spawned under
 workspace diagnostic each get their own sink without cross-talk or locking.
 
-See also: [`throw_macro_error`](@ref), [`push_macro_error!`], [`push_macro_warning!`]
+See also: [`push_macro_error!`](@ref), [`push_macro_warning!`](@ref)
 """
 struct MacroDiagnostic
     node::SyntaxTreeC
@@ -278,9 +277,13 @@ function _validate_spawn_threadpool(threadpool::SyntaxTreeC)
     nothing
 end
 
-function Base.Threads.var"@spawn"(__context__::JL.MacroContext, ::SyntaxTreeC...)
-    throw_macro_error(__context__.macrocall::SyntaxTreeC,
-        "wrong number of arguments in @spawn")
+function Base.Threads.var"@spawn"(__context__::JL.MacroContext, args::SyntaxTreeC...)
+    mc = __context__.macrocall::SyntaxTreeC
+    push_macro_error!(mc, "wrong number of arguments in @spawn")
+    # Recovery: flow whatever the user wrote through scope analysis. 0-arg →
+    # `nothing`, ≥3-arg → a block of every arg so identifiers inside stay visible.
+    isempty(args) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
+    return JL.@ast(__context__, mc, [JS.K"block" args... nothing::JS.K"Value"])
 end
 
 # New-style implementation of `Base.@label`. Mirrors `Base.@goto` in
@@ -291,14 +294,21 @@ end
 # expr`) are intentionally not supported here — the goto-target form is the
 # common case and the only one needed for most LSP analyses.
 function Base.var"@label"(__context__::JL.MacroContext, ex::SyntaxTreeC)
-    JS.kind(ex) === JS.K"Identifier" ||
-        throw_macro_error(ex, "@label requires an identifier")
+    if JS.kind(ex) !== JS.K"Identifier"
+        push_macro_error!(ex, "@label requires an identifier")
+        # Recovery: let the expression flow through so any identifier inside still
+        # reaches scope analysis. Goto-target semantics are lost.
+        return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC, ex)
+    end
     return JL.@ast(__context__, ex, [JS.K"symboliclabel" ex])
 end
 
-function Base.var"@label"(__context__::JL.MacroContext, ::SyntaxTreeC...)
-    throw_macro_error(__context__.macrocall::SyntaxTreeC,
+function Base.var"@label"(__context__::JL.MacroContext, args::SyntaxTreeC...)
+    mc = __context__.macrocall::SyntaxTreeC
+    push_macro_error!(mc,
         "@label currently only supports the `@label name` form")
+    isempty(args) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
+    return JL.@ast(__context__, mc, [JS.K"block" args...])
 end
 
 # New-style implementation of `Base.@something`. The macro is sometimes called with arguments
@@ -341,8 +351,9 @@ end
 # we mirror that leniency, but route extras through a leading `block` so identifiers
 # inside (e.g. an interpolated `"got $y"`) still get scope-resolved.
 function Base.var"@assert"(__context__::JL.MacroContext)
-    throw_macro_error(__context__.macrocall::SyntaxTreeC,
-        "@assert: at least one argument is required")
+    mc = __context__.macrocall::SyntaxTreeC
+    push_macro_error!(mc, "@assert: at least one argument is required")
+    return JL.@ast(__context__, mc, nothing::JS.K"Value")
 end
 
 function Base.var"@assert"(
@@ -405,8 +416,9 @@ function Base.CoreLogging.var"@debug"(
 end
 
 function Base.CoreLogging.var"@debug"(__context__::JL.MacroContext)
-    throw_macro_error(__context__.macrocall::SyntaxTreeC,
-        "@debug requires at least one argument: a `message`")
+    mc = __context__.macrocall::SyntaxTreeC
+    push_macro_error!(mc, "@debug requires at least one argument: a `message`")
+    return JL.@ast(__context__, mc, nothing::JS.K"Value")
 end
 
 function Base.CoreLogging.var"@info"(
@@ -416,8 +428,9 @@ function Base.CoreLogging.var"@info"(
 end
 
 function Base.CoreLogging.var"@info"(__context__::JL.MacroContext)
-    throw_macro_error(__context__.macrocall::SyntaxTreeC,
-        "@info requires at least one argument: a `message`")
+    mc = __context__.macrocall::SyntaxTreeC
+    push_macro_error!(mc, "@info requires at least one argument: a `message`")
+    return JL.@ast(__context__, mc, nothing::JS.K"Value")
 end
 
 function Base.CoreLogging.var"@warn"(
@@ -427,8 +440,9 @@ function Base.CoreLogging.var"@warn"(
 end
 
 function Base.CoreLogging.var"@warn"(__context__::JL.MacroContext)
-    throw_macro_error(__context__.macrocall::SyntaxTreeC,
-        "@warn requires at least one argument: a `message`")
+    mc = __context__.macrocall::SyntaxTreeC
+    push_macro_error!(mc, "@warn requires at least one argument: a `message`")
+    return JL.@ast(__context__, mc, nothing::JS.K"Value")
 end
 
 function Base.CoreLogging.var"@error"(
@@ -438,8 +452,9 @@ function Base.CoreLogging.var"@error"(
 end
 
 function Base.CoreLogging.var"@error"(__context__::JL.MacroContext)
-    throw_macro_error(__context__.macrocall::SyntaxTreeC,
-        "@error requires at least one argument: a `message`")
+    mc = __context__.macrocall::SyntaxTreeC
+    push_macro_error!(mc, "@error requires at least one argument: a `message`")
+    return JL.@ast(__context__, mc, nothing::JS.K"Value")
 end
 
 # `@logmsg` adds a leading `level` argument. The level is a user-written
@@ -452,9 +467,12 @@ function Base.CoreLogging.var"@logmsg"(
     return _logmsg_stub(__context__, (level, message, exs...), "@logmsg")
 end
 
-function Base.CoreLogging.var"@logmsg"(__context__::JL.MacroContext, ::SyntaxTreeC...)
-    throw_macro_error(__context__.macrocall::SyntaxTreeC,
+function Base.CoreLogging.var"@logmsg"(__context__::JL.MacroContext, args::SyntaxTreeC...)
+    mc = __context__.macrocall::SyntaxTreeC
+    push_macro_error!(mc,
         "@logmsg requires at least two arguments: a `level` and a `message`")
+    isempty(args) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
+    return JL.@ast(__context__, mc, [JS.K"block" args... nothing::JS.K"Value"])
 end
 
 function _logmsg_stub(
@@ -466,7 +484,11 @@ function _logmsg_stub(
     for ex in exs
         k = JS.kind(ex)
         if k === JS.K"="
-            kwname = _validate_logmsg_kw(ex, name)
+            if JS.numchildren(ex) != 2
+                push_macro_error!(ex, "$name: malformed keyword argument")
+                continue
+            end
+            kwname = _validate_logmsg_kw(ex)
             if kwname !== nothing
                 if kwname in seen_kws
                     # Base would let the synthesized `(; k=…, k=…)` named tuple fail
@@ -479,9 +501,11 @@ function _logmsg_stub(
             end
             push!(children, ex[2])
         elseif k === JS.K"..."
-            JS.numchildren(ex) >= 1 ||
-                throw_macro_error(ex, "$name: malformed splat argument")
-            push!(children, ex[1])
+            if JS.numchildren(ex) >= 1
+                push!(children, ex[1])
+            else
+                push_macro_error!(ex, "$name: malformed splat argument")
+            end
         else
             push!(children, ex)
         end
@@ -492,10 +516,9 @@ end
 # Returns the kwarg name as a `String`, or `nothing` if the name isn't a
 # plain identifier. The latter case (e.g. `"foo"=val`, which Base silently
 # routes through `Symbol(k)`) is rare enough that we just skip the
-# duplicate check rather than reject it outright.
-function _validate_logmsg_kw(kw::SyntaxTreeC, name::AbstractString)
-    JS.numchildren(kw) == 2 ||
-        throw_macro_error(kw, "$name: malformed keyword argument")
+# duplicate check rather than reject it outright. Assumes `JS.numchildren(kw) == 2`
+# (the caller pre-validates the shape so it can safely access `kw[2]`).
+function _validate_logmsg_kw(kw::SyntaxTreeC)
     key = kw[1]
     if JS.kind(key) === JS.K"Identifier" && hasproperty(key, :name_val)
         n = key.name_val
@@ -512,29 +535,43 @@ end
 # accepted (`f(args...; kwargs...)`, `x.f`, `xs[i]`, `x.f = v`, `xs[i] = v`); other shapes
 # are rejected at expansion time with a clear message.
 function Base.var"@invoke"(__context__::JL.MacroContext, ex::SyntaxTreeC)
-    f, args, kwargs = _destructure_invoke_callex(__context__, ex, "@invoke")
+    destructured = _destructure_invoke_callex(__context__, ex, "@invoke")
+    destructured === nothing &&
+        return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC, ex)
+    f, args, kwargs = destructured
     return _build_invoke_call(__context__, ex, f, args, kwargs)
 end
 
-function Base.var"@invoke"(__context__::JL.MacroContext, ::SyntaxTreeC...)
-    throw_macro_error(__context__.macrocall::SyntaxTreeC,
+function Base.var"@invoke"(__context__::JL.MacroContext, args::SyntaxTreeC...)
+    mc = __context__.macrocall::SyntaxTreeC
+    push_macro_error!(mc,
         "@invoke expects exactly one argument: `f(args...; kwargs...)` (or one of `x.f`, `xs[i]`, `x.f = v`, `xs[i] = v`)")
+    isempty(args) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
+    return JL.@ast(__context__, mc, [JS.K"block" args...])
 end
 
 function Base.var"@invokelatest"(__context__::JL.MacroContext, ex::SyntaxTreeC)
-    f, args, kwargs = _destructure_invoke_callex(__context__, ex, "@invokelatest")
+    destructured = _destructure_invoke_callex(__context__, ex, "@invokelatest")
+    destructured === nothing &&
+        return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC, ex)
+    f, args, kwargs = destructured
     return _build_invokelatest_call(__context__, f, args, kwargs)
 end
 
-function Base.var"@invokelatest"(__context__::JL.MacroContext, ::SyntaxTreeC...)
-    throw_macro_error(__context__.macrocall::SyntaxTreeC,
+function Base.var"@invokelatest"(__context__::JL.MacroContext, args::SyntaxTreeC...)
+    mc = __context__.macrocall::SyntaxTreeC
+    push_macro_error!(mc,
         "@invokelatest expects exactly one argument: `f(args...; kwargs...)` (or one of `x.f`, `xs[i]`, `x.f = v`, `xs[i] = v`)")
+    isempty(args) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
+    return JL.@ast(__context__, mc, [JS.K"block" args...])
 end
 
 # Mirror of Base's `destructure_callex` for EST: returns `(f, args, kwargs)` where
 # `f` is the function (already a `K"top"` reference for the synthesized `getproperty`,
 # `setindex!`, etc. forms), `args` are the positional arguments, and `kwargs` are the
 # raw `K"kw"` nodes (collected from both bare-`kw` children and `K"parameters"` blocks).
+# Returns `nothing` when `ex` doesn't match any accepted shape; the caller is
+# responsible for falling back to a recovery expansion.
 function _destructure_invoke_callex(
         ctx::JL.MacroContext, ex::SyntaxTreeC, m::AbstractString
     )
@@ -582,11 +619,13 @@ function _destructure_invoke_callex(
             f = JL.@ast(ctx, ex, [JS.K"top" "setindex!"::JS.K"Identifier"])
             return f, args, SyntaxTreeC[]
         end
-        throw_macro_error(ex,
+        push_macro_error!(ex,
             "$m: expected a `setproperty!` expression `x.f = v` or `setindex!` expression `x[i] = v`")
+        return nothing
     end
-    throw_macro_error(ex,
+    push_macro_error!(ex,
         "$m: expected a `:call` expression `f(args...; kwargs...)`")
+    return nothing
 end
 
 # Build `Core.invoke(f, Tuple{T1, ...}, x, ...)`, mirroring Base's expansion. Each `x::T`
@@ -651,8 +690,12 @@ end
 # This strips default values from struct fields and generates keyword constructors,
 # matching the semantics of Base.@kwdef.
 function Base.var"@kwdef"(__context__::JL.MacroContext, ex::SyntaxTreeC)
-    JS.kind(ex) === JS.K"struct" ||
-        throw_macro_error(ex, "Invalid usage of @kwdef")
+    if JS.kind(ex) !== JS.K"struct"
+        push_macro_error!(ex, "Invalid usage of @kwdef")
+        # Recovery: let the argument flow through unchanged so e.g. a half-typed
+        # struct or an accidentally-decorated function still reaches scope analysis.
+        return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC, ex)
+    end
 
     # EST struct children: [Value(is_mutable), type_sig, body]
     type_sig = ex[2]
@@ -781,7 +824,10 @@ function _kwdef_make_constructors(
 
         return SyntaxTreeC[def1, def2]
     else
-        throw_macro_error(type_sig, "Invalid type signature for @kwdef")
+        # Recovery: emit no constructors. The bare (stripped) struct definition
+        # still reaches downstream lowering.
+        push_macro_error!(type_sig, "Invalid type signature for @kwdef")
+        return SyntaxTreeC[]
     end
 end
 
@@ -804,6 +850,7 @@ function Test.var"@test"(__context__::JL.MacroContext, ex::SyntaxTreeC, kws::Syn
     # still reach scope analysis.
     for kw in kws
         name = _validate_test_kw(kw)
+        name === nothing && continue # malformed kw already reported via sink
         push!(rhss, kw[2])
         if name == "broken"
             seen_broken === nothing || push_macro_error!(kw,
@@ -833,7 +880,7 @@ function Test.var"@test_broken"(
     mc = __context__.macrocall::SyntaxTreeC
     rhss = SyntaxTreeC[]
     for kw in kws
-        _validate_test_kw(kw)
+        _validate_test_kw(kw) === nothing && continue
         push!(rhss, kw[2])
     end
     isempty(rhss) && return JL.@ast(__context__, mc, ex)
@@ -846,7 +893,7 @@ function Test.var"@test_skip"(
     mc = __context__.macrocall::SyntaxTreeC
     rhss = SyntaxTreeC[]
     for kw in kws
-        _validate_test_kw(kw)
+        _validate_test_kw(kw) === nothing && continue
         push!(rhss, kw[2])
     end
     isempty(rhss) && return JL.@ast(__context__, mc, ex)
@@ -860,9 +907,12 @@ function Test.var"@test_throws"(
         [JS.K"block" extype ex])
 end
 
-function Test.var"@test_throws"(__context__::JL.MacroContext, ::SyntaxTreeC...)
-    throw_macro_error(__context__.macrocall::SyntaxTreeC,
+function Test.var"@test_throws"(__context__::JL.MacroContext, args::SyntaxTreeC...)
+    mc = __context__.macrocall::SyntaxTreeC
+    push_macro_error!(mc,
         "@test_throws expects exactly two arguments: `extype` and `ex`")
+    isempty(args) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
+    return JL.@ast(__context__, mc, [JS.K"block" args...])
 end
 
 function Test.var"@test_warn"(
@@ -878,13 +928,16 @@ end
 
 function Test.var"@test_logs"(__context__::JL.MacroContext, args::SyntaxTreeC...)
     mc = __context__.macrocall::SyntaxTreeC
-    isempty(args) && throw_macro_error(mc, "@test_logs needs at least one argument")
+    if isempty(args)
+        push_macro_error!(mc, "@test_logs needs at least one argument")
+        return JL.@ast(__context__, mc, nothing::JS.K"Value")
+    end
     body = last(args)
     block_children = SyntaxTreeC[]
     for i in 1:length(args)-1
         arg = args[i]
         if JS.kind(arg) === JS.K"="
-            _validate_test_kw(arg)
+            _validate_test_kw(arg) === nothing && continue
             push!(block_children, arg[2])
         else
             push!(block_children, arg)
@@ -905,9 +958,12 @@ function Test.var"@test_deprecated"(
         [JS.K"block" pattern ex])
 end
 
-function Test.var"@test_deprecated"(__context__::JL.MacroContext, ::SyntaxTreeC...)
-    throw_macro_error(__context__.macrocall::SyntaxTreeC,
+function Test.var"@test_deprecated"(__context__::JL.MacroContext, args::SyntaxTreeC...)
+    mc = __context__.macrocall::SyntaxTreeC
+    push_macro_error!(mc,
         "@test_deprecated expects one or two arguments: `[pattern] expr`")
+    isempty(args) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
+    return JL.@ast(__context__, mc, [JS.K"block" args...])
 end
 
 function Test.var"@inferred"(__context__::JL.MacroContext, ex::SyntaxTreeC)
@@ -921,29 +977,42 @@ function Test.var"@inferred"(
         [JS.K"block" allow ex])
 end
 
-function Test.var"@inferred"(__context__::JL.MacroContext, ::SyntaxTreeC...)
-    throw_macro_error(__context__.macrocall::SyntaxTreeC,
-        "@inferred expects one or two arguments: `[allow] ex`")
+function Test.var"@inferred"(__context__::JL.MacroContext, args::SyntaxTreeC...)
+    mc = __context__.macrocall::SyntaxTreeC
+    push_macro_error!(mc, "@inferred expects one or two arguments: `[allow] ex`")
+    isempty(args) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
+    return JL.@ast(__context__, mc, [JS.K"block" args...])
 end
 
 function _validate_test_kw(kw::SyntaxTreeC)
-    JS.kind(kw) === JS.K"=" ||
-        throw_macro_error(kw, "invalid test macro call: expected `keyword=value`")
-    JS.numchildren(kw) == 2 ||
-        throw_macro_error(kw, "invalid test macro call: malformed keyword argument")
+    if JS.kind(kw) !== JS.K"="
+        push_macro_error!(kw, "invalid test macro call: expected `keyword=value`")
+        return nothing
+    end
+    if JS.numchildren(kw) != 2
+        push_macro_error!(kw, "invalid test macro call: malformed keyword argument")
+        return nothing
+    end
     name = kw[1]
-    (JS.kind(name) === JS.K"Identifier" && hasproperty(name, :name_val)) ||
-        throw_macro_error(name, "invalid test macro call: keyword name must be an identifier")
+    if !(JS.kind(name) === JS.K"Identifier" && hasproperty(name, :name_val))
+        push_macro_error!(name, "invalid test macro call: keyword name must be an identifier")
+        return nothing
+    end
     return name.name_val::String
 end
 
 function Test.var"@testset"(__context__::JL.MacroContext, args::SyntaxTreeC...)
     mc = __context__.macrocall::SyntaxTreeC
-    isempty(args) && throw_macro_error(mc, "No arguments to @testset")
+    if isempty(args)
+        push_macro_error!(mc, "No arguments to @testset")
+        return JL.@ast(__context__, mc, nothing::JS.K"Value")
+    end
 
     body = last(args)
     if JS.kind(body) ∉ JS.KSet"for block call let"
-        throw_macro_error(body,
+        # Recovery: let the body flow through anyway. Wrapped in `let` below so its
+        # bindings still get the testset-local scope treatment.
+        push_macro_error!(body,
             "@testset: body argument must be a `for`, `begin`/`end`, function call, or `let` expression")
     end
 
@@ -966,13 +1035,17 @@ function Test.var"@testset"(__context__::JL.MacroContext, args::SyntaxTreeC...)
             # `Dict` literal and lets last-wins absorb them; warn instead of erroring
             # so we still flag the redundancy without aborting expansion.
             name = _validate_testset_option(arg)
-            if name in seen_options
+            if name === nothing
+                continue # malformed option already reported via sink
+            elseif name in seen_options
                 push_macro_warning!(arg, "@testset: option `$name` provided more than once")
             else
                 push!(seen_options, name)
             end
         else
-            throw_macro_error(arg, "@testset: unexpected argument")
+            # Recovery: skip the unrecognized arg — Base would error here but we
+            # prefer to keep the testset's body analyzable.
+            push_macro_error!(arg, "@testset: unexpected argument")
         end
     end
 
@@ -986,11 +1059,15 @@ function Test.var"@testset"(__context__::JL.MacroContext, args::SyntaxTreeC...)
 end
 
 function _validate_testset_option(arg::SyntaxTreeC)
-    JS.numchildren(arg) == 2 ||
-        throw_macro_error(arg, "@testset: malformed option")
+    if JS.numchildren(arg) != 2
+        push_macro_error!(arg, "@testset: malformed option")
+        return nothing
+    end
     name = arg[1]
-    (JS.kind(name) === JS.K"Identifier" && hasproperty(name, :name_val)) ||
-        throw_macro_error(name, "@testset: option name must be an identifier")
+    if !(JS.kind(name) === JS.K"Identifier" && hasproperty(name, :name_val))
+        push_macro_error!(name, "@testset: option name must be an identifier")
+        return nothing
+    end
     return name.name_val::String
 end
 
@@ -1009,8 +1086,9 @@ const _ASSUME_EFFECTS_SETTINGS = (
 )
 
 function Base.var"@assume_effects"(__context__::JL.MacroContext)
-    throw_macro_error(__context__.macrocall::SyntaxTreeC,
-        "@assume_effects: at least one argument is required")
+    mc = __context__.macrocall::SyntaxTreeC
+    push_macro_error!(mc, "@assume_effects: at least one argument is required")
+    return JL.@ast(__context__, mc, nothing::JS.K"Value")
 end
 
 function Base.var"@assume_effects"(

--- a/test/utils/test_jl_syntax_macros.jl
+++ b/test/utils/test_jl_syntax_macros.jl
@@ -69,9 +69,7 @@ end
 # `MacroDiagnostic` entries.
 function collect_macro_diagnostics(f)
     sink = JETLS.MacroDiagnostic[]
-    Base.ScopedValues.@with JETLS.MACRO_DIAGNOSTIC_SINK => sink begin
-        f()
-    end
+    Base.ScopedValues.@with JETLS.MACRO_DIAGNOSTIC_SINK => sink f()
     return sink
 end
 
@@ -254,16 +252,16 @@ end
         end
 
         # Zero arguments and 3+ arguments both fall through to the variadic fallback
-        # method (truly unrecoverable, so this stays a hard `MacroExpansionError`).
+        # method: report via the sink and wrap the args (if any) in a block so they
+        # still reach scope analysis.
         for code in ("Threads.@spawn", "Threads.@spawn :default :foo 1+1")
-            let err = try
+            let diags = collect_macro_diagnostics() do
                     jlexpand(code)
-                    nothing
-                catch err
-                    err
                 end
-                @test err isa JL.MacroExpansionError
-                @test occursin("wrong number of arguments in @spawn", err.msg)
+                @test length(diags) == 1
+                d = only(diags)
+                @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+                @test occursin("wrong number of arguments in @spawn", d.msg)
             end
         end
 
@@ -304,28 +302,25 @@ end
 end
 
 @testset "@label" begin
-    # Non-identifier argument is rejected.
-    let err = try
+    # Non-identifier argument: report via sink, let the expression flow through.
+    let diags = collect_macro_diagnostics() do
             jlexpand("@label 42")
-            nothing
-        catch err
-            err
         end
-        @test err isa JL.MacroExpansionError
-        @test occursin("requires an identifier", err.msg)
+        @test length(diags) == 1
+        d = only(diags)
+        @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+        @test occursin("requires an identifier", d.msg)
     end
 
     # The block forms (`@label expr`, `@label name expr`) are intentionally not
-    # supported; the variadic fallback gives a clear message instead of a
-    # `MethodError`.
-    let err = try
+    # supported; the variadic fallback reports via sink and wraps args in a block.
+    let diags = collect_macro_diagnostics() do
             jlexpand("@label foo body")
-            nothing
-        catch err
-            err
         end
-        @test err isa JL.MacroExpansionError
-        @test occursin("only supports the `@label name` form", err.msg)
+        @test length(diags) == 1
+        d = only(diags)
+        @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+        @test occursin("only supports the `@label name` form", d.msg)
     end
 
     # Full lowering succeeds when paired with `@goto`.
@@ -401,15 +396,14 @@ end
     end
 
     @testset "validation" begin
-        # Zero-argument form rejected.
-        let err = try
+        # Zero-argument form: report via sink, recover with `nothing`.
+        let diags = collect_macro_diagnostics() do
                 jlexpand("@assert")
-                nothing
-            catch err
-                err
             end
-            @test err isa JL.MacroExpansionError
-            @test occursin("at least one argument is required", err.msg)
+            @test length(diags) == 1
+            d = only(diags)
+            @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+            @test occursin("at least one argument is required", d.msg)
         end
     end
 
@@ -491,16 +485,15 @@ logging_resolve(code::AbstractString) = jlresolve(logging_module, code)
     end
 
     @testset "validation" begin
-        # Zero-arg form rejected for each macro.
+        # Zero-arg form for each macro: report via sink, recover with `nothing`.
         for name in ("@debug", "@info", "@warn", "@error")
-            let err = try
+            let diags = collect_macro_diagnostics() do
                     logging_expand(name)
-                    nothing
-                catch err
-                    err
                 end
-                @test err isa JL.MacroExpansionError
-                @test occursin("$name requires at least one argument", err.msg)
+                @test length(diags) == 1
+                d = only(diags)
+                @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+                @test occursin("$name requires at least one argument", d.msg)
             end
         end
 
@@ -557,14 +550,13 @@ end
         # 0 and 1 arg both fall through to the variadic fallback, since
         # `@logmsg` requires both a `level` and a `message`.
         for code in ("@logmsg", "@logmsg lvl")
-            let err = try
+            let diags = collect_macro_diagnostics() do
                     logging_expand(code)
-                    nothing
-                catch err
-                    err
                 end
-                @test err isa JL.MacroExpansionError
-                @test occursin("@logmsg requires at least two arguments", err.msg)
+                @test length(diags) == 1
+                d = only(diags)
+                @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+                @test occursin("@logmsg requires at least two arguments", d.msg)
             end
         end
 
@@ -679,41 +671,40 @@ end
 
     @testset "validation" begin
         for name in ("@invoke", "@invokelatest")
-            # Zero / multiple arguments fall through to the variadic fallback.
+            # Zero / multiple arguments fall through to the variadic fallback,
+            # reported via sink. Args (if any) are wrapped in a block.
             for code in ("$name", "$name f(x) g(y)")
-                let err = try
+                let diags = collect_macro_diagnostics() do
                         jlexpand(code)
-                        nothing
-                    catch err
-                        err
                     end
-                    @test err isa JL.MacroExpansionError
-                    @test occursin("expects exactly one argument", err.msg)
+                    @test length(diags) == 1
+                    d = only(diags)
+                    @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+                    @test occursin("expects exactly one argument", d.msg)
                 end
             end
 
-            # Bare identifier / literal isn't one of the allowed call shapes.
+            # Bare identifier / literal isn't one of the allowed call shapes;
+            # the `ex` flows through as-is so identifiers reach scope analysis.
             for code in ("$name 42", "$name foo")
-                let err = try
+                let diags = collect_macro_diagnostics() do
                         jlexpand(code)
-                        nothing
-                    catch err
-                        err
                     end
-                    @test err isa JL.MacroExpansionError
-                    @test occursin("expected a `:call` expression", err.msg)
+                    @test length(diags) == 1
+                    d = only(diags)
+                    @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+                    @test occursin("expected a `:call` expression", d.msg)
                 end
             end
 
             # `=` form requires the LHS to be `x.f` or `xs[i]`.
-            let err = try
+            let diags = collect_macro_diagnostics() do
                     jlexpand("$name a = b")
-                    nothing
-                catch err
-                    err
                 end
-                @test err isa JL.MacroExpansionError
-                @test occursin("setproperty!", err.msg)
+                @test length(diags) == 1
+                d = only(diags)
+                @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+                @test occursin("setproperty!", d.msg)
             end
         end
     end
@@ -786,15 +777,15 @@ test_macro_lower(code::AbstractString) = jlresolve(test_lowering_module, code)
             @test occursin("cannot set both `skip` and `broken`", d.msg)
         end
 
-        # Non-`key=value` positional arguments are rejected (unrecoverable AST shape).
-        let err = try
+        # Non-`key=value` positional arguments are reported via sink; the malformed
+        # kw is skipped, the test body still expands.
+        let diags = collect_macro_diagnostics() do
                 test_macro_expand("@test x foo")
-                nothing
-            catch err
-                err
             end
-            @test err isa JL.MacroExpansionError
-            @test occursin("expected `keyword=value`", err.msg)
+            @test length(diags) == 1
+            d = only(diags)
+            @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+            @test occursin("expected `keyword=value`", d.msg)
         end
     end
 
@@ -853,27 +844,26 @@ end
     end
 
     @testset "validation" begin
-        # No-argument form rejected.
-        let err = try
+        # No-argument form: report via sink, recover with `nothing`.
+        let diags = collect_macro_diagnostics() do
                 test_macro_expand("@testset")
-                nothing
-            catch err
-                err
             end
-            @test err isa JL.MacroExpansionError
-            @test occursin("No arguments to @testset", err.msg)
+            @test length(diags) == 1
+            d = only(diags)
+            @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+            @test occursin("No arguments to @testset", d.msg)
         end
 
-        # Body argument must be a `for`/`begin`/`call`/`let`.
+        # Body argument that's not `for`/`begin`/`call`/`let`: reported via sink,
+        # the body still flows through the `let` wrapper so identifiers reach scope.
         for body in ("42", "\"x\"", "x = 1")
-            let err = try
+            let diags = collect_macro_diagnostics() do
                     test_macro_expand("@testset \"name\" $body")
-                    nothing
-                catch err
-                    err
                 end
-                @test err isa JL.MacroExpansionError
-                @test occursin("body argument must be", err.msg)
+                @test length(diags) == 1
+                d = only(diags)
+                @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+                @test occursin("body argument must be", d.msg)
             end
         end
 
@@ -911,15 +901,15 @@ end
             @test strip(JS.sourcetext(d.node)) == "verbose=false"
         end
 
-        # Unexpected leading arguments (e.g. integer literals) are rejected.
-        let err = try
+        # Unexpected leading arguments (e.g. integer literals) are reported via
+        # sink and skipped; the testset body still expands.
+        let diags = collect_macro_diagnostics() do
                 test_macro_expand("@testset 42 begin end")
-                nothing
-            catch err
-                err
             end
-            @test err isa JL.MacroExpansionError
-            @test occursin("unexpected argument", err.msg)
+            @test length(diags) == 1
+            d = only(diags)
+            @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+            @test occursin("unexpected argument", d.msg)
         end
 
         # Qualified testset types (e.g. `Test.DefaultTestSet`) are accepted.
@@ -966,17 +956,17 @@ end
     end
 
     @testset "validation" begin
-        # `@test_throws` strictly requires two positional arguments.
+        # `@test_throws` strictly requires two positional arguments; other shapes
+        # report via sink and wrap (or drop) the args.
         for code in ("@test_throws", "@test_throws BoundsError",
                      "@test_throws BoundsError xxx yyy")
-            let err = try
+            let diags = collect_macro_diagnostics() do
                     test_macro_expand(code)
-                    nothing
-                catch err
-                    err
                 end
-                @test err isa JL.MacroExpansionError
-                @test occursin("@test_throws expects exactly two arguments", err.msg)
+                @test length(diags) == 1
+                d = only(diags)
+                @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+                @test occursin("@test_throws expects exactly two arguments", d.msg)
             end
         end
     end
@@ -1005,16 +995,16 @@ end
     end
 
     @testset "validation" begin
-        # Non-`key=value` positional arguments are rejected.
+        # Non-`key=value` positional arguments are reported via sink; the
+        # malformed kw is skipped, the body still expands.
         for name in ("@test_broken", "@test_skip")
-            let err = try
+            let diags = collect_macro_diagnostics() do
                     test_macro_expand("$name xxx foo")
-                    nothing
-                catch err
-                    err
                 end
-                @test err isa JL.MacroExpansionError
-                @test occursin("expected `keyword=value`", err.msg)
+                @test length(diags) == 1
+                d = only(diags)
+                @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+                @test occursin("expected `keyword=value`", d.msg)
             end
         end
     end
@@ -1069,14 +1059,13 @@ end
     end
 
     @testset "validation" begin
-        let err = try
+        let diags = collect_macro_diagnostics() do
                 test_macro_expand("@test_logs")
-                nothing
-            catch err
-                err
             end
-            @test err isa JL.MacroExpansionError
-            @test occursin("@test_logs needs at least one argument", err.msg)
+            @test length(diags) == 1
+            d = only(diags)
+            @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+            @test occursin("@test_logs needs at least one argument", d.msg)
         end
     end
 
@@ -1103,14 +1092,13 @@ end
 
     @testset "validation" begin
         for code in ("@test_deprecated", "@test_deprecated a b c")
-            let err = try
+            let diags = collect_macro_diagnostics() do
                     test_macro_expand(code)
-                    nothing
-                catch err
-                    err
                 end
-                @test err isa JL.MacroExpansionError
-                @test occursin("@test_deprecated expects one or two arguments", err.msg)
+                @test length(diags) == 1
+                d = only(diags)
+                @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+                @test occursin("@test_deprecated expects one or two arguments", d.msg)
             end
         end
     end
@@ -1129,14 +1117,13 @@ end
 
     @testset "validation" begin
         for code in ("@inferred", "@inferred Int foo(x) extra")
-            let err = try
+            let diags = collect_macro_diagnostics() do
                     test_macro_expand(code)
-                    nothing
-                catch err
-                    err
                 end
-                @test err isa JL.MacroExpansionError
-                @test occursin("@inferred expects one or two arguments", err.msg)
+                @test length(diags) == 1
+                d = only(diags)
+                @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+                @test occursin("@inferred expects one or two arguments", d.msg)
             end
         end
     end
@@ -1182,15 +1169,14 @@ end
     end
 
     @testset "validation" begin
-        # Zero-argument form rejected.
-        let err = try
+        # Zero-argument form: report via sink, recover with `nothing`.
+        let diags = collect_macro_diagnostics() do
                 jlexpand("Base.@assume_effects")
-                nothing
-            catch err
-                err
             end
-            @test err isa JL.MacroExpansionError
-            @test occursin("at least one argument is required", err.msg)
+            @test length(diags) == 1
+            d = only(diags)
+            @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+            @test occursin("at least one argument is required", d.msg)
         end
 
         # Unknown setting name (in non-final position) surfaces as Error severity


### PR DESCRIPTION
Follow-up to 236cb0ec. The previous commit kept `throw_macro_error` as an escape hatch for cases deemed "unrecoverable" — argument-count mismatches, malformed AST shapes, `@kwdef` on non-structs, etc. In practice every one of these has a sensible recovery: drop the offending part and let the user's expression flow through, or fall back to `nothing::K"Value"` when there's nothing left to analyze. The escape hatch was costing LSP UX for no real benefit, so this commit removes it.

All 26 remaining `throw_macro_error` sites in
`src/utils/jl-syntax-macros.jl` are now `push_macro_error!` paired with a recovery expansion:

- variadic fallbacks (`@spawn`, `@label`, `@invoke`, `@invokelatest`, `@test_throws`, `@test_deprecated`, `@inferred`, `@logmsg`) — wrap args in `[block args...]`, or `nothing` when empty
- zero-arg fallbacks (`@assert`, `@debug`/`@info`/`@warn`/`@error`, `@test_logs`, `@testset`, `@assume_effects`) — emit `nothing::K"Value"`
- shape errors that take a single argument (`@kwdef` on non-struct, `@invoke` on a non-call `ex`) — let the argument flow through unchanged so identifiers inside still reach scope analysis
- `_validate_test_kw`, `_validate_testset_option`, and `_destructure_invoke_callex` switch to a "return `nothing` on error" convention; callers skip the malformed entry instead of unwinding the stack
- `_kwdef_make_constructors` on an unrecognized type signature emits no constructors and lets the stripped struct definition proceed

`throw_macro_error` is deleted. The `macro_issue_contract` doc snippet is rewritten to "never throw — always recover" with the common recovery shapes listed inline; the doc table now only distinguishes `push_macro_error!` from `push_macro_warning!`. A short note acknowledges that `JL.MacroExpansionError` can still be thrown from `JuliaLowering` itself (macro-not-found, etc.) and is handled by `per_stmt_diagnostics!`'s fallback path.

User-visible impact: the CHANGELOG entry from af48ca7a already described "any error reported in place keeps the enclosing form analyzable"; this commit extends that to *every* misuse our stubs detect, not just the half-dozen examples called out previously. The CHANGELOG line is updated accordingly.

Tests in `test/utils/test_jl_syntax_macros.jl` switch from `MacroExpansionError` catch+assert to `collect_macro_diagnostics`
+ severity-and-message checks; the existing `recoverable macro stub error keeps enclosing toplevel inferrable` test in `test_TypeAnnotation.jl` already covered the user-visible benefit so no new integration tests are added.