### PR TITLE
file-cache: Avoid unsynced syntax tree retention

### DIFF
--- a/src/analysis/occurrence-analysis.jl
+++ b/src/analysis/occurrence-analysis.jl
@@ -336,22 +336,73 @@ function is_matching_global_binding(
 end
 
 function find_global_binding_occurrences!(
+        state::ServerState, uri::URI, fi::FileInfo, binfo::JL.BindingInfo;
+        lookup_func = gen_lookup_out_of_scope!(state, uri),
+    )
+    cached = get_cached_global_binding_occurrences(state, uri, binfo)
+    cached === nothing || return cached
+    st0_top = build_syntax_tree(fi)
+    return find_global_binding_occurrences_from_tree!(
+        state, uri, fi, st0_top, binfo; lookup_func)
+end
+
+function get_cached_global_binding_occurrences(
+        state::ServerState, uri::URI, binfo::JL.BindingInfo
+    )
+    cache_uri = canonical_cache_uri(state, uri)
+    file_cache = get(load(state.binding_occurrences_cache), cache_uri, nothing)
+    file_cache === nothing && return nothing
+    globals = @something file_cache.globals return nothing
+    return lookup_global_binding_occurrences(globals, binfo)
+end
+
+function find_global_binding_occurrences_from_tree!(
         state::ServerState, uri::URI, fi::FileInfo, st0_top::SyntaxTreeC, binfo::JL.BindingInfo;
         lookup_func = gen_lookup_out_of_scope!(state, uri),
     )
-    ret = Set{CachedBindingOccurrence}()
+    cached = get_cached_global_binding_occurrences(state, uri, binfo)
+    cached === nothing || return cached
+    globals = BindingOccurrencesResult()
     iterate_toplevel_tree(st0_top) do st0::SyntaxTreeC
         binding_occurrences = @something get_binding_occurrences!(
             state, uri, fi, st0; lookup_func) return
-        for (binfo′, occurrences) in binding_occurrences
-            if is_matching_global_binding(binfo′, binfo)
-                for occurrence in occurrences
-                    push!(ret, occurrence)
-                end
-            end
-        end
+        add_global_binding_occurrences!(globals, binding_occurrences)
+    end
+    store_global_binding_occurrences!(state, uri, globals)
+    return lookup_global_binding_occurrences(globals, binfo)
+end
+
+function lookup_global_binding_occurrences(
+        globals::BindingOccurrencesResult, binfo::JL.BindingInfo
+    )
+    ret = Set{CachedBindingOccurrence}()
+    for (binfo′, occurrences) in globals
+        is_matching_global_binding(binfo′, binfo) || continue
+        union!(ret, occurrences)
     end
     return ret
+end
+
+function add_global_binding_occurrences!(
+        globals::BindingOccurrencesResult, result::BindingOccurrencesResult
+    )
+    for (binfo, occurrences) in result
+        binfo.kind === :global || continue
+        union!(get!(Set{CachedBindingOccurrence}, globals, binfo), occurrences)
+    end
+    return globals
+end
+
+function store_global_binding_occurrences!(
+        state::ServerState, uri::URI, globals::BindingOccurrencesResult
+    )
+    cache_uri = canonical_cache_uri(state, uri)
+    store!(state.binding_occurrences_cache) do cache::BindingOccurrencesCacheData
+        file_cache = get(cache, cache_uri, nothing)
+        by_range = file_cache === nothing ? BindingOccurrencesRangeCache() : file_cache.by_range
+        new_file_cache = BindingOccurrencesCacheEntry(by_range, globals)
+        return BindingOccurrencesCacheData(cache, cache_uri => new_file_cache), nothing
+    end
 end
 
 # Cached entry point. The cache key is only the byte range — `lookup_func`
@@ -367,8 +418,8 @@ function get_binding_occurrences!(
     range_key = JS.byte_range(st0)
     return store!(state.binding_occurrences_cache) do cache::BindingOccurrencesCacheData
         file_cache = get(cache, cache_uri, nothing)
-        if file_cache !== nothing && haskey(file_cache, range_key)
-            return cache, file_cache[range_key]
+        if file_cache !== nothing && haskey(file_cache.by_range, range_key)
+            return cache, file_cache.by_range[range_key]
         end
         # Cache lowering failures as empty results so repeated calls for the same statement
         cache_result = BindingOccurrencesResult()
@@ -381,11 +432,10 @@ function get_binding_occurrences!(
                 end
             end
         end
-        if file_cache === nothing
-            file_cache = BindingOccurrencesCacheEntry(range_key => cache_result)
-        else
-            file_cache = BindingOccurrencesCacheEntry(file_cache, range_key => cache_result)
-        end
+        by_range = file_cache === nothing ?
+            BindingOccurrencesRangeCache(range_key => cache_result) :
+            BindingOccurrencesRangeCache(file_cache.by_range, range_key => cache_result)
+        file_cache = BindingOccurrencesCacheEntry(by_range, nothing)
         return BindingOccurrencesCacheData(cache, cache_uri => file_cache), cache_result
     end
 end

--- a/src/declaration.jl
+++ b/src/declaration.jl
@@ -103,8 +103,7 @@ function find_global_binding_declarations(
         end begin
             get_unsynced_file_info!(state, search_uri)
         end continue
-        search_st0_top = build_syntax_tree(fi)
-        for occurrence in find_global_binding_occurrences!(state, search_uri, fi, search_st0_top, binfo)
+        for occurrence in find_global_binding_occurrences!(state, search_uri, fi, binfo)
             occurrence.kind === :decl || continue
             range, adjusted_uri =
                 unadjust_range(state, search_uri, jsobj_to_range(occurrence.tree, fi))

--- a/src/definition.jl
+++ b/src/definition.jl
@@ -47,8 +47,7 @@ function LSP.Location(m::Method)
     if file === nothing
         file = String(m.file) # method defined in unsaved buffer
     else
-        file = file::String
-        file = to_full_path(file)
+        file = to_full_path(file::String)
     end
     return Location(;
         uri = filename2uri(file),
@@ -249,8 +248,7 @@ function find_global_binding_definitions(
         end begin
             get_unsynced_file_info!(state, search_uri)
         end continue
-        search_st0_top = build_syntax_tree(fi)
-        for occurrence in find_global_binding_occurrences!(state, search_uri, fi, search_st0_top, binfo)
+        for occurrence in find_global_binding_occurrences!(state, search_uri, fi, binfo)
             if occurrence.kind === :def
                 range, adjusted_uri = unadjust_range(state, search_uri, jsobj_to_range(occurrence.tree, fi))
                 push!(seen_locations, (adjusted_uri, range))

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -860,11 +860,6 @@ function analyze_unused_assignments!(
     end
 end
 
-struct DefUsedNames
-    def::Set{String}
-    used::Set{String}
-    DefUsedNames() = new(Set{String}(), Set{String}())
-end
 const DefUsedNamesCacheData = Base.PersistentDict{UInt,Dict{Module,DefUsedNames}}
 const DefUsedNamesCache = LWContainer{DefUsedNamesCacheData, LWStats}
 
@@ -1517,12 +1512,6 @@ function per_stmt_diagnostics!(
         skip_analysis_requiring_context, allow_unused_underscore, allow_noreturn_optimization)
 end
 
-struct ImportInfo
-    uri::URI
-    name_range::Range
-    delete_range::Range
-end
-
 function compute_unit_def_used_names(
         server::Server, search_uris::Set{URI};
         skip_context_check::Bool = false # used by tests only
@@ -1536,22 +1525,47 @@ function compute_unit_def_used_names(
         end begin
             get_unsynced_file_info!(state, search_uri)
         end continue
+        cached = get(load(state.per_file_diagnostics_cache),
+            canonical_cache_uri(state, search_uri), nothing)
+        if cached !== nothing
+            merge_def_used_names!(mod_def_used_names, cached.def_used_names)
+            continue
+        end
         search_st0_top = build_syntax_tree(search_fi)
 
         iterate_toplevel_tree(search_st0_top) do st0::SyntaxTreeC
             binding_occurrences = @something get_binding_occurrences!(
                 state, search_uri, search_fi, st0) return
             context_module = get_context_module(state, search_uri, offset_to_xy(search_fi, JS.first_byte(st0)))
-            for (binfo_key, occurrences) in binding_occurrences
-                binfo_key.kind === :global || continue
-                if any(o -> o.kind === :use, occurrences)
-                    def_used_names = get!(DefUsedNames, mod_def_used_names, context_module)
-                    push!(def_used_names.used, binfo_key.name)
-                elseif any(o -> o.kind === :def, occurrences)
-                    def_used_names = get!(DefUsedNames, mod_def_used_names, context_module)
-                    push!(def_used_names.def, binfo_key.name)
-                end
-            end
+            update_def_used_names!(mod_def_used_names, context_module, binding_occurrences)
+        end
+    end
+    return mod_def_used_names
+end
+
+function merge_def_used_names!(
+        dst::Dict{Module,DefUsedNames}, src::Dict{Module,DefUsedNames}
+    )
+    for (context_module, names) in src
+        dst_names = get!(DefUsedNames, dst, context_module)
+        union!(dst_names.def, names.def)
+        union!(dst_names.used, names.used)
+    end
+    return dst
+end
+
+function update_def_used_names!(
+        mod_def_used_names::Dict{Module,DefUsedNames}, context_module::Module,
+        binding_occurrences::BindingOccurrencesResult
+    )
+    for (binfo_key, occurrences) in binding_occurrences
+        binfo_key.kind === :global || continue
+        if any(o -> o.kind === :use, occurrences)
+            def_used_names = get!(DefUsedNames, mod_def_used_names, context_module)
+            push!(def_used_names.used, binfo_key.name)
+        elseif any(o -> o.kind === :def, occurrences)
+            def_used_names = get!(DefUsedNames, mod_def_used_names, context_module)
+            push!(def_used_names.def, binfo_key.name)
         end
     end
     return mod_def_used_names
@@ -1580,7 +1594,7 @@ end
 # Detects unused imports by scanning all workspace files for usages of imported names.
 # This analysis can be slow if implemented naively, but achieves practical performance through:
 # - Early return for files without import/using statements (~1ms depending on file size)
-# - Syntax tree caching for unsynced files (see `FileInfo.syntax_tree0`)
+# - Per-file diagnostic summaries for cached files
 # - Binding occurrences caching (see `BindingOccurrencesCache`)
 # - Per-unit used-name memoization via `used_names_cache`, which lets a single
 #   `workspace/diagnostic` pull reuse the expensive `mod_used_names` aggregation
@@ -1588,20 +1602,10 @@ end
 # - Unchanged file skipping in workspace/diagnostic
 function analyze_unused_imports!(
         diagnostics::Vector{Diagnostic}, def_used_names_cache::DefUsedNamesCache,
-        server::Server, uri::URI, fi::FileInfo, st0_top::SyntaxTreeC;
+        server::Server, uri::URI,
+        mod_imported_names::Dict{Module,Dict{String,Vector{ImportInfo}}};
         skip_context_check::Bool = false # used by tests only
     )
-    state = server.state
-    mod_imported_names = Dict{Module,Dict{String,Vector{ImportInfo}}}()
-    traverse(st0_top) do st0::SyntaxTreeC
-        JS.kind(st0) ∈ JS.KSet"import using" || return nothing
-        context_module = get_context_module(state, uri, offset_to_xy(fi, JS.first_byte(st0)))
-        for (name, name_range, delete_range) in collect_explicit_import_names(st0, fi)
-            imported_names = get!(Dict{String,Vector{ImportInfo}}, mod_imported_names, context_module)
-            push!(get!(Vector{ImportInfo}, imported_names, name), ImportInfo(uri, name_range, delete_range))
-        end
-        return TraversalNoRecurse()
-    end
     isempty(mod_imported_names) && return diagnostics
 
     search_uris = collect_search_uris(server, uri)
@@ -1626,6 +1630,35 @@ function analyze_unused_imports!(
     end
 
     return diagnostics
+end
+
+function analyze_unused_imports!(
+        diagnostics::Vector{Diagnostic}, def_used_names_cache::DefUsedNamesCache,
+        server::Server, uri::URI, fi::FileInfo, st0_top::SyntaxTreeC;
+        skip_context_check::Bool = false # used by tests only
+    )
+    mod_imported_names = collect_explicit_imports_by_module(server.state, uri, fi, st0_top)
+    return analyze_unused_imports!(
+        diagnostics, def_used_names_cache, server, uri, mod_imported_names;
+        skip_context_check)
+end
+
+function collect_explicit_imports_by_module(
+        state::ServerState, uri::URI, fi::FileInfo, st0_top::SyntaxTreeC
+    )
+    mod_imported_names = Dict{Module,Dict{String,Vector{ImportInfo}}}()
+    traverse(st0_top) do st0::SyntaxTreeC
+        JS.kind(st0) ∈ JS.KSet"import using" || return nothing
+        context_module = get_context_module(state, uri, offset_to_xy(fi, JS.first_byte(st0)))
+        for (name, name_range, delete_range) in collect_explicit_import_names(st0, fi)
+            imported_names =
+                get!(Dict{String,Vector{ImportInfo}}, mod_imported_names, context_module)
+            push!(get!(Vector{ImportInfo}, imported_names, name),
+                ImportInfo(uri, name_range, delete_range))
+        end
+        return TraversalNoRecurse()
+    end
+    return mod_imported_names
 end
 
 # Returns tuples of (name, name_range, delete_range).
@@ -1703,6 +1736,10 @@ function compute_per_file_diagnostics(
     diagnostics = Diagnostic[]
     candidates = UndefGlobalCandidate[]
     skip_analysis_requiring_context = !has_analyzed_context(server.state, uri; lookup_func)
+    def_used_names = Dict{Module,DefUsedNames}()
+    explicit_imports = skip_analysis_requiring_context ?
+        Dict{Module,Dict{String,Vector{ImportInfo}}}() :
+        collect_explicit_imports_by_module(server.state, uri, file_info, st0_top)
     allow_unused_underscore = get_config(server, :diagnostic, :allow_unused_underscore)
     soft_scope = is_notebook_cell_uri(server.state, uri)
     iterate_toplevel_tree(st0_top) do st0::SyntaxTreeC
@@ -1713,8 +1750,17 @@ function compute_per_file_diagnostics(
         per_stmt_diagnostics!(diagnostics, candidates, uri, file_info, st0,
             context_module, world, analyzer, postprocessor;
             skip_analysis_requiring_context, allow_unused_underscore, soft_scope)
+        if !skip_analysis_requiring_context
+            binding_occurrences = if lookup_func === nothing
+                get_binding_occurrences!(server.state, uri, file_info, st0)
+            else
+                get_binding_occurrences!(server.state, uri, file_info, st0; lookup_func)
+            end
+            binding_occurrences !== nothing &&
+                update_def_used_names!(def_used_names, context_module, binding_occurrences)
+        end
     end
-    return PerFileDiagnosticsResult(diagnostics, candidates)
+    return PerFileDiagnosticsResult(diagnostics, candidates, def_used_names, explicit_imports)
 end
 
 # Cached accessor for the per-file `PerFileDiagnosticsResult`. The cached `diagnostics`
@@ -1723,6 +1769,25 @@ end
 # the lowering-time world + analyzer state, so the cross-file phase only needs to filter
 # them against the unit's `DefUsedNames` set. Cache misses and cancelled computations
 # both return without caching; only a fully computed result is stored.
+function get_per_file_diagnostics!(
+        server::Server, uri::URI, file_info::FileInfo, cancel_flag::CancelFlag;
+        lookup_func = nothing
+    )
+    cache_uri = canonical_cache_uri(server.state, uri)
+    return store!(server.state.per_file_diagnostics_cache) do cache::PerFileDiagnosticsCacheData
+        if haskey(cache, cache_uri)
+            return cache, cache[cache_uri]
+        end
+        st0_top = build_syntax_tree(file_info)
+        result = compute_per_file_diagnostics(
+            server, uri, file_info, st0_top, cancel_flag; lookup_func)
+        if is_cancelled(cancel_flag)
+            return cache, result
+        end
+        return PerFileDiagnosticsCacheData(cache, cache_uri => result), result
+    end
+end
+
 function get_per_file_diagnostics!(
         server::Server, uri::URI, file_info::FileInfo, st0_top::SyntaxTreeC,
         cancel_flag::CancelFlag;
@@ -1765,14 +1830,15 @@ end
 # which is memoized per-unit on `def_used_names_cache`.
 function cross_file_diagnostics!(
         diagnostics::Vector{Diagnostic}, def_used_names_cache::DefUsedNamesCache,
-        server::Server, uri::URI, file_info::FileInfo, st0_top::SyntaxTreeC,
-        per_file::PerFileDiagnosticsResult;
+        server::Server, uri::URI, per_file::PerFileDiagnosticsResult;
         skip_context_check::Bool = false # used by tests only
     )
     search_uris = collect_search_uris(server, uri)
     mod_def_used_names = compute_def_used_names!(def_used_names_cache, server, search_uris; skip_context_check)
     emit_undef_global_diagnostics!(diagnostics, per_file.undef_global_candidates, mod_def_used_names)
-    analyze_unused_imports!(diagnostics, def_used_names_cache, server, uri, file_info, st0_top; skip_context_check)
+    analyze_unused_imports!(
+        diagnostics, def_used_names_cache, server, uri, per_file.explicit_imports;
+        skip_context_check)
     return diagnostics
 end
 
@@ -1781,12 +1847,11 @@ function toplevel_lowering_diagnostics!(
         file_info::FileInfo, cancel_flag::CancelFlag=DUMMY_CANCEL_FLAG;
         lookup_func = nothing
     )
-    st0_top = build_syntax_tree(file_info)
-    cached = get_per_file_diagnostics!(server, uri, file_info, st0_top, cancel_flag; lookup_func)
+    cached = get_per_file_diagnostics!(server, uri, file_info, cancel_flag; lookup_func)
     is_cancelled(cancel_flag) && return cached.diagnostics
     diagnostics = copy(cached.diagnostics)
     if has_analyzed_context(server.state, uri; lookup_func)
-        cross_file_diagnostics!(diagnostics, def_used_names_cache, server, uri, file_info, st0_top, cached)
+        cross_file_diagnostics!(diagnostics, def_used_names_cache, server, uri, cached)
     end
     return diagnostics
 end

--- a/src/document-highlight.jl
+++ b/src/document-highlight.jl
@@ -92,7 +92,7 @@ function global_document_highlights!(
         state::ServerState, uri::URI, fi::FileInfo, st0_top::SyntaxTreeC,
         binfo::JL.BindingInfo,
     )
-    for occurrence in find_global_binding_occurrences!(state, uri, fi, st0_top, binfo)
+    for occurrence in find_global_binding_occurrences_from_tree!(state, uri, fi, st0_top, binfo)
         add_highlight_for_occurrence!(highlights′, state, uri, fi, occurrence)
     end
     return highlights′

--- a/src/notebook.jl
+++ b/src/notebook.jl
@@ -33,8 +33,9 @@ end
 function cache_notebook_file_info!(server::Server, notebook_uri::URI, notebook_info::NotebookInfo)
     state = server.state
     parsed_stream = ParseStream!(notebook_info.concat.source)
+    st0 = JS.build_tree(JS.SyntaxTree, parsed_stream; filename=uri2filename(notebook_uri))
     fi = FileInfo(notebook_info.version, parsed_stream, notebook_uri, notebook_info.encoding;
-        inferred_context_cache=InferredContextCache())
+        syntax_tree0=st0, inferred_context_cache=InferredContextCache())
     store!(state.file_cache) do cache
         Base.PersistentDict(cache, notebook_uri => fi), fi
     end

--- a/src/references.jl
+++ b/src/references.jl
@@ -169,9 +169,8 @@ function collect_global_references!(
         end begin
             get_unsynced_file_info!(server.state, uri)
         end continue
-        search_st0_top = build_syntax_tree(fi)
         global_find_references_in_file!(
-            seen_locations, state, uri, fi, search_st0_top, binfo;
+            seen_locations, state, uri, fi, binfo;
             include_declaration)
     end
     return true
@@ -179,10 +178,10 @@ end
 
 function global_find_references_in_file!(
         seen_locations::Set{Tuple{URI,Range}}, state::ServerState, uri::URI, fi::FileInfo,
-        st0_top::SyntaxTreeC, binfo::JL.BindingInfo;
+        binfo::JL.BindingInfo;
         include_declaration::Bool = true,
     )
-    for occurrence in find_global_binding_occurrences!(state, uri, fi, st0_top, binfo)
+    for occurrence in find_global_binding_occurrences!(state, uri, fi, binfo)
         if include_declaration || occurrence.kind === :use
             range, adjusted_uri = unadjust_range(state, uri, jsobj_to_range(occurrence.tree, fi))
             push!(seen_locations, (adjusted_uri, range))

--- a/src/rename.jl
+++ b/src/rename.jl
@@ -381,7 +381,7 @@ function collect_global_rename_edits_in_file!(
         st0_top::SyntaxTreeC, binfo::JL.BindingInfo, newName::String
     )
     ismacro = startswith(binfo.name, '@')
-    for occurrence in find_global_binding_occurrences!(state, uri, fi, st0_top, binfo)
+    for occurrence in find_global_binding_occurrences_from_tree!(state, uri, fi, st0_top, binfo)
         id_byte_range = JS.byte_range(occurrence.tree)
         classification = classify_import_rename(st0_top, id_byte_range, occurrence.kind)
         if classification === :needs_as

--- a/src/types.jl
+++ b/src/types.jl
@@ -98,9 +98,11 @@ struct FileInfo
     filename::String
     encoding::LSP.PositionEncodingKind.Ty
     testsetinfos::Vector{TestsetInfo}
-    # Pruned `st0` cache. Access through `build_syntax_tree`, which returns a copy
-    # safe for lowering.
-    syntax_tree0::SyntaxTreeC
+    # Pruned `st0` cache for synchronized documents. Access through
+    # `build_syntax_tree`, which returns a copy safe for lowering. Unsynced files
+    # keep this `nothing`; workspace-wide hot paths should rely on summary caches
+    # instead of retaining `st0` for every file.
+    syntax_tree0::Union{Nothing,SyntaxTreeC}
     # Intentionally unbounded within a `FileInfo`: synced documents usually receive
     # repeated type queries for the same top-level tree. Content updates replace the
     # whole `FileInfo`, and full-analysis updates clear this cache so old analysis
@@ -122,12 +124,7 @@ struct FileInfo
             syntax_tree0::Union{Nothing,SyntaxTreeC} = nothing,
             inferred_context_cache::Union{Nothing,InferredContextCache} = nothing
         )
-        syntax_tree0 = if syntax_tree0 === nothing
-            JS.build_tree(JS.SyntaxTree, parsed_stream; filename)
-        else
-            syntax_tree0
-        end
-        syntax_tree0 = JS.prune(syntax_tree0)
+        syntax_tree0 = syntax_tree0 === nothing ? nothing : JS.prune(syntax_tree0)
         line_starts = build_line_starts(parsed_stream.textbuf)
         new(version, parsed_stream, filename, encoding, testsetinfos, syntax_tree0,
             inferred_context_cache, line_starts)
@@ -722,7 +719,14 @@ struct CachedBindingOccurrence
 end
 
 const BindingOccurrencesResult = Dict{BindingInfoKey,Set{CachedBindingOccurrence}}
-const BindingOccurrencesCacheEntry = Base.PersistentDict{UnitRange{Int},BindingOccurrencesResult}
+const BindingOccurrencesRangeCache = Base.PersistentDict{UnitRange{Int},BindingOccurrencesResult}
+struct BindingOccurrencesCacheEntry
+    by_range::BindingOccurrencesRangeCache
+    # Complete file-level global summary; `nothing` means it has not been built
+    # for this file version. Range-cache misses currently discard it defensively,
+    # although same-version top-level ranges should normally be stable.
+    globals::Union{Nothing,BindingOccurrencesResult}
+end
 
 const AnyBindingOccurrence = Union{BindingOccurrence,CachedBindingOccurrence}
 
@@ -774,6 +778,16 @@ struct LoweringDiagnosticKey
     kind::Symbol
     name::String
 end
+struct DefUsedNames
+    def::Set{String}
+    used::Set{String}
+    DefUsedNames() = new(Set{String}(), Set{String}())
+end
+struct ImportInfo
+    uri::URI
+    name_range::Range
+    delete_range::Range
+end
 # Undef-global candidate emitted by the per-file phase (with fresh `ctx3`),
 # consumed by the cross-file phase (which only does a cheap def-name lookup).
 # Everything needed for the final `Diagnostic` is pre-computed so the cache
@@ -787,6 +801,8 @@ end
 struct PerFileDiagnosticsResult
     diagnostics::Vector{Diagnostic}
     undef_global_candidates::Vector{UndefGlobalCandidate}
+    def_used_names::Dict{Module,DefUsedNames}
+    explicit_imports::Dict{Module,Dict{String,Vector{ImportInfo}}}
 end
 const PerFileDiagnosticsCacheData = Base.PersistentDict{URI,PerFileDiagnosticsResult}
 const PerFileDiagnosticsCache = LWContainer{PerFileDiagnosticsCacheData, LWStats}

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -12,6 +12,10 @@ function copy_syntax_tree(st::SyntaxTreeC)
 end
 
 function build_syntax_tree(fi::FileInfo)
+    if fi.syntax_tree0 === nothing
+        st0 = JS.build_tree(JS.SyntaxTree, fi.parsed_stream; filename=fi.filename)
+        return JS.prune(st0)
+    end
     # The lowering pipeline modifies the internal state of `st0`,
     # so we need to create a copy for each read to avoid race conditions.
     return copy_syntax_tree(fi.syntax_tree0)

--- a/test/analysis/test_occurrence_analysis.jl
+++ b/test/analysis/test_occurrence_analysis.jl
@@ -712,7 +712,7 @@ function with_global_binding_occurrences(
     @test target_binfo.kind === :global
     @test target_binfo.name == target_name
 
-    occurrences = JETLS.find_global_binding_occurrences!(
+    occurrences = JETLS.find_global_binding_occurrences_from_tree!(
         state, furi, fi, st0_top, target_binfo;
         lookup_func = Returns(JETLS.OutOfScope(lowering_module)))
 

--- a/test/test_code_action.jl
+++ b/test/test_code_action.jl
@@ -25,17 +25,23 @@ function get_lowering_diagnostics(
     st0_top = JETLS.build_syntax_tree(fi)
     diagnostics = LSP.Diagnostic[]
     candidates = JETLS.UndefGlobalCandidate[]
+    def_used_names = Dict{Module,JETLS.DefUsedNames}()
     JETLS.iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
         JETLS.per_stmt_diagnostics!(diagnostics, candidates, uri, fi,
             st0, context_module, world, #=analyzer=#nothing, JETLS.LSPostProcessor();
             kwargs...)
+        binding_occurrences = JETLS.get_binding_occurrences!(server.state, uri, fi, st0)
+        binding_occurrences !== nothing &&
+            JETLS.update_def_used_names!(def_used_names, context_module, binding_occurrences)
     end
+    explicit_imports = JETLS.collect_explicit_imports_by_module(server.state, uri, fi, st0_top)
     # Mirror the cross-file phase. `skip_context_check=true` because the test server
     # has no populated `analysis_manager` — we want this single file to count as
     # part of its own unit anyway.
-    per_file = JETLS.PerFileDiagnosticsResult(diagnostics, candidates)
+    per_file = JETLS.PerFileDiagnosticsResult(
+        diagnostics, candidates, def_used_names, explicit_imports)
     JETLS.cross_file_diagnostics!(diagnostics, JETLS.DefUsedNamesCache(),
-        server, uri, fi, st0_top, per_file; skip_context_check=true)
+        server, uri, per_file; skip_context_check=true)
     if code !== nothing
         filter!(d -> d.code == code, diagnostics)
     end

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -26,17 +26,23 @@ function get_lowering_diagnostics(
     @assert JS.kind(st0_top) === JS.K"toplevel"
     diagnostics = LSP.Diagnostic[]
     candidates = JETLS.UndefGlobalCandidate[]
+    def_used_names = Dict{Module,JETLS.DefUsedNames}()
     JETLS.iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
         JETLS.per_stmt_diagnostics!(diagnostics, candidates, uri, fi,
             st0, context_module, world, #=analyzer=#nothing, JETLS.LSPostProcessor();
             kwargs...)
+        binding_occurrences = JETLS.get_binding_occurrences!(server.state, uri, fi, st0)
+        binding_occurrences !== nothing &&
+            JETLS.update_def_used_names!(def_used_names, context_module, binding_occurrences)
     end
+    explicit_imports = JETLS.collect_explicit_imports_by_module(server.state, uri, fi, st0_top)
     # Mirror the cross-file phase. `skip_context_check=true` because the test server
     # has no populated `analysis_manager` — we want this single file to count as
     # part of its own unit anyway.
-    per_file = JETLS.PerFileDiagnosticsResult(diagnostics, candidates)
+    per_file = JETLS.PerFileDiagnosticsResult(
+        diagnostics, candidates, def_used_names, explicit_imports)
     JETLS.cross_file_diagnostics!(diagnostics, JETLS.DefUsedNamesCache(),
-        server, uri, fi, st0_top, per_file; skip_context_check=true)
+        server, uri, per_file; skip_context_check=true)
     if code !== nothing
         filter!(d -> d.code == code, diagnostics)
     end


### PR DESCRIPTION
Scope the pruned `st0` snapshot to synchronized documents and let unsynced `FileInfo` values rebuild syntax trees only on demand. Open documents still reuse copied cached trees, while workspace files no longer retain parsed syntax trees after global searches.

Move workspace-wide diagnostics and global occurrence lookups toward summary caches instead: `PerFileDiagnosticsResult` now carries the cross-file summaries needed by diagnostics, and
`BindingOccurrencesCache` stores a lazily built file-level global occurrence summary for warm definition, declaration, and reference searches.

This keeps warm global searches at least comparable to the previous unsynced-`st0` cache path while reducing retained memory. In the JETLS self-analysis scenario measured during development, unsynced file cache size dropped by roughly 22 MiB, the occurrence cache grew by roughly 6 MiB, and the net major-cache footprint fell by about 16 MiB. End-to-end heap snapshots after `findReferences` showed the same order of improvement, from roughly 483 MiB down to 467 MiB.