### PR TITLE
LSP: Restrict `omitempties` to drop only `nothing`

### DIFF
--- a/LSP/src/DSL/interface.jl
+++ b/LSP/src/DSL/interface.jl
@@ -163,16 +163,13 @@ function process_interface_def!(toplevelblk::Expr, structbody::Expr,
     push!(toplevelblk.args, kwdef)
     if !isempty(omittable_fields)
         omitempties = Tuple(omittable_fields)
-        if Name === :InitializeParams
-            # HACK: In the write->read roundtrip of `InitializationRequest` in the
-            # `withserver` test, empty `workspaceFolders` needs to be serialized without
-            # being omitted. So override the `omitempties` for `InitializeParams`.
-            # In the normal lifecycle of a language server, `InitializeParams` is never
-            # serialized, so adding this hack doesn't affect the language server's behavior
-            # (except in the tests)
-            omitempties = ()
-        end
         push!(toplevelblk.args, :(StructTypes.omitempties(::Type{$Name}) = $omitempties))
+        # Restrict the omitempties check to `=== nothing`. StructTypes' default
+        # `isempty` also drops empty `Vector`/`String`/`Dict`, which would erase a
+        # legitimate `result = T[]` from a response and produce a JSON object with
+        # neither `result` nor `error` — VSCode rejects that shape.
+        push!(toplevelblk.args,
+            :(@inline StructTypes.isempty(::Type{$Name}, x) = x === nothing))
     end
     if is_anon
         push!(toplevelblk.args, :(Base.convert(::Type{$Name}, nt::NamedTuple) = $Name(; nt...)))

--- a/src/code-action.jl
+++ b/src/code-action.jl
@@ -44,7 +44,7 @@ function handle_CodeActionRequest(
     return send(server,
         CodeActionResponse(;
             id = msg.id,
-            result = @somereal code_actions null))
+            result = code_actions))
 end
 
 function unused_variable_code_actions!(

--- a/src/code-lens.jl
+++ b/src/code-lens.jl
@@ -41,7 +41,7 @@ function handle_CodeLensRequest(server::Server, msg::CodeLensRequest, cancel_fla
     return send(server,
         CodeLensResponse(;
             id = msg.id,
-            result = @somereal code_lenses null))
+            result = code_lenses))
 end
 
 const REFERENCES_CODE_LENS_SYMBOL_KINDS = (

--- a/src/declaration.jl
+++ b/src/declaration.jl
@@ -35,9 +35,8 @@ function handle_DeclarationRequest(
     end
     fi = result
 
-    locations, origin_node =
-        find_declaration(server, uri, fi, origin_position; fallback_to_definition=true)
-    if origin_node === nothing || isempty(locations)
+    locations, origin_node = @something find_declaration(
+            server, uri, fi, origin_position; fallback_to_definition=true) begin
         return send(server, DeclarationResponse(; id = msg.id, result = null))
     end
     if supports(server, :textDocument, :declaration, :linkSupport)
@@ -51,19 +50,20 @@ end
 
 """
     find_declaration(server, uri, fi, pos; soft_scope, fallback_to_definition=false) ->
-        (locations::Vector{Location}, origin_node::Union{SyntaxTreeC,Nothing})
+        Union{Tuple{Vector{Location}, SyntaxTreeC}, Nothing}
 
-Core routine behind `textDocument/declaration`. Returns the declaration
-locations for the symbol at `pos` (source-level `:decl` occurrences —
-`import`/`using` sites, `local x`, empty `function foo end`) together
-with the syntax-tree node representing the cursor's origin.
+Core routine behind `textDocument/declaration`. On success returns the
+declaration locations for the symbol at `pos` (source-level `:decl`
+occurrences — `import`/`using` sites, `local x`, empty `function foo end`)
+together with the syntax-tree node representing the cursor's origin.
+Returns `nothing` when no declaration could be located.
 
 With `fallback_to_definition=true`, an empty result falls through to
-[`find_definition`](@ref) so the caller never returns an empty
-response for a resolvable symbol. This mirrors rust-analyzer's
-behavior where "go to declaration" defers to "go to definition" for
-languages that don't have a distinct declaration concept for every
-binding.
+[`find_definition`](@ref), giving the caller a definition site to fall
+back on when a symbol has no distinct declaration. This mirrors
+rust-analyzer's behavior where "go to declaration" defers to "go to
+definition" for languages that don't have a distinct declaration
+concept for every binding.
 """
 function find_declaration(
         server::Server, uri::URI, fi::FileInfo, pos::Position;
@@ -87,7 +87,7 @@ function find_declaration(
         end
         isempty(locations) || return locations, binding
     end
-    fallback_to_definition || return Location[], nothing
+    fallback_to_definition || return nothing
     return find_definition(server, uri, fi, pos; soft_scope)
 end
 

--- a/src/definition.jl
+++ b/src/definition.jl
@@ -89,8 +89,7 @@ function handle_DefinitionRequest(
     end
     fi = result
 
-    locations, origin_node = find_definition(server, uri, fi, origin_position)
-    if origin_node === nothing || isempty(locations)
+    locations, origin_node = @something find_definition(server, uri, fi, origin_position) begin
         return send(server, DefinitionResponse(; id = msg.id, result = null))
     end
     if supports(server, :textDocument, :definition, :linkSupport)
@@ -105,15 +104,13 @@ end
 
 """
     find_definition(server, uri, fi, pos; soft_scope) ->
-        (locations::Vector{Location}, origin_node::Union{SyntaxTreeC,Nothing})
+        Union{Tuple{Vector{Location}, SyntaxTreeC}, Nothing}
 
-Core routine behind `textDocument/definition`. Returns the definition locations for
-the symbol at `pos` together with the syntax-tree node that represents the cursor's
-origin (used by callers to compute `LocationLink.originSelectionRange`).
-An empty `locations` paired with a non-`nothing` `origin_node` means
-"a binding/identifier was found, but no definition location could be produced" — callers
-can treat this the same as "no result".
-`isnothing(origin_node)` means we could not even identify a target node at `pos`.
+Core routine behind `textDocument/definition`. On success returns
+`(locations, origin_node)` where `origin_node` is the syntax-tree node that
+represents the cursor's origin (used by callers to compute
+`LocationLink.originSelectionRange`).
+Returns `nothing` when no definition could be produced at `pos`.
 
 Lookup order:
 1. Call-site matches via the [`TypeAnnotation`](@ref) pipeline: when the cursor is on
@@ -170,7 +167,8 @@ function find_definition(
     binding_jump = find_binding_definitions(server, uri, fi, st0, offset, context_module, soft_scope)
     binding_jump === nothing || return binding_jump
 
-    (node === nothing || rng === nothing) && return Location[], nothing
+    node === nothing && return nothing
+    rng === nothing && return nothing
 
     # Phase 3: value-based fallback (Module → `moduleloc`, callable → all method `functionloc`s).
     # For K"call" surfaces this is reached only when Phase 1's matches narrowing didn't
@@ -188,7 +186,7 @@ function find_definition(
         op_locations === nothing || return op_locations, node
     end
 
-    return Location[], node
+    return nothing
 end
 
 # Phase 1: jump to the methods CC's dispatch picked at a call site —
@@ -265,10 +263,7 @@ function find_global_binding_definitions(
 end
 
 # Phase 3: resolve `node` to a `Core.Const` and surface its definition.
-# - Module value → `Base.moduleloc`. Returns `Location[]` (rather than
-#   `nothing`) when the location is unknown so the caller short-circuits;
-#   Module surfaces aren't in `_OPERATOR_CALL_KINDS`, so Phase 4 wouldn't
-#   fire anyway, but the explicit short-circuit makes the intent clear.
+# - Module value → `Base.moduleloc`. Returns `nothing` when the location is unknown.
 # - Other value → all methods' `functionloc`s. Returns `nothing` when no
 #   resolvable methods remain, letting Phase 4 try the operator dispatch
 #   for call-like surfaces.
@@ -285,8 +280,8 @@ function find_value_definitions(
     objtyp isa Core.Const || return nothing
     objval = objtyp.val
     if objval isa Module
-        is_location_unknown(objval) && return Location[]
-        return [unadjust_location(state, uri, Location(objval))]
+        is_location_unknown(objval) && return nothing
+        return Location[unadjust_location(state, uri, Location(objval))]
     end
     target_methods = filter(!is_location_unknown,
         unique(Base.updated_methodloc, methods_at_world(world, objval)))

--- a/src/document-highlight.jl
+++ b/src/document-highlight.jl
@@ -41,8 +41,7 @@ function handle_DocumentHighlightRequest(
     document_highlights!(highlights, state, uri, fi, pos)
     return send(server, DocumentHighlightResponse(;
         id = msg.id,
-        result = @somereal highlights null
-    ))
+        result = highlights))
 end
 
 function document_highlights!(

--- a/src/document-link.jl
+++ b/src/document-link.jl
@@ -38,7 +38,7 @@ function handle_DocumentLinkRequest(
     return send(server,
         DocumentLinkResponse(;
             id = msg.id,
-            result = @somereal links null))
+            result = links))
 end
 
 function collect_include_document_links!(

--- a/src/document-symbol.jl
+++ b/src/document-symbol.jl
@@ -48,7 +48,7 @@ function handle_DocumentSymbolRequest(
     fi = result
     symbols = get_document_symbols!(state, uri, fi)
     symbols = localize_document_symbols(state, uri, symbols)
-    result = isempty(symbols) ? null : map(strip_name_from_detail, symbols)
+    result = map(strip_name_from_detail, symbols)
     return send(server, DocumentSymbolResponse(; id = msg.id, result))
 end
 

--- a/src/inlay-hint.jl
+++ b/src/inlay-hint.jl
@@ -47,7 +47,7 @@ function handle_InlayHintRequest(
 
     return send(server, InlayHintResponse(;
         id = msg.id,
-        result = @somereal localize_inlay_hints(state, uri, inlay_hints) null))
+        result = localize_inlay_hints(state, uri, inlay_hints)))
 end
 
 const INLAY_HINT_MIN_LINES = 25

--- a/src/references.jl
+++ b/src/references.jl
@@ -74,7 +74,7 @@ function do_find_references(
     if result isa ResponseError
         return send(server, ReferencesResponse(; id = msg_id, result = nothing, error = result))
     else
-        return send(server, ReferencesResponse(; id = msg_id, result = @somereal result null))
+        return send(server, ReferencesResponse(; id = msg_id, result))
     end
 end
 

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -645,10 +645,9 @@ function handle_SignatureHelpRequest(
     return send(server,
         SignatureHelpResponse(;
             id = msg.id,
-            result = isempty(signatures) ?
-              null
-            : SignatureHelp(;
-                  signatures,
-                  activeSignature,
-                  activeParameter)))
+            result = isempty(signatures) ? null :
+                SignatureHelp(;
+                    signatures,
+                    activeSignature,
+                    activeParameter)))
 end

--- a/src/type-definition.jl
+++ b/src/type-definition.jl
@@ -73,9 +73,7 @@ function find_type_definition(server::Server, uri::URI, fi::FileInfo, pos::Posit
     typ = @something infer_type_at_range(st0_top, context_module, rng; world) return nothing
 
     target_type = @something extract_target_type(typ) return nothing
-    locations = type_locations(state, uri, target_type, world)
-    isempty(locations) && return nothing
-    return locations, node
+    return type_locations(state, uri, target_type, world), node
 end
 
 # Convert a lattice element to a concrete `Type` whose definition the user wants

--- a/src/workspace-symbol.jl
+++ b/src/workspace-symbol.jl
@@ -59,15 +59,15 @@ end
 function do_workspace_symbol(
         server::Server, msg_id::MessageId, params::WorkspaceSymbolParams;
         kwargs...)
-    symbols = workspace_symbol(server, params; kwargs...)
+    symbols = workspace_symbols(server, params; kwargs...)
     if symbols isa ResponseError
         return send(server, WorkspaceSymbolResponse(; id = msg_id, result = nothing, error = request_cancelled_error()))
     else
-        return send(server, WorkspaceSymbolResponse(; id = msg_id, result = @somereal symbols null))
+        return send(server, WorkspaceSymbolResponse(; id = msg_id, result = symbols))
     end
 end
 
-function workspace_symbol(
+function workspace_symbols(
         server::Server, params::WorkspaceSymbolParams;
         token::Union{Nothing,ProgressToken} = nothing,
         kwargs...

--- a/test/test_declaration.jl
+++ b/test/test_declaration.jl
@@ -21,8 +21,8 @@ function declaration_testcase(
     end
     return server, fi, positions, furi
 end
-find_declaration_locations(server, furi, fi, pos) =
-    first(JETLS.find_declaration(server, furi, fi, pos))
+find_declaration_locations(server, furi, fi, pos; kwargs...) =
+    first(@something JETLS.find_declaration(server, furi, fi, pos; kwargs...) return nothing)
 
 @testset "declaration for imported names" begin
     let code = """
@@ -84,8 +84,7 @@ end
         """
         server, fi, positions, furi = declaration_testcase(code, 4)
         for pos in positions
-            locations = find_declaration_locations(server, furi, fi, pos)
-            @test isempty(locations)
+            @test isnothing(find_declaration_locations(server, furi, fi, pos))
         end
     end
 end
@@ -99,7 +98,7 @@ end
         """
         server, fi, positions, furi = declaration_testcase(code, 4)
         for pos in positions
-            locations, _ = JETLS.find_declaration(
+            locations = find_declaration_locations(
                 server, furi, fi, pos; fallback_to_definition=true)
             @test length(locations) == 1
             @test only(locations).uri == furi
@@ -115,7 +114,7 @@ end
         """
         server, fi, positions, furi = declaration_testcase(code, 4)
         for pos in positions
-            locations, _ = JETLS.find_declaration(
+            locations = find_declaration_locations(
                 server, furi, fi, pos; fallback_to_definition=true)
             @test length(locations) == 1
             @test only(locations).uri == furi

--- a/test/test_definition.jl
+++ b/test/test_definition.jl
@@ -71,11 +71,10 @@ end
     end == 1
 end
 
-# Single-cursor `find_definition` wrapper that skips the LSP roundtrip
-# and the workspace full-analysis. `context_module` overrides the
-# analysis-derived module so the test can seed the lookup with a
-# pre-populated side module (defined as a runtime `module ... end` in
-# this file). Returns `(locations, origin_node)` like `JETLS.find_definition`.
+# Single-cursor `find_definition` wrapper that skips the LSP roundtrip and the workspace
+# full-analysis. `context_module` overrides the analysis-derived module so the test can
+# seed the lookup with a pre-populated side module (defined as a runtime `module ... end`
+# in this file).
 function find_definition(
         text::AbstractString, pos::Position;
         filename::AbstractString = joinpath(@__DIR__, "testfile_$(gensym(:definition)).jl"),
@@ -91,7 +90,7 @@ function find_definition(
 end
 
 # `definition_test(text, expected; ...)` — single-cursor assertion shorthand.
-# `expected === nothing`    → expects `find_definition` to return no locations.
+# `expected === nothing`    → expects `find_definition` to return `nothing`.
 # `expected isa Int`        → expects exactly one location at `expected`
 #                              (0-based line). File is not checked — for
 #                              in-source jumps the URI is a gensym'd temp file,
@@ -106,10 +105,12 @@ function definition_test(
     )
     clean_text, positions = JETLS.get_text_and_positions(text)
     @assert length(positions) == 1
-    locations, _ = find_definition(clean_text, only(positions); context_module)
+    result = find_definition(clean_text, only(positions); context_module)
     if expected === nothing
-        @test isempty(locations) broken=broken
-    elseif expected isa Int
+        return @test result === nothing broken=broken
+    end
+    locations, _ = @something result
+    if expected isa Int
         @test length(locations) == 1 broken=broken
         if length(locations) == 1
             @test first(locations).range.start.line == expected broken=broken
@@ -198,12 +199,12 @@ end
 
         @testset "`Base.Compiler.tmeet` resolves" begin
             text, positions = JETLS.get_text_and_positions("Base.Compiler.tm│eet")
-            locs, _ = find_definition(text, only(positions))
+            locs, _ = @something find_definition(text, only(positions)) error("expected result")
             @test length(locs) >= 1
         end
         @testset "`sin(1.0)` jumps to `Base.sin(::Float64)`" begin
             text, positions = JETLS.get_text_and_positions("si│n(1.0)")
-            locs, _ = find_definition(text, only(positions))
+            locs, _ = @something find_definition(text, only(positions)) error("expected result")
             @test any(locs) do l
                 JETLS.uri2filepath(l.uri) == sin_cand_file &&
                 l.range.start.line == (sin_cand_line - 1)
@@ -211,7 +212,7 @@ end
         end
         @testset "`+` operator resolves" begin
             text, positions = JETLS.get_text_and_positions("1 +│ 2")
-            locs, _ = find_definition(text, only(positions))
+            locs, _ = @something find_definition(text, only(positions)) error("expected result")
             @test length(locs) >= 1
         end
         @testset "`Base.cos(x)` ignores local `cos(x) = 1`" begin
@@ -222,7 +223,7 @@ end
                         Base.co│s(x)
                     end
                 """)
-            locs, _ = find_definition(text, only(positions); filename)
+            locs, _ = @something find_definition(text, only(positions); filename) error("expected result")
             @test length(locs) >= 1
             @test all(l -> JETLS.uri2filepath(l.uri) != filename, locs)
         end
@@ -247,7 +248,7 @@ end
                     $cursor_text
                 end
             """)
-            locs, _ = find_definition(text, only(positions))
+            locs, _ = @something find_definition(text, only(positions)) error("expected result")
             return locs
         end
 
@@ -422,7 +423,7 @@ end
                 si│n(1.0)
             end
         """)
-    locs, _ = find_definition(text, only(positions); filename)
+    locs, _ = @something find_definition(text, only(positions); filename) error("expected result")
     @test length(locs) >= 1
     # Jump must go outside the synthetic source (to `Base`'s source).
     @test all(l -> JETLS.uri2filepath(l.uri) != filename, locs)


### PR DESCRIPTION
StructTypes' default `isempty` collapses empty `Vector`, `String`, and `Dict` into the omitempties list, so a response with `result = T[]` serialized into a JSON object containing neither `result` nor `error` — a shape VSCode rejects. Recent workarounds in 48d7ad83 and 014ec1e7 papered over this in individual handlers via `@somereal X null`, but the root cause lived in the LSP DSL.

For every `@interface` struct with omittable fields, define `StructTypes.isempty(::Type{T}, x) = x === nothing` so only `nothing` fields get dropped. Empty arrays now go out as `[]`.

With this in place:
- Drop the `InitializeParams` HACK that overrode `omitempties = ()` purely to keep an empty `workspaceFolders` alive in the `withserver` test roundtrip.
- Drop per-handler `@somereal X null` workarounds in `code-action`, `code-lens`, `document-highlight`, `document-link`, `document-symbol`, `inlay-hint`, `references`, and `workspace-symbol`.
- Refactor `find_declaration` / `find_definition` / `find_type_definition` to return `Union{Tuple{Vector{Location}, SyntaxTreeC}, Nothing}` so the "no result" path is signalled via `nothing` rather than an empty vector. Callers use `@something` to short-circuit and send `result = null`.
- Rename `workspace_symbol` to `workspace_symbols` to match its plural return value.

Side benefit: the override inlines to `===` instead of dispatching through the generic `isempty(x)`, so write-heavy paths get a small-to-large speedup. The biggest measured win is `InitializeResult` serialization at ~4x with half the allocations; typical `CompletionResponse` payloads are unchanged within noise.