### PR TITLE
completions: Honor `completionItem.resolveSupport.properties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Identifiers inside `@show`, `@debug`, `@info`, `@warn`, `@error`, and `@logmsg` calls — including kwarg values (e.g. `flag` in `@info "msg" extra=flag`) and splatted operands (e.g. `kws` in `@info "msg" kws...`) — are now picked up by scope resolution, so undef-var diagnostics and find-references work for them. Previously the identifiers in these macros were silently ignored. For the logging macros, duplicate kwarg names also surface as `lowering/macro-expansion-error` anchored at the call site.
 
+- Fixed completion items to honor the client's `completionItem.resolveSupport.properties` capability. Previously, properties such as `kind` and `labelDetails` were updated during `completionItem/resolve` regardless of whether the client advertised lazy support for them, which caused visible glitches in some clients (e.g. flickering completion lists in [cmp-nvim-lsp](https://github.com/hrsh7th/cmp-nvim-lsp)). (Closed https://github.com/aviatesk/JETLS.jl/issues/711)
+
 ## 2026-05-08
 
 - Commit: [`72cc49c`](https://github.com/aviatesk/JETLS.jl/commit/72cc49c)

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -881,30 +881,55 @@ end
 const builtin_functions = Core.Builtin[getglobal(Core, n) for n in names(Core) if getglobal(Core, n) isa Core.Builtin]
 const builtin_types = Type[getglobal(Core, n) for n in names(Core) if getglobal(Core, n) isa Type]
 
+# Spec quirks around lazy-resolvable properties (see aviatesk/JETLS.jl#711):
+# - 3.16.0+ with `resolveSupport.properties` declared: the list is exhaustive —
+#   any property not in it cannot be resolved lazily (the resolved value is
+#   silently dropped or even mis-rendered).
+# - Pre-3.16.0 (no `resolveSupport`): only `documentation` and `detail` are
+#   lazy-resolvable. We honor this for backward compatibility.
+function supports_completion_item_resolve(state::ServerState, property::AbstractString)
+    if getobjpath(state, :init_params, :clientInfo, :name) ∈ ("Zed", "Zed Dev")
+        # Special case: Zed under-declares `resolveSupport` but actually applies lazy
+        # updates for every non-`label` field, so opt it into the full set unconditionally.
+        return true
+    end
+    properties = getcapability(state, :textDocument, :completion, :completionItem,
+        :resolveSupport, :properties)
+    if properties !== nothing
+        return property in properties
+    end
+    return property in ("documentation", "detail")
+end
+
 function resolve_completion_item(state::ServerState, item::CompletionItem)
     completion_resolver_info = @something load(state.completion_resolver_info) return item
     data = item.data
     if (data isa GlobalCompletionData &&
         completion_resolver_info isa GlobalCompletionResolverInfo &&
         data.resolver_id == completion_resolver_info.id)
-        return resolve_global_completion_item(item, data, completion_resolver_info)
+        return resolve_global_completion_item(state, item, data, completion_resolver_info)
     elseif (data isa MethodSignatureCompletionData &&
             completion_resolver_info isa MethodSignatureCompletionResolverInfo &&
             data.resolver_id == completion_resolver_info.id)
-        return resolve_method_signature_completion_item(item, data, completion_resolver_info)
+        return resolve_method_signature_completion_item(state, item, data, completion_resolver_info)
     elseif (data isa PropertyCompletionData &&
             completion_resolver_info isa PropertyCompletionResolverInfo &&
             data.resolver_id == completion_resolver_info.id)
-        return resolve_property_completion_item(item, data, completion_resolver_info)
+        return resolve_property_completion_item(state, item, data, completion_resolver_info)
     else
         return item
     end
 end
 
 function resolve_property_completion_item(
-        item::CompletionItem, data::PropertyCompletionData,
+        state::ServerState, item::CompletionItem, data::PropertyCompletionData,
         completion_resolver_info::PropertyCompletionResolverInfo,
     )
+    supports_labelDetails = supports_completion_item_resolve(state, "labelDetails")
+    supports_detail = supports_completion_item_resolve(state, "detail")
+    supports_documentation = supports_completion_item_resolve(state, "documentation")
+    (supports_labelDetails || supports_detail || supports_documentation) || return item
+
     (; prefixtyp, world, postprocessor) = completion_resolver_info
 
     # `Union` (tmerge) the per-component `getproperty(::T, Core.Const(name))` result, so a
@@ -915,27 +940,35 @@ function resolve_property_completion_item(
         gp_rt = @something abstract_call_const(getproperty, Any[comp, name], world) continue
         rawtyp = CC.tmerge(rawtyp, gp_rt)
     end
-
     typstr = truncate_typstr(
         postprocessor(sprint(show, rawtyp; context = :compact => true)),
         #=maxdepth=#3, #=maxwidth=#20)
     detail = " ::" * typstr
-    labelDetails = CompletionItemLabelDetails(; detail, description = "property")
     full_typstr = postprocessor(string(rawtyp))
     value = """
     ```julia
     $(data.prefix).$(data.label) :: $(full_typstr)
     ```
     """
-    documentation = MarkupContent(; kind = MarkupKind.Markdown, value)
 
+    labelDetails = supports_labelDetails ?
+        CompletionItemLabelDetails(; detail, description = "property") : item.labelDetails
+    detail = supports_detail ? detail : item.detail
+    documentation = supports_documentation ?
+        MarkupContent(; kind = MarkupKind.Markdown, value) : item.documentation
     return CompletionItem(item; labelDetails, detail, documentation)
 end
 
 function resolve_global_completion_item(
-        item::CompletionItem, data::GlobalCompletionData,
+        state::ServerState, item::CompletionItem, data::GlobalCompletionData,
         completion_resolver_info::GlobalCompletionResolverInfo
     )
+    supports_labelDetails = supports_completion_item_resolve(state, "labelDetails")
+    supports_kind = supports_completion_item_resolve(state, "kind")
+    supports_detail = supports_completion_item_resolve(state, "detail")
+    supports_documentation = supports_completion_item_resolve(state, "documentation")
+    supports_labelDetails || supports_kind || supports_detail || supports_documentation || return item
+
     (; context_module, world, postprocessor) = completion_resolver_info
     name = Symbol(data.name)
     docs = postprocessor(Base.invoke_in_world(world,
@@ -975,20 +1008,27 @@ function resolve_global_completion_item(
             end
         end
     end
-    if !isnothing(detail)
+
+    if !isnothing(detail) && supports_labelDetails
         labelDetails = CompletionItemLabelDetails(; description = "global " * detail)
     end
-    return CompletionItem(item;
-        labelDetails, kind, detail,
-        documentation = MarkupContent(;
-            kind = MarkupKind.Markdown,
-            value = docs))
+    supports_kind || (kind = item.kind)
+    supports_detail || (detail = item.detail)
+    documentation = supports_documentation ?
+        MarkupContent(; kind = MarkupKind.Markdown, value = docs) : item.documentation
+
+    return CompletionItem(item; labelDetails, kind, detail, documentation)
 end
 
 function resolve_method_signature_completion_item(
-        item::CompletionItem, data::MethodSignatureCompletionData,
+        state::ServerState, item::CompletionItem, data::MethodSignatureCompletionData,
         completion_resolver_info::MethodSignatureCompletionResolverInfo
     )
+    supports_labelDetails = supports_completion_item_resolve(state, "labelDetails")
+    supports_detail = supports_completion_item_resolve(state, "detail")
+    supports_documentation = supports_completion_item_resolve(state, "documentation")
+    supports_labelDetails || supports_detail || supports_documentation || return item
+
     (; world, matches, postprocessor) = completion_resolver_info
     1 ≤ data.match_idx ≤ length(matches) || return item # just to make sure
     match = matches[data.match_idx]
@@ -1009,11 +1049,14 @@ function resolve_method_signature_completion_item(
     ```
     ---
     """ * docstr
-    documentation = MarkupContent(; kind = MarkupKind.Markdown, value)
-    return CompletionItem(item;
-        labelDetails = CompletionItemLabelDetails(; detail, description = "method"),
-        detail,
-        documentation)
+
+    labelDetails = supports_labelDetails ?
+        CompletionItemLabelDetails(; detail, description = "method") : item.labelDetails
+    detail = supports_detail ? detail : item.detail
+    documentation = supports_documentation ?
+        MarkupContent(; kind = MarkupKind.Markdown, value) : item.documentation
+
+    return CompletionItem(item; labelDetails, detail, documentation)
 end
 
 # request handler

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -150,8 +150,8 @@ getcapability(state, :general, :positionEncodings)
 """
 getcapability(server::Server, paths::Symbol...) = getcapability(server.state, paths...)
 function getcapability(state::ServerState, paths::Symbol...)
-    return isdefined(state, :init_params) &&
-        getobjpath(state.init_params.capabilities, paths...)
+    isdefined(state, :init_params) || return nothing
+    return getobjpath(state.init_params.capabilities, paths...)
 end
 
 """

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -362,7 +362,13 @@ function with_completion_items(
     state.init_params = InitializeParams(;
         processId = getpid(),
         rootUri = nothing,
-        capabilities = ClientCapabilities())
+        capabilities = ClientCapabilities(;
+            textDocument = TextDocumentClientCapabilities(;
+                completion = CompletionClientCapabilities(;
+                    completionItem = (;
+                        resolveSupport = (;
+                            properties = ["documentation", "detail", "kind", "labelDetails"])
+                    )))))
     fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)
     JETLS.store!(state.file_cache) do cache
         Base.PersistentDict(cache, uri => fi), nothing


### PR DESCRIPTION
Properties such as `kind` and `labelDetails` were previously updated during `completionItem/resolve` regardless of whether the client opted into lazy resolution for them, causing visible glitches in clients like cmp-nvim-lsp.

`resolve_*_completion_item` now consults
`supports_completion_item_resolve` for each property it would update, falling back to the original value from the request item when the client does not advertise lazy support for that property. When none of the targeted properties are supported, the resolver short-circuits early, skipping reflection and documentation lookups entirely.

Per the LSP spec, `resolveSupport.properties` is treated as an exhaustive list when declared; clients without the capability fall back to the pre-3.16.0 default of `documentation` and `detail` only. Zed is special-cased since it under-declares the capability but actually applies lazy updates for every non- `label` field.

Also fixes `getcapability` to return `nothing` (instead of `false`) when `init_params` has not yet been set, so callers can distinguish "capability not declared" from "capability declared as false".

---

- Closes aviatesk/JETLS.jl#711