### PR TITLE
hover: Strip Documenter `@ref` links in `lsrender`

### DIFF
--- a/src/utils/general.jl
+++ b/src/utils/general.jl
@@ -301,15 +301,24 @@ const JULIA_LIKE_LANGUAGES = [
     "jldoctest"
 ]
 
+# Documenter cross-reference links — `[label](@ref)` / `[label](@ref target)` —
+# get reduced to bare `label` text in LSP output. The target isn't a navigable
+# URL, so clients either pop a "can't open this URI" prompt or silently drop the
+# click; showing the label as plain text is the least surprising fallback until
+# a proper resolver lands.
+const REF_LINK_REGEX = r"\[([^\]]+)\]\(@ref(?:\s[^)]*)?\)"
+strip_ref_links(s::AbstractString) = replace(s, REF_LINK_REGEX => s"\1")
+
 """
     lsrender(md) -> String
 
 Render Markdown for LSP display with the following conversions:
 - Code blocks with Julia-like languages (see `JULIA_LIKE_LANGUAGES`) normalized to "julia"
+- Documenter `@ref` cross-reference links flattened to their label text
 
-TODO: Handle `@ref` correctly
+TODO: Resolve `@ref` targets to actual definitions rather than stripping the link.
 """
-lsrender(md::Union{Markdown.MarkdownElement, Markdown.MD}) = sprint(lsrender, md)
+lsrender(md::Union{Markdown.MarkdownElement, Markdown.MD}) = strip_ref_links(sprint(lsrender, md))
 lsrender(io::IO, md::Markdown.MarkdownElement) = Markdown.plain(io, md)
 
 function lsrender(io::IO, md::Markdown.MD)

--- a/test/utils/test_markdown.jl
+++ b/test/utils/test_markdown.jl
@@ -92,4 +92,37 @@ using JETLS: JL, JS, Markdown
     end
 end
 
+@testset "Documenter @ref links stripped" begin
+    # `[label](@ref)` → bare `label`
+    let md = Markdown.parse("See [foo](@ref) for details.")
+        @test JETLS.lsrender(md) == "See foo for details.\n"
+    end
+
+    # `[label](@ref target)` with explicit target also stripped
+    let md = Markdown.parse("Refer to [Foo](@ref bar) instead.")
+        @test JETLS.lsrender(md) == "Refer to Foo instead.\n"
+    end
+
+    # Code-formatted labels preserve their backticks
+    let md = Markdown.parse("Use [`f`](@ref) and [`g`](@ref baz) here.")
+        @test JETLS.lsrender(md) == "Use `f` and `g` here.\n"
+    end
+
+    # Multiple refs on the same line
+    let md = Markdown.parse("[a](@ref), [b](@ref), and [c](@ref).")
+        @test JETLS.lsrender(md) == "a, b, and c.\n"
+    end
+
+    # Non-@ref links are left untouched
+    let md = Markdown.parse("See [the docs](https://example.com) and [`f`](@ref).")
+        @test JETLS.lsrender(md) ==
+            "See [the docs](https://example.com) and `f`.\n"
+    end
+
+    # `@reference` (not a Documenter ref) must not be stripped
+    let md = Markdown.parse("[link](@reference)")
+        @test JETLS.lsrender(md) == "[link](@reference)\n"
+    end
+end
+
 end # module test_markdown


### PR DESCRIPTION
Reduce Documenter cross-reference links — `[label](@ref)` and `[label](@ref target)` — to their bare label text when rendering docstrings for LSP display. Without this, the unresolved `@ref` URI flowed through `textDocument/hover` and completion documentation verbatim, and clicking the link triggered a "can't open this URI" prompt (or was silently dropped) depending on the editor.

The replacement is a regex pass at the `String`-returning entry of `lsrender`, so every consumer that goes through the existing `LSPostProcessor` path picks it up.

A proper resolver that rewrites `@ref` targets to navigable definitions is left for a follow-up.