### PR TITLE
analysis: Fix unused-argument false positive on nested `@generated`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Updated JuliaSyntax.jl and JuliaLowering.jl dependency versions to latest.
 
+### Fixed
+
+- Fixed false `lowering/unused-argument` reports — and missed argument occurrences for find-references / document-highlight / rename — on `@generated` functions nested inside another construct (e.g. as an inner constructor in a `struct` body). (Closed https://github.com/aviatesk/JETLS.jl/issues/722)
+
 ## 2026-05-27
 
 - Commit: [`0b038c7`](https://github.com/aviatesk/JETLS.jl/commit/0b038c7)

--- a/src/analysis/occurrence-analysis.jl
+++ b/src/analysis/occurrence-analysis.jl
@@ -1,6 +1,6 @@
 """
     compute_binding_occurrences(
-            ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, is_generated::Bool;
+            ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC;
             include_global_bindings::Bool = false
         ) -> binding_occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}}
 
@@ -31,7 +31,7 @@ a set of `BindingOccurrence` objects that record where and how the binding appea
     variable diagnostics or comprehensive binding analysis.
 """
 function compute_binding_occurrences(
-        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, is_generated::Bool;
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC;
         include_global_bindings::Bool = false
     )
     occurrences = Dict{JL.BindingInfo,Set{BindingOccurrence}}()
@@ -63,23 +63,7 @@ function compute_binding_occurrences(
 
     compute_binding_occurrences!(occurrences, ctx3, st3; include_global_bindings)
 
-    # In `@generated` functions, arguments are typically used only inside returned
-    # quoted expressions (`:(...)`) which appear as `inert` nodes after lowering.
-    # Scope resolution doesn't look inside `inert` nodes, so these arguments appear
-    # unused. We scan `inert` nodes for identifiers matching argument names and
-    # record them as `:use` occurrences.
-    if is_generated
-        inert_ids = collect_inert_identifiers(st3)
-        for (binfo, _) in occurrences
-            binfo.kind === :argument || continue
-            id_nodes = get(inert_ids, binfo.name, nothing)
-            if id_nodes !== nothing
-                for id_node in id_nodes
-                    push!(occurrences[binfo], BindingOccurrence(id_node, :use))
-                end
-            end
-        end
-    end
+    record_generated_inert_argument_uses!(occurrences, ctx3, st3)
 
     # Aggregate occurrences for bindings that have the same name and location.
     # JL sometimes represents bindings that are considered "identical" at the source level
@@ -131,6 +115,38 @@ function collect_inert_identifiers(st3::SyntaxTreeC)
         return true
     end
     return result
+end
+
+function innermost_generated_range(node::SyntaxTreeC)
+    provs = JS.flattened_provenance(node)
+    for i = length(provs):-1:1
+        prov = provs[i]
+        is_generated0(prov) && return JS.byte_range(prov)
+    end
+    return nothing
+end
+
+function record_generated_inert_argument_uses!(
+        occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC
+    )
+    inert_ids = nothing
+    for (binfo, _) in occurrences
+        binfo.kind === :argument || continue
+        binding_ex = JL.binding_ex(ctx3, binfo.id)
+        generated_range = @something innermost_generated_range(binding_ex) continue
+        ids = if inert_ids === nothing
+            inert_ids = collect_inert_identifiers(st3)
+        else
+            inert_ids
+        end
+        id_nodes = @something get(ids, binfo.name, nothing) continue
+        for id_node in id_nodes
+            innermost_generated_range(id_node) == generated_range || continue
+            push!(occurrences[binfo], BindingOccurrence(id_node, :use))
+        end
+    end
+    return occurrences
 end
 
 """
@@ -411,9 +427,7 @@ function compute_full_binding_occurrences(
     catch
         return nothing
     end
-    is_generated = is_generated0(st0)
-    binding_occurrences = compute_binding_occurrences(ctx3, st3, is_generated;
-        include_global_bindings = true)
+    binding_occurrences = compute_binding_occurrences(ctx3, st3; include_global_bindings=true)
 
     collect_macrocall_occurrences!(binding_occurrences, context_module, st0; soft_scope)
     # Global bindings used inside inert nodes (quoted expressions) are not

--- a/src/analysis/occurrence-analysis.jl
+++ b/src/analysis/occurrence-analysis.jl
@@ -117,13 +117,14 @@ function collect_inert_identifiers(st3::SyntaxTreeC)
     return result
 end
 
-function innermost_generated_range(node::SyntaxTreeC)
-    provs = JS.flattened_provenance(node)
-    for i = length(provs):-1:1
-        prov = provs[i]
-        is_generated0(prov) && return JS.byte_range(prov)
+function enclosing_generated_range(node::SyntaxTreeC)
+    s = node
+    while true
+        ms = JS.macro_prov(s)
+        isnothing(ms) && return nothing
+        is_generated0(ms) && return JS.byte_range(ms)
+        s = ms
     end
-    return nothing
 end
 
 function record_generated_inert_argument_uses!(
@@ -134,7 +135,7 @@ function record_generated_inert_argument_uses!(
     for (binfo, _) in occurrences
         binfo.kind === :argument || continue
         binding_ex = JL.binding_ex(ctx3, binfo.id)
-        generated_range = @something innermost_generated_range(binding_ex) continue
+        generated_range = @something enclosing_generated_range(binding_ex) continue
         ids = if inert_ids === nothing
             inert_ids = collect_inert_identifiers(st3)
         else
@@ -142,7 +143,7 @@ function record_generated_inert_argument_uses!(
         end
         id_nodes = @something get(ids, binfo.name, nothing) continue
         for id_node in id_nodes
-            innermost_generated_range(id_node) == generated_range || continue
+            enclosing_generated_range(id_node) == generated_range || continue
             push!(occurrences[binfo], BindingOccurrence(id_node, :use))
         end
     end

--- a/src/declaration.jl
+++ b/src/declaration.jl
@@ -77,13 +77,13 @@ function find_declaration(
 
     binding_result = select_target_binding(st0, offset, context_module; caller="find_declaration", soft_scope)
     if !isnothing(binding_result)
-        (; ctx3, st3, st0, binding) = binding_result
+        (; ctx3, st3, binding) = binding_result
         binfo = JL.get_binding(ctx3, binding)
         if binfo.kind === :global
             locations = find_global_binding_declarations(server, uri, binfo)
         else
             locations = find_local_binding_declarations(
-                state, uri, fi, ctx3, st3, binfo; is_generated=is_generated0(st0))
+                state, uri, fi, ctx3, st3, binfo)
         end
         isempty(locations) || return locations, binding
     end
@@ -120,11 +120,10 @@ end
 
 function find_local_binding_declarations(
         state::ServerState, uri::URI, fi::FileInfo,
-        ctx3, st3, binfo::JL.BindingInfo;
-        is_generated::Bool = false,
+        ctx3, st3, binfo::JL.BindingInfo,
     )
     locations = Location[]
-    binding_occurrences = compute_binding_occurrences(ctx3, st3, is_generated)
+    binding_occurrences = compute_binding_occurrences(ctx3, st3)
     haskey(binding_occurrences, binfo) || return locations
     seen_locations = Set{Tuple{URI,Range}}()
     for occurrence in binding_occurrences[binfo]

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -1295,7 +1295,7 @@ function analyze_lowered_code!(
         allow_noreturn_optimization::Vector{Symbol} = Symbol[]
     )
     (; ctx3, ctx4, st0, st3) = res
-    binding_occurrences = compute_binding_occurrences(ctx3, st3, is_generated0(st0);
+    binding_occurrences = compute_binding_occurrences(ctx3, st3;
         include_global_bindings=true)
 
     reported = Set{LoweringDiagnosticKey}() # to prevent duplicate reports for unused default or keyword arguments

--- a/src/document-highlight.jl
+++ b/src/document-highlight.jl
@@ -53,7 +53,7 @@ function document_highlights!(
     (; context_module) = get_context_info(state, uri, pos)
     soft_scope = is_notebook_cell_uri(state, uri)
 
-    (; ctx3, st3, st0, binding) = @something begin
+    (; ctx3, st3, binding) = @something begin
         select_target_binding(st0_top, offset, context_module; caller="document_highlights!", soft_scope)
     end return highlights
 
@@ -63,8 +63,7 @@ function document_highlights!(
     if binfo.kind === :global
         global_document_highlights!(highlights′, state, uri, fi, st0_top, binfo)
     else
-        local_document_highlights!(highlights′, state, uri, fi, ctx3, st3, binfo;
-            is_generated=is_generated0(st0))
+        local_document_highlights!(highlights′, state, uri, fi, ctx3, st3, binfo)
     end
 
     for (range, kind) in highlights′
@@ -101,10 +100,9 @@ end
 
 function local_document_highlights!(
         highlights′::Dict{Range,DocumentHighlightKind.Ty},
-        state::ServerState, uri::URI, fi::FileInfo, ctx3, st3, binfo::JL.BindingInfo;
-        is_generated::Bool = false,
+        state::ServerState, uri::URI, fi::FileInfo, ctx3, st3, binfo::JL.BindingInfo,
     )
-    binding_occurrences = compute_binding_occurrences(ctx3, st3, is_generated)
+    binding_occurrences = compute_binding_occurrences(ctx3, st3)
     if haskey(binding_occurrences, binfo)
         for occurrence in binding_occurrences[binfo]
             add_highlight_for_occurrence!(highlights′, state, uri, fi, occurrence)

--- a/src/references.jl
+++ b/src/references.jl
@@ -88,7 +88,7 @@ function find_references(
     soft_scope = is_notebook_cell_uri(server.state, uri)
     locations = Location[]
 
-    (; ctx3, st3, st0, binding) = @something begin
+    (; ctx3, st3, binding) = @something begin
         select_target_binding(st0_top, offset, context_module; caller="find_references", soft_scope)
     end return locations
 
@@ -98,7 +98,7 @@ function find_references(
         error !== nothing && return error
     else
         find_local_references!(locations, server, uri, fi, ctx3, st3, binfo;
-            include_declaration, is_generated=is_generated0(st0))
+            include_declaration)
     end
 
     return locations
@@ -195,10 +195,9 @@ function find_local_references!(
         locations::Vector{Location}, server::Server, uri::URI, fi::FileInfo,
         ctx3, st3, binfo::JL.BindingInfo;
         include_declaration::Bool = true,
-        is_generated::Bool = false,
     )
     seen_locations = Set{Tuple{URI,Range}}()
-    binding_occurrences = compute_binding_occurrences(ctx3, st3, is_generated)
+    binding_occurrences = compute_binding_occurrences(ctx3, st3)
     if haskey(binding_occurrences, binfo)
         for occurrence in binding_occurrences[binfo]
             if include_declaration || occurrence.kind === :use

--- a/src/rename.jl
+++ b/src/rename.jl
@@ -197,7 +197,7 @@ function local_binding_rename(
     st0_top = build_syntax_tree(fi)
     offset = xy_to_offset(fi, pos)
 
-    (; ctx3, st3, st0, binding) = @something begin
+    (; ctx3, st3, binding) = @something begin
         select_target_binding(st0_top, offset, context_module; caller="local_binding_rename", soft_scope)
     end return nothing
 
@@ -216,7 +216,7 @@ function local_binding_rename(
         end
     end
 
-    binding_occurrences = compute_binding_occurrences(ctx3, st3, is_generated0(st0))
+    binding_occurrences = compute_binding_occurrences(ctx3, st3)
     haskey(binding_occurrences, binfo) ||
         return (; result = nothing,
             error = ResponseError(;

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -185,10 +185,12 @@ function is_macrocall_st0(st0::SyntaxTreeC, names::AbstractString...; from::Unio
     JS.kind(st0) === JS.K"macrocall" || return false
     JS.numchildren(st0) >= 1 || return false
     macro_name = st0[1]
-    JS.kind(macro_name) === JS.K"Identifier" || return false
-    hasproperty(macro_name, :name_val) || return false
-    name_val = macro_name.name_val
-    name_val isa String || return false
+    name_val = if hasproperty(macro_name, :name_val)
+        macro_name.name_val
+    else
+        JS.sourcetext(macro_name)
+    end
+    name_val isa AbstractString || return false
     return name_val in names && (isnothing(from) || (JS.hasattr(macro_name, :mod) && macro_name.mod === from))
 end
 
@@ -359,19 +361,24 @@ function foreach_inert_identifier(@specialize(callback), node::SyntaxTreeC)
     return res !== false
 end
 
-function find_inert_identifier_name(st::SyntaxTreeC, offset::Integer)
-    name = Ref{Union{Nothing,String}}(nothing)
+function find_inert_identifier(st::SyntaxTreeC, offset::Integer)
+    found = Ref{Union{Nothing,SyntaxTreeC}}(nothing)
     foreach_inert_identifier(st) do id_node::SyntaxTreeC
         if offset in JS.byte_range(id_node)
-            JS.hasattr(id_node, :name_val) || return true
-            name_val = id_node.name_val
-            name_val isa AbstractString || return true
-            name[] = name_val
+            found[] = id_node
             return false
         end
         return true
     end
-    return name[]
+    return found[]
+end
+
+function find_inert_identifier_name(st::SyntaxTreeC, offset::Integer)
+    id_node = @something find_inert_identifier(st, offset) return nothing
+    JS.hasattr(id_node, :name_val) || return nothing
+    name_val = id_node.name_val
+    name_val isa AbstractString || return nothing
+    return name_val
 end
 
 function is_nospecialize_or_specialize_macrocall3(st3::SyntaxTreeC)

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -283,11 +283,11 @@ function find_inert_target_binding(
     JS.hasattr(id_node, :name_val) || return nothing
     name = id_node.name_val
     name isa AbstractString || return nothing
-    generated_range = @something innermost_generated_range(id_node) return nothing
+    generated_range = @something enclosing_generated_range(id_node) return nothing
     for binfo in ctx3.bindings.info
         binfo.kind === :argument || continue
         binfo.name == name || continue
-        innermost_generated_range(JL.binding_ex(ctx3, binfo.id)) == generated_range || continue
+        enclosing_generated_range(JL.binding_ex(ctx3, binfo.id)) == generated_range || continue
         return JL.binding_ex(ctx3, binfo.id)
     end
     return nothing

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -219,13 +219,13 @@ function is_kwcall_lambda(ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC)
 end
 
 function _select_target_binding(
-        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, offset::Int;
-        is_generated::Bool = false)
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, offset::Int
+    )
     return @something(
         find_target_binding(ctx3, st3, offset),
         find_target_binding(ctx3, st3, offset-1), # Support cases like `var│`, `func│(5)`
-        is_generated ? find_inert_target_binding(ctx3, st3, offset) : nothing,
-        is_generated ? find_inert_target_binding(ctx3, st3, offset-1) : nothing,
+        find_inert_target_binding(ctx3, st3, offset),
+        find_inert_target_binding(ctx3, st3, offset-1),
         return nothing)
 end
 
@@ -264,7 +264,7 @@ function select_target_binding(
         JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
         return nothing
     end
-    primary = _select_target_binding(ctx3, st3, offset; is_generated=is_generated0(st0))
+    primary = _select_target_binding(ctx3, st3, offset)
     if primary !== nothing
         binding = normalize_local_alias_to_global(ctx3, primary)
         return (; ctx3, st3, st0, binding)
@@ -279,10 +279,15 @@ end
 
 function find_inert_target_binding(
         ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, offset::Int)
-    name = @something find_inert_identifier_name(st3, offset) return nothing
+    id_node = @something find_inert_identifier(st3, offset) return nothing
+    JS.hasattr(id_node, :name_val) || return nothing
+    name = id_node.name_val
+    name isa AbstractString || return nothing
+    generated_range = @something innermost_generated_range(id_node) return nothing
     for binfo in ctx3.bindings.info
         binfo.kind === :argument || continue
         binfo.name == name || continue
+        innermost_generated_range(JL.binding_ex(ctx3, binfo.id)) == generated_range || continue
         return JL.binding_ex(ctx3, binfo.id)
     end
     return nothing

--- a/test/analysis/test_occurrence_analysis.jl
+++ b/test/analysis/test_occurrence_analysis.jl
@@ -13,15 +13,14 @@ with_binding_occurrences(callback, code::AbstractString; kwargs...) =
     with_binding_occurrences(callback, lowering_module, code; kwargs...)
 function with_binding_occurrences(
         callback, context_module::Module, code::AbstractString;
-        remove_macrocalls::Bool = false,
-        is_generated::Bool = false
+        remove_macrocalls::Bool = false
     )
     st0 = jlparse(code; rule=:statement)
     if remove_macrocalls
         st0 = JETLS.remove_macrocalls(st0)
     end
     (; ctx3, st3) = JETLS.jl_lower_for_scope_resolution(context_module, st0)
-    binding_occurrences = JETLS.compute_binding_occurrences(ctx3, st3, is_generated)
+    binding_occurrences = JETLS.compute_binding_occurrences(ctx3, st3)
     callback(binding_occurrences)
 end
 
@@ -414,7 +413,7 @@ end
                 hasmethod(copy, (T,)) && return :(copy(rng))
                 return :(deepcopy(rng))
             end
-            """; is_generated=true) do binding_occurrences
+            """) do binding_occurrences
             @test any(binding_occurrences) do (binding, occurrences)
                 binding.name == "rng" && binding.kind === :argument &&
                 any(occurrences) do o
@@ -427,7 +426,7 @@ end
             @generated function foo(x, unused)
                 return :(x + 1)
             end
-            """; is_generated=true) do binding_occurrences
+            """) do binding_occurrences
             @test any(binding_occurrences) do (binding, occurrences)
                 binding.name == "x" && binding.kind === :argument &&
                 any(o -> o.kind === :use, occurrences)
@@ -435,6 +434,22 @@ end
             @test !any(binding_occurrences) do (binding, occurrences)
                 binding.name == "unused" && binding.kind === :argument &&
                 any(o -> o.kind === :use, occurrences)
+            end
+        end
+
+        # aviatesk/JETLS.jl#722: a `@generated` function nested inside a
+        # `struct` body must still attribute its argument's inert uses.
+        with_binding_occurrences("""
+            struct Test722
+                x::Int
+                @generated function Test722(x)
+                    return Expr(:new, :(Test722), :x)
+                end
+            end
+            """) do binding_occurrences
+            @test any(binding_occurrences) do (binding, occurrences)
+                binding.name == "x" && binding.kind === :argument &&
+                any(o -> o.kind === :use && JS.source_line(o.tree) == 4, occurrences)
             end
         end
     end

--- a/test/test_document_highlight.jl
+++ b/test/test_document_highlight.jl
@@ -439,6 +439,29 @@ end
                 end
             end
 
+            let code = """
+                struct Test722
+                    x::Int
+                    @generated function Test722(│x│)
+                        return Expr(:new, :(Test722), :│x│)
+                    end
+                end
+                """
+                fi, positions = highlight_testcase(code, 4)
+                for pos in positions
+                    highlights = JETLS.document_highlights(fi, pos)
+                    @test length(highlights) == 2
+                    @test count(highlights) do highlight
+                        highlight.range.start == positions[1] &&
+                        highlight.range.var"end" == positions[2]
+                    end == 1
+                    @test count(highlights) do highlight
+                        highlight.range.start == positions[3] &&
+                        highlight.range.var"end" == positions[4]
+                    end == 1
+                end
+            end
+
             # Static parameter merging: `T` in argument annotation, `where` clause,
             # and body should all be unified.
             let code = """

--- a/test/test_document_highlight.jl
+++ b/test/test_document_highlight.jl
@@ -439,6 +439,8 @@ end
                 end
             end
 
+            # aviatesk/JETLS.jl#722: a `@generated` function nested inside a
+            # `struct` body must still attribute its argument's inert uses.
             let code = """
                 struct Test722
                     x::Int

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -399,6 +399,16 @@ module EmptyModule end
             @test diagnostic.message == "Unused argument `override`"
             @test diagnostic.range.start.line == 2
         end
+        let diagnostics = get_lowering_diagnostics("""
+            struct Test722
+                x::Int
+                @generated function Test722(x)
+                    return Expr(:new, :(Test722), :x)
+                end
+            end
+            """)
+            @test isempty(diagnostics)
+        end
     end
 
     # https://github.com/aviatesk/JETLS.jl/issues/481

--- a/test/test_references.jl
+++ b/test/test_references.jl
@@ -163,6 +163,24 @@ end
             end
         end
 
+        # aviatesk/JETLS.jl#722: a `@generated` function nested inside a
+        # `struct` body must still attribute its argument's inert uses.
+        let code = """
+            struct Test722
+                x::Int
+                @generated function Test722(│x│)
+                    return Expr(:new, :(Test722), :│x│)
+                end
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 4
+            for pos in positions
+                refs = find_references(clean_code, pos)
+                @test length(refs) == 2
+            end
+        end
+
         # Regression test for `is_matching_global_binding` + occurrence remap:
         # a `@generated` argument whose name coincides with a module-level
         # `global` must NOT be linked to that global. In earlier implementations

--- a/test/test_rename.jl
+++ b/test/test_rename.jl
@@ -301,6 +301,29 @@ end
                 end
             end
         end
+
+        # aviatesk/JETLS.jl#722: a `@generated` function nested inside a
+        # `struct` body must still attribute its argument's inert uses.
+        let code = """
+            struct Test722
+                x::Int
+                @generated function Test722(│x│)
+                    return Expr(:new, :(Test722), :│x│)
+                end
+            end
+            """
+            fi, positions, furi = rename_testcase(code, 4)
+            for pos in positions
+                (; result, error) = JETLS.local_binding_rename(
+                    server, furi, fi, pos, @__MODULE__, "y")
+                @test result isa WorkspaceEdit && isnothing(error)
+                for (uri, edits) in result.changes
+                    @test furi == uri
+                    @test length(edits) == 2
+                    @test all(edit -> edit.newText == "y", edits)
+                end
+            end
+        end
     end
 end
 

--- a/test/utils/test_jl_syntax_macros.jl
+++ b/test/utils/test_jl_syntax_macros.jl
@@ -36,7 +36,7 @@ children_kinds(st::JS.SyntaxTree) = JS.Kind[JS.kind(c) for c in JS.children(st)]
 # provenance" testset.
 function assert_binding_provenance(res, kind::Symbol, name::AbstractString)
     binding_occurrences = JETLS.compute_binding_occurrences(
-        res.ctx3, res.st3, false; include_global_bindings=true)
+        res.ctx3, res.st3; include_global_bindings=true)
     binfo = nothing
     for (b, _) in binding_occurrences
         if b.kind === kind && b.name == name
@@ -57,7 +57,7 @@ end
 # metadata symbols and not user references).
 function assert_no_binding(res, kind::Symbol, name::AbstractString)
     binding_occurrences = JETLS.compute_binding_occurrences(
-        res.ctx3, res.st3, false; include_global_bindings=true)
+        res.ctx3, res.st3; include_global_bindings=true)
     found = any(binding_occurrences) do (b, _)
         b.kind === kind && b.name == name
     end


### PR DESCRIPTION
`compute_binding_occurrences` previously checked only whether the
*top* of the lowerable subtree was a `@generated` macrocall (via
`is_generated0(st0)`). That missed cases where the `@generated`
function lives inside another construct -- e.g. as an inner
constructor in a `struct` body -- producing a false
`lowering/unused-argument` diagnostic and breaking find-references,
document-highlight, and rename on the argument.

The detection is now per-binding via `flattened_provenance`: for
each `:argument` binding whose provenance includes a `@generated`
ancestor, inert-node uses of the argument name within the same
`@generated` macrocall range are recorded as `:use` occurrences.

As a side effect, the `is_generated::Bool` parameter (and `st0`
field destructuring at call sites) is dropped from
`compute_binding_occurrences`, `_select_target_binding`,
`local_document_highlights!`, `find_local_references!`,
`find_local_binding_declarations`, and `local_binding_rename`,
since the per-binding check on `st3` no longer needs a hint from
the original parse tree.

- Closes https://github.com/aviatesk/JETLS.jl/issues/722