### PR TITLE
config: Remove expired legacy aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,14 +44,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > This disables analysis for matched files. Basic features like completion still might work, but most LSP features will be unfunctional.
 > Note that `analysis_overrides` is provided as a temporary workaround and may be removed or changed at any time. A proper fix is being worked on.
 
-> [!warning]
-> The `inlay_hint` configuration was reorganized into nested sub-tables so each hint kind has its own `enabled` toggle alongside its options.
-> The new shape adds [`inlay_hint.block_end.enabled`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/inlay_hint/block_end/enabled) for toggling block-end hints independently, and renames `inlay_hint.block_end_min_lines` to [`inlay_hint.block_end.min_lines`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/inlay_hint/block_end/min_lines).
-> Existing configs keep working for now: the legacy key is still accepted at load time and mapped onto the new key in memory (your config file is not modified automatically), with a one-shot deprecation warning. The legacy alias will be removed in releases after **June 2026**, so if you are still using `inlay_hint.block_end_min_lines`, please update your config.
+### Removed
 
-> [!warning]
-> The `completion.method_signature.prepend_inference_result` configuration option was removed. Inferred return types are now always shown both as `CompletionItem.detail` (` -> T` typically shown next to the candidate label) and as a leading `signature -> T` code fence at the top of the method signature completion documentation, so the previous client-specific opt-in is no longer needed.
-> Existing configs keep working for now: the removed key is still accepted at load time and silently dropped, with a one-shot deprecation warning. The legacy key will be rejected outright in releases after **June 2026**, so if you are still setting `completion.method_signature.prepend_inference_result`, please remove it from your config.
+- Removed the legacy `inlay_hint.block_end_min_lines` configuration alias. Use `inlay_hint.block_end.min_lines` instead.
+
+- Removed support for the legacy `completion.method_signature.prepend_inference_result` configuration key.
+  Inferred return types are now always shown in completion details and method signature documentation.
 
 ### Changed
 

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -11,11 +11,7 @@ end
 # `old_path => nothing` to deprecate a key without a replacement.
 # Each path is a list of nested keys; `migrate_deprecated_config_keys!` consults this
 # table and rewrites raw user config dicts before parsing.
-const deprecated_configurations = Pair{Vector{String},Union{Nothing,Vector{String}}}[
-    # 2026 June
-    ["inlay_hint", "block_end_min_lines"] => ["inlay_hint", "block_end", "min_lines"],
-    ["completion", "method_signature", "prepend_inference_result"] => nothing,
-]
+const deprecated_configurations = Pair{Vector{String},Union{Nothing,Vector{String}}}[]
 
 const __init__hooks__ = Any[]
 push_init_hook!(hook) = push!(__init__hooks__, hook)


### PR DESCRIPTION
Remove the June 2026 legacy configuration aliases now that the announcement window has elapsed.

Update the changelog entry to describe the aliases as removed instead of continuing the deprecation announcement.