### PR TITLE
diagnostic: Add lowering/unconstrained-static-parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > This disables analysis for matched files. Basic features like completion still might work, but most LSP features will be unfunctional.
 > Note that `analysis_overrides` is provided as a temporary workaround and may be removed or changed at any time. A proper fix is being worked on.
 
+### Added
+
+- Added [`lowering/unconstrained-static-parameter`](https://aviatesk.github.io/JETLS.jl/release/diagnostic/#diagnostic/reference/lowering/unconstrained-static-parameter) diagnostic that warns when a method declares a static parameter that does not appear in the type of any function parameter, so its value cannot be deduced when the method is called.
+  This matches the warning Julia itself emits when evaluating such a method definition.
+  For example:
+  ```julia
+  f(::T) where {T,S} = S  # Method definition declares type variable `S` but does not use it in the type of any function parameter
+                          # (JETLS lowering/unconstrained-static-parameter)
+  ```
+
 ## 2026-06-03
 
 - Commit: [`a42a435`](https://github.com/aviatesk/JETLS.jl/commit/a42a435)

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -101,30 +101,31 @@ diagnostic, you'll find:
 
 Here is a summary table of the diagnostics explained in this section:
 
-| Code                                                                                             | Default Severity      | Source        | Description                                        |
-| ------------------------------------------------------------------------------------------------ | --------------------- | ------------- | -------------------------------------------------- |
-| [`syntax/parse-error`](@ref diagnostic/reference/syntax/parse-error)                             | `Error`               | `JETLS/live`  | Syntax parsing errors detected by JuliaSyntax.jl   |
-| [`lowering/error`](@ref diagnostic/reference/lowering/error)                                     | `Error`               | `JETLS/live`  | General lowering errors                            |
-| [`lowering/macro-expansion-error`](@ref diagnostic/reference/lowering/macro-expansion-error)     | `Error/Warning`       | `JETLS/live`  | Issues detected during macro expansion             |
-| [`lowering/undef-global-var`](@ref diagnostic/reference/lowering/undef-global-var)               | `Warning`             | `JETLS/live`  | References to undefined global variables           |
-| [`lowering/undef-local-var`](@ref diagnostic/reference/lowering/undef-local-var)                 | `Warning/Information` | `JETLS/live`  | References to undefined local variables            |
-| [`lowering/ambiguous-soft-scope`](@ref diagnostic/reference/lowering/ambiguous-soft-scope)       | `Warning`             | `JETLS/live`  | Assignment in soft scope shadows a global variable |
-| [`lowering/captured-boxed-variable`](@ref diagnostic/reference/lowering/captured-boxed-variable) | `Information`         | `JETLS/live`  | Variables captured by closures that require boxing |
-| [`lowering/unused-argument`](@ref diagnostic/reference/lowering/unused-argument)                 | `Information`         | `JETLS/live`  | Function arguments that are never used             |
-| [`lowering/unused-local`](@ref diagnostic/reference/lowering/unused-local)                       | `Information`         | `JETLS/live`  | Local variables that are never used                |
-| [`lowering/unused-assignment`](@ref diagnostic/reference/lowering/unused-assignment)             | `Information`         | `JETLS/live`  | Assignments whose values are never read            |
-| [`lowering/unused-import`](@ref diagnostic/reference/lowering/unused-import)                     | `Information`         | `JETLS/live`  | Imported names that are never used                 |
-| [`lowering/unreachable-code`](@ref diagnostic/reference/lowering/unreachable-code)               | `Information`         | `JETLS/live`  | Code after a block terminator that is never reached  |
-| [`lowering/unsorted-import-names`](@ref diagnostic/reference/lowering/unsorted-import-names)     | `Hint`                | `JETLS/live`  | Import/export names not sorted alphabetically      |
-| [`toplevel/error`](@ref diagnostic/reference/toplevel/error)                                     | `Error`               | `JETLS/save`  | Errors during code loading                         |
-| [`toplevel/method-overwrite`](@ref diagnostic/reference/toplevel/method-overwrite)               | `Warning`             | `JETLS/save`  | Method definitions that overwrite previous ones    |
-| [`toplevel/abstract-field`](@ref diagnostic/reference/toplevel/abstract-field)                   | `Information`         | `JETLS/save`  | Struct fields with abstract types                  |
-| [`inference/undef-global-var`](@ref diagnostic/reference/inference/undef-global-var)             | `Warning`             | `JETLS/save`  | References to undefined global variables           |
-| [`inference/field-error`](@ref diagnostic/reference/inference/field-error)                       | `Warning`             | `JETLS/save`  | Access to non-existent struct fields               |
-| [`inference/bounds-error`](@ref diagnostic/reference/inference/bounds-error)                     | `Warning`             | `JETLS/save`  | Out-of-bounds field access by index                |
-| [`inference/method-error`](@ref diagnostic/reference/inference/method-error)                     | `Warning`             | `JETLS/save`  | No matching method found for function calls        |
-| [`inference/non-boolean-cond`](@ref diagnostic/reference/inference/non-boolean-cond)             | `Warning`             | `JETLS/save`  | Non-boolean value used in boolean context          |
-| [`testrunner/test-failure`](@ref diagnostic/reference/testrunner/test-failure)                   | `Error`               | `JETLS/extra` | Test failures from TestRunner integration          |
+| Code                                                                                                           | Default Severity      | Source        | Description                                            |
+| -------------------------------------------------------------------------------------------------------------- | --------------------- | ------------- | ------------------------------------------------------ |
+| [`syntax/parse-error`](@ref diagnostic/reference/syntax/parse-error)                                           | `Error`               | `JETLS/live`  | Syntax parsing errors detected by JuliaSyntax.jl       |
+| [`lowering/error`](@ref diagnostic/reference/lowering/error)                                                   | `Error`               | `JETLS/live`  | General lowering errors                                |
+| [`lowering/macro-expansion-error`](@ref diagnostic/reference/lowering/macro-expansion-error)                   | `Error/Warning`       | `JETLS/live`  | Issues detected during macro expansion                 |
+| [`lowering/undef-global-var`](@ref diagnostic/reference/lowering/undef-global-var)                             | `Warning`             | `JETLS/live`  | References to undefined global variables               |
+| [`lowering/undef-local-var`](@ref diagnostic/reference/lowering/undef-local-var)                               | `Warning/Information` | `JETLS/live`  | References to undefined local variables                |
+| [`lowering/ambiguous-soft-scope`](@ref diagnostic/reference/lowering/ambiguous-soft-scope)                     | `Warning`             | `JETLS/live`  | Assignment in soft scope shadows a global variable     |
+| [`lowering/captured-boxed-variable`](@ref diagnostic/reference/lowering/captured-boxed-variable)               | `Information`         | `JETLS/live`  | Variables captured by closures that require boxing     |
+| [`lowering/unconstrained-static-parameter`](@ref diagnostic/reference/lowering/unconstrained-static-parameter) | `Warning`             | `JETLS/live`  | Static parameters not used in function parameter types |
+| [`lowering/unused-argument`](@ref diagnostic/reference/lowering/unused-argument)                               | `Information`         | `JETLS/live`  | Function arguments that are never used                 |
+| [`lowering/unused-local`](@ref diagnostic/reference/lowering/unused-local)                                     | `Information`         | `JETLS/live`  | Local variables that are never used                    |
+| [`lowering/unused-assignment`](@ref diagnostic/reference/lowering/unused-assignment)                           | `Information`         | `JETLS/live`  | Assignments whose values are never read                |
+| [`lowering/unused-import`](@ref diagnostic/reference/lowering/unused-import)                                   | `Information`         | `JETLS/live`  | Imported names that are never used                     |
+| [`lowering/unreachable-code`](@ref diagnostic/reference/lowering/unreachable-code)                             | `Information`         | `JETLS/live`  | Code after a block terminator that is never reached    |
+| [`lowering/unsorted-import-names`](@ref diagnostic/reference/lowering/unsorted-import-names)                   | `Hint`                | `JETLS/live`  | Import/export names not sorted alphabetically          |
+| [`toplevel/error`](@ref diagnostic/reference/toplevel/error)                                                   | `Error`               | `JETLS/save`  | Errors during code loading                             |
+| [`toplevel/method-overwrite`](@ref diagnostic/reference/toplevel/method-overwrite)                             | `Warning`             | `JETLS/save`  | Method definitions that overwrite previous ones        |
+| [`toplevel/abstract-field`](@ref diagnostic/reference/toplevel/abstract-field)                                 | `Information`         | `JETLS/save`  | Struct fields with abstract types                      |
+| [`inference/undef-global-var`](@ref diagnostic/reference/inference/undef-global-var)                           | `Warning`             | `JETLS/save`  | References to undefined global variables               |
+| [`inference/field-error`](@ref diagnostic/reference/inference/field-error)                                     | `Warning`             | `JETLS/save`  | Access to non-existent struct fields                   |
+| [`inference/bounds-error`](@ref diagnostic/reference/inference/bounds-error)                                   | `Warning`             | `JETLS/save`  | Out-of-bounds field access by index                    |
+| [`inference/method-error`](@ref diagnostic/reference/inference/method-error)                                   | `Warning`             | `JETLS/save`  | No matching method found for function calls            |
+| [`inference/non-boolean-cond`](@ref diagnostic/reference/inference/non-boolean-cond)                           | `Warning`             | `JETLS/save`  | Non-boolean value used in boolean context              |
+| [`testrunner/test-failure`](@ref diagnostic/reference/testrunner/test-failure)                                 | `Error`               | `JETLS/extra` | Test failures from TestRunner integration              |
 
 ### [Syntax diagnostic (`syntax/*`)](@id diagnostic/reference/syntax)
 
@@ -513,6 +514,41 @@ end
     them. Also note that the cases where the flisp lowerer (a.k.a. `code_lowered`)
     generates `Core.Box` do not necessarily match the cases where JETLS reports
     captured boxes.
+
+#### [Unconstrained static parameter (`lowering/unconstrained-static-parameter`)](@id diagnostic/reference/lowering/unconstrained-static-parameter)
+
+**Default severity**: `Warning`
+
+Static parameters that are declared by a method but do not appear in the type
+of any function parameter. Such a type variable cannot be deduced when the
+method is called and may be undefined when the method body or return type
+annotation refers to it. This mirrors the warning Julia itself prints when
+evaluating such a method definition.
+
+Example:
+
+```julia
+f(::T) where {T,S} = S  # Method definition declares type variable `S` but does not use it in the type of any function parameter
+                        # (JETLS lowering/unconstrained-static-parameter)
+```
+
+This diagnostic is about whether the type variable can be deduced at the call
+site, not whether the static parameter is referenced in the method body. A
+static parameter that appears in a function parameter type is not reported,
+even if the body does not use it:
+
+```julia
+f(::T) where T = nothing  # OK: `T` appears in a function parameter type
+```
+
+Bounds on constrained type variables are also considered, but a bound reference
+only constrains type variables declared earlier in the `where` clause:
+
+```julia
+f(::T) where {S,T<:S} = S  # OK: `S` constrains the dispatched type variable `T`
+f(::T) where {T<:S,S} = S  # Method definition declares type variable `S` but does not use it in the type of any function parameter
+                           # (JETLS lowering/unconstrained-static-parameter)
+```
 
 #### [Unused argument (`lowering/unused-argument`)](@id diagnostic/reference/lowering/unused-argument)
 

--- a/src/analysis/closure-to-opaque.jl
+++ b/src/analysis/closure-to-opaque.jl
@@ -1,6 +1,6 @@
 module Closure2Opaque
 
-using ..JETLS: JL, JS, SyntaxTreeC, TraversalReturn, traverse
+using ..JETLS: JL, JS, SyntaxTreeC, TraversalReturn, is_core_svec_call, traverse
 
 export rewrite_local_closures_to_opaque
 
@@ -273,13 +273,6 @@ function find_sig_call_for(root::SyntaxTreeC, sig_var_id::Int)
         end
         nothing
     end
-end
-
-function is_core_svec_call(call_node::SyntaxTreeC)
-    JS.numchildren(call_node) >= 1 || return false
-    callee = call_node[1]
-    return JS.kind(callee) === JS.K"core" && JS.hasattr(callee, :name_val) &&
-        callee.name_val == "svec"
 end
 
 # Detect a vararg-typed entry in the user-argtypes svec. JL lowers both `(xs...)`

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -758,6 +758,101 @@ function return_insert_data(
     return range.var"end", "\n$(indent)return $bn"
 end
 
+# `JL.method_def_expr` packages each lowered method's signature metadata as
+# `svec(svec(arg_types...), svec(static_parameters...), source_location)`, where the
+# static parameters are the locals `JL.assign_sparams` binds via `core.TypeVar` calls.
+# Matching that shape covers every method definition form — named, anonymous, callable
+# struct, macro-generated — while quoted code stays inert and never produces it.
+function method_signature_metadata(node::SyntaxTreeC)
+    JS.numchildren(node) == 4 && is_core_svec_call(node) || return nothing
+    arg_types = node[2]
+    sparams = node[3]
+    JS.kind(arg_types) === JS.K"call" && is_core_svec_call(arg_types) || return nothing
+    JS.kind(sparams) === JS.K"call" && is_core_svec_call(sparams) || return nothing
+    JS.kind(node[4]) === JS.K"SourceLocation" || return nothing
+    return arg_types, sparams
+end
+
+function collect_binding_ids!(ids::Set{JL.IdTag}, st::SyntaxTreeC)
+    traverse(st) do node::SyntaxTreeC
+        JS.kind(node) === JS.K"BindingId" && push!(ids, JL._binding_id(node))
+        return nothing
+    end
+    return ids
+end
+
+function analyze_unconstrained_static_parameters!(
+        diagnostics::Vector{Diagnostic}, fi::FileInfo, ctx3::JL.VariableAnalysisContext,
+        st3::SyntaxTreeC, reported::Set{LoweringDiagnosticKey}
+    )
+    typevar_assignments = Dict{JL.IdTag,SyntaxTreeC}()
+    signature_metadatas = Tuple{SyntaxTreeC,SyntaxTreeC}[]
+    traverse(st3) do node::SyntaxTreeC
+        k = JS.kind(node)
+        if k === JS.K"=" && JS.numchildren(node) == 2 &&
+                JS.kind(node[1]) === JS.K"BindingId"
+            rhs = node[2]
+            if JS.kind(rhs) === JS.K"call" && JS.numchildren(rhs) >= 2 &&
+                    is_core_ref(rhs[1], "TypeVar")
+                typevar_assignments[JL._binding_id(node[1])] = rhs
+            end
+        elseif k === JS.K"call"
+            metadata = method_signature_metadata(node)
+            metadata === nothing || push!(signature_metadatas, metadata)
+        end
+        return nothing
+    end
+    for (arg_types, sparams) in signature_metadatas
+        sparam_ids = JL.IdTag[]
+        for i = 2:JS.numchildren(sparams)
+            sparam = sparams[i]
+            # non-`BindingId` entries are e.g. the placeholder in `where {T,_}`
+            JS.kind(sparam) === JS.K"BindingId" || continue
+            id = JL._binding_id(sparam)
+            haskey(typevar_assignments, id) && push!(sparam_ids, id)
+        end
+        isempty(sparam_ids) && continue
+        arg_type_ids = collect_binding_ids!(Set{JL.IdTag}(), arg_types)
+        constrained = Bool[id in arg_type_ids for id in sparam_ids]
+        # A constrained type variable's bounds also constrain the type variables they
+        # reference, but only those declared earlier: in `f(::T) where {T<:S, S}` the
+        # `S` bound of `T` resolves to the later declaration without constraining it
+        # (mirroring `JL.select_used_typevars`)
+        todo = findall(constrained)
+        while !isempty(todo)
+            i = pop!(todo)
+            bound_ids = collect_binding_ids!(Set{JL.IdTag}(), typevar_assignments[sparam_ids[i]])
+            for j = 1:i-1
+                constrained[j] && continue
+                sparam_ids[j] in bound_ids || continue
+                constrained[j] = true
+                push!(todo, j)
+            end
+        end
+        for i = eachindex(sparam_ids)
+            constrained[i] && continue
+            binfo = JL.get_binding(ctx3, sparam_ids[i])
+            binfo.is_internal && continue
+            bn = binfo.name
+            startswith(bn, "#") && continue
+            provs = JS.flattened_provenance(JL.binding_ex(ctx3, binfo.id))
+            is_from_user_ast(provs) || continue
+            range = jsobj_to_range(last(provs), fi)
+            key = LoweringDiagnosticKey(range, :static_parameter, bn)
+            key in reported ? continue : push!(reported, key)
+            push!(diagnostics, Diagnostic(;
+                range,
+                severity = DiagnosticSeverity.Warning,
+                message = "Method definition declares type variable `$bn` but does not use it in the type of any function parameter",
+                source = DIAGNOSTIC_SOURCE_LIVE,
+                code = LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE,
+                codeDescription = diagnostic_code_description(
+                    LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)))
+        end
+    end
+    return diagnostics
+end
+
 function analyze_unused_bindings!(
         diagnostics::Vector{Diagnostic}, fi::FileInfo, st0::SyntaxTreeC, ctx3::JL.VariableAnalysisContext,
         binding_occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
@@ -1387,6 +1482,8 @@ function analyze_lowered_code!(
 
     reported = Set{LoweringDiagnosticKey}() # to prevent duplicate reports for unused default or keyword arguments
     (kwarg_type_names, kwarg_locations) = compute_kwarg_type_annotation_names(st0)
+
+    analyze_unconstrained_static_parameters!(diagnostics, fi, ctx3, st3, reported)
 
     has_implicit_args = is_macro0(st0) || is_generated0(st0)
     analyze_unused_bindings!(

--- a/src/types.jl
+++ b/src/types.jl
@@ -473,6 +473,7 @@ const LOWERING_ERROR_CODE = "lowering/error"
 const LOWERING_MACRO_EXPANSION_ERROR_CODE = "lowering/macro-expansion-error"
 const LOWERING_UNDEF_GLOBAL_VAR_CODE = "lowering/undef-global-var"
 const LOWERING_UNDEF_LOCAL_VAR_CODE = "lowering/undef-local-var"
+const LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE = "lowering/unconstrained-static-parameter"
 const LOWERING_CAPTURED_BOXED_VARIABLE_CODE = "lowering/captured-boxed-variable"
 const LOWERING_UNSORTED_IMPORT_NAMES_CODE = "lowering/unsorted-import-names"
 const LOWERING_UNUSED_IMPORT_CODE = "lowering/unused-import"
@@ -499,6 +500,7 @@ const ALL_DIAGNOSTIC_CODES = Set{String}(String[
     LOWERING_MACRO_EXPANSION_ERROR_CODE,
     LOWERING_UNDEF_GLOBAL_VAR_CODE,
     LOWERING_UNDEF_LOCAL_VAR_CODE,
+    LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE,
     LOWERING_CAPTURED_BOXED_VARIABLE_CODE,
     LOWERING_UNSORTED_IMPORT_NAMES_CODE,
     LOWERING_UNUSED_IMPORT_CODE,

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -592,6 +592,18 @@ function collect_identifier_names!(names::Set{String}, st::SyntaxTreeC)
     return names
 end
 
+# `K"core"` leaves can't appear in user-written source (`Core.x` lowers through
+# `K"globalref"`), so these match only lowering-generated references.
+function is_core_ref(node::SyntaxTreeC, name::String)
+    return JS.kind(node) === JS.K"core" && JS.hasattr(node, :name_val) &&
+        node.name_val == name
+end
+
+function is_core_svec_call(call_node::SyntaxTreeC)
+    JS.numchildren(call_node) >= 1 || return false
+    return is_core_ref(call_node[1], "svec")
+end
+
 """
 Like `Base.unique`, but over node ids, and with this comment promising that the
 lowest-index copy of each node is kept.

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -505,6 +505,154 @@ module EmptyModule end
         end
     end
 
+    @testset "unconstrained static parameter" begin
+        expected_message(n) = "Method definition declares type variable `$n` but does not use it in the type of any function parameter"
+        let diagnostics = get_lowering_diagnostics("""
+            f(::T) where {T,S} = S
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test length(diagnostics) == 1
+            diagnostic = only(diagnostics)
+            @test diagnostic.severity == DiagnosticSeverity.Warning
+            @test diagnostic.message == expected_message("S")
+            # anchored at the `S` declaration in the `where` clause
+            @test diagnostic.range.start.line == 0
+            @test diagnostic.range.start.character == 16
+        end
+        let diagnostics = get_lowering_diagnostics("""
+            f(::T, ::S) where {T,S} = S
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test isempty(diagnostics)
+        end
+        let diagnostics = get_lowering_diagnostics("""
+            f(::T) where {S,T<:S} = S
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test isempty(diagnostics)
+        end
+        let diagnostics = get_lowering_diagnostics("""
+            f(::T) where {T,S<:T} = S
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test length(diagnostics) == 1
+            @test only(diagnostics).message == expected_message("S")
+        end
+        # bounds constrain transitively
+        let diagnostics = get_lowering_diagnostics("""
+            f(::T) where {R,S<:R,T<:S} = R
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test isempty(diagnostics)
+        end
+        # a bound reference does not constrain a later declaration
+        # (Julia itself warns on this definition)
+        let diagnostics = get_lowering_diagnostics("""
+            f(::T) where {T<:S,S} = S
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test length(diagnostics) == 1
+            @test only(diagnostics).message == expected_message("S")
+        end
+        # a type variable referenced only as a lower bound is treated as constrained,
+        # mirroring `JL.select_used_typevars` (and Julia's warning behavior)
+        let diagnostics = get_lowering_diagnostics("""
+            f(::T) where {S,T>:S} = S
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test isempty(diagnostics)
+        end
+        let diagnostics = get_lowering_diagnostics("""
+            function f(x::T)::S where {T,S}
+                return x
+            end
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test length(diagnostics) == 1
+            @test only(diagnostics).message == expected_message("S")
+        end
+        let diagnostics = get_lowering_diagnostics("""
+            struct Box{T}
+                Box{T}() where T = new{T}()
+            end
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test isempty(diagnostics)
+        end
+        let diagnostics = get_lowering_diagnostics("""
+            struct Callable{T} end
+            function (::Callable{T})(x) where {T,S}
+                S
+            end
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test length(diagnostics) == 1
+            @test only(diagnostics).message == expected_message("S")
+        end
+        # anonymous functions define methods too
+        let diagnostics = get_lowering_diagnostics("""
+            function (x::T) where {T,S}
+                S
+            end
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test length(diagnostics) == 1
+            @test only(diagnostics).message == expected_message("S")
+        end
+        # the analysis runs post-macro-expansion
+        let diagnostics = get_lowering_diagnostics("""
+            f(@nospecialize(x::T)) where T = x
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test isempty(diagnostics)
+        end
+        let diagnostics = get_lowering_diagnostics("""
+            @inline f(::T) where {T,S} = S
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test length(diagnostics) == 1
+            @test only(diagnostics).message == expected_message("S")
+        end
+        # a qualified name does not constrain a same-named type variable
+        let diagnostics = get_lowering_diagnostics("""
+            f(x::Base.RefValue) where {RefValue} = RefValue
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test length(diagnostics) == 1
+            @test only(diagnostics).message == expected_message("RefValue")
+        end
+        # quoted method definitions are data, not methods
+        let diagnostics = get_lowering_diagnostics("""
+            ex = :(f(::T) where {T,S} = S)
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test isempty(diagnostics)
+        end
+        let diagnostics = get_lowering_diagnostics("""
+            @eval f(::T) where {T,S} = S
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test isempty(diagnostics)
+        end
+        # a keyword argument type constrains the static parameter (via the body method)
+        let diagnostics = get_lowering_diagnostics("""
+            f(; x::T) where T = x
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test isempty(diagnostics)
+        end
+        # lowering generates multiple methods here; the report is deduplicated
+        let diagnostics = get_lowering_diagnostics("""
+            f(::T; kw=1) where {T,S} = S
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test length(diagnostics) == 1
+            @test only(diagnostics).message == expected_message("S")
+        end
+        let diagnostics = get_lowering_diagnostics("""
+            f(x::T, y=1) where {T,S} = S
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test length(diagnostics) == 1
+            @test only(diagnostics).message == expected_message("S")
+        end
+        let diagnostics = get_lowering_diagnostics("""
+            f(::T) where {T,_} = T
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test isempty(diagnostics)
+        end
+        # the inner `where`'s `T` is a different type variable from the outer one
+        let diagnostics = get_lowering_diagnostics("""
+            function f(x::(Vector{T} where T)) where T
+                T
+            end
+            """; code = JETLS.LOWERING_UNCONSTRAINED_STATIC_PARAMETER_CODE)
+            @test length(diagnostics) == 1
+            @test only(diagnostics).message == expected_message("T")
+        end
+    end
+
     @testset "module splitter" begin
         script = """
         module TestModuleSplit


### PR DESCRIPTION
Add a new live diagnostic that warns when a method declares a static parameter that does not appear in the type of any function parameter, e.g. `f(::T) where {T,S} = S`, mirroring the warning Julia itself emits when evaluating such a method definition.

JuliaLowering used to reject these cases with a `LoweringError`, which JETLS surfaced as a `lowering/error` diagnostic. That error was removed in JuliaLang/julia#62048 (f913a6065f) since Julia proper only warns about them, so JETLS now carries the check itself as a dedicated warning-severity diagnostic.

The analysis runs on the scope-resolved tree (`st3`/`ctx3`): it matches the signature metadata `JL.method_def_expr` generates (`svec(svec(arg_types...), svec(sparams...), source_location)`) and checks whether each static parameter's `BindingId` occurs in the arg-types subtree, with bound references constraining only earlier declarations, mirroring `JL.select_used_typevars`. Working on lowered code makes the check macro-expansion aware, keeps quoted method templates inert, and covers anonymous functions and callable structs uniformly. Diagnostics are anchored at the `where`-clause identifier via binding provenance, and reports are deduplicated across the multiple methods lowering generates for keyword and optional arguments.

Also moves `is_core_svec_call` from `Closure2Opaque` to `src/utils/ast.jl` (adding `is_core_ref`) so the diagnostic and the closure rewrite share it.