### PR TITLE
diagnostics: Clarify tail assignment diagnostics

### DIFF
--- a/LSP/src/basic-json-structures.jl
+++ b/LSP/src/basic-json-structures.jl
@@ -623,6 +623,8 @@ struct UnusedVariableData
     is_tuple_unpacking::Bool
     assignment_range::Union{Nothing,Range}
     lhs_eq_range::Union{Nothing,Range}
+    return_insert_position::Union{Nothing,Position}
+    return_insert_text::Union{Nothing,String}
 end
 export UnusedVariableData
 

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -612,7 +612,7 @@ end
 ```
 
 When the unused assignment expression is returned from tail position, the
-diagnostic explains that the value is returned directly. For example, the
+diagnostic explains that the value is returned implicitly. For example, the
 final assignment below returns the assignment expression's value, but the
 binding `s` itself is not read after that assignment:
 

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -555,9 +555,23 @@ function unused_local()
 end
 ```
 
+When an unused local is introduced by an assignment expression that is
+returned from tail position, the diagnostic explains that the local binding
+is not read. For example, the function below returns the assignment
+expression's value by Julia's implicit return rule, but the binding `s`
+itself is not read after the assignment:
+
+```julia
+function wrapped(x)
+    s = "($x)"  # consider `return s` to return the binding explicitly
+end
+```
+
 !!! tip "Code action available"
     Several code actions are available for this diagnostic:
     - "Prefix with '_'" to indicate the variable is intentionally unused
+    - "Insert explicit return" for simple tail assignments where the
+      assigned binding should be returned explicitly
     - "Delete assignment" to remove only the left-hand side (keeping the
       right-hand side expression)
     - "Delete statement" to remove the entire assignment statement
@@ -597,8 +611,25 @@ function g()
 end
 ```
 
+When the unused assignment expression is returned from tail position, the
+diagnostic explains that the value is returned directly. For example, the
+final assignment below returns the assignment expression's value, but the
+binding `s` itself is not read after that assignment:
+
+```julia
+function build_string(xs)
+    s = "("
+    for x in xs
+        s *= x
+    end
+    s *= ")"  # consider `return s` to return the binding explicitly
+end
+```
+
 !!! tip "Code action available"
-    Two code actions are available for this diagnostic:
+    Several code actions are available for this diagnostic:
+    - "Insert explicit return" for simple tail assignments where the
+      assigned binding should be returned explicitly
     - "Delete assignment" to remove only the left-hand side (keeping the
       right-hand side expression)
     - "Delete statement" to remove the entire assignment statement

--- a/src/code-action.jl
+++ b/src/code-action.jl
@@ -136,6 +136,19 @@ function add_delete_unused_var_code_actions!(
     )
     data = diagnostic.data
     if data isa UnusedVariableData && !data.is_tuple_unpacking
+        if data.return_insert_position !== nothing && data.return_insert_text !== nothing
+            position = data.return_insert_position
+            push!(code_actions, CodeAction(;
+                title = "Insert explicit return",
+                kind = CodeActionKind.QuickFix,
+                diagnostics = Diagnostic[diagnostic],
+                isPreferred = true,
+                edit = WorkspaceEdit(;
+                    changes = Dict{URI,Vector{TextEdit}}(
+                        uri => TextEdit[TextEdit(;
+                            range = Range(; start=position, var"end"=position),
+                            newText = data.return_insert_text)]))))
+        end
         if data.lhs_eq_range !== nothing
             push!(code_actions, CodeAction(;
                 title = "Delete assignment",

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -676,6 +676,88 @@ function has_matching_argument_binding(
     return false
 end
 
+function is_assignment_expression(st::SyntaxTreeC)
+    k = JS.kind(st)
+    k === JS.K"=" && return true
+    if k === JS.K"unknown_head" && hasproperty(st, :name_val)
+        name = st.name_val
+        return name isa AbstractString && endswith(name, "=")
+    end
+    return false
+end
+
+same_syntax_range(a::SyntaxTreeC, b::SyntaxTreeC) =
+    JS.kind(a) === JS.kind(b) && JS.byte_range(a) == JS.byte_range(b)
+
+function is_last_child(parent::SyntaxTreeC, child::SyntaxTreeC)
+    n = JS.numchildren(parent)
+    n == 0 && return false
+    return same_syntax_range(parent[n], child)
+end
+
+function is_tail_branch_child(parent::SyntaxTreeC, child::SyntaxTreeC)
+    for i in 2:JS.numchildren(parent)
+        same_syntax_range(parent[i], child) && return true
+    end
+    return false
+end
+
+function assignment_expression_for_prov(st0::SyntaxTreeC, prov::SyntaxTreeC)
+    assignments = byte_ancestors(is_assignment_expression, st0, JS.byte_range(prov))
+    isempty(assignments) && return nothing
+    return first(assignments)
+end
+
+function tail_returned_assignment_kind(
+        st0::SyntaxTreeC, assignment::Union{Nothing,SyntaxTreeC}
+    )
+    isnothing(assignment) && return :none
+    ancestors = byte_ancestors(st0, JS.byte_range(assignment))
+    simple = true
+    for i in 1:length(ancestors)-1
+        child = ancestors[i]
+        parent = ancestors[i+1]
+        pk = JS.kind(parent)
+        if pk === JS.K"return"
+            return :tail
+        elseif pk === JS.K"block"
+            is_last_child(parent, child) || return :none
+        elseif pk === JS.K"function"
+            is_last_child(parent, child) || return :none
+            return simple ? :simple : :tail
+        elseif pk === JS.K"if" || pk === JS.K"elseif" || pk === JS.K"?"
+            is_tail_branch_child(parent, child) || return :none
+            simple = false
+        else
+            return :none
+        end
+    end
+    return :none
+end
+
+function unused_local_binding_message(bn::String, tail_kind::Symbol)
+    if tail_kind !== :none
+        return "Local binding `$bn` is not read; consider `return $bn` to return it explicitly"
+    end
+    return "Unused local binding `$bn`"
+end
+
+function unused_assignment_message(bn::String, tail_kind::Symbol)
+    if tail_kind !== :none
+        return "Value assigned to `$bn` is returned directly; consider `return $bn` to return the binding explicitly"
+    end
+    return "Value assigned to `$bn` is never used"
+end
+
+function return_insert_data(
+        assignment::SyntaxTreeC, fi::FileInfo, bn::String, tail_kind::Symbol
+    )
+    tail_kind === :simple || return nothing, nothing
+    range = jsobj_to_range(assignment, fi)
+    indent = get_line_indent(fi, range.start.line)
+    return range.var"end", "\n$(indent)return $bn"
+end
+
 function analyze_unused_bindings!(
         diagnostics::Vector{Diagnostic}, fi::FileInfo, st0::SyntaxTreeC, ctx3::JL.VariableAnalysisContext,
         binding_occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
@@ -721,9 +803,12 @@ function analyze_unused_bindings!(
             code = LOWERING_UNUSED_ARGUMENT_CODE
             data = UnusedArgumentData(prov_loc in kwarg_locations)
         else
-            message = "Unused local binding `$bn`"
+            assignment = assignment_expression_for_prov(st0, prov)
+            tail_kind = tail_returned_assignment_kind(st0, assignment)
+            message = unused_local_binding_message(bn, tail_kind)
             code = LOWERING_UNUSED_LOCAL_CODE
-            data = compute_unused_variable_data(st0, prov, fi)
+            data = assignment === nothing ? nothing :
+                compute_unused_variable_data(assignment, fi, bn, tail_kind)
         end
         push!(diagnostics, Diagnostic(;
             range,
@@ -758,16 +843,19 @@ function analyze_unused_assignments!(
             range = jsobj_to_range(prov, fi)
             key = LoweringDiagnosticKey(range, binfo.kind, bn)
             key in reported ? continue : push!(reported, key)
+            assignment = assignment_expression_for_prov(st0, prov)
+            tail_kind = tail_returned_assignment_kind(st0, assignment)
             push!(diagnostics, Diagnostic(;
                 range,
                 severity = DiagnosticSeverity.Information,
-                message = "Value assigned to `$bn` is never used",
+                message = unused_assignment_message(bn, tail_kind),
                 source = DIAGNOSTIC_SOURCE_LIVE,
                 code = LOWERING_UNUSED_ASSIGNMENT_CODE,
                 codeDescription = diagnostic_code_description(
                     LOWERING_UNUSED_ASSIGNMENT_CODE),
                 tags = DiagnosticTag.Ty[DiagnosticTag.Unnecessary],
-                data = compute_unused_variable_data(st0, prov, fi)))
+                data = assignment === nothing ? nothing :
+                    compute_unused_variable_data(assignment, fi, bn, tail_kind)))
         end
     end
 end
@@ -900,12 +988,9 @@ function analyze_undefined_local_bindings!(
     end
 end
 
-function compute_unused_variable_data(st0::SyntaxTreeC, prov::SyntaxTreeC, fi::FileInfo)
-    # Find parent K"=" node using byte_ancestors
-    ancestors = byte_ancestors(st::SyntaxTreeC->JS.kind(st)===JS.K"=", st0, JS.byte_range(prov))
-    isempty(ancestors) && return nothing
-
-    assignment = first(ancestors)
+function compute_unused_variable_data(
+        assignment::SyntaxTreeC, fi::FileInfo, bn::String, tail_kind::Symbol
+    )
     JS.numchildren(assignment) ≥ 2 || return nothing
 
     lhs = assignment[1]
@@ -913,7 +998,7 @@ function compute_unused_variable_data(st0::SyntaxTreeC, prov::SyntaxTreeC, fi::F
     # Check for destructuring patterns (tuple unpacking)
     is_tuple = JS.kind(lhs) === JS.K"tuple"
     if is_tuple
-        return UnusedVariableData(true, nothing, nothing)
+        return UnusedVariableData(true, nothing, nothing, nothing, nothing)
     end
 
     # lhs_eq_range: from LHS start to actual RHS start in source (exclusive).
@@ -922,16 +1007,23 @@ function compute_unused_variable_data(st0::SyntaxTreeC, prov::SyntaxTreeC, fi::F
     # K"String") have a byte range that excludes delimiters, so
     # `first_byte(rhs)` may point past the opening delimiter.
     assignment_range = jsobj_to_range(assignment, fi)
-    lhs_start = offset_to_xy(fi, JS.first_byte(lhs))
-    textbuf = fi.parsed_stream.textbuf
-    eq_byte = @something findnext(==(UInt8('=')), textbuf, JS.last_byte(lhs) + 1) return nothing
-    rhs_byte = eq_byte + 1
-    while rhs_byte ≤ length(textbuf) && textbuf[rhs_byte] in (UInt8(' '), UInt8('\t'))
-        rhs_byte += 1
+    lhs_eq_range = if JS.kind(assignment) === JS.K"="
+        lhs_start = offset_to_xy(fi, JS.first_byte(lhs))
+        textbuf = fi.parsed_stream.textbuf
+        eq_byte = @something findnext(==(UInt8('=')), textbuf, JS.last_byte(lhs) + 1) return nothing
+        rhs_byte = eq_byte + 1
+        while rhs_byte ≤ length(textbuf) && textbuf[rhs_byte] in (UInt8(' '), UInt8('\t'))
+            rhs_byte += 1
+        end
+        rhs_start = offset_to_xy(fi, rhs_byte)
+        Range(; start=lhs_start, var"end"=rhs_start)
+    else
+        nothing
     end
-    rhs_start = offset_to_xy(fi, rhs_byte)
-    lhs_eq_range = Range(; start=lhs_start, var"end"=rhs_start)
-    return UnusedVariableData(false, assignment_range, lhs_eq_range)
+    return_insert_position, return_insert_text = return_insert_data(
+        assignment, fi, bn, tail_kind)
+    return UnusedVariableData(
+        false, assignment_range, lhs_eq_range, return_insert_position, return_insert_text)
 end
 
 function analyze_captured_boxes!(

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -744,7 +744,7 @@ end
 
 function unused_assignment_message(bn::String, tail_kind::Symbol)
     if tail_kind !== :none
-        return "Value assigned to `$bn` is returned directly; consider `return $bn` to return the binding explicitly"
+        return "Value assigned to `$bn` is returned implicitly; consider `return $bn` to return the binding explicitly"
     end
     return "Value assigned to `$bn` is never used"
 end

--- a/src/notebook.jl
+++ b/src/notebook.jl
@@ -316,8 +316,15 @@ function localize_diagnostic_data(@nospecialize(data), concat::ConcatenatedNoteb
         if lhs_eq_range !== nothing
             lhs_eq_range = localize_range(lhs_eq_range, concat)
         end
+        return_insert_position = data.return_insert_position
+        if return_insert_position !== nothing
+            _, local_position = @something global_to_cell_position(
+                concat, return_insert_position) return data
+            return_insert_position = local_position
+        end
         return UnusedVariableData(
-            data.is_tuple_unpacking, assignment_range, lhs_eq_range)
+            data.is_tuple_unpacking, assignment_range, lhs_eq_range,
+            return_insert_position, data.return_insert_text)
     end
     return data
 end

--- a/test/test_code_action.jl
+++ b/test/test_code_action.jl
@@ -155,8 +155,27 @@ end
         @test delete_actions[2].edit.changes[uri][1].range.start == positions[1]
         @test delete_actions[2].edit.changes[uri][1].range.var"end" == positions[3]
         # No rename action for unused assignments
-        rename_actions = filter(a -> contains(a.title, "Prefix") || contains(a.title, "Replace"), code_actions)
+        rename_actions = filter(code_actions) do action
+            contains(action.title, "Prefix") || contains(action.title, "Replace")
+        end
         @test isempty(rename_actions)
+    end
+
+    let (code_actions, uri, positions) = get_unused_var_code_actions("""
+        function f()
+            x = 1
+            println(x)
+            x = 2│
+        end
+        """)
+        return_actions = filter(a -> a.title == "Insert explicit return", code_actions)
+        @test length(return_actions) == 1
+        action = only(return_actions)
+        @test action.isPreferred == true
+        edit = only(action.edit.changes[uri])
+        @test edit.range.start == positions[1]
+        @test edit.range.var"end" == positions[1]
+        @test edit.newText == "\n    return x"
     end
 end
 

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -99,6 +99,19 @@ module EmptyModule end
     end
 
     let diagnostics = get_lowering_diagnostics("""
+        function foo(x)
+            str = "(\$x)"
+        end
+        """)
+        @test length(diagnostics) == 1
+        diagnostic = only(diagnostics)
+        @test diagnostic.code == JETLS.LOWERING_UNUSED_LOCAL_CODE
+        @test diagnostic.message ==
+            "Local binding `str` is not read; consider `return str` to return it explicitly"
+        @test diagnostic.severity == DiagnosticSeverity.Information
+    end
+
+    let diagnostics = get_lowering_diagnostics("""
         function foo(x; y=nothing)
             return x
         end
@@ -966,7 +979,8 @@ end
                 d -> d.code == JETLS.LOWERING_UNUSED_ASSIGNMENT_CODE,
                 diagnostics)]
             @test dead_store_diag.severity == DiagnosticSeverity.Information
-            @test dead_store_diag.message == "Value assigned to `y` is never used"
+            @test dead_store_diag.message ==
+                "Value assigned to `y` is returned directly; consider `return y` to return the binding explicitly"
             @test dead_store_diag.range.start.line == 2
         end
     end
@@ -1177,7 +1191,8 @@ end
             diagnostic = only(diagnostics)
             @test diagnostic.code == JETLS.LOWERING_UNUSED_ASSIGNMENT_CODE
             @test diagnostic.severity == DiagnosticSeverity.Information
-            @test diagnostic.message == "Value assigned to `z` is never used"
+            @test diagnostic.message ==
+                "Value assigned to `z` is returned directly; consider `return z` to return the binding explicitly"
             @test diagnostic.range.start.line == 6
         end
     end
@@ -1242,6 +1257,26 @@ end
             diagnostic = only(diagnostics)
             @test diagnostic.message == "Value assigned to `z` is never used"
             @test diagnostic.range.start.line == 3
+        end
+    end
+
+    @testset "tail assignment value returned" begin
+        let diagnostics = get_lowering_diagnostics("""
+            function f(xs)
+                str = "("
+                for x in xs
+                    str *= x
+                    str *= ","
+                end
+                str *= ")"
+            end
+            """; code=JETLS.LOWERING_UNUSED_ASSIGNMENT_CODE)
+            @test length(diagnostics) == 1
+            diagnostic = only(diagnostics)
+            @test diagnostic.message ==
+                "Value assigned to `str` is returned directly; consider `return str` to return the binding explicitly"
+            @test diagnostic.severity == DiagnosticSeverity.Information
+            @test diagnostic.range.start.line == 6
         end
     end
 

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -980,7 +980,7 @@ end
                 diagnostics)]
             @test dead_store_diag.severity == DiagnosticSeverity.Information
             @test dead_store_diag.message ==
-                "Value assigned to `y` is returned directly; consider `return y` to return the binding explicitly"
+                "Value assigned to `y` is returned implicitly; consider `return y` to return the binding explicitly"
             @test dead_store_diag.range.start.line == 2
         end
     end
@@ -1192,7 +1192,7 @@ end
             @test diagnostic.code == JETLS.LOWERING_UNUSED_ASSIGNMENT_CODE
             @test diagnostic.severity == DiagnosticSeverity.Information
             @test diagnostic.message ==
-                "Value assigned to `z` is returned directly; consider `return z` to return the binding explicitly"
+                "Value assigned to `z` is returned implicitly; consider `return z` to return the binding explicitly"
             @test diagnostic.range.start.line == 6
         end
     end
@@ -1274,7 +1274,7 @@ end
             @test length(diagnostics) == 1
             diagnostic = only(diagnostics)
             @test diagnostic.message ==
-                "Value assigned to `str` is returned directly; consider `return str` to return the binding explicitly"
+                "Value assigned to `str` is returned implicitly; consider `return str` to return the binding explicitly"
             @test diagnostic.severity == DiagnosticSeverity.Information
             @test diagnostic.range.start.line == 6
         end


### PR DESCRIPTION
Address aviatesk/JETLS.jl#723.

In tail-position assignments, Julia returns the assignment expression, while the assigned binding itself may still never be read.
For example, in:
```julia
function f()
    x = 1
end
```
the function returns the value of `x = 1`, not a later read of `x`. 
The old `Unused local binding x` wording did not explain that implicit-return distinction. 

JETLS now reports this message, wrapped here:
```
Local binding `x` is not read; consider `return x` to return it explicitly
```

For tail dead stores, JETLS similarly reports a message of the form, wrapped here:
```
Value assigned to `x` is returned directly; consider `return x` to return the binding explicitly
```

Classify returned assignment expressions and report this more specific message. Simple block-tail assignments also carry insertion metadata so the quick fix can add that explicit return.