### PR TITLE
file-cache: Always cache pruned `st0`

### DIFF
--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -1099,6 +1099,12 @@ function get_type_for_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
         return Core.Const(nothing)
     elseif surface_kind in JS.KSet"function macro"
         return type_for_funcdef(ctx, rng)
+    elseif surface_kind === JS.K"="
+        # Pruned `st0` can collapse short-form function-definition provenance from
+        # `K"function"` to the surface `K"="`. The inferred tree still carries the
+        # method-like lowered node, so use that as the authoritative signal.
+        typ = type_for_funcdef(ctx, rng)
+        typ === nothing || return typ
     elseif surface_kind in JS.KSet"comparison && || if ?"
         # Ternary `b ? x : 0` is `K"if"` in the surface tree but `K"?"` in the
         # inferred tree's provenance (JuliaLowering retains the parser kind).

--- a/src/document-symbol.jl
+++ b/src/document-symbol.jl
@@ -958,7 +958,9 @@ function extract_local_scope_bindings!(
             # `func(x) = (@asis y = 42; x + y)` using `macro asis(x); :($(esc(x))); end`,
             # we might want `y` to appear in the outline.
             if length(prov) > 1
-                if !is_nospecialize_or_specialize_macrocall3(source_node)
+                if !(is_nospecialize_or_specialize_macrocall3(source_node) ||
+                     # After pruning st0 the `@nospecialize` textref can survive in st0 macrocall shape.
+                     is_nospecialize_or_specialize_macrocall0(source_node))
                     continue
                 end
             end

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -36,7 +36,8 @@ function cache_file_info!(
     st0 = JS.build_tree(JS.SyntaxTree, parsed_stream; filename)
     testsetinfos, any_deleted = compute_testsetinfos!(server, st0, prev_testsetinfos)
 
-    fi = FileInfo(version, parsed_stream, filename, state.encoding, testsetinfos)
+    fi = FileInfo(version, parsed_stream, filename, state.encoding, testsetinfos;
+        syntax_tree0=st0)
     store!(state.file_cache) do cache
         Base.PersistentDict(cache, uri => fi), nothing
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -53,19 +53,17 @@ function build_line_starts(textbuf::Vector{UInt8})
     return starts
 end
 
-# Primary file cache for document synchronization.
-# Created on `textDocument/didOpen` and updated on `textDocument/didChange`.
-# Contains the current editor state, including unsaved edits.
+# Current text snapshot for both synchronized documents and on-demand unsynced workspace
+# files, plus per-version caches derived from the parsed stream.
 struct FileInfo
     version::Int
     parsed_stream::JS.ParseStream
     filename::String
     encoding::LSP.PositionEncodingKind.Ty
     testsetinfos::Vector{TestsetInfo}
-    # Optional pruned `st0` cache, currently used for unsynced workspace files
-    # whose trees are scanned repeatedly by diagnostics and global occurrence search.
-    # Access through `build_syntax_tree`, which returns a copy safe for lowering.
-    syntax_tree0::Union{Nothing,SyntaxTreeC}
+    # Pruned `st0` cache. Access through `build_syntax_tree`, which returns a copy
+    # safe for lowering.
+    syntax_tree0::SyntaxTreeC
     # Cached line-starts index for the current `parsed_stream.textbuf`. `offset_to_xy`
     # / `xy_to_offset` are called heavily by every LSP feature, so amortizing the
     # O(N) line scan once per FileInfo (constructed on didOpen / didChange) is a
@@ -76,13 +74,14 @@ struct FileInfo
             version::Int, parsed_stream::JS.ParseStream, filename::AbstractString,
             encoding::LSP.PositionEncodingKind.Ty = LSP.PositionEncodingKind.UTF16,
             testsetinfos::Vector{TestsetInfo} = EMPTY_TESTSETINFOS;
-            cache_tree::Bool = false
+            syntax_tree0::Union{Nothing,SyntaxTreeC} = nothing
         )
-        if cache_tree
-            syntax_tree0 = JS.prune(JS.build_tree(JS.SyntaxTree, parsed_stream; filename))
+        syntax_tree0 = if syntax_tree0 === nothing
+            JS.build_tree(JS.SyntaxTree, parsed_stream; filename)
         else
-            syntax_tree0 = nothing
+            syntax_tree0
         end
+        syntax_tree0 = JS.prune(syntax_tree0)
         line_starts = build_line_starts(parsed_stream.textbuf)
         new(version, parsed_stream, filename, encoding, testsetinfos, syntax_tree0, line_starts)
     end

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -12,14 +12,9 @@ function copy_syntax_tree(st::SyntaxTreeC)
 end
 
 function build_syntax_tree(fi::FileInfo)
-    cached = fi.syntax_tree0
-    if isnothing(cached)
-        return JS.build_tree(JS.SyntaxTree, fi.parsed_stream; filename = fi.filename)
-    else
-        # The lowering pipeline modifies the internal state of `st0`,
-        # so we need to create a copy for each read to avoid race conditions
-        return copy_syntax_tree(cached)
-    end
+    # The lowering pipeline modifies the internal state of `st0`,
+    # so we need to create a copy for each read to avoid race conditions.
+    return copy_syntax_tree(fi.syntax_tree0)
 end
 
 @static if JL.DEBUG
@@ -200,6 +195,9 @@ end
 is_mainfunc0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@main")
 
 is_generated0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@generated")
+
+is_nospecialize_or_specialize_macrocall0(st0::SyntaxTreeC) =
+    is_macrocall_st0(st0, "@nospecialize", "@specialize")
 
 is_macro0(st0::SyntaxTreeC) = JS.kind(st0) === JS.K"macro"
 

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -275,7 +275,7 @@ function _store_unsynced_file_info!(state::ServerState, uri::URI; force::Bool=fa
             JETLS_DEV_MODE && Base.showerror(stderr, e, catch_backtrace())
             return cache, nothing
         end
-        fi = FileInfo(version, parsed_stream, filename, state.encoding; cache_tree=true)
+        fi = FileInfo(version, parsed_stream, filename, state.encoding)
         return UnsyncedFileCacheData(cache, uri => fi), fi
     end
 end


### PR DESCRIPTION
`FileInfo` now always stores a pruned `st0` snapshot. Single-file latency wins are expected to be modest because rebuilding `st0` is usually only a few milliseconds, but reusing the tree avoids repeated allocations across hover, definition, document symbols, and occurrence queries for the same document version.

`build_syntax_tree` returns a copy of that cache so lowering can mutate the tree without touching shared state. The synced-document path reuses the tree already built for testset discovery, and unsynced files no longer need a separate `cache_tree` switch.

Performance measurement example: On this commit, `src/diagnostic.jl` is about 89KiB. Rebuilding `st0` for it takes about 11ms and allocates 12.1MiB across 153k objects. Building and pruning the initial cache takes about 22ms and 18.2MiB across 191k objects, while copying the cached pruned tree takes about 60us and 1.4MiB across 49 objects.

That tradeoff is acceptable for synced documents because a normal edit is followed by several same-version requests, such as diagnostics, document links, document highlights, semantic tokens, and code actions. User interaction can then add hover, definition, document symbols, and occurrence queries.

One caveat is that `JS.prune` preserves source locations but can collapse source-only provenance nodes. For example, short-form function definitions may lose the intermediate `K"function"` node and surface as `K"="` instead. `TypeAnnotation` handles this by falling back to method-like lowered nodes when dispatching type queries for that range.

The same caveat appears in document symbols for `@nospecialize` arguments. After pruning, the provenance textref can survive in an st0-shaped macrocall, so document-symbol extraction accepts that shape alongside the st3 macrocall form.