### PR TITLE
TypeAnnotation: Infer untyped closure argtypes from call sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Improved type precision for local closures with untyped parameters (`do x`, `x -> ...`): their parameter types are now inferred from the argument types observed at the closure's call sites instead of degrading to `Any`, so hover, inlay hints and other type-aware features show precise types in closure bodies, in comprehensions, and for results of higher-order calls like `map`. Parameter annotations other than `::Any` are always respected as-is.
+
 - JETLS now performs correct scope resolution on identifiers used inside `@static` macrocalls, which previously could yield incorrect results in edge cases.
   Invalid `@static` usage (an unsupported expression shape, or a condition that fails to evaluate to a `Bool`) is now reported in place as `lowering/macro-expansion-error` while the code still flows through to analysis.
 

--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -101,10 +101,11 @@ No `Method` lookup, no dispatch, no `Base._which`.
 Untyped closure parameters (`do x`, `x -> ...`) have no declared types to feed the
 body's signature-view inference, so a single pass would annotate such bodies against
 `Tuple{Any,…}`. Instead, [`infer_toplevel_tree`](@ref) runs up to
-`MAX_OC_REFINEMENT_PASSES` inference passes: each pass records the argtypes every OC
-body is actually called with (`record_oc_argtype_observation!`, keyed by body byte
-range), and the next pass substitutes the per-slot join into the declared-`Any` slots of
-the OC's argt (`refine_partial_opaque_argt`) before the eager body inference runs. Body
+`MAX_OC_REFINEMENT_PASSES` inference passes: each pass records OC argtypes observed
+at calls and `Base.Generator` construction sites (`record_oc_argtype_observation!`,
+keyed by body byte range), and the next pass substitutes the per-slot join into the
+declared-`Any` slots of the OC's argt (`refine_partial_opaque_argt`) before the eager
+body inference runs. Body
 annotations therefore stay a deterministic signature view — the signature itself is just
 inferred from observed call sites, the same annotation model as Kotlin/Swift-style
 lambda parameter inference. Refinement fills only the unannotated blanks, per slot:
@@ -193,9 +194,9 @@ struct ASTTypeAnnotator <: CC.AbstractInterpreter
     oc_body_trees::IdDict{Method,SyntaxTreeC}
     # Push site: `abstract_eval_new_opaque_closure`. Consume site: `finishinfer!`.
     oc_methods_to_annotate::Set{Method}
-    # Per OC body byte range, the per-slot join of call-site argtypes observed for
-    # slots the user left untyped (`Union{}` = unobserved). Shared across all thunk
-    # interps of one inference pass; see `record_oc_argtype_observation!`.
+    # Per OC body byte range, the per-slot join of argtypes observed for slots the
+    # user left untyped (`Union{}` = unobserved). Shared across all thunk interps of
+    # one inference pass; see `record_oc_argtype_observation!`.
     oc_argtype_observations::OCArgtypeTable
     # Refinements derived from the previous pass's observations, applied by
     # `refine_partial_opaque_argt`; `nothing` during the first pass.
@@ -467,9 +468,48 @@ function CC.abstract_call_opaque_closure(
         si::CC.StmtInfo, sv::CC.AbsIntState, check::Bool)
 end
 
-# Join each call site's argtypes into `interp.oc_argtype_observations`, per slot —
-# see `refinable_oc_shape` / `is_unannotated_slot` for the matching preconditions and
-# the slot-eligibility policy.
+# `Generator(f, iter)` invokes `f` as iteration advances. In nested generators,
+# such as multi-`for` comprehensions lowered through `Flatten`, that invocation is
+# mediated by iterator machinery, so the `PartialOpaque` call hook may not observe
+# it. Treat the construction as observing `f` at the iterator element type.
+function CC.abstract_call_gf_by_type(
+        interp::ASTTypeAnnotator, @nospecialize(func), arginfo::CC.ArgInfo,
+        si::CC.StmtInfo, @nospecialize(atype), sv::CC.AbsIntState, max_methods::Int
+    )
+    func === Base.Generator && record_generator_argtype_observation!(interp, arginfo)
+    return @invoke CC.abstract_call_gf_by_type(
+        interp::CC.AbstractInterpreter, func::Any, arginfo::CC.ArgInfo,
+        si::CC.StmtInfo, atype::Any, sv::CC.AbsIntState, max_methods::Int)
+end
+
+function record_generator_argtype_observation!(
+        interp::ASTTypeAnnotator, arginfo::CC.ArgInfo
+    )
+    argtypes = arginfo.argtypes
+    length(argtypes) == 3 || return nothing
+    closure = CC.widenslotwrapper(argtypes[2])
+    closure isa CC.PartialOpaque || return nothing
+    iter_eltype = @something iterator_upper_bound_type(interp, argtypes[3]) return nothing
+    is_refined_slot(iter_eltype) || return nothing
+    return record_oc_argtype_observation!(
+        interp, closure, CC.ArgInfo(nothing, Any[closure.env, iter_eltype]))
+end
+
+function iterator_upper_bound_type(interp::ASTTypeAnnotator, @nospecialize(iter_arg))
+    iter_type = CC.widenconst(CC.widenslotwrapper(iter_arg))
+    iter_type isa Type || return nothing
+    iter_type === Any && return nothing
+    rt = try
+        Base._return_type(Base._iterator_upper_bound, Tuple{iter_type}, interp.world)
+    catch
+        return nothing
+    end
+    return rt isa Type ? rt : nothing
+end
+
+# Join observed argtypes into `interp.oc_argtype_observations`, per slot — see
+# `refinable_oc_shape` / `is_unannotated_slot` for the matching preconditions and the
+# slot-eligibility policy.
 function record_oc_argtype_observation!(
         interp::ASTTypeAnnotator, closure::CC.PartialOpaque, arginfo::CC.ArgInfo
     )

--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -96,6 +96,23 @@ No `Method` lookup, no dispatch, no `Base._which`.
     entries. Static svec evaluation avoids both; the synthetic-name slot simply
     degrades to `Any` (see Limitations).
 
+# Closure argument-type refinement
+
+Untyped closure parameters (`do x`, `x -> ...`) have no declared types to feed the
+body's signature-view inference, so a single pass would annotate such bodies against
+`Tuple{Any,…}`. Instead, [`infer_toplevel_tree`](@ref) runs up to
+`MAX_OC_REFINEMENT_PASSES` inference passes: each pass records the argtypes every OC
+body is actually called with (`record_oc_argtype_observation!`, keyed by body byte
+range), and the next pass substitutes the per-slot join into the declared-`Any` slots of
+the OC's argt (`refine_partial_opaque_argt`) before the eager body inference runs. Body
+annotations therefore stay a deterministic signature view — the signature itself is just
+inferred from observed call sites, the same annotation model as Kotlin/Swift-style
+lambda parameter inference. Refinement fills only the unannotated blanks, per slot:
+non-`Any` user annotations are authoritative and never refined (such slots behave
+exactly like top-level typed method parameters), while an explicit `::Any` annotation
+is indistinguishable from an unannotated parameter after lowering and is refined the
+same way. Closures never called within the analyzed tree keep their `Any` view.
+
 # Limitations
 
 The static-svec approach inherits a few precision losses around lowering's
@@ -141,6 +158,15 @@ export InferredTreeContext, build_inferred_context_for_range, get_matches_for_ra
 
 struct ASTTypeAnnotatorToken end
 
+# Keyed per OC body byte range plus the OC's parameter names — both stable across
+# re-lowering passes, unlike `Method` identity. The byte range alone is ambiguous:
+# nested generator lambdas (`[x + y for x in xs for y in ys]`) all collapse their body
+# provenance onto the same user expression, and a range-only key would cross-apply one
+# lambda's observations to another. One entry per OC parameter slot; used both for
+# call-site argtype observations and for the refinements derived from them.
+const OCArgtypeKey = Tuple{UnitRange{Int},Tuple{Vararg{Symbol}}}
+const OCArgtypeTable = Dict{OCArgtypeKey,Vector{Any}}
+
 struct SyntheticFilter
     bindings::JL.Bindings
     destructure_ranges::Vector{UnitRange{Int}}
@@ -167,6 +193,19 @@ struct ASTTypeAnnotator <: CC.AbstractInterpreter
     oc_body_trees::IdDict{Method,SyntaxTreeC}
     # Push site: `abstract_eval_new_opaque_closure`. Consume site: `finishinfer!`.
     oc_methods_to_annotate::Set{Method}
+    # Per OC body byte range, the per-slot join of call-site argtypes observed for
+    # slots the user left untyped (`Union{}` = unobserved). Shared across all thunk
+    # interps of one inference pass; see `record_oc_argtype_observation!`.
+    oc_argtype_observations::OCArgtypeTable
+    # Refinements derived from the previous pass's observations, applied by
+    # `refine_partial_opaque_argt`; `nothing` during the first pass.
+    oc_argtype_refinements::Union{Nothing,OCArgtypeTable}
+    # `Method` → refinement-key memo for `refinable_oc_shape`. The key derivation
+    # (`Base.method_argnames` + tuple construction) allocates, and the observation hook
+    # runs on every `PartialOpaque` call-site evaluation; the key is immutable per
+    # `Method` and `Method`s are fresh per pass, so per-interp memoization is exact.
+    # `nothing` marks Methods without a registered body tree.
+    oc_key_memo::IdDict{Method,Union{Nothing,OCArgtypeKey}}
     function ASTTypeAnnotator(
             world::UInt,
             toptree::SyntaxTreeC,
@@ -178,10 +217,14 @@ struct ASTTypeAnnotator <: CC.AbstractInterpreter
             opt_params::CC.OptimizationParams = CC.OptimizationParams(),
             inf_cache::Vector{CC.InferenceResult} = CC.InferenceResult[],
             oc_body_trees::IdDict{Method,SyntaxTreeC} = IdDict{Method,SyntaxTreeC}(),
-            oc_methods_to_annotate::Set{Method} = Set{Method}()
+            oc_methods_to_annotate::Set{Method} = Set{Method}(),
+            oc_argtype_observations::OCArgtypeTable = OCArgtypeTable(),
+            oc_argtype_refinements::Union{Nothing,OCArgtypeTable} = nothing,
+            oc_key_memo::IdDict{Method,Union{Nothing,OCArgtypeKey}} = IdDict{Method,Union{Nothing,OCArgtypeKey}}()
         )
         return new(world, inf_params, opt_params, inf_cache, toptree, topmi,
-            filter, oc_body_trees, oc_methods_to_annotate)
+            filter, oc_body_trees, oc_methods_to_annotate,
+            oc_argtype_observations, oc_argtype_refinements, oc_key_memo)
     end
 end
 CC.InferenceParams(interp::ASTTypeAnnotator) = interp.inf_params
@@ -252,15 +295,36 @@ end
 # accepts a class of incompleteness, so this unsoundness is also judged to be acceptable.
 # In most cases, it could become a problem when user code explicitly defines method
 # definitions for the `OpaqueClosure` type, and such cases are currently not very common.
+# The `PartialOpaque` construction replicates the default method instead of `@invoke`ing it:
+# the default eagerly infers the body against the *unrefined* signature before
+# `refine_partial_opaque_argt` could apply, and call-site observations recorded inside
+# that signature-view-with-`Any` frame would poison the per-slot joins
+# (`tmerge(Any, T) === Any`), blocking refinement convergence for nested closures.
+# Replicating lets the single eager body inference run against the refined signature.
 function CC.abstract_eval_new_opaque_closure(
         interp::ASTTypeAnnotator, e::Expr, sstate::CC.StatementState, sv::CC.InferenceState
     )
-    future = @invoke CC.abstract_eval_new_opaque_closure(
-        interp::CC.AbstractInterpreter, e::Expr, sstate::CC.StatementState, sv::CC.InferenceState)
-    rt_exct_effects = future[]
-    po = rt_exct_effects.rt
-    po isa CC.PartialOpaque || return future
-    CC.call_result_unused(sv, sv.currpc) && return future
+    ea = e.args
+    if length(ea) < 5
+        return @invoke CC.abstract_eval_new_opaque_closure(
+            interp::CC.AbstractInterpreter, e::Expr, sstate::CC.StatementState,
+            sv::CC.InferenceState)
+    end
+    argtypes = CC.collect_argtypes(interp, ea, sstate, sv)
+    if argtypes === nothing
+        return CC.Future(CC.RTEffects(Union{}, Any, CC.EFFECTS_THROWS))
+    end
+    rt = CC.opaque_closure_tfunc(CC.typeinf_lattice(interp),
+        argtypes[1], argtypes[2], argtypes[3], argtypes[5], argtypes[6:end],
+        CC.frame_instance(sv))
+    if ea[4] !== true && rt isa CC.PartialOpaque
+        rt = CC.widenconst(rt) # propagation of `PartialOpaque` disabled
+    end
+    effects = CC.Effects() # match the default method's `TODO` placeholder
+    if !(rt isa CC.PartialOpaque) || CC.call_result_unused(sv, sv.currpc)
+        return CC.Future(CC.RTEffects(rt, Any, effects))
+    end
+    po = refine_partial_opaque_argt(interp, rt)
     # Mark this OC's `Method`; `finishinfer!` annotates the citree (signature
     # view, like top-level methods) and atomically consumes the marker, so
     # per-call-site specializations see it missing and skip. Deletion must
@@ -268,17 +332,15 @@ function CC.abstract_eval_new_opaque_closure(
     # — that continuation can run synchronously (cache-hit body inference)
     # before the body's `finishinfer!`, breaking the invariant.
     push!(interp.oc_methods_to_annotate, po.source)
-    # Re-run the eager body inference the default just did; CC's specialization
-    # cache absorbs the duplication and this avoids re-implementing the
-    # function's `:opaque_closure`-Expr argument-collection plumbing.
-    argtypes = CC.most_general_argtypes(po)
-    pushfirst!(argtypes, po.env)
-    arginfo, stmtinfo = CC.ArgInfo(nothing, argtypes), CC.StmtInfo(true, false)
+    oc_argtypes = CC.most_general_argtypes(po)
+    pushfirst!(oc_argtypes, po.env)
+    arginfo, stmtinfo = CC.ArgInfo(nothing, oc_argtypes), CC.StmtInfo(true, false)
     callinfo = CC.abstract_call_opaque_closure(
         interp, po, arginfo, stmtinfo, sv, #=check=#false)::CC.Future
-    return CC.Future{CC.RTEffects}(callinfo, interp, sv) do callinfo, _, _
+    return CC.Future{CC.RTEffects}(callinfo, interp, sv) do callinfo, _, sv
+        sv.stmt_info[sv.currpc] = CC.OpaqueClosureCreateInfo(callinfo)
         refined_rt = refine_partial_opaque_rt(po, callinfo.rt)
-        return CC.RTEffects(refined_rt, rt_exct_effects.exct, rt_exct_effects.effects, rt_exct_effects.refinements)
+        return CC.RTEffects(refined_rt, Any, effects)
     end
 end
 
@@ -295,6 +357,143 @@ function refine_partial_opaque_rt(po::CC.PartialOpaque, @nospecialize inferred_r
         return po
     end
     return CC.PartialOpaque(refined_typ, po.env, po.parent, po.source)
+end
+
+# Shared precondition matcher for the two sides of closure argtype refinement —
+# `record_oc_argtype_observation!` (observation) and `refine_partial_opaque_argt`
+# (application): resolve a `PartialOpaque` to its refinement key (the OC body's byte
+# range — stable across re-lowering passes, unlike `Method` identity) and its declared
+# argt parameter list. Returns `nothing` when any precondition fails:
+# - `source` must be a `Method` registered in `interp.oc_body_trees`, i.e. an OC this
+#   pipeline created; OCs constructed inside foreign code under inference don't necessarily
+#   correspond to any tree we annotate.
+# - `typ` must be one of the two shapes our pipeline produces: the single-UnionAll-over-rt
+#   shape from `opaque_closure_tfunc` (rt still a free var), or the concrete `DataType`
+#   left after `refine_partial_opaque_rt` bakes the rt in — the latter is what call sites
+#   see whenever the eager body inference produced a concrete rt, so the observation side
+#   must accept it or such closures are never observed.
+#   Anything more complex (e.g. hand-written OCs with free argt vars, where `typ.body`
+#   is still a `UnionAll`) bails: `refine_partial_opaque_argt`'s reconstruction is only
+#   correct for the simple shapes, and recording what the application side can't consume
+#   would only waste passes.
+# - argt must be a plain `Vararg`-free `Tuple`, so slots map 1:1 onto call-site argtypes.
+function refinable_oc_shape(interp::ASTTypeAnnotator, po::CC.PartialOpaque)
+    m = po.source
+    m isa Method || return nothing
+    key = @something get!(interp.oc_key_memo, m) do
+        body_tree = get(interp.oc_body_trees, m, nothing)
+        body_tree === nothing && return nothing
+        argnames = (Base.method_argnames(m)[2:end]...,) # drop the implicit env slot
+        return (JS.byte_range(body_tree), argnames)
+    end return nothing
+    # The typ-dependent checks can't be memoized per `Method`: the same `Method` flows
+    # in both unrefined and refined `PartialOpaque`s, whose `typ`s differ.
+    typ = po.typ
+    oc = typ isa UnionAll ? typ.body : typ
+    oc isa DataType || return nothing
+    argt = oc.parameters[1]
+    argt isa DataType || return nothing
+    argt <: Tuple || return nothing
+    params = argt.parameters
+    any(CC.isvarargtype, params) && return nothing
+    return (; key, params)
+end
+
+# Refinement-eligibility policy for a single parameter slot: only slots the user left
+# unannotated participate, so non-`Any` annotations stay authoritative (an explicit
+# `::Any` is indistinguishable from an unannotated parameter after lowering and is
+# treated the same way).
+#
+# The application side always sees a freshly lowered argt, where unannotated slots are
+# still literally `Any` — the 1-arg form suffices. The observation side sees the
+# *post-refinement* `PartialOpaque`, where a previously refined slot is no longer
+# `Any`; the 3-arg form extends the test with the pass's applied refinement entry so
+# refined slots keep being re-observed and the refinement set stays stable across
+# passes (see `merge_refinements`).
+is_unannotated_slot(@nospecialize declared) = declared === Any
+is_unannotated_slot(@nospecialize(declared), refined::Union{Nothing,Vector{Any}}, i::Int) =
+    is_unannotated_slot(declared) || (refined !== nothing && is_refined_slot(refined[i]))
+
+# `Union{}` marks an unobserved slot; an `Any` join carries no refinement.
+is_refined_slot(@nospecialize t) = !(t === Union{} || t === Any)
+
+# Substitute call-site-observed types (joined by the previous inference pass; see
+# `record_oc_argtype_observation!`) into the declared-`Any` slots of `PartialOpaque.typ`'s
+# argt parameter. The body's eager signature-view inference and `refine_partial_opaque_rt`
+# then both run against the refined signature, so the body annotation and the OC's rt
+# parameter become as precise as the observed call sites allow. The body annotation thus
+# remains a deterministic signature view — the signature itself is just inferred from
+# call sites, the same annotation model as Kotlin/Swift-style lambda parameter inference.
+function refine_partial_opaque_argt(interp::ASTTypeAnnotator, po::CC.PartialOpaque)
+    refinements = @something interp.oc_argtype_refinements return po
+    # Application only ever sees the freshly constructed `PartialOpaque` (rt refinement
+    # happens later, in `abstract_eval_new_opaque_closure`'s continuation), so the typ
+    # is the UnionAll-over-rt shape; the guard documents the reconstruction's precondition
+    # rather than a reachable case.
+    typ = po.typ
+    typ isa UnionAll || return po
+    (; key, params) = @something refinable_oc_shape(interp, po) return po
+    refined_slots = @something get(refinements, key, nothing) return po
+    length(params) == length(refined_slots) || return po
+    newparams = Any[params[i] for i = 1:length(params)]
+    changed = false
+    for i = 1:length(params)
+        is_unannotated_slot(params[i]) || continue
+        is_refined_slot(refined_slots[i]) || continue
+        newparams[i] = refined_slots[i]
+        changed = true
+    end
+    changed || return po
+    refined_typ = try
+        Base.rewrap_unionall(Core.OpaqueClosure{Tuple{newparams...}, typ.var}, typ)
+    catch
+        return po
+    end
+    return CC.PartialOpaque(refined_typ, po.env, po.parent, po.source)
+end
+
+# Record the argtypes each OC body is actually called with, keyed by the body's byte
+# range — stable across re-lowering passes, unlike `Method` identity. The eager
+# signature-view inference from `abstract_eval_new_opaque_closure` passes `check=false`
+# and must not be recorded: it would join `most_general_argtypes` (the declared `Any`s)
+# into every observation and erase the refinement.
+function CC.abstract_call_opaque_closure(
+        interp::ASTTypeAnnotator, closure::CC.PartialOpaque, arginfo::CC.ArgInfo,
+        si::CC.StmtInfo, sv::CC.AbsIntState, check::Bool
+    )
+    check && record_oc_argtype_observation!(interp, closure, arginfo)
+    return @invoke CC.abstract_call_opaque_closure(
+        interp::CC.AbstractInterpreter, closure::CC.PartialOpaque, arginfo::CC.ArgInfo,
+        si::CC.StmtInfo, sv::CC.AbsIntState, check::Bool)
+end
+
+# Join each call site's argtypes into `interp.oc_argtype_observations`, per slot —
+# see `refinable_oc_shape` / `is_unannotated_slot` for the matching preconditions and
+# the slot-eligibility policy.
+function record_oc_argtype_observation!(
+        interp::ASTTypeAnnotator, closure::CC.PartialOpaque, arginfo::CC.ArgInfo
+    )
+    (; key, params) = @something refinable_oc_shape(interp, closure) return nothing
+    n = length(params)
+    argtypes = arginfo.argtypes
+    # `argtypes[1]` is the env (substituted by `abstract_call_unknown`); the rest must
+    # map 1:1 onto the OC's params — splat calls with unknown arity don't.
+    length(argtypes) == n + 1 || return nothing
+    any(CC.isvarargtype, argtypes) && return nothing
+    oc_argtype_refinements = interp.oc_argtype_refinements
+    refined = oc_argtype_refinements === nothing ? nothing :
+        get(oc_argtype_refinements, key, nothing)
+    refined !== nothing && length(refined) != n && (refined = nothing)
+    obs = get!(() -> Any[Union{} for _ = 1:n], interp.oc_argtype_observations, key)
+    length(obs) == n || return nothing # byte-range collision between different-arity OCs
+    𝕃 = CC.typeinf_lattice(interp)
+    for i = 1:n
+        is_unannotated_slot(params[i], refined, i) || continue
+        t = CC.widenconst(argtypes[i+1])
+        t === Union{} && continue
+        obs[i] = obs[i] === Union{} ? t : CC.tmerge(𝕃, obs[i], t)
+    end
+    return nothing
 end
 
 # Slot type at a specific use site. `argextype(SlotNumber)` returns the joined
@@ -326,7 +525,7 @@ end
 
 function collect_call_matches!(matches::Vector{Core.MethodMatch}, @nospecialize info)
     if info isa CC.MethodMatchInfo
-        for m in info.results.matches
+        for m in info.results
             push!(matches, m)
         end
     elseif info isa CC.UnionSplitInfo
@@ -612,12 +811,94 @@ the full-analysis prerequisite, and the current limitations.
 infer_toplevel_tree(args...; kwargs...) =
     (@something _infer_toplevel_tree(args...; kwargs...) return nothing).toptree
 
+# Pass cap for the closure argtype refinement loop in `_infer_toplevel_tree`: pass 1
+# collects observations; pass 2 applies them. A 3rd pass is only reached when pass 2's
+# refined inference observes new refinements itself (e.g. an inner closure whose call
+# sites live inside an outer refined closure body).
+const MAX_OC_REFINEMENT_PASSES = 3
+
 function _infer_toplevel_tree(
         ctx3::JL.VariableAnalysisContext, inferrable_tree3::SyntaxTreeC,
         st0::SyntaxTreeC, context_module::Module;
         world::UInt = Base.get_world_counter()
     )
     filter = SyntheticFilter(st0, ctx3.bindings)
+    interp = refinements = nothing
+    for _ = 1:MAX_OC_REFINEMENT_PASSES
+        observations = OCArgtypeTable()
+        interp = @something infer_lowered_tree(
+            ctx3, inferrable_tree3, context_module, world, filter,
+            observations, refinements) return interp
+        nextrefinements = @something merge_refinements(
+            refinements, viable_oc_argtype_refinements(observations)) break
+        isequal(nextrefinements, refinements) && break
+        refinements = nextrefinements
+    end
+    return interp
+end
+
+# Join, per slot, the previous pass's refinements with the new pass's observations,
+# so the refinement sequence `_infer_toplevel_tree` iterates is monotone (bounded
+# ascent via `tmerge`, saturating at `Any` where the slot drops out via
+# `is_refined_slot`). Monotonicity guarantees convergence to a fixpoint, and the
+# `isequal` break detects it.
+#
+# Why merge rather than just take the new pass's observations: that would only
+# converge if observations were stable across passes, and stability is an assumption
+# about CC's heuristics we'd rather not depend on. Concretely, a refined OC could in
+# principle stop being observed in a later pass (if its improved type made a guarding
+# branch or dispatch resolve away the call site it was observed at), and a plain
+# replace would then oscillate the refinement in and out. In practice this is hard to
+# even provoke — refining an OC's argt/rt doesn't change that it flows as a
+# `PartialOpaque` and re-enters its body at each call site, so observations stay
+# stable, and neither the test suite nor deliberately constructed cases exercise the
+# difference. So `merge` is a cheap, monotone safety net over a non-monotone
+# observation pattern we couldn't realize, not a routinely-needed step.
+function merge_refinements(prev::Union{Nothing,OCArgtypeTable}, next::Union{Nothing,OCArgtypeTable})
+    prev === nothing && return next
+    next === nothing && return prev
+    merged = copy(prev)
+    for (key, slots) in next
+        prevslots = get(merged, key, nothing)
+        if prevslots === nothing || length(prevslots) != length(slots)
+            merged[key] = slots
+            continue
+        end
+        mergedslots = Vector{Any}(undef, length(slots))
+        for i = 1:length(slots)
+            p, t = prevslots[i], slots[i]
+            mergedslots[i] = p === Union{} ? t : t === Union{} ? p : CC.tmerge(p, t)
+        end
+        merged[key] = mergedslots
+    end
+    return merged
+end
+
+# Keep only observations that would actually refine a slot: a slot joined to `Any` (or
+# never observed) carries no information, and an all-unrefinable entry would only
+# trigger useless extra passes.
+function viable_oc_argtype_refinements(observations::OCArgtypeTable)
+    refinements = nothing
+    for (key, slots) in observations
+        any(is_refined_slot, slots) || continue
+        refinements = @something refinements OCArgtypeTable()
+        refinements[key] = slots
+    end
+    return refinements
+end
+
+# Each pass re-lowers from `(ctx3, st3)` rather than reusing the previous pass's lowered
+# code: re-lowering materializes fresh OC `Method`s, so a later pass's inference can't
+# hit the engine cache entries (shared via the `cache_owner` token) that the previous
+# pass created for the same body — a cache hit would skip `finishinfer!` and leave the
+# body tree unannotated. Refinements are keyed by body byte range, which is stable
+# across re-lowering.
+function infer_lowered_tree(
+        ctx3::JL.VariableAnalysisContext, inferrable_tree3::SyntaxTreeC,
+        context_module::Module, world::UInt, filter::SyntheticFilter,
+        observations::OCArgtypeTable,
+        refinements::Union{Nothing,OCArgtypeTable}
+    )
     inferrable_tree = try
         # Route single-method local closures through `OpaqueClosure` instead of
         # the synthetic-struct path. CC's native OC handling then resolves the
@@ -637,8 +918,10 @@ function _infer_toplevel_tree(
     Meta.isexpr(lwr, :thunk) || error("infer_toplevel_tree: Unexpected lowering result")
     src = lwr.args[1]::CodeInfo
 
-    interp = infer_thunk!(inferrable_tree, src, context_module, nothing, world, filter)
-    infer_method_defs!(inferrable_tree, src, context_module, world, filter)
+    interp = infer_thunk!(inferrable_tree, src, context_module, nothing, world, filter,
+        observations, refinements)
+    infer_method_defs!(inferrable_tree, src, context_module, world, filter,
+        observations, refinements)
     return interp
 end
 
@@ -654,10 +937,12 @@ end
 function infer_thunk!(
         tree::SyntaxTreeC, src::CodeInfo, context_module::Module,
         argtypes::Union{Nothing,Vector{Any}}, world::UInt, filter::SyntheticFilter,
+        observations::OCArgtypeTable, refinements::Union{Nothing,OCArgtypeTable},
     )
     strip_latestworld!(src)
     mi = construct_toplevel_mi(src, context_module)
-    interp = ASTTypeAnnotator(world, tree, mi, filter)
+    interp = ASTTypeAnnotator(world, tree, mi, filter;
+        oc_argtype_observations=observations, oc_argtype_refinements=refinements)
     register_oc_body_trees!(interp.oc_body_trees, tree, src)
     result = CC.InferenceResult(mi)
     if argtypes !== nothing
@@ -713,7 +998,8 @@ end
 
 function infer_method_defs!(
         inferred::SyntaxTreeC, src::CodeInfo, context_module::Module, world::UInt,
-        filter::SyntheticFilter,
+        filter::SyntheticFilter, observations::OCArgtypeTable,
+        refinements::Union{Nothing,OCArgtypeTable},
     )
     block = inferred[1]
     nstmts = JS.numchildren(block)
@@ -742,7 +1028,8 @@ function infer_method_defs!(
         argtypes = something(
             resolve_method_argtypes(sig_ref, src, nargs, context_module, world),
             Any[Any for _ in 1:nargs])
-        infer_thunk!(body_tree, body_codeinfo, context_module, argtypes, world, filter)
+        infer_thunk!(body_tree, body_codeinfo, context_module, argtypes, world, filter,
+            observations, refinements)
     end
     return
 end
@@ -1255,6 +1542,11 @@ function tmerge_at_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
     is_oc_site = any(s -> JS.kind(s) === JS.K"new_opaque_closure", nodes)
     typ = nothing
     for st in nodes
+        # `K"core"` leaves are lowering-introduced `Core.X` references (e.g. the
+        # `Core.Any` argtype entry of a closure's argt svec, whose provenance sits on
+        # the parameter's surface position); users can't write them, so their types
+        # (`Const(Any)` etc.) must not leak into surface queries.
+        JS.kind(st) === JS.K"core" && continue
         hasproperty(st, :type) || continue
         if is_oc_site && get(ctx.oc_body_scope, st._id, nothing) !== rng
             continue

--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -863,12 +863,13 @@ function _infer_toplevel_tree(
         world::UInt = Base.get_world_counter()
     )
     filter = SyntheticFilter(st0, ctx3.bindings)
+    inf_cache = CC.InferenceResult[]
     interp = refinements = nothing
     for _ = 1:MAX_OC_REFINEMENT_PASSES
         observations = OCArgtypeTable()
         interp = @something infer_lowered_tree(
             ctx3, inferrable_tree3, context_module, world, filter,
-            observations, refinements) return interp
+            observations, refinements, inf_cache) return interp
         nextrefinements = @something merge_refinements(
             refinements, viable_oc_argtype_refinements(observations)) break
         isequal(nextrefinements, refinements) && break
@@ -928,16 +929,15 @@ function viable_oc_argtype_refinements(observations::OCArgtypeTable)
 end
 
 # Each pass re-lowers from `(ctx3, st3)` rather than reusing the previous pass's lowered
-# code: re-lowering materializes fresh OC `Method`s, so a later pass's inference can't
-# hit the engine cache entries (shared via the `cache_owner` token) that the previous
-# pass created for the same body — a cache hit would skip `finishinfer!` and leave the
-# body tree unannotated. Refinements are keyed by body byte range, which is stable
-# across re-lowering.
+# code. Re-lowering materializes fresh OC `Method`s, so sharing `inf_cache` across
+# passes won't make OC body inference hit stale entries and skip `finishinfer!`.
+# Non-OC callees can still reuse pass-local inference results. Refinements are keyed
+# by body byte range, which is stable across re-lowering.
 function infer_lowered_tree(
         ctx3::JL.VariableAnalysisContext, inferrable_tree3::SyntaxTreeC,
         context_module::Module, world::UInt, filter::SyntheticFilter,
-        observations::OCArgtypeTable,
-        refinements::Union{Nothing,OCArgtypeTable}
+        observations::OCArgtypeTable, refinements::Union{Nothing,OCArgtypeTable},
+        inf_cache::Vector{CC.InferenceResult}
     )
     inferrable_tree = try
         # Route single-method local closures through `OpaqueClosure` instead of
@@ -959,9 +959,9 @@ function infer_lowered_tree(
     src = lwr.args[1]::CodeInfo
 
     interp = infer_thunk!(inferrable_tree, src, context_module, nothing, world, filter,
-        observations, refinements)
+        observations, refinements, inf_cache)
     infer_method_defs!(inferrable_tree, src, context_module, world, filter,
-        observations, refinements)
+        observations, refinements, inf_cache)
     return interp
 end
 
@@ -978,11 +978,12 @@ function infer_thunk!(
         tree::SyntaxTreeC, src::CodeInfo, context_module::Module,
         argtypes::Union{Nothing,Vector{Any}}, world::UInt, filter::SyntheticFilter,
         observations::OCArgtypeTable, refinements::Union{Nothing,OCArgtypeTable},
+        inf_cache::Vector{CC.InferenceResult}
     )
     strip_latestworld!(src)
     mi = construct_toplevel_mi(src, context_module)
     interp = ASTTypeAnnotator(world, tree, mi, filter;
-        oc_argtype_observations=observations, oc_argtype_refinements=refinements)
+        oc_argtype_observations=observations, oc_argtype_refinements=refinements, inf_cache)
     register_oc_body_trees!(interp.oc_body_trees, tree, src)
     result = CC.InferenceResult(mi)
     if argtypes !== nothing
@@ -1037,9 +1038,9 @@ function resolve_toplevel_symbols!(src::CodeInfo, context_module::Module)
 end
 
 function infer_method_defs!(
-        inferred::SyntaxTreeC, src::CodeInfo, context_module::Module, world::UInt,
-        filter::SyntheticFilter, observations::OCArgtypeTable,
-        refinements::Union{Nothing,OCArgtypeTable},
+        inferred::SyntaxTreeC, src::CodeInfo, context_module::Module, world::UInt, filter::SyntheticFilter,
+        observations::OCArgtypeTable, refinements::Union{Nothing,OCArgtypeTable},
+        inf_cache::Vector{CC.InferenceResult}
     )
     block = inferred[1]
     nstmts = JS.numchildren(block)
@@ -1069,7 +1070,7 @@ function infer_method_defs!(
             resolve_method_argtypes(sig_ref, src, nargs, context_module, world),
             Any[Any for _ in 1:nargs])
         infer_thunk!(body_tree, body_codeinfo, context_module, argtypes, world, filter,
-            observations, refinements)
+            observations, refinements, inf_cache)
     end
     return
 end

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -563,22 +563,17 @@ end
                 end
             end
 
-            # A multi-`for` comprehension lowers to nested generator closures. The outer
-            # iteration variable's closure is observed (so `x` refines to `Int`), but the
-            # inner generator closure is only ever called at the type level inside
-            # `Iterators.flatten`'s machinery — never as a `PartialOpaque` — so `y` is
-            # never observed and the body stays `Any`. Unlike the depth-3 case this is
-            # not a pass-cap limitation (more passes wouldn't help); resolving it needs
-            # observation at the generator construction site, a different mechanism.
-            @testset "multi-`for` comprehension inner variable is unobserved" begin
+            # A multi-`for` comprehension lowers to nested generator closures.
+            # Requires `record_generator_argtype_observation!`'s synthetic observation recording.
+            @testset "multi-`for` comprehension inner variable" begin
                 let code = """
                     let xs = [1, 2, 3], ys = [1.0]
                         [x + y for x in xs for y in ys]
                     end
                     """
                     _, ctx = type_annotate(code)
-                    @test_broken widenconst(get_type_for_range(ctx, range_of(code, "x + y"))) === Float64
-                    @test_broken widenconst(get_type_for_range(ctx, range_of(code, "[x + y for x in xs for y in ys]"))) === Vector{Float64}
+                    @test widenconst(get_type_for_range(ctx, range_of(code, "x + y"))) === Float64
+                    @test widenconst(get_type_for_range(ctx, range_of(code, "[x + y for x in xs for y in ys]"))) === Vector{Float64}
                 end
             end
 

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -518,6 +518,23 @@ end
                 end
             end
 
+            @testset "Base.Compiler.return_type of untyped closure" begin
+                let code = """
+                    let
+                        f = x -> x + 1
+                        Base.Compiler.return_type(f, Tuple{Int})
+                    end
+                    """
+                    _, ctx = type_annotate(code)
+                    # `return_type` sees the rewritten closure as a `PartialOpaque`,
+                    # but its compiler tfunc does not infer the OC body through that
+                    # wrapper. Since there is no regular call site to observe `x::Int`,
+                    # the closure signature and the `return_type` result stay imprecise.
+                    @test_broken widenconst(get_type_for_range(ctx, range_of(code, "x + 1"))) === Int
+                    @test_broken get_type_for_range(ctx, range_of(code, "Base.Compiler.return_type(f, Tuple{Int})")) === Core.Const(Int)
+                end
+            end
+
             # Nested: the inner closure's call sites live inside the outer do-closure's
             # body, so its observations only become informative once the outer body is
             # re-inferred under its own refinement — the 3rd pass picks them up.

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -9,7 +9,20 @@ using LinearAlgebra: LinearAlgebra
 
 include("../HierarchicalTestSet.jl")
 
-module type_annotate_module end
+module type_annotate_module
+# Helper for closure-argument-refinement tests: a user higher-order function the
+# `PartialOpaque` gets const-prop forwarded into.
+callback(f, x) = f(x)
+# Side-effect-only iteration helper mirroring `JETLS.traverse`'s shape (worklist
+# mutation, callback result discarded).
+function eachint(f, xs::Vector{Int})
+    stack = copy(xs)
+    while !isempty(stack)
+        f(pop!(stack))
+    end
+    return nothing
+end
+end
 
 # Run the full TypeAnnotation pipeline through its exported driver and return
 # `(fi, ctx)` for the toplevel containing byte 1 — i.e. the *first* top-level
@@ -295,18 +308,20 @@ end
         # bodies. Body inference uses the eager `most_general_argtypes(po.typ)`
         # specialization, and per-call-site specializations only update the call site
         # annotation (`finishinfer!`'s marker is consumed once at the eager `finishinfer!`
-        # and skipped for subsequent dispatches). The untyped multi-call shape below is the
-        # most observable demonstration: under "last-write-wins" the body would depend on
-        # which call site CC infers last; here it should be `Any`.
+        # and skipped for subsequent dispatches). For untyped parameters the signature
+        # itself is inferred as the join of observed call-site argtypes (see "Closure
+        # argument-type refinement" in the `TypeAnnotation` module docstring) — still
+        # deterministic (a join over the call-site set, not "last-write-wins"), so the
+        # untyped multi-call shape below annotates the body at `Union{Float64, Int}`.
         @testset "closure body annotation is signature-based" begin
             let code = """
                 function multi_call(xs::Vector{Float64}, ys::Vector{Int})
-                    f(x) = 2x
+                    f(x) = 2 * x
                     (f(xs[1]), f(ys[1]))
                 end
                 """
                 _, ctx = type_annotate(code)
-                @test widenconst(get_type_for_range(ctx, range_of(code, "2x"))) === Any
+                @test widenconst(get_type_for_range(ctx, range_of(code, "2 * x"))) === Union{Float64, Int}
                 @test widenconst(get_type_for_range(ctx, range_of(code, "f(xs[1])"))) === Float64
                 @test widenconst(get_type_for_range(ctx, range_of(code, "f(ys[1])"))) === Int
             end
@@ -444,16 +459,14 @@ end
                 @test widenconst(get_type_for_range(ctx, map_call)) === Vector{Int}
             end
 
-            # Untyped `do x`: the body is annotated from the eager
-            # `most_general_argtypes(Tuple{Any})` specialization (signature view, like a
-            # top-level untyped method body), so `x * 2` is `Any`. That matches what native
-            # closure inference would expose for the method body.
-            # The call-site annotation widens to `Vector` though: the OC's rt parameter
-            # stays `T<:Any` (no concrete rt to bind from the eager body), so
-            # `Generator{Vector{Int}, F<:OC{Tuple{Any}, T}}` is non-concrete and
-            # `Base._collect` can't recover the element type. Native closures dispatch
-            # through the synthetic struct's method table and infer this as `Vector{Int}`;
-            # matching that here would need call-site-aware refinement (thus kept `@test_broken`).
+            # Untyped `do x`: pass 1 observes the OC being called with `Int` inside
+            # `map`'s `collect` chain (the `PartialOpaque` survives there via
+            # `PartialStruct{Generator}` forwarding) and pass 2 re-infers the body
+            # against the refined `Tuple{Int}` signature, so `x * 2` annotates as `Int`.
+            # The refined rt then makes `Generator{Vector{Int}, OC{Tuple{Int}, Int}}`
+            # concrete enough for `Base._collect`'s `Compiler.return_type` probe, sizing
+            # the call-site annotation to `Vector{Int}` — matching native closure
+            # inference on both counts.
             let code = """
                 function with_do(xs::Vector{Int})
                     map(xs) do x
@@ -462,9 +475,164 @@ end
                 end
                 """
                 _, ctx = type_annotate(code)
-                @test widenconst(get_type_for_range(ctx, range_of(code, "x * 2"))) === Any
+                @test widenconst(get_type_for_range(ctx, range_of(code, "x * 2"))) === Int
                 map_call = range_of(code, "map(xs) do x\n        x * 2\n    end")
-                @test_broken widenconst(get_type_for_range(ctx, map_call)) === Vector{Int}
+                @test widenconst(get_type_for_range(ctx, map_call)) === Vector{Int}
+            end
+        end
+
+        # Closure argument-type refinement (see the `TypeAnnotation` module docstring):
+        # untyped closure parameters get their signature inferred from the join of
+        # observed call-site argtypes across inference passes, instead of degrading
+        # the body view to `Any`.
+        @testset "untyped closure argument refinement" begin
+            # User higher-order function: `aggressive_constant_propagation` forwards
+            # the `PartialOpaque` into `callback`'s body, so the OC call inside it is
+            # observed precisely — captured variables resolve too.
+            @testset "user HOF with captured variable" begin
+                let code = """
+                    function withcls(x::Float64)
+                        y = rand()
+                        res = callback(x) do z
+                            z + y
+                        end
+                        res
+                    end
+                    """
+                    _, ctx = type_annotate(code)
+                    @test widenconst(get_type_for_range(ctx, range_of(code, "z + y"))) === Float64
+                    @test widenconst(get_type_for_range(ctx, range_of(code, "res"))) === Float64
+                end
+            end
+
+            @testset "direct call of untyped closure" begin
+                let code = """
+                    function direct(v::Float64)
+                        f(x) = x + 1
+                        f(v)
+                    end
+                    """
+                    _, ctx = type_annotate(code)
+                    @test widenconst(get_type_for_range(ctx, range_of(code, "x + 1"))) === Float64
+                    @test widenconst(get_type_for_range(ctx, range_of(code, "f(v)"))) === Float64
+                end
+            end
+
+            # Nested: the inner closure's call sites live inside the outer do-closure's
+            # body, so its observations only become informative once the outer body is
+            # re-inferred under its own refinement — the 3rd pass picks them up.
+            @testset "nested untyped closures" begin
+                let code = """
+                    function nested(xs::Vector{Int})
+                        map(xs) do x
+                            g(y) = y + x
+                            g(2 * x)
+                        end
+                    end
+                    """
+                    _, ctx = type_annotate(code)
+                    @test widenconst(get_type_for_range(ctx, range_of(code, "y + x"))) === Int
+                    @test widenconst(get_type_for_range(ctx, range_of(code, "g(2 * x)"))) === Int
+                end
+            end
+
+            # Refinement propagates one nesting level per pass, so `MAX_OC_REFINEMENT_PASSES`
+            # (=3) covers closure nesting up to depth 2. At depth 3 — each closure called
+            # with an expression depending on the enclosing closure's parameter — the
+            # innermost body would only be refined by a 4th pass and stays `Any`:
+            #   pass 1 observes `x` (from `map`); pass 2 applies `x::Int`, observes `y`;
+            #   pass 3 applies `y::Int`, observes `z` — but `z`'s refinement is never applied.
+            @testset "depth-3 nested closures exceed the pass cap" begin
+                let code = """
+                    function nested3(xs::Vector{Int})
+                        map(xs) do x
+                            g = function (y)
+                                h = z -> z + y
+                                h(2 * y)
+                            end
+                            g(2 * x)
+                        end
+                    end
+                    """
+                    _, ctx = type_annotate(code)
+                    # Outer two levels refine within the cap.
+                    @test widenconst(get_type_for_range(ctx, range_of(code, "2 * x"))) === Int
+                    @test widenconst(get_type_for_range(ctx, range_of(code, "2 * y"))) === Int
+                    # The innermost body would need a 4th pass to refine `z`.
+                    @test_broken widenconst(get_type_for_range(ctx, range_of(code, "z + y"))) === Int
+                end
+            end
+
+            # A multi-`for` comprehension lowers to nested generator closures. The outer
+            # iteration variable's closure is observed (so `x` refines to `Int`), but the
+            # inner generator closure is only ever called at the type level inside
+            # `Iterators.flatten`'s machinery — never as a `PartialOpaque` — so `y` is
+            # never observed and the body stays `Any`. Unlike the depth-3 case this is
+            # not a pass-cap limitation (more passes wouldn't help); resolving it needs
+            # observation at the generator construction site, a different mechanism.
+            @testset "multi-`for` comprehension inner variable is unobserved" begin
+                let code = """
+                    let xs = [1, 2, 3], ys = [1.0]
+                        [x + y for x in xs for y in ys]
+                    end
+                    """
+                    _, ctx = type_annotate(code)
+                    @test_broken widenconst(get_type_for_range(ctx, range_of(code, "x + y"))) === Float64
+                    @test_broken widenconst(get_type_for_range(ctx, range_of(code, "[x + y for x in xs for y in ys]"))) === Vector{Float64}
+                end
+            end
+
+            # User-written parameter annotations are authoritative: the observed `Int`
+            # must not narrow the declared `Number` view.
+            @testset "user annotation is not narrowed" begin
+                let code = """
+                    function annotated(xs::Vector{Int})
+                        map(xs) do x::Number
+                            identity(x)
+                        end
+                    end
+                    """
+                    _, ctx = type_annotate(code)
+                    @test widenconst(get_type_for_range(ctx, range_of(code, "identity(x)"))) === Number
+                end
+            end
+
+            # A side-effect-only `do` body returning `nothing` bakes a concrete rt into
+            # the OC type already in pass 1 (`refine_partial_opaque_rt`), so call sites
+            # see a non-UnionAll `PartialOpaque`. The observation side must accept that
+            # shape — with the old UnionAll-only guard such closures were never observed
+            # and their bodies stayed `Any`.
+            @testset "nothing-returning closure through side-effect HOF" begin
+                let code = """
+                    function bump_all(out::Vector{Int}, xs::Vector{Int})
+                        eachint(xs) do z
+                            push!(out, z + 1)
+                            nothing
+                        end
+                        return out
+                    end
+                    """
+                    _, ctx = type_annotate(code)
+                    # The lowered `z + 1` node's range includes leading trivia here, so
+                    # query the `z` use and the enclosing `push!` call instead.
+                    zrng = range_of(code, "z + 1")
+                    @test widenconst(get_type_for_range(ctx, first(zrng):first(zrng))) === Int
+                    pushrng = range_of(code, "push!(out, z + 1)")
+                    @test widenconst(get_type_for_range(ctx, pushrng)) === Vector{Int}
+                end
+            end
+
+            # No call sites → nothing observed → the body keeps the `Any` view.
+            @testset "never-called closure stays Any" begin
+                let code = """
+                    function unused_closure()
+                        f(x) = x + 1
+                        f
+                    end
+                    """
+                    _, ctx = type_annotate(code)
+                    @test widenconst(get_type_for_range(ctx, range_of(code, "x + 1"))) === Any
+                end
             end
         end
 
@@ -687,6 +855,19 @@ end
             _, ctx = type_annotate(code)
             rng = range_of(code, "Any[Any for _ in 1:n]")
             @test widenconst(get_type_for_range(ctx, rng)) === Vector{Any}
+        end
+
+        # Same collision for short-form funcdef bodies; the juxtaposed `2x` call's
+        # kind takes the range, so the synthesized `*` callee no longer leaks into
+        # the merge.
+        let code = """
+            function juxt(xs::Vector{Float64})
+                g(x) = 2x
+                g(xs[1])
+            end
+            """
+            _, ctx = type_annotate(code)
+            @test widenconst(get_type_for_range(ctx, range_of(code, "2x"))) === Float64
         end
     end
 
@@ -1194,21 +1375,17 @@ end
                 @test typ === Union{Int, String, Nothing}
             end
         end
-        # A user-written `return X` inside a branching expression exits the
-        # function entirely; `X` must not contribute to the enclosing
-        # expression's value (only the implicit fall-through does). When
-        # `X` is itself a tail-recursing form (`if` / `&&` / `||` / ternary
-        # / comparison / `block`), lowering splits it into per-branch tail
-        # returns at narrower byte ranges than `X` itself, so a literal
-        # byte-range match doesn't suffice. The walker over `st3`
-        # (post-desugaring, post-macro-expansion) handles all these uniform
-        # cases since they're already collapsed to `K"if"` / `K"block"` /
-        # nested `K"return"`.
+        # A user-written `return X` inside a branching expression exits the function
+        # entirely; `X` must not contribute to the enclosing expression's value (only the
+        # implicit fall-through does). When `X` is itself a tail-recursing form
+        # (`if` / `&&` / `||` / ternary / comparison / `block` / `try`-`catch`),
+        # lowering splits it into per-branch tail returns at narrower byte ranges than `X`
+        # itself, so a literal byte-range match doesn't suffice. The walker over `st3`
+        # (post-desugaring, post-macro-expansion) handles all these uniform cases since
+        # they collect the nested `K"return"`s regardless of the wrapping form.
         #
-        # In every case below, the outer `if b ... end` should resolve to
-        # `Nothing` (the implicit fall-through is the only path that reaches
-        # `out`). `try` / `catch` is not yet covered (recorded as
-        # `@test_broken`).
+        # In every case below, the outer `if b ... end` should resolve to `Nothing`
+        # (the implicit fall-through is the only path that reaches `out`).
         @testset "user return inside branching expression" begin
             @testset "simple value" begin
                 let code = """

--- a/test/test_inlay_hint.jl
+++ b/test/test_inlay_hint.jl
@@ -916,7 +916,9 @@ end
         end
     end
 
-    # Untyped iter vars reflect the current precision of TypeAnnotation.
+    # Untyped iter vars resolve precisely via TypeAnnotation's closure
+    # argument-type refinement (the generator body is a lowered closure whose
+    # argtypes are observed at its `iterate`-driven call sites).
     @testset "comprehension expressions" begin
         @testset "untyped iter var" begin
             let code = """
@@ -938,7 +940,7 @@ end
                     """
                 @test apply_inlay_hints(code, get_type_inlay_hints(code)) == """
                     let xs = rand(3)::Vector{Float64}
-                        [2x::Any for x in xs::Vector{Float64}]::Vector
+                        [2x::Float64 for x in xs::Vector{Float64}]::Vector{Float64}
                     end
                     """
             end
@@ -963,12 +965,16 @@ end
                     """
                 @test apply_inlay_hints(code, get_type_inlay_hints(code)) == """
                     let xs = [1, 2, 3]::Vector{$Int}
-                        [x for x in xs::Vector{$Int} if (x::Any > 0)::Any]::Vector
+                        [x for x in xs::Vector{$Int} if (x::$Int > 0)::Bool]::Vector{$Int}
                     end
                     """
             end
 
-            # Multi-`for` (cartesian) lowers to nested OCs.
+            # Multi-`for` (cartesian) lowers to nested OCs. The outer iteration variable
+            # refines from its observed call sites; the inner lambda is only ever called
+            # at the type level inside `Iterators.flatten`'s machinery, so `y` honestly
+            # stays `Any` (cross-applying the outer's observation to it is prevented by
+            # the argname component of the refinement key).
             let code = """
                     let xs = [1, 2, 3], ys = [1.0]
                         [x + y for x in xs for y in ys]
@@ -976,7 +982,7 @@ end
                     """
                 @test apply_inlay_hints(code, get_type_inlay_hints(code)) == """
                     let xs = [1, 2, 3]::Vector{$Int}, ys = [1.0]::Vector{Float64}
-                        [(x::$Int + y::Any)::Any for x::Any in xs::Vector{$Int} for y in ys::Vector{Float64}]::Vector
+                        [(x::$Int + y::Any)::Any for x::$Int in xs::Vector{$Int} for y in ys::Vector{Float64}]::Vector
                     end
                     """
             end
@@ -1023,8 +1029,8 @@ end
                 @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
             end
 
-            # Multi-`for` (cartesian). Body types resolve precisely; the result widens to
-            # bare `Vector` with the current TypeAnnotation precision.
+            # Multi-`for` (cartesian) lowers to nested OCs; both the body types and
+            # the result element type resolve precisely.
             let code = """
                     let xs = [1, 2, 3], ys = [1.0]
                         [x + y for x::$Int in xs for y::Float64 in ys]
@@ -1032,7 +1038,7 @@ end
                     """
                 @test apply_inlay_hints(code, get_type_inlay_hints(code)) == """
                     let xs = [1, 2, 3]::Vector{$Int}, ys = [1.0]::Vector{Float64}
-                        [(x::$Int + y::Float64)::Float64 for x::$Int in xs::Vector{$Int} for y::Float64 in ys::Vector{Float64}]::Vector
+                        [(x::$Int + y::Float64)::Float64 for x::$Int in xs::Vector{$Int} for y::Float64 in ys::Vector{Float64}]::Vector{Float64}
                     end
                     """
             end
@@ -1463,7 +1469,7 @@ end
                 """
             expected = """
                 function with_rt(xs::Vector{Float64})::Float64
-                    f(y)::Float64 = ((xs::Vector{Float64})[1]::Float64 + y::Any)::Any
+                    f(y)::Float64 = ((xs::Vector{Float64})[1]::Float64 + y::Float64)::Float64
                     f(2.0)::Float64
                 end
                 """
@@ -1529,7 +1535,7 @@ end
                 end
                 """
             expected = """
-                let g = x -> 2x::Any
+                let g = x -> 2x::Float64
                     g(1.0)
                 end
                 """
@@ -1575,8 +1581,8 @@ end
             @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
         end
 
-        # `map`'s result widens to `Vector` (not `Vector{$Int}`) with the
-        # current TypeAnnotation precision.
+        # Untyped `do x` resolves precisely via closure argument-type refinement,
+        # including `map`'s result element type.
         @testset "untyped do-block" begin
             code = """
                 let xs = [1, 2, 3]
@@ -1588,8 +1594,8 @@ end
             @test apply_inlay_hints(code, get_type_inlay_hints(code)) == """
                 let xs = [1, 2, 3]::Vector{$Int}
                     map(xs::Vector{$Int}) do x
-                        (x::Any * 2)::Any
-                    end::Vector
+                        (x::$Int * 2)::$Int
+                    end::Vector{$Int}
                 end
                 """
         end

--- a/test/test_inlay_hint.jl
+++ b/test/test_inlay_hint.jl
@@ -970,11 +970,7 @@ end
                     """
             end
 
-            # Multi-`for` (cartesian) lowers to nested OCs. The outer iteration variable
-            # refines from its observed call sites; the inner lambda is only ever called
-            # at the type level inside `Iterators.flatten`'s machinery, so `y` honestly
-            # stays `Any` (cross-applying the outer's observation to it is prevented by
-            # the argname component of the refinement key).
+            # Multi-`for` lowers to nested generator OCs.
             let code = """
                     let xs = [1, 2, 3], ys = [1.0]
                         [x + y for x in xs for y in ys]
@@ -982,7 +978,7 @@ end
                     """
                 @test apply_inlay_hints(code, get_type_inlay_hints(code)) == """
                     let xs = [1, 2, 3]::Vector{$Int}, ys = [1.0]::Vector{Float64}
-                        [(x::$Int + y::Any)::Any for x::$Int in xs::Vector{$Int} for y in ys::Vector{Float64}]::Vector
+                        [(x::$Int + y::Float64)::Float64 for x::$Int in xs::Vector{$Int} for y in ys::Vector{Float64}]::Vector{Float64}
                     end
                     """
             end

--- a/test/test_type_definition.jl
+++ b/test/test_type_definition.jl
@@ -116,7 +116,8 @@ end
 
         # `do`-block calls — JuliaSyntax extends the call's byte range to the
         # closing `end`, so `func() do ... end│` resolves to the call's return
-        # type just like `func()│`.
+        # type just like `func()│`. The untyped `do x` refines from its call
+        # sites, so the result is the concrete `Vector{Int}`.
         @test with_find_type_definition("""
                 function f()
                     map([1,2,3]) do x
@@ -125,7 +126,7 @@ end
                 end
             """) do _, result, _
             @test result !== null
-            vec_files = base_method_files(Vector)
+            vec_files = base_method_files(Vector{Int})
             @test all(loc -> JETLS.uri2filepath(loc.uri) in vec_files, result)
             return 1
         end == 1


### PR DESCRIPTION
Untyped closure parameters (`do x`, `x -> ...`) used to leave the body's signature-view inference with `Tuple{Any,…}` argtypes, so hover and inlay hints degraded to `Any` inside such bodies and for results of higher-order calls like `map`.

Run inference in up to 3 passes: each pass records the argtypes every OC body is actually called with (an `abstract_call_opaque_closure` hook observing `PartialOpaque` callees), and the next pass substitutes the per-slot join into the declared-`Any` slots of the OC's argt before the eager body inference runs. Body annotations thus stay a deterministic signature view — the signature itself is just inferred from the observed call sites, the same annotation model as Kotlin/Swift-style lambda parameter inference. Non-`Any` user annotations are never refined, and extra passes only run when a pass found a viable refinement.

Notable implementation points:
- Observations/refinements are keyed by the OC body's byte range plus parameter names: stable across the per-pass re-lowering (fresh `Method`s keep the shared engine cache from short-circuiting `finishinfer!`, which would leave bodies unannotated), and unambiguous for nested generator lambdas collapsing onto the same source range.
- `abstract_eval_new_opaque_closure` replicates the default construction instead of `@invoke`ing it: the default's eager body inference on the unrefined signature would record `Any` observations inside nested closures, poisoning the per-slot joins.
- Refinements merge monotonically (per-slot `tmerge`) across passes: a successfully refined OC often stops being observed (its baked-in rt lets `map`/`collect` chains resolve at the type level), and dropping its entry would oscillate the refinement back out.

With the refined rt baked into the OC type, `Base._collect`'s `return_type` probe now sizes `map(xs) do x ... end` results precisely (`Vector{Int}` instead of `Vector`), resolving a long-standing `@test_broken`. Comprehension generators are lowered closures, so their bodies and element types resolve precisely too.

Performance: extra passes run only for trees where a viable refinement was observed. After sharing the local `ASTTypeAnnotator` inference cache across refinement passes, the overhead is much smaller. Measured across representative JETLS source files, using one Julia process per file and measuring cold runs independently per file, the aggregate deltas are +1.7% time / +1.2% allocations for cold runs and +8.4% time / +3.3% allocations for warm runs. In that workload, 21 top-level trees reached pass 2 and only 1 reached pass 3, producing 28 final refinement entries and 31 refined slots.

Notable warm deltas after cache sharing were:

- `completions.jl`: 465.8 ms -> 496.5 ms, +30.8 ms (+6.6%)
- `diagnostic.jl`: 658.8 ms -> 705.1 ms, +46.3 ms (+7.0%)
- `TypeAnnotation.jl`: 539.8 ms -> 619.0 ms, +79.3 ms (+14.7%)
- `semantic-tokens.jl`: 48.8 ms -> 53.0 ms, +4.2 ms (+8.7%)

The remaining cost is re-inference of the enclosing body under the refined OC types; the per-pass re-lowering itself remains negligible, and the extra allocation is transient rather than retained memory.
