### PR TITLE
workspace-symbol: Normalize empty container names

### DIFF
--- a/src/document-symbol.jl
+++ b/src/document-symbol.jl
@@ -1270,7 +1270,7 @@ function extract_local_variable_detail(
         if !isnothing(grandparent) && JS.kind(grandparent) === JS.K"for"
             detail = "for " * lstrip(JS.sourcetext(parent))
         else
-            detail = strip(first(split(JS.sourcetext(parent), '\n')))
+            detail = first(split(strip(JS.sourcetext(parent)), '\n'))
         end
         parent = grandparent
     end

--- a/src/workspace-symbol.jl
+++ b/src/workspace-symbol.jl
@@ -145,6 +145,9 @@ function flatten_document_symbols!(
     flatten_document_symbols!(workspace_symbols, doc_symbols, uri, notebook_info)
 end
 
+workspace_symbol_container_name(container_name::Union{Nothing,String}) =
+    isempty(@something container_name return nothing) ? nothing : container_name
+
 function flatten_document_symbols!(
         workspace_symbols::Vector{WorkspaceSymbol}, doc_symbols::Vector{DocumentSymbol},
         uri::URI, notebook_info::Union{Nothing,NotebookInfo};
@@ -164,7 +167,7 @@ function flatten_document_symbols!(
                 name = doc_sym.name,
                 kind = doc_sym.kind,
                 location,
-                containerName = parent_detail))
+                containerName = workspace_symbol_container_name(parent_detail)))
         elseif doc_sym.kind == SymbolKind.Namespace
             # Namespace symbols (if/let/for/while/@static if blocks) are introduced for
             # hierarchical structure in document outline, not representing actual definitions.
@@ -176,7 +179,7 @@ function flatten_document_symbols!(
                 name = doc_sym.name,
                 kind = doc_sym.kind,
                 location,
-                containerName = doc_sym.detail))
+                containerName = workspace_symbol_container_name(doc_sym.detail)))
         end
         children = doc_sym.children
         if children !== nothing

--- a/test/test_document_symbol.jl
+++ b/test/test_document_symbol.jl
@@ -988,6 +988,32 @@ end
             @test x_sym.detail == "x = i * 2"
         end
 
+        # Later iterators in a multiline for header should keep their binding detail.
+        let code = """
+            function foo(pkgdata)
+                for (file, fi) in zip(srcfiles, fileinfos),
+                    (mod, exs_infos) in fi.mod_exs_infos,
+                    (rex, exinfos) in exs_infos
+                    exinfos
+                end
+            end
+            """
+            symbols = get_document_symbols(code)
+            @test length(symbols) == 1
+            children = symbols[1].children
+            @test children !== nothing
+            for_sym = only(filter(c -> c.kind == SymbolKind.Namespace, children))
+            @test for_sym.children !== nothing
+            mod_sym = only(filter(c -> c.name == "mod", for_sym.children))
+            exs_infos_sym = only(filter(c -> c.name == "exs_infos", for_sym.children))
+            rex_sym = only(filter(c -> c.name == "rex", for_sym.children))
+            exinfos_sym = only(filter(c -> c.name == "exinfos", for_sym.children))
+            @test mod_sym.detail == "(mod, exs_infos) in fi.mod_exs_infos"
+            @test exs_infos_sym.detail == "(mod, exs_infos) in fi.mod_exs_infos"
+            @test rex_sym.detail == "(rex, exinfos) in exs_infos"
+            @test exinfos_sym.detail == "(rex, exinfos) in exs_infos"
+        end
+
         # nested for loops
         let code = """
             function foo()
@@ -1088,6 +1114,25 @@ end
             @test a_sym.detail == "a = 1"
             b_sym = only(filter(c -> c.name == "b", let_sym.children))
             @test b_sym.detail == "b = a + 1"
+        end
+
+        # Later bindings in a multiline let header should keep their binding detail.
+        let code = """
+            function foo(st0, b)
+                let bas = byte_ancestors(st0, b),
+                    i = findfirst(is_relevant_call, bas)
+                    return i
+                end
+            end
+            """
+            symbols = get_document_symbols(code)
+            @test length(symbols) == 1
+            children = symbols[1].children
+            @test children !== nothing
+            let_sym = only(filter(c -> c.kind == SymbolKind.Namespace, children))
+            @test let_sym.children !== nothing
+            i_sym = only(filter(c -> c.name == "i", let_sym.children))
+            @test i_sym.detail == "i = findfirst(is_relevant_call, bas)"
         end
     end
 


### PR DESCRIPTION
Avoid emitting empty `containerName` values for workspace symbols.

The root cause is fixed in `document-symbol.jl` by preserving detail text for later bindings in multiline `let` and `for` headers. The `workspace_symbol_container_name` normalization is kept as a defensive guard against empty `containerName` values reaching workspace symbol responses.