### PR TITLE
hover/completions: Strip "No documentation found" placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Documenter admonitions (`!!! note`, `!!! tip`, `!!! warning`, `!!! danger`, `!!! info`, `!!! compat`) in docstrings now render as Markdown blockquotes with a category-emoji header (e.g. `> **💡 Tip**`) wherever JETLS surfaces docstrings (hover, completion documentation, signature help).
   Previously the `!!!` block leaked through verbatim, leaving the editor's Markdown view to render it in unintended ways.
 
+- Hover and method-signature completion documentation no longer surface Base's "No documentation found for ..." placeholder paragraph for bindings that exist but carry no docstring. The auto-generated method / type summary that follows the placeholder is still shown, so the hover stays informative without the placeholder noise.
+
 ### Fixed
 
 - Fixed spurious diagnostics like `` `{ }` outside of `where` is reserved for future use `` falsely appearing on Jupyter notebook (`.ipynb`) files in VS Code. (Fixed https://github.com/aviatesk/JETLS.jl/issues/703)

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -58,6 +58,30 @@ function DocsBinding(parentmod::Module, identifier::Symbol, world::UInt)
 end
 
 """
+    lookup_doc_stripped(object, world::UInt) -> Markdown.MD
+
+`Base.Docs.doc(object)` with the leading "No documentation found for ..."
+placeholder paragraph stripped, so hover/completion surfaces don't show that
+noise text for undocumented bindings while still keeping the auto-generated
+method/type summary that follows it.
+"""
+function lookup_doc_stripped(@nospecialize(object), world::UInt)
+    md = Base.invoke_in_world(world, Base.Docs.doc, object)::Markdown.MD
+    # Tied to Base's exact placeholder phrasing (`Base.Docs.summarize` /
+    # `bindingsummary`) — if upstream ever changes that wording, this filter
+    # silently stops working.
+    filtered = filter(md.content) do @nospecialize(m)
+        m isa Markdown.Paragraph || return true
+        content = m.content
+        (content isa Vector{Any} && !isempty(content)) || return true
+        content1 = content[1]
+        content1 isa String || return true
+        return !startswith(content1, "No documentation found for")
+    end
+    return Markdown.MD(filtered, md.meta)
+end
+
+"""
     narrow_doc_lookup(binding::Base.Docs.Binding, sig) -> Markdown.MD | Nothing
 
 Narrowed sig-aware variant of `Base.Docs.doc(binding, sig)`.
@@ -117,10 +141,12 @@ end
 
 Look up the docstring for `parentmod.name`, narrowed by `sig` when provided
 (via [`narrow_doc_lookup`](@ref); no narrowing when `sig === nothing`).
-Returns `nothing` on lookup failure rather than the "No documentation found"
-placeholder `Markdown.MD` that `Base.Docs.doc` would otherwise return — that
-placeholder is preserved by direct call sites that explicitly want the
-user-visible "No documentation found" message.
+Returns `nothing` when the binding is undefined or when lookup throws.
+
+When the binding exists but has no docstring, [`lookup_doc_stripped`](@ref) strips
+the "No documentation found for ..." placeholder paragraph so the
+auto-generated method/type summary still surfaces without the placeholder
+noise.
 """
 function lookup_doc_for_binding(
         parentmod::Module, name::Symbol, @nospecialize(sig), world::UInt
@@ -131,9 +157,9 @@ function lookup_doc_for_binding(
     end
     try
         if sig === nothing
-            return Base.invoke_in_world(world, Base.Docs.doc, binding)::Markdown.MD
+            return lookup_doc_stripped(binding, world)
         end
-        return Base.invoke_in_world(world, narrow_doc_lookup, binding, sig)
+        return Base.invoke_in_world(world, narrow_doc_lookup, binding, sig)::Union{Nothing,Markdown.MD}
     catch
         return nothing
     end
@@ -148,22 +174,24 @@ end
 
 Look up sig-narrowed docs for a `Function` / `Module` / `Type` value `v`,
 resolving its canonical `Base.Docs.Binding` via `aliasof` so cross-module
-`using`-aliases land on the actual owner's `MultiDoc`. Returns the full
-`Base.Docs.doc` result when `sig === nothing` (no narrowing requested).
+`using`-aliases land on the actual owner's `MultiDoc`. When `sig === nothing`,
+returns the [`lookup_doc_stripped`](@ref) result as a fallback.
 
-Restricting to `Function`/`Module`/`Type` keeps literals, struct instances,
-`nothing` / `missing` etc. from surfacing the "No documentation found"
-placeholder that `Base.Docs.doc` produces for arbitrary values.
+The `Function`/`Module`/`Type` restriction skips lookup entirely for
+literals, struct instances, `nothing` / `missing` etc. — values whose
+`Base.Docs.doc` output is *only* the placeholder with no useful summary
+to keep. For documentable values that nonetheless carry no docstring,
+[`lookup_doc_stripped`](@ref) handles the placeholder removal.
 """
 function lookup_doc_for_value(@nospecialize(v), @nospecialize(sig), world::UInt)
     v isa Function || v isa Module || v isa Type || return nothing
     try
         if sig === nothing
-            return Base.invoke_in_world(world, Base.Docs.doc, v)::Markdown.MD
+            return lookup_doc_stripped(v, world)
         end
         binding = Base.invoke_in_world(world, Base.Docs.aliasof, v, typeof(v))
         binding isa Base.Docs.Binding || return nothing
-        return Base.invoke_in_world(world, narrow_doc_lookup, binding, sig)
+        return Base.invoke_in_world(world, narrow_doc_lookup, binding, sig)::Union{Nothing,Markdown.MD}
     catch
         return nothing
     end

--- a/test/test_hover.jl
+++ b/test/test_hover.jl
@@ -59,7 +59,7 @@ end
 # when `get_hover` returns nothing. Other hover scenarios are covered
 # locally via `hover_test` below, which skips the LSP roundtrip and the
 # workspace full-analysis.
-@testset "'Hover' request/response sanity" begin
+@testset HierarchicalTestSet "'Hover' request/response sanity" begin
     @testset "expression hover" begin
         single_hover_test("""
             \"\"\"Documented binding.\"\"\"
@@ -174,20 +174,20 @@ module M_undoc_abstract_dispatch
     gen(a::Vector{T}) where T = a
 end
 
-@testset "'hover' user-binding resolution" begin
+@testset HierarchicalTestSet "'hover' user-binding resolution" begin
     @testset "documented global binding" begin
         hover_test("documented_binding│", "Documented binding.";
             context_module = M_doc_binding)
     end
 
     @testset "undocumented global binding" begin
-        hover_test("undocumented_binding│", "No documentation found";
-            context_module = M_undoc_binding)
+        hover_test("undocumented_binding│", "undocumented_binding";
+            context_module = M_undoc_binding,
+            notpat = "No documentation found")
     end
 
     @testset "non-existent identifier" begin
-        hover_test("unexisting_binding│", r"\(global\) unexisting_binding";
-            notpat = "No documentation found")
+        hover_test("unexisting_binding│", r"\(global\) unexisting_binding")
     end
 
     @testset "global function with docstring" begin
@@ -324,7 +324,7 @@ end
     end
 end
 
-@testset "'hover' Core / Base / locally-bound resolution" begin
+@testset HierarchicalTestSet "'hover' Core / Base / locally-bound resolution" begin
     @testset "Core singleton (`nothing`) docstring" begin
         hover_test("nothing│", JETLS.lsrender(@doc nothing))
     end
@@ -350,7 +350,7 @@ end
     end
 end
 
-@testset "'hover' for local bindings inside a macrocall" begin
+@testset HierarchicalTestSet "'hover' for local bindings inside a macrocall" begin
     # Regression: argument binding `xxx` introduced under `@something` must
     # still resolve to the surrounding function's parameter rather than
     # whatever the macro's expansion happens to reference.
@@ -362,7 +362,7 @@ end
     """, "(argument) xxx")
 end
 
-@testset "'hover' shows inferred type for local bindings" begin
+@testset HierarchicalTestSet "'hover' shows inferred type for local bindings" begin
     @testset "type-annotated argument" begin
         hover_test("""
             function f(x::Int)
@@ -425,7 +425,7 @@ end
     end
 end
 
-@testset "'hover' on call-like surfaces" begin
+@testset HierarchicalTestSet "'hover' on call-like surfaces" begin
     # Selector regression: `[1, 2, 3]│` (cursor right after `]`) used to miss
     # because `K"vect"` wasn't in `select_enclosing_call`'s kind set.
     @testset "array literal" begin

--- a/test/utils/test_docs.jl
+++ b/test/utils/test_docs.jl
@@ -51,6 +51,8 @@ module M_docs_sample
     undoc(x::Int) = x  # no doc
     """Doc for `undoc(::String)`."""
     undoc(x::String) = x
+
+    nodoc(x) = x  # binding with no docstring on any method
 end
 
 # Captured after the fixture modules above are defined so `invoke_in_world`
@@ -190,6 +192,16 @@ end
     @testset "non-existent binding returns nothing" begin
         @test JETLS.lookup_doc_for_binding(M_docs_sample, :nonexistent, nothing, world) === nothing
         @test JETLS.lookup_doc_for_binding(M_docs_sample, :nonexistent, Tuple{Int}, world) === nothing
+    end
+
+    @testset "undocumented binding strips the 'No documentation found' placeholder" begin
+        md = JETLS.lookup_doc_for_binding(M_docs_sample, :nodoc, nothing, world)
+        @test md isa Markdown.MD
+        s = string(md)
+        @test !occursin("No documentation found", s)
+        # The auto-generated summary that follows the placeholder should
+        # survive so the hover surface still has something informative.
+        @test occursin("nodoc", s)
     end
 end
 


### PR DESCRIPTION
When hovering on a binding that exists but carries no docstring (or asking for documentation of an undocumented method), `Base.Docs.doc` returns a `Markdown.MD` that begins with a "No documentation found for ..." paragraph followed by the auto-generated method/type summary. The placeholder paragraph was leaking through to the hover and method-signature completion documentation surfaces as noisy filler.

Introduce `lookup_doc_stripped` to wrap `Base.Docs.doc` and drop that leading paragraph by matching against Base's exact phrasing in `Markdown.Paragraph` content. Route the `sig === nothing` branches of `lookup_doc_for_binding` and `lookup_doc_for_value` through this helper so the placeholder no longer appears while the auto-generated summary that follows it stays intact.