### PR TITLE
hover: Render Documenter admonitions as Markdown blockquotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   Previously any of these would propagate a `MacroExpansionError`, remove the entire macrocall from analysis, and take every other LSP feature requiring full lowering of the enclosing function (hover, inlay, signature help, undef-var, references, …) down with it.
   Reports come with `Error` severity when Base would reject the misuse and `Warning` severity when Base accepts it silently or only deprecates.
 
+- Documenter admonitions (`!!! note`, `!!! tip`, `!!! warning`, `!!! danger`, `!!! info`, `!!! compat`) in docstrings now render as Markdown blockquotes with a category-emoji header (e.g. `> **💡 Tip**`) wherever JETLS surfaces docstrings (hover, completion documentation, signature help).
+  Previously the `!!!` block leaked through verbatim, leaving the editor's Markdown view to render it in unintended ways.
+
 ### Fixed
 
 - Fixed spurious diagnostics like `` `{ }` outside of `where` is reserved for future use `` falsely appearing on Jupyter notebook (`.ipynb`) files in VS Code. (Fixed https://github.com/aviatesk/JETLS.jl/issues/703)

--- a/src/utils/general.jl
+++ b/src/utils/general.jl
@@ -337,6 +337,35 @@ function lsrender(io::IO, code::Markdown.Code)
     println(io, "`" ^ n)
 end
 
+function admonition_marker(category::AbstractString)
+    cat = lowercase(category)
+    cat == "note"    && return "📝"
+    cat == "info"    && return "ℹ️"
+    cat == "tip"     && return "💡"
+    cat == "warning" && return "⚠️"
+    cat == "danger"  && return "🚨"
+    cat == "compat"  && return "⬆️"
+    return "💬"
+end
+
+function lsrender(io::IO, ad::Markdown.Admonition)
+    marker = admonition_marker(ad.category)
+    title = isempty(ad.title) ? uppercasefirst(ad.category) : ad.title
+    println(io, "> **", marker, " ", title, "**")
+    isempty(ad.content) && return
+    body = sprint() do bio
+        for i = 1:(length(ad.content)-1)
+            lsrender(bio, ad.content[i])
+            println(bio)
+        end
+        lsrender(bio, ad.content[end])
+    end
+    println(io, ">")
+    for line in eachsplit(rstrip(body), '\n')
+        isempty(line) ? println(io, ">") : println(io, "> ", line)
+    end
+end
+
 @static if VERSION < v"1.13.0-DEV.823" # JuliaLang/julia#58916
 lsrender(io::IO, table::Markdown.Table) = Markdown.plain(io, table)
 lsrender(io::IO, latex::Markdown.LaTeX) = Markdown.plain(io, latex)

--- a/test/utils/test_markdown.jl
+++ b/test/utils/test_markdown.jl
@@ -92,6 +92,141 @@ using JETLS: JL, JS, Markdown
     end
 end
 
+@testset "Documenter admonitions rendered as blockquotes" begin
+    # Default category title → emoji + capitalized category
+    let input = """
+        !!! tip
+            Body text.
+        """
+        expected = """
+        > **💡 Tip**
+        >
+        > Body text.
+        """
+        @test JETLS.lsrender(Markdown.parse(input)) == expected
+    end
+
+    # Custom title overrides the default
+    let input = """
+        !!! warning "Watch out"
+            Be careful.
+        """
+        expected = """
+        > **⚠️ Watch out**
+        >
+        > Be careful.
+        """
+        @test JETLS.lsrender(Markdown.parse(input)) == expected
+    end
+
+    # Multiple paragraphs are separated by `>` lines
+    let input = """
+        !!! info
+            First.
+
+            Second.
+        """
+        expected = """
+        > **ℹ️ Info**
+        >
+        > First.
+        >
+        > Second.
+        """
+        @test JETLS.lsrender(Markdown.parse(input)) == expected
+    end
+
+    # Code block nested in an admonition stays a fenced block under `>`
+    let input = """
+        !!! note
+            See:
+
+            ```julia
+            x = 1
+            ```
+        """
+        expected = """
+        > **📝 Note**
+        >
+        > See:
+        >
+        > ```julia
+        > x = 1
+        > ```
+        """
+        @test JETLS.lsrender(Markdown.parse(input)) == expected
+    end
+
+    # `jldoctest` inside an admonition is also normalized to `julia`
+    let input = """
+        !!! note
+            ```jldoctest
+            julia> 1 + 1
+            2
+            ```
+        """
+        expected = """
+        > **📝 Note**
+        >
+        > ```julia
+        > julia> 1 + 1
+        > 2
+        > ```
+        """
+        @test JETLS.lsrender(Markdown.parse(input)) == expected
+    end
+
+    # Unknown category falls back to the generic marker
+    let input = """
+        !!! custom "My Admonition"
+            Body.
+        """
+        expected = """
+        > **💬 My Admonition**
+        >
+        > Body.
+        """
+        @test JETLS.lsrender(Markdown.parse(input)) == expected
+    end
+
+    # Admonition mixed with surrounding content
+    let input = """
+        Hello.
+
+        !!! danger "!!"
+            Boom.
+
+        After.
+        """
+        expected = """
+        Hello.
+
+        > **🚨 !!**
+        >
+        > Boom.
+
+        After.
+        """
+        @test JETLS.lsrender(Markdown.parse(input)) == expected
+    end
+
+    # All known categories resolve to their dedicated marker
+    let categories = [
+            ("note",    "📝"),
+            ("info",    "ℹ️"),
+            ("tip",     "💡"),
+            ("warning", "⚠️"),
+            ("danger",  "🚨"),
+            ("compat",  "⬆️"),
+        ]
+        for (cat, marker) in categories
+            @test JETLS.admonition_marker(cat) == marker
+            @test JETLS.admonition_marker(uppercase(cat)) == marker
+        end
+        @test JETLS.admonition_marker("something-else") == "💬"
+    end
+end
+
 @testset "Documenter @ref links stripped" begin
     # `[label](@ref)` → bare `label`
     let md = Markdown.parse("See [foo](@ref) for details.")


### PR DESCRIPTION
`lsrender` now converts `Markdown.Admonition` blocks into portable blockquote Markdown so Documenter admonition syntax no longer leaks through verbatim to editor Markdown views.

Each admonition becomes:

    > **<emoji> <Title>**
    >
    > body...

Categories that Documenter's HTML writer styles get a dedicated emoji marker (`note` 📝, `info` ℹ️, `tip` 💡, `warning` ⚠️, `danger` 🚨, `compat` ⬆️); any other category falls back to 💬. The header title defaults to the capitalized category when no explicit `!!! cat "Title"` is given.

This affects every surface that goes through `lsrender`: `textDocument/hover`, completion documentation, signature help, etc.