### PR TITLE
utils/docs: Resolve renamed imports in `DocsBinding` via partition API

### DIFF
--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -34,26 +34,24 @@ end
 """
     DocsBinding(parentmod::Module, identifier::Symbol, world::UInt) -> Base.Docs.Binding
 
-Construct a `Base.Docs.Binding` for `parentmod.identifier`, working around
-an upstream bug in `Base.Docs.Binding`'s alias resolution for renamed
-imports — `using X: X as Y` makes the stock constructor produce a binding
-to a non-existent `X.Y`, so doc lookup fails (see JuliaLang/julia#55119).
+Construct a `Base.Docs.Binding` for `parentmod.identifier`, working around an upstream bug
+in `Base.Docs.Binding`'s alias resolution for renamed imports — `using X: y as z` /
+`import X: y as z` make the stock constructor produce a binding to a non-existent `X.z`,
+so doc lookup fails (see JuliaLang/julia#61869).
 
-This wrapper bypasses that resolution when `identifier` resolves to a
-renamed `Module` (`nameof(x) !== identifier`), keeping the binding tied
-to `parentmod.identifier` so doc lookup can find the actual value's docs.
-Function-rename (`using Base: cos as mycos`) hits the same upstream bug
-but isn't handled here — hover routes those through
-[`lookup_doc_for_value`](@ref) instead.
+When `identifier`'s binding partition is an explicit by-name import — the only kinds
+(`PARTITION_KIND_EXPLICIT` / `PARTITION_KIND_IMPORTED`) where `as`-rename is syntactically
+possible — resolve to the canonical `(mod, name)` via the partition's restriction and feed
+that to the stock `Base.Docs.Binding`. Other kinds fall through to the stock constructor
+unchanged.
 """
-function DocsBinding end
-@eval function DocsBinding(parentmod::Module, identifier::Symbol, world::UInt)
+function DocsBinding(parentmod::Module, identifier::Symbol, world::UInt)
     if Base.invoke_in_world(world, isdefinedglobal, parentmod, identifier)
-        x = Base.invoke_in_world(world, getglobal, parentmod, identifier)
-        if x isa Module && nameof(x) !== identifier
-            # Bypass `Base.Docs.Binding`'s buggy alias resolution for
-            # renamed-module imports — see docstring above.
-            return $(Expr(:new, Base.Docs.Binding, :parentmod, :identifier))
+        bpart = Base.lookup_binding_partition(world, GlobalRef(parentmod, identifier))
+        if Base.is_some_explicit_imported(Base.binding_kind(bpart))
+            imported = Base.partition_restriction(bpart)::Core.Binding
+            return Base.invoke_in_world(
+                world, Base.Docs.Binding, imported.globalref.mod, imported.globalref.name)
         end
     end
     return Base.invoke_in_world(world, Base.Docs.Binding, parentmod, identifier)

--- a/test/utils/test_docs.jl
+++ b/test/utils/test_docs.jl
@@ -22,6 +22,16 @@ meth_with_sparam(::T) where T<:Union{Float32,Float64} = nothing
         Tuple{<:Union{Float32,Float64}}
 end
 
+# Fixtures for renamed-import handling in `DocsBinding`. Each module uses
+# `using Base: ... as ...` so the local symbol differs from the canonical
+# name — the case JuliaLang/julia#55119 fails on without the workaround.
+module M_module_rename
+    using Base: Base as B
+end
+module M_function_rename
+    using Base: sum as mysum
+end
+
 # Sample bindings exercised across the lookup tests.
 module M_docs_sample
     """Generic doc for `op`."""
@@ -47,6 +57,19 @@ end
 # calls in `lookup_doc_for_*` reach a world that can see them (avoids
 # Julia 1.12+ "access to binding in a world prior to its definition world").
 const world = Base.get_world_counter()
+
+@testset "DocsBinding resolves `as`-renamed imports" begin
+    # Module rename: `B === Base`, canonical binding is the Base module's
+    # self-reference (normalised to `(Main, :Base)` by Binding's module-symbol
+    # rule), not the non-existent `Base.B`.
+    b = JETLS.DocsBinding(M_module_rename, :B, world)
+    @test b.var === :Base
+
+    # Function rename: canonical is `Base.sum`, not the non-existent `Base.mysum`.
+    b = JETLS.DocsBinding(M_function_rename, :mysum, world)
+    @test b.mod === Base
+    @test b.var === :sum
+end
 
 @testset "narrow_doc_lookup" begin
     b_op = Base.Docs.Binding(M_docs_sample, :op)


### PR DESCRIPTION
The previous `DocsBinding` workaround only caught renamed modules (`using X: X as Y`) by inspecting `nameof(x) !== identifier` after a `getglobal`. Renamed bindings of any other kind — most notably `using X: y as z` for functions — still produced a `Binding(X, :z)` through the buggy `Base.Docs.Binding` constructor and lost doc lookup.

Replace the `nameof` check with a binding partition probe, mirroring the upstream fix proposed in JuliaLang/julia#61869:

- When `(parentmod, identifier)`'s partition kind is `PARTITION_KIND_EXPLICIT` or `PARTITION_KIND_IMPORTED` — the only kinds whose surface syntax (`using X: y as z` / `import X: y as z`) admits an `as`-rename — read the partition's restriction (`Core.Binding`) and feed its globalref's canonical `(mod, name)` to the stock `Base.Docs.Binding` constructor.
- Other kinds (`IMPLICIT_GLOBAL`, `CONST`, local definitions, etc.) fall through to the stock constructor unchanged. The local symbol is the canonical symbol in those cases, so the buggy alias normalisation doesn't apply.

This also lets us drop the `@eval` + `Expr(:new, ...)` bypass: once we hand the constructor a canonical pair, its alias resolution becomes a no-op (or a correct module-symbol normalisation) instead of a destructive rename.

The workaround stays live until the upstream fix lands in a released Julia. New `test/utils/test_docs.jl` cases cover the module-rename case (already supported) and the function-rename case (newly fixed).