### PR TITLE
file-cache: Cache inferred tree contexts

### DIFF
--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -10,30 +10,25 @@ byte-range type lookups.
 
 LSP feature code should normally only need these:
 
-- [`infer_type_at_range`](@ref) — single-shot "type at this byte range",
-  for features that issue one query per cursor position (go to type
-  definition, single hover-type, …).
-- [`build_inferred_context_at`](@ref) — build an [`InferredTreeContext`](@ref) once for a
-  toplevel and reuse it across multiple queries on the same context
-  (signature help and call completion query the function head plus each argument).
-- [`get_type_for_range`](@ref) — the byte-range → type query; call against a
-  context returned by `build_inferred_context_at`.
-- [`get_matches_for_range`](@ref) — the byte-range → `Vector{Core.MethodMatch}`
-  query. Returns the methods CC's dispatch picked at a call site, for features
-  that want narrower jumps than `methods(callee)` (go-to-method-definition).
-- [`InferredTreeContext`](@ref) — the query handle exported so feature
-  code can spell its type in signatures (e.g. `Union{Nothing,InferredTreeContext}`).
+- [`build_inferred_context_for_range`](@ref) locates the top-level tree containing a
+  byte range and returns an [`InferredTreeContext`](@ref). Pass `cache` when the
+  caller can reuse inferred contexts for the same document version.
+- [`get_type_for_range`](@ref) queries the inferred type at a surface byte range
+  from an [`InferredTreeContext`](@ref).
+- [`get_matches_for_range`](@ref) queries the `Vector{Core.MethodMatch}` that
+  CC's dispatch picked at a call site, for features that want narrower jumps
+  than `methods(callee)` (go-to-method-definition).
+- [`InferredTreeContext`](@ref) is exported so feature code can spell its type
+  in signatures (e.g. `Union{Nothing,InferredTreeContext}`).
 
-The full pipeline below is documented because the prerequisites and
-limitations propagate to the exported API — every type the exported entries
-surface (whether through `infer_type_at_range` or through `get_type_for_range`
-on a context built by `build_inferred_context_at`) is subject to the
-constraints in "Prerequisite" and "Limitations".
+The lower-level pipeline is documented because its prerequisites and
+limitations determine what the exported API can return. In particular, every
+type surfaced through [`get_type_for_range`](@ref) is subject to the constraints
+in "Prerequisite" and "Limitations".
 
 # Pipeline
 
-The four public pieces interlock in a fixed order — each step's output feeds the
-next:
+The pipeline has four steps. Each step's output feeds the next:
 
 1. **Lower for scope resolution**:
    [`get_inferrable_tree(st0::SyntaxTreeC, context_module::Module) -> (; ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC) | nothing`](@ref get_inferrable_tree)
@@ -50,10 +45,10 @@ next:
    toplevel and inside method bodies — carry per-statement types.
 
 3. **Build query indexes**:
-   [`InferredTreeContext(inferred_tree::SyntaxTreeC, st3::SyntaxTreeC) -> ctx::InferredTreeContext`](@ref InferredTreeContext)
-   wraps the annotated tree with \$O(N)\$-built indexes (`by_byte_range`, `surface_kind_index`,
-   OC body scope, …) so downstream queries are \$O(1)\$ per call.
-   Build once per inferred tree, reuse across many queries.
+   [`build_inferred_context_for_range`](@ref) wraps the annotated tree with
+   \$O(N)\$-built indexes (`by_byte_range`, `surface_kind_index`, OC body scope,
+   …) so downstream queries are \$O(1)\$ per call. Build once per inferred tree,
+   reuse across many queries.
 
 4. **Query**:
    [`get_type_for_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer}) -> typ`](@ref get_type_for_range)
@@ -61,10 +56,9 @@ next:
    the lowered surface kind (`K"call"`, `K"macrocall"`, `K"function"`, branching forms, …)
    and returns the inferred lattice element.
 
-For LSP feature code, [`build_inferred_context_at`](@ref) collapses steps 1–3 into a single
-call (locate the toplevel containing a byte range, run the pipeline,
-return a ready-to-query [`InferredTreeContext`](@ref)).
-[`infer_type_at_range`](@ref) further folds in step 4 for the common single-query case.
+For LSP feature code, [`build_inferred_context_for_range`](@ref) collapses steps 1–3 into
+a single call (locate the toplevel containing a byte range, run the pipeline, return a
+ready-to-query [`InferredTreeContext`](@ref), optionally through a per-document-version cache).
 
 # Prerequisite: full-analysis must have run first
 
@@ -134,12 +128,13 @@ module TypeAnnotation
 
 using Core.IR
 using JET: CC
-using ..JETLS: JETLS_DEBUG_LOWERING, JL, JS, SyntaxTreeC, TraversalReturn,
-    iterate_toplevel_tree, jl_lower_for_scope_resolution, rewrite_local_closures_to_opaque,
-    traversal_terminator, traverse
+using ..JETLS: InferredContextCache, InferredContextCacheData, JETLS_DEBUG_LOWERING,
+    JL, JS, SyntaxTreeC, TraversalReturn, iterate_toplevel_tree,
+    jl_lower_for_scope_resolution, load, rewrite_local_closures_to_opaque, store!, traverse
+import ..JETLS: InferredTreeContext
 
-export InferredTreeContext, build_inferred_context_at, get_matches_for_range,
-    get_type_for_range, infer_type_at_range
+export InferredTreeContext, build_inferred_context_for_range, get_matches_for_range,
+    get_type_for_range
 
 # ASTTypeAnnotator
 # ================
@@ -838,14 +833,16 @@ end
 
 """
     InferredTreeContext(
-            inferred_tree::SyntaxTreeC, st3::SyntaxTreeC
+            inferred_tree::SyntaxTreeC, st3::SyntaxTreeC,
+            surface_kind_index::Dict{UnitRange{Int},JS.Kind},
+            macrocall_types::Dict{UnitRange{Int},Vector{Any}}
         ) -> ctx::InferredTreeContext
 
 [`TypeAnnotation`](@ref) pipeline step 3: wrap an annotated `inferred_tree` (from
 [`infer_toplevel_tree`](@ref)) plus the post-scope-resolution `st3` (from
-[`get_inferrable_tree`](@ref)) with prebuilt indexes, yielding a query handle
-that [`get_type_for_range`](@ref) and friends can answer in \$O(1)\$ per call (or
-\$O(log N)\$ for the branching case).
+[`get_inferrable_tree`](@ref)) and provenance indexes built before pruning,
+yielding a query handle that [`get_type_for_range`](@ref) and friends can answer
+in \$O(1)\$ per call (or \$O(log N)\$ for the branching case).
 
 `st3` (rather than the surface tree) is needed to identify byte ranges of
 *user-written* `K"return"` surface forms, which `type_for_branching` looks up
@@ -861,76 +858,24 @@ as new queries demand different indexes.
 
 See the [`TypeAnnotation`](@ref) module docstring for the full pipeline.
 """
-struct InferredTreeContext
-    inferred_tree::SyntaxTreeC
-    # `byte_range => kind` for the surface node each lowered node was lowered
-    # from (first element of `JS.flattened_provenance`). First-write-wins,
-    # mirroring a `traverse`-then-pick-first lookup.
-    surface_kind_index::Dict{UnitRange{Int}, JS.Kind}
-    # Every lowered node keyed by its own `byte_range`, in preorder. The
-    # preorder property is load-bearing for the "last `K"call"` wins"
-    # semantics in `type_for_call`.
-    by_byte_range::Dict{UnitRange{Int}, Vector{SyntaxTreeC}}
-    # Typed `K"call"` nodes whose first provenance is a `K"macrocall"`, keyed
-    # by the **macrocall's** `byte_range` (not the lowered call's own range —
-    # string macros lower to a `K"call"` with a smaller span than the
-    # macrocall, so we key by the surface span the user wrote).
-    macrocall_typed_calls::Dict{UnitRange{Int}, Vector{SyntaxTreeC}}
-    # Every `K"return"` node, in two parallel `Vector`s sorted by
-    # `JS.first_byte` (so `searchsortedfirst` is valid on `return_first_bytes`).
-    # User-vs-synthetic classification is derived per-query from
-    # `user_return_form_ranges` below — @mlechu's idea.
-    return_first_bytes::Vector{Int}
-    return_nodes::Vector{SyntaxTreeC}
-    # Byte ranges of every user-written `K"return"` surface form in `st3`
-    # (`st3` not `st0` so macro-expansion-introduced `K"return"`s are included).
-    # Consumed by `type_for_branching`.
-    user_return_form_ranges::Vector{UnitRange{Int}}
-    # For each lowered node inside the body of some OC, the byte range of that OC's
-    # `K"opaque_closure_method"`. Used by `tmerge_at_range` to filter OC construction
-    # scaffolding sharing a byte range with the user's yield expression: a node is kept
-    # only when the OC whose body it's in has the queried byte range — so inner-OC noise
-    # inside an outer OC body (e.g. multi-`for` comprehension, closure-of-closure) is
-    # filtered when querying at the inner OC's range.
-    oc_body_scope::Dict{Int,UnitRange{Int}}
-end
-
-function InferredTreeContext(inferred_tree::SyntaxTreeC, st3::SyntaxTreeC)
-    surface_kind_index = Dict{UnitRange{Int}, JS.Kind}()
+function InferredTreeContext(
+        inferred_tree::SyntaxTreeC, st3::SyntaxTreeC,
+        surface_kind_index::Dict{UnitRange{Int},JS.Kind},
+        macrocall_types::Dict{UnitRange{Int},Vector{Any}}
+    )
     by_byte_range = Dict{UnitRange{Int}, Vector{SyntaxTreeC}}()
-    macrocall_typed_calls = Dict{UnitRange{Int}, Vector{SyntaxTreeC}}()
     return_first_bytes = Int[]
     return_nodes = SyntaxTreeC[]
 
+    # These indexes retain tree nodes, so they must be built from the pruned tree;
+    # otherwise the context would keep the unpruned graph alive.
     traverse(inferred_tree) do st::SyntaxTreeC
         rng = JS.byte_range(st)
         push!(get!(Vector{SyntaxTreeC}, by_byte_range, rng), st)
-
-        provs = JS.flattened_provenance(st)
-        if !isempty(provs)
-            fprov = first(provs)
-            fprov_rng = JS.byte_range(fprov)
-            # Register *every* provenance entry, not just `first(provs)`. For
-            # macro-wrapped surface forms — `@inline f(x) = body` whose chain is
-            # `[macrocall, function]` — this makes the inner funcdef's span queryable
-            # in addition to the macrocall's outer span.
-            for prov in provs
-                prov_rng = JS.byte_range(prov)
-                haskey(surface_kind_index, prov_rng) ||
-                    (surface_kind_index[prov_rng] = JS.kind(prov))
-            end
-
-            if JS.kind(st) === JS.K"call" && hasproperty(st, :type) &&
-                    length(provs) >= 2 && JS.kind(fprov) === JS.K"macrocall"
-                push!(get!(Vector{SyntaxTreeC}, macrocall_typed_calls, fprov_rng), st)
-            end
-        end
-
         if JS.kind(st) === JS.K"return"
             push!(return_first_bytes, JS.first_byte(st))
             push!(return_nodes, st)
         end
-
         return nothing
     end
 
@@ -947,8 +892,33 @@ function InferredTreeContext(inferred_tree::SyntaxTreeC, st3::SyntaxTreeC)
 
     return InferredTreeContext(
         inferred_tree, surface_kind_index, by_byte_range,
-        macrocall_typed_calls, return_first_bytes, return_nodes,
+        macrocall_types, return_first_bytes, return_nodes,
         user_return_form_ranges, oc_body_scope)
+end
+
+function collect_provenance_indexes(inferred_tree::SyntaxTreeC)
+    surface_kind_index = Dict{UnitRange{Int},JS.Kind}()
+    macrocall_types = Dict{UnitRange{Int},Vector{Any}}()
+    traverse(inferred_tree) do st::SyntaxTreeC
+        provs = JS.flattened_provenance(st)
+        if !isempty(provs)
+            # Register *every* provenance entry, not just `first(provs)`. For
+            # macro-wrapped surface forms — `@inline f(x) = body` whose chain is
+            # `[macrocall, function]` — this makes the inner funcdef's span queryable
+            # in addition to the macrocall's outer span.
+            for prov in provs
+                prov_rng = JS.byte_range(prov)
+                haskey(surface_kind_index, prov_rng) ||
+                    (surface_kind_index[prov_rng] = JS.kind(prov))
+            end
+        end
+        if JS.kind(st) === JS.K"call" && hasproperty(st, :type) &&
+                length(provs) >= 2 && JS.kind(first(provs)) === JS.K"macrocall"
+            push!(get!(Vector{Any}, macrocall_types, JS.byte_range(first(provs))), st.type)
+        end
+        return nothing
+    end
+    return surface_kind_index, macrocall_types
 end
 
 # `K"code_info"` only marks an OC body when it's the body slot of a
@@ -1003,62 +973,70 @@ function find_outermost_user_return_form(
 end
 
 """
-    build_inferred_context_at(
+    build_inferred_context_for_range(
             st0_top::SyntaxTreeC, context_module::Module, rng::UnitRange{<:Integer};
             world::UInt = Base.get_world_counter(),
-            caller::AbstractString = "build_inferred_context_at"
+            caller::AbstractString = "build_inferred_context_for_range",
+            cache::Union{Nothing,InferredContextCache} = nothing
         ) -> ctx::InferredTreeContext | nothing
 
 Compose [`TypeAnnotation`](@ref) pipeline steps 1–3 into a single call: locate the
 top-level subtree of `st0_top` that contains `rng`, run [`get_inferrable_tree`](@ref)
 and [`infer_toplevel_tree`](@ref) on it, and wrap the result in an
-[`InferredTreeContext`](@ref). Returns `nothing` when no top-level subtree contains `rng`,
-or when lowering / inference fails.
+[`InferredTreeContext`](@ref).
+Returns `nothing` when no top-level subtree contains `rng`, or when lowering / inference fails.
 
-The standard entry point for LSP features that need to issue **multiple**
-[`get_type_for_range`](@ref) queries against the same toplevel — e.g. signature
-help looks up the function's type and then each argument's type. For a single
-range lookup, [`infer_type_at_range`](@ref) is the convenience shortcut that
-also folds in step 4.
+This is the standard entry point for LSP features that need TypeAnnotation queries.
+Callers can then issue one or more [`get_type_for_range`](@ref) /
+[`get_matches_for_range`](@ref) queries against the returned context.
+When `cache` is provided, inferred contexts are reused by `(context_module, world,
+top-level range)`, allowing repeated requests for the same synced document version to skip
+lowering and inference.
+
+Cache misses build outside the cache lock. Racing requests may duplicate inference for the
+same key, but unrelated cache hits/misses are not blocked.
 """
-function build_inferred_context_at(
+function build_inferred_context_for_range(
         st0_top::SyntaxTreeC, context_module::Module, rng::UnitRange{<:Integer};
         world::UInt = Base.get_world_counter(),
-        caller::AbstractString = "build_inferred_context_at"
+        caller::AbstractString = "build_inferred_context_for_range",
+        cache::Union{Nothing,InferredContextCache} = nothing
     )
     return iterate_toplevel_tree(st0_top) do st0::SyntaxTreeC
-        rng ⊆ JS.byte_range(st0) || return nothing
-        result = @something get_inferrable_tree(
-            st0, context_module; world, caller) return traversal_terminator
-        (; ctx3, st3) = result
-        inferred = @something infer_toplevel_tree(
-            ctx3, st3, st0, context_module; world) return traversal_terminator
-        return TraversalReturn(InferredTreeContext(inferred, st3); terminate=true)
+        top_rng = JS.byte_range(st0)
+        rng ⊆ top_rng || return nothing
+        if cache === nothing
+            ctx = build_inferred_context(st0, context_module; world, caller)
+            return TraversalReturn(ctx; terminate=true)
+        end
+        key = (context_module, world, top_rng)
+        entries = load(cache)
+        if haskey(entries, key)
+            return TraversalReturn(entries[key]; terminate=true)
+        end
+        # Build outside the cache lock: racing requests may duplicate inference
+        # for the same key, but they don't block unrelated cache hits/misses.
+        new_ctx = build_inferred_context(st0, context_module; world, caller)
+        ctx = store!(cache) do entries
+            if haskey(entries, key)
+                return entries, entries[key]
+            end
+            return InferredContextCacheData(entries, key => new_ctx), new_ctx
+        end
+        return TraversalReturn(ctx; terminate=true)
     end
 end
 
-"""
-    infer_type_at_range(
-            st0_top::SyntaxTreeC, context_module::Module, rng::UnitRange{<:Integer};
-            world::UInt = Base.get_world_counter()
-        ) -> typ | nothing
-
-Compose all four [`TypeAnnotation`](@ref) pipeline steps into a single call: run inference
-on the top-level subtree containing `rng` and return the inferred type at `rng`.
-Returns `nothing` if lowering / inference fails, or no `:type` annotation exists at `rng`.
-
-The shared cursor-to-type bridge for LSP features that need only one query
-(go to type definition, single-shot hover-type, …).
-For features that need multiple queries against the same toplevel, build the context once with
-[`build_inferred_context_at`](@ref) and reuse it across [`get_type_for_range`](@ref) calls.
-"""
-function infer_type_at_range(
-        st0_top::SyntaxTreeC, context_module::Module, rng::UnitRange{<:Integer};
+function build_inferred_context(
+        st0::SyntaxTreeC, context_module::Module;
         world::UInt = Base.get_world_counter(),
+        caller::AbstractString = "build_inferred_context"
     )
-    ctx = @something build_inferred_context_at(
-        st0_top, context_module, rng; world, caller="infer_type_at_range") return nothing
-    return get_type_for_range(ctx, rng)
+    (; ctx3, st3) = @something get_inferrable_tree(st0, context_module; world, caller) return nothing
+    inferred = @something infer_toplevel_tree(ctx3, st3, st0, context_module; world) return nothing
+    # `JS.prune` minimizes provenance, so collect query-dispatch indexes first.
+    surface_kind_index, macrocall_types = collect_provenance_indexes(inferred)
+    return InferredTreeContext(JS.prune(inferred), st3, surface_kind_index, macrocall_types)
 end
 
 """
@@ -1117,15 +1095,14 @@ surface_kind_at_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer}) =
     get(ctx.surface_kind_index, rng, nothing)
 
 # A macrocall expansion produces many `K"call"`s whose byte ranges fall under
-# the original `K"macrocall"` source span. `macrocall_typed_calls` indexes only
-# those whose first provenance is the macrocall (skipping nodes the expansion
-# imported from elsewhere); among them, the last typed non-Const call carries
-# the value type. `Const` entries are skipped because they're usually metadata
-# the expansion baked in (line numbers, `Module`, …), not the user value.
+# the original `K"macrocall"` source span. `macrocall_types` indexes only calls
+# whose first provenance is the macrocall (skipping nodes the expansion imported
+# from elsewhere); among them, the last non-Const type carries the value type.
+# `Const` entries are skipped because they're usually metadata the expansion
+# baked in (line numbers, `Module`, ...), not the user value.
 function type_for_macroexpansion(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
     typ = nothing
-    for st5 in get(ctx.macrocall_typed_calls, rng, ())
-        ntyp = st5.type
+    for ntyp in get(ctx.macrocall_types, rng, ())
         ntyp isa Core.Const && continue
         typ = ntyp
     end
@@ -1307,7 +1284,7 @@ kwcall scaffolding `K"call"`s share the byte range and precede it in preorder) i
 consulted, so when its callee is unresolved this returns `nothing` rather than
 leaking the scaffolding's matches.
 
-Pair with [`build_inferred_context_at`](@ref) for the context.
+Pair with [`build_inferred_context_for_range`](@ref) for the context.
 """
 function get_matches_for_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
     last_call = nothing

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -635,6 +635,7 @@ function update_analysis_cache!(state::ServerState, analysis_result::AnalysisRes
     # Revise-based analysis keeps module identity stable across runs, so we
     # skip invalidation when `module_range_infos` is unchanged.
     for uri in analyzed_uris
+        clear_inferred_context_cache!(state, uri)
         if module_range_infos_unchanged(prev_cache, analysis_result, uri)
             continue
         end

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -86,13 +86,13 @@ Computes once and caches:
 Two heavier pieces are built lazily on first request:
 - `InferredTreeContext` — shared between any routines that actually need
   type info at the cursor (always `call_completions!`, optionally
-  `global_completions!` for dot-prefix). `build_inferred_context_at` keys
+  `global_completions!` for dot-prefix). `build_inferred_context_for_range` keys
   off the toplevel statement containing the cursor, so a single context
   serves every routine here.
 - `cursor_bindings` result — shared between `local_completions!` and the
   kwarg branch of `call_completions!`.
 
-A future refactor that unifies `cursor_bindings` and `build_inferred_context_at`
+A future refactor that unifies `cursor_bindings` and `build_inferred_context_for_range`
 at the `jl_lower_for_scope_resolution` level can replace the lazy accessors
 without disturbing call sites.
 """
@@ -133,7 +133,7 @@ function CompletionCtx(
         Base.RefValue{Union{Nothing,Vector{Tuple{JL.BindingInfo,SyntaxTreeC,Int}}}}())
 end
 
-# Why not `build_inferred_context_at(..., offset:offset; ...)` directly:
+# Why not query the inferred-context cache with `offset:offset` directly:
 # It filters toplevel subtrees by `rng ⊆ JS.byte_range(toplevel)`, and the
 # cursor can sit past the toplevel's `last_byte` in incomplete code (e.g.
 # `sin(42,│\n` — parser ends the `K"call"` at byte 7, cursor at byte 8 is
@@ -142,9 +142,13 @@ end
 function get_inferred_ctx!(comp_ctx::CompletionCtx; caller::AbstractString)
     isassigned(comp_ctx.inferred_ctx) && return comp_ctx.inferred_ctx[]
     toplevel = lowerable_toplevel_at(comp_ctx.st0_top, comp_ctx.offset)
-    ctx = toplevel === nothing ? nothing : build_inferred_context_at(
-        comp_ctx.st0_top, comp_ctx.context_module, JS.byte_range(toplevel);
-        world=comp_ctx.world, caller)
+    ctx = if toplevel === nothing
+        nothing
+    else
+        build_inferred_context_for_range(
+            comp_ctx.st0_top, comp_ctx.context_module, JS.byte_range(toplevel);
+            world=comp_ctx.world, caller, cache=comp_ctx.fi.inferred_context_cache)
+    end
     return comp_ctx.inferred_ctx[] = ctx
 end
 

--- a/src/definition.jl
+++ b/src/definition.jl
@@ -152,7 +152,8 @@ function find_definition(
         rng = ctx = nothing
     else
         rng = JS.byte_range(node)
-        ctx = build_inferred_context_at(st0, context_module, rng; world, caller="find_definition")
+        ctx = build_inferred_context_for_range(st0, context_module, rng;
+            world, caller="find_definition", cache=fi.inferred_context_cache)
     end
 
     # Phase 1: matches-narrowing. Runs *before* the binding pass so

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -5,14 +5,23 @@ function ParseStream!(s::Union{AbstractString,Vector{UInt8}})
 end
 
 # Drop every per-file cache entry for `uri`. Called whenever a file's content
-# changes (didChange/didOpen, notebook cell edits, watched-file events) or its
-# module context changes (full-analysis updates). `clear_*_cache!` (e.g. for
-# diagnostic config changes) is separate because not all caches share that
-# invalidation trigger.
+# changes (didChange/didOpen, notebook cell edits, watched-file events).
+# Full-analysis updates invalidate semantic caches separately because not all
+# per-file caches depend on module context.
 function invalidate_per_file_caches!(state::ServerState, uri::URI)
     invalidate_document_symbol_cache!(state, uri)
     invalidate_binding_occurrences_cache!(state, uri)
     invalidate_per_file_diagnostics_cache!(state, uri)
+end
+
+function clear_inferred_context_cache!(state::ServerState, uri::URI)
+    uri = canonical_cache_uri(state, uri)
+    store!(state.file_cache) do cache
+        fi = @something get(cache, uri, nothing) return cache, nothing
+        fi.inferred_context_cache === nothing && return cache, nothing
+        new_fi = FileInfo(fi; inferred_context_cache=InferredContextCache())
+        return Base.PersistentDict(cache, uri => new_fi), nothing
+    end
 end
 
 """
@@ -37,7 +46,7 @@ function cache_file_info!(
     testsetinfos, any_deleted = compute_testsetinfos!(server, st0, prev_testsetinfos)
 
     fi = FileInfo(version, parsed_stream, filename, state.encoding, testsetinfos;
-        syntax_tree0=st0)
+        syntax_tree0=st0, inferred_context_cache=InferredContextCache())
     store!(state.file_cache) do cache
         Base.PersistentDict(cache, uri => fi), nothing
     end

--- a/src/hover.jl
+++ b/src/hover.jl
@@ -100,7 +100,8 @@ function get_hover(
     end
 
     display_rng = JS.byte_range(display_node)
-    ctx = build_inferred_context_at(st0_top, context_module, display_rng; world, caller="get_hover")
+    ctx = build_inferred_context_for_range(st0_top, context_module, display_rng;
+        world, caller="get_hover", cache=fi.inferred_context_cache)
     type_str = typ = nothing
     if ctx !== nothing
         display_typ = get_type_for_range(ctx, display_rng)
@@ -192,16 +193,14 @@ binding_kind_label(kind::Symbol) =
     kind === :static_parameter ? "(static parameter)" :
     kind === :local ? "(local)" : "(global)"
 
-# Convert a lattice element returned by `infer_type_at_range` into a string
-# suitable for display in a hover. Returns `nothing` for "implementation
-# detail" lattice elements that the user shouldn't see — `Type{T}` (the value
-# is itself a type), and function singletons whose name already appears in
-# `source_text` as a whole word (e.g. hovering on `sin│` would otherwise show
-# `sin :: typeof(sin)`, which is just noise). For function singletons whose
-# name is *not* visible in the source — `s[2]│` resolving to `cos`, or
-# `mycos│` aliased from `cos` — the singleton type is returned as
-# `typeof(<name>)` so the hover header announces which value the expression
-# resolves to without conflating value and type positions.
+# Convert a lattice element from `get_type_for_range` into a string suitable for display
+# in a hover. Returns `nothing` for implementation-detail lattice elements that the user
+# shouldn't see: `Type{T}` (the value is itself a type), and function singletons whose
+# name already appears in `source_text` as a whole word (e.g. hovering on `sin│` would
+# otherwise show `sin :: typeof(sin)`, which is just noise). For function singletons whose
+# name is not visible in the source — `s[2]│` resolving to `cos`, or `mycos│` aliased from
+# `cos` — the singleton type is returned as `typeof(<name>)` so the hover header announces
+# which value the expression resolves to without conflating value and type positions.
 function hover_type_string(@nospecialize(typ), source_text::AbstractString)
     typ isa Core.PartialOpaque && return format_partial_opaque(typ)
     widened = CC.widenconst(typ)

--- a/src/notebook.jl
+++ b/src/notebook.jl
@@ -33,7 +33,8 @@ end
 function cache_notebook_file_info!(server::Server, notebook_uri::URI, notebook_info::NotebookInfo)
     state = server.state
     parsed_stream = ParseStream!(notebook_info.concat.source)
-    fi = FileInfo(notebook_info.version, parsed_stream, notebook_uri, notebook_info.encoding)
+    fi = FileInfo(notebook_info.version, parsed_stream, notebook_uri, notebook_info.encoding;
+        inferred_context_cache=InferredContextCache())
     store!(state.file_cache) do cache
         Base.PersistentDict(cache, notebook_uri => fi), fi
     end

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -560,7 +560,7 @@ function find_all_matches(
 end
 
 function cursor_siginfos(
-        context_module::Module, fi::FileInfo, b::Int;
+        fi::FileInfo, b::Int, context_module::Module;
         world::UInt = Base.get_world_counter(),
         postprocessor::LSPostProcessor = LSPostProcessor()
     )
@@ -577,8 +577,8 @@ function cursor_siginfos(
     # - (a) the surrounding toplevel failed to lower (e.g. method def with unused where-vars)
     # - (b) the call's head is a macro identifier that doesn't survive macroexpansion.
     # Both fall back to a global-binding lookup of `call[1]`.
-    ctx = build_inferred_context_at(
-        st0, context_module, JS.byte_range(call); world, caller="cursor_siginfos")
+    ctx = build_inferred_context_for_range(st0, context_module, JS.byte_range(call);
+        world, caller="cursor_siginfos", cache=fi.inferred_context_cache)
     fntyp = ctx === nothing ? nothing : get_type_for_range(ctx, JS.byte_range(call[1]))
     if fntyp === nothing
         fntyp = resolve_global_const(context_module, call[1], world)
@@ -640,7 +640,7 @@ function handle_SignatureHelpRequest(
     pos = adjust_position(state, uri, msg.params.position)
     (; context_module, world, postprocessor) = get_context_info(state, uri, pos)
     b = xy_to_offset(fi, pos)
-    signatures = cursor_siginfos(context_module, fi, b; world, postprocessor)
+    signatures = cursor_siginfos(fi, b, context_module; world, postprocessor)
     activeSignature = activeParameter = nothing
     return send(server,
         SignatureHelpResponse(;

--- a/src/type-definition.jl
+++ b/src/type-definition.jl
@@ -70,7 +70,9 @@ function find_type_definition(server::Server, uri::URI, fi::FileInfo, pos::Posit
 
     rng = JS.byte_range(node)
     (; context_module, world) = get_context_info(state, uri, pos)
-    typ = @something infer_type_at_range(st0_top, context_module, rng; world) return nothing
+    ctx = @something build_inferred_context_for_range(st0_top, context_module, rng;
+        world, caller="find_type_definition", cache=fi.inferred_context_cache) return nothing
+    typ = @something get_type_for_range(ctx, rng) return nothing
 
     target_type = @something extract_target_type(typ) return nothing
     return type_locations(state, uri, target_type, world), node

--- a/src/types.jl
+++ b/src/types.jl
@@ -53,6 +53,43 @@ function build_line_starts(textbuf::Vector{UInt8})
     return starts
 end
 
+struct InferredTreeContext
+    inferred_tree::SyntaxTreeC
+    # `byte_range => kind` for the surface node each lowered node was lowered
+    # from (first element of `JS.flattened_provenance`). First-write-wins,
+    # mirroring a `traverse`-then-pick-first lookup.
+    surface_kind_index::Dict{UnitRange{Int}, JS.Kind}
+    # Every lowered node keyed by its own `byte_range`, in preorder. The
+    # preorder property is load-bearing for the "last `K"call"` wins"
+    # semantics in `type_for_call`.
+    by_byte_range::Dict{UnitRange{Int}, Vector{SyntaxTreeC}}
+    # Result types from typed `K"call"` nodes whose first provenance is a
+    # `K"macrocall"`, keyed by the macrocall's `byte_range`.
+    macrocall_types::Dict{UnitRange{Int}, Vector{Any}}
+    # Every `K"return"` node, in two parallel `Vector`s sorted by
+    # `JS.first_byte` (so `searchsortedfirst` is valid on `return_first_bytes`).
+    # User-vs-synthetic classification is derived per-query from
+    # `user_return_form_ranges` below — @mlechu's idea.
+    return_first_bytes::Vector{Int}
+    return_nodes::Vector{SyntaxTreeC}
+    # Byte ranges of every user-written `K"return"` surface form in `st3`
+    # (`st3` not `st0` so macro-expansion-introduced `K"return"`s are included).
+    # Consumed by `type_for_branching`.
+    user_return_form_ranges::Vector{UnitRange{Int}}
+    # For each lowered node inside the body of some OC, the byte range of that OC's
+    # `K"opaque_closure_method"`. Used by `tmerge_at_range` to filter OC construction
+    # scaffolding sharing a byte range with the user's yield expression: a node is kept
+    # only when the OC whose body it's in has the queried byte range — so inner-OC noise
+    # inside an outer OC body (e.g. multi-`for` comprehension, closure-of-closure) is
+    # filtered when querying at the inner OC's range.
+    oc_body_scope::Dict{Int,UnitRange{Int}}
+end
+
+const InferredContextCacheKey = Tuple{Module,UInt,UnitRange{Int}}
+const InferredContextCacheData = Base.PersistentDict{
+    InferredContextCacheKey,Union{Nothing,InferredTreeContext}}
+const InferredContextCache = LWContainer{InferredContextCacheData,LWStats}
+
 # Current text snapshot for both synchronized documents and on-demand unsynced workspace
 # files, plus per-version caches derived from the parsed stream.
 struct FileInfo
@@ -64,6 +101,14 @@ struct FileInfo
     # Pruned `st0` cache. Access through `build_syntax_tree`, which returns a copy
     # safe for lowering.
     syntax_tree0::SyntaxTreeC
+    # Intentionally unbounded within a `FileInfo`: synced documents usually receive
+    # repeated type queries for the same top-level tree. Content updates replace the
+    # whole `FileInfo`, and full-analysis updates clear this cache so old analysis
+    # worlds can be released. Unlike the pruned `syntax_tree0` cache, inferred
+    # contexts are several times heavier; e.g. caching them for unsynced workspace
+    # files would retain roughly 140 MiB for JETLS' own `src/`, so keep this `nothing`
+    # outside synchronized documents.
+    inferred_context_cache::Union{Nothing,InferredContextCache}
     # Cached line-starts index for the current `parsed_stream.textbuf`. `offset_to_xy`
     # / `xy_to_offset` are called heavily by every LSP feature, so amortizing the
     # O(N) line scan once per FileInfo (constructed on didOpen / didChange) is a
@@ -74,7 +119,8 @@ struct FileInfo
             version::Int, parsed_stream::JS.ParseStream, filename::AbstractString,
             encoding::LSP.PositionEncodingKind.Ty = LSP.PositionEncodingKind.UTF16,
             testsetinfos::Vector{TestsetInfo} = EMPTY_TESTSETINFOS;
-            syntax_tree0::Union{Nothing,SyntaxTreeC} = nothing
+            syntax_tree0::Union{Nothing,SyntaxTreeC} = nothing,
+            inferred_context_cache::Union{Nothing,InferredContextCache} = nothing
         )
         syntax_tree0 = if syntax_tree0 === nothing
             JS.build_tree(JS.SyntaxTree, parsed_stream; filename)
@@ -83,7 +129,8 @@ struct FileInfo
         end
         syntax_tree0 = JS.prune(syntax_tree0)
         line_starts = build_line_starts(parsed_stream.textbuf)
-        new(version, parsed_stream, filename, encoding, testsetinfos, syntax_tree0, line_starts)
+        new(version, parsed_stream, filename, encoding, testsetinfos, syntax_tree0,
+            inferred_context_cache, line_starts)
     end
 end
 @define_override_constructor FileInfo # For testsetinfos update

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -18,7 +18,7 @@ module type_annotate_module end
 function type_annotate(code::AbstractString, context_module::Module = type_annotate_module)
     fi = JETLS.FileInfo(1, code, @__FILE__)
     st0_top = JETLS.build_syntax_tree(fi)
-    ctx = build_inferred_context_at(st0_top, context_module, 1:1)
+    ctx = build_inferred_context_for_range(st0_top, context_module, 1:1)
     @test ctx !== nothing
     return fi, ctx
 end
@@ -62,17 +62,40 @@ function query_all_types(fi::JETLS.FileInfo, ctx::InferredTreeContext, text::Abs
     return types
 end
 
-# Smoke-test for the single-shot driver — the rest of the file exercises the
-# composed `build_inferred_context_at` + `get_type_for_range` form via
-# `type_annotate`, so this just verifies the convenience wrapper composes the
-# same answer for one query.
-@testset "infer_type_at_range" begin
-    let code = "sin(1.0)"
-        fi = JETLS.FileInfo(1, code, @__FILE__)
-        st0_top = JETLS.build_syntax_tree(fi)
-        typ = infer_type_at_range(st0_top, Main, range_of(code, "sin(1.0)"))
-        @test typ === Core.Const(sin(1.0))
+@testset "build_inferred_context_for_range cache" begin
+    code = """
+    function add_one(x::Int)
+        y = x + 1
+        y
     end
+    function add_two(z::Int)
+        z + 2
+    end
+    """
+    cache = JETLS.InferredContextCache()
+    fi = JETLS.FileInfo(1, code, @__FILE__; inferred_context_cache=cache)
+    st0_top = JETLS.build_syntax_tree(fi)
+    rng1 = range_of(code, "x + 1")
+    rng2 = range_of(code, "y")
+    ctx1 = build_inferred_context_for_range(st0_top, type_annotate_module, rng1; cache)
+    ctx2 = build_inferred_context_for_range(st0_top, type_annotate_module, rng2; cache)
+    @test ctx1 !== nothing
+    @test get_type_for_range(ctx1, rng1) === Int
+    @test ctx1 === ctx2
+    @test get_type_for_range(ctx2, rng2) === Int
+    @test length(JETLS.load(cache)) == 1
+    rng4 = rng3 = range_of(code, "z + 2")
+    ctx3 = build_inferred_context_for_range(st0_top, type_annotate_module, rng3; cache)
+    @test ctx3 !== nothing
+    @test get_type_for_range(ctx3, rng3) === Int
+    @test ctx3 !== ctx1
+    @test length(JETLS.load(cache)) == 2
+    # Without `cache`, the same range is rebuilt instead of reusing `ctx3`.
+    ctx4 = build_inferred_context_for_range(st0_top, type_annotate_module, rng4)
+    @test ctx4 !== nothing
+    @test get_type_for_range(ctx4, rng4) === Int
+    @test ctx4 !== ctx3
+    @test length(JETLS.load(cache)) == 2
 end
 
 @testset HierarchicalTestSet "get_inferrable_tree" begin

--- a/test/test_signature_help.jl
+++ b/test/test_signature_help.jl
@@ -14,7 +14,7 @@ function siginfos(context_module::Module, code::AbstractString; kwargs...)
     position = only(positions)
     fi = JETLS.FileInfo(0, clean_code, @__FILE__)
     b = JETLS.xy_to_offset(fi, position)
-    return JETLS.cursor_siginfos(context_module, fi, b)
+    return JETLS.cursor_siginfos(fi, b, context_module)
 end
 
 n_si(args...) = length(siginfos(args...))


### PR DESCRIPTION
Add an optional per-`FileInfo` `InferredContextCache` and route synced LSP type-query paths through it. The cache is keyed by context module, world, and top-level range so stale analysis results are not reused.

Only synchronized file snapshots allocate this cache. Unsynced `FileInfo` entries keep it as `nothing` to avoid retaining heavy inferred trees for workspace-wide paths.

The memory measurements behind that choice are significant. A pruned `st0` cache for JETLS `src/` is about 29.74 MiB, with `src/diagnostic.jl` alone at 1.72 MiB. The inferred contexts are much heavier: about 10.41 MiB for `src/diagnostic.jl` and 5.89 MiB for `src/utils/ast.jl` after pruning and summary extraction.

Measuring all of JETLS `src/` with file-appropriate context modules retains about 124.22 MiB for inferred-context cache entries, compared with 29.74 MiB for the pruned `st0` cache. That is a different cost profile from the `st0` cache, so the inferred cache stays scoped to synchronized documents.

Cache misses build outside the cache lock, accepting duplicate inference during races so unrelated cache hits do not wait on lowering or inference.

Full-analysis updates clear synced inferred-context caches so old analysis worlds can be released before the next type query rebuilds against the latest context.

Tests cover cache hits, separate top-level entries, uncached rebuilds, cache clearing, and queryability through `get_type_for_range`.