### PR TITLE
jl-syntax-macros: New-style `@static` with inactive-code hints

### DIFF
--- a/.JETLSConfig.toml
+++ b/.JETLSConfig.toml
@@ -35,6 +35,13 @@ match_type = "regex"
 severity = "off"
 path = "src/testrunner/testrunner-types.jl"
 
+[[diagnostic.patterns]]
+pattern = "lowering/inactive-code"
+match_by = "code"
+match_type = "literal" # Outrank the code-regex catch-all diagnostic rules below
+severity = "hint"
+path = "**/*.jl"
+
 # Treat all other diagnostics as warnings (for early detection via jetls check)
 [[diagnostic.patterns]]
 pattern = ".*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
   <img width="976" height="637" alt="Inlay type hint demo" src="https://github.com/user-attachments/assets/baa2ff1b-df38-4304-a479-f2a2b4ba3e7b" />
 
+- Added [`lowering/inactive-code`](https://aviatesk.github.io/JETLS.jl/release/diagnostic/#diagnostic/reference/lowering/inactive-code) diagnostic that marks `@static` branches not taken in the current environment (e.g. a Windows-only branch when analyzing on macOS) at `Hint` severity with the `Unnecessary` tag, so editors gray out code that is excluded from analysis.
+
 - Added [`lowering/unconstrained-static-parameter`](https://aviatesk.github.io/JETLS.jl/release/diagnostic/#diagnostic/reference/lowering/unconstrained-static-parameter) diagnostic that warns when a method declares a static parameter that does not appear in the type of any function parameter, so its value cannot be deduced when the method is called.
   This matches the warning Julia itself emits when evaluating such a method definition.
   For example:
@@ -60,6 +62,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   f(::T) where {T,S} = S  # Method definition declares type variable `S` but does not use it in the type of any function parameter
                           # (JETLS lowering/unconstrained-static-parameter)
   ```
+
+### Changed
+
+- JETLS now performs correct scope resolution on identifiers used inside `@static` macrocalls, which previously could yield incorrect results in edge cases.
+  Invalid `@static` usage (an unsupported expression shape, or a condition that fails to evaluate to a `Bool`) is now reported in place as `lowering/macro-expansion-error` while the code still flows through to analysis.
 
 ### Fixed
 

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -116,6 +116,7 @@ Here is a summary table of the diagnostics explained in this section:
 | [`lowering/unused-assignment`](@ref diagnostic/reference/lowering/unused-assignment)                           | `Information`         | `JETLS/live`  | Assignments whose values are never read                |
 | [`lowering/unused-import`](@ref diagnostic/reference/lowering/unused-import)                                   | `Information`         | `JETLS/live`  | Imported names that are never used                     |
 | [`lowering/unreachable-code`](@ref diagnostic/reference/lowering/unreachable-code)                             | `Information`         | `JETLS/live`  | Code after a block terminator that is never reached    |
+| [`lowering/inactive-code`](@ref diagnostic/reference/lowering/inactive-code)                                   | `Hint`                | `JETLS/live`  | Code excluded by `@static` in the current environment  |
 | [`lowering/unsorted-import-names`](@ref diagnostic/reference/lowering/unsorted-import-names)                   | `Hint`                | `JETLS/live`  | Import/export names not sorted alphabetically          |
 | [`toplevel/error`](@ref diagnostic/reference/toplevel/error)                                                   | `Error`               | `JETLS/save`  | Errors during code loading                             |
 | [`toplevel/method-overwrite`](@ref diagnostic/reference/toplevel/method-overwrite)                             | `Warning`             | `JETLS/save`  | Method definitions that overwrite previous ones        |
@@ -828,6 +829,34 @@ end
     produce incorrect results.
     Such overloading is extremely unlikely in practice, and this possibility is
     accepted as a trade-off for better diagnostics.
+
+#### [Inactive code (`lowering/inactive-code`)](@id diagnostic/reference/lowering/inactive-code)
+
+**Default severity**: `Hint`
+
+Reported on `@static` branches that are not taken in the current environment.
+JETLS evaluates `@static` conditions during analysis, so only the branch taken
+on the analyzing machine (its OS, Julia version, etc.) is analyzed; the other
+branches are excluded entirely, meaning LSP features such as diagnostics, hover,
+and inlay hints are unavailable inside them. The inactive region is marked with
+the `Unnecessary` tag,[^unnecessary_tag] so editors render it grayed out.
+
+Example (analyzed on a non-Windows machine):
+
+```julia
+function home_dir()
+    @static if Sys.iswindows()
+        ENV["USERPROFILE"]  # Inactive `@static` branch (condition evaluated to `false`)
+                            # (JETLS lowering/inactive-code)
+    else
+        ENV["HOME"]
+    end
+end
+```
+
+Unlike [`lowering/unreachable-code`](@ref diagnostic/reference/lowering/unreachable-code),
+this does not indicate a problem: the branch is intentionally inactive here
+and may be active in other environments, so no removal action is offered.
 
 #### [Unsorted import names (`lowering/unsorted-import-names`)](@id diagnostic/reference/lowering/unsorted-import-names)
 

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -576,8 +576,10 @@ function emit_macro_diagnostics!(
             severity = d.severity,
             message = d.msg,
             source = DIAGNOSTIC_SOURCE_LIVE,
-            code = LOWERING_MACRO_EXPANSION_ERROR_CODE,
-            codeDescription = diagnostic_code_description(LOWERING_MACRO_EXPANSION_ERROR_CODE)))
+            code = d.code,
+            codeDescription = diagnostic_code_description(d.code),
+            tags = d.code == LOWERING_INACTIVE_CODE ?
+                DiagnosticTag.Ty[DiagnosticTag.Unnecessary] : nothing))
     end
     return diagnostics
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -479,6 +479,7 @@ const LOWERING_UNSORTED_IMPORT_NAMES_CODE = "lowering/unsorted-import-names"
 const LOWERING_UNUSED_IMPORT_CODE = "lowering/unused-import"
 const LOWERING_UNUSED_LABEL_CODE = "lowering/unused-label"
 const LOWERING_UNREACHABLE_CODE = "lowering/unreachable-code"
+const LOWERING_INACTIVE_CODE = "lowering/inactive-code"
 const LOWERING_AMBIGUOUS_SOFT_SCOPE_CODE = "lowering/ambiguous-soft-scope"
 const TOPLEVEL_ERROR_CODE = "toplevel/error"
 const TOPLEVEL_METHOD_OVERWRITE_CODE = "toplevel/method-overwrite"
@@ -506,6 +507,7 @@ const ALL_DIAGNOSTIC_CODES = Set{String}(String[
     LOWERING_UNUSED_IMPORT_CODE,
     LOWERING_UNUSED_LABEL_CODE,
     LOWERING_UNREACHABLE_CODE,
+    LOWERING_INACTIVE_CODE,
     LOWERING_AMBIGUOUS_SOFT_SCOPE_CODE,
     TOPLEVEL_ERROR_CODE,
     TOPLEVEL_METHOD_OVERWRITE_CODE,

--- a/src/utils/jl-syntax-macros.jl
+++ b/src/utils/jl-syntax-macros.jl
@@ -51,13 +51,15 @@ struct MacroDiagnostic
     node::SyntaxTreeC
     msg::String
     severity::DiagnosticSeverity.Ty
+    code::String
 end
 
 """
     MACRO_DIAGNOSTIC_SINK :: ScopedValue{Union{Nothing,Vector{MacroDiagnostic}}}
 
-Side channel that lets macro stubs surface issues as LSP diagnostics without
-aborting expansion — the producer/consumer contract for [`push_macro_error!`](@ref)
+Side channel that lets macro stubs surface issues — and purely informational
+notes like [`push_inactive_code!`](@ref) — as LSP diagnostics without aborting
+expansion; the producer/consumer contract for [`push_macro_error!`](@ref)
 and [`push_macro_warning!`](@ref).
 
 Consumers bind this to a vector via `Base.ScopedValues.@with` around their lowering
@@ -78,11 +80,12 @@ const MACRO_DIAGNOSTIC_SINK =
     Base.ScopedValues.ScopedValue{Union{Nothing,Vector{MacroDiagnostic}}}(nothing)
 
 @noinline function push_macro_diagnostic!(
-        node::SyntaxTreeC, msg::AbstractString, severity::DiagnosticSeverity.Ty
+        node::SyntaxTreeC, msg::AbstractString, severity::DiagnosticSeverity.Ty,
+        code::String = LOWERING_MACRO_EXPANSION_ERROR_CODE
     )
     sink = MACRO_DIAGNOSTIC_SINK[]
     sink === nothing && return
-    push!(sink, MacroDiagnostic(node, String(msg), severity))
+    push!(sink, MacroDiagnostic(node, String(msg), severity, code))
     return
 end
 
@@ -107,6 +110,22 @@ $macro_issue_contract
 """
 push_macro_error!(node::SyntaxTreeC, msg::AbstractString) =
     push_macro_diagnostic!(node, msg, DiagnosticSeverity.Error)
+
+"""
+    push_inactive_code!(node::SyntaxTreeC, condval::Bool)
+
+Report `node` — a branch dropped at macro expansion time, e.g. the not-taken
+side of an `@static` conditional — as `lowering/inactive-code` at Hint severity
+into [`MACRO_DIAGNOSTIC_SINK`](@ref) (no-op if the sink is unbound). The
+consumer tags these `DiagnosticTag.Unnecessary` so clients render the region
+grayed out. Unlike the issue helpers above this is purely informational: the
+code is intentionally inactive in the current environment, not a problem.
+`condval` is the value the governing condition evaluated to.
+"""
+push_inactive_code!(node::SyntaxTreeC, condval::Bool) =
+    push_macro_diagnostic!(node,
+        "Inactive `@static` branch (condition evaluated to `$condval`)",
+        DiagnosticSeverity.Hint, LOWERING_INACTIVE_CODE)
 
 # Simple (non-qualified) macro names whose new-style implementations in this file and
 # `JuliaLowering/src/syntax_macros.jl` preserve fine-grained source provenance during
@@ -145,6 +164,7 @@ const NEW_STYLE_MACROCALL_NAMES = (
     "@something",
     "@spawn",
     "@specialize",
+    "@static",
     "@test",
     "@test_broken",
     "@test_deprecated",
@@ -1149,5 +1169,81 @@ function _extract_assume_effect_setting_name(setting::SyntaxTreeC)
             return name isa AbstractString ? name : nothing
         end
     end
+    return nothing
+end
+
+# New-style implementation of `Base.@static`. Like the real macro, the condition is
+# evaluated at expansion time and only the taken branch survives — but as a new-style
+# macro that branch keeps its fine-grained provenance. The condition is `JL.eval`'d in
+# `__context__.scope_layer.mod`, the module JuliaLowering hands to old-style macros as
+# `__module__`. A condition that fails to evaluate (or doesn't produce a `Bool`) is
+# reported via the sink and recovered by returning the whole conditional unchanged, so
+# every branch and the condition itself still reach scope analysis as a runtime
+# conditional.
+#
+# Each dropped branch is reported via `push_inactive_code!` so editors can gray out
+# code that is excluded in the current environment (and won't get completion, hover,
+# diagnostics, etc.). When a branch chains further conditionals (`elseif`, right-nested
+# `&&`/`||`), dropping it covers the whole remaining chain — including conditions that
+# were consequently never evaluated — in one contiguous range.
+#
+# In EST a ternary stays `K"?"` (Expr conversion is what folds it into `:if`), so the
+# if-like kinds form one equivalence class when deciding whether to keep folding a
+# selected branch, mirroring Base's `x.head === :elseif || x.head === hd` loop.
+const _STATIC_IF_KINDS = JS.KSet"if elseif ?"
+const _STATIC_COND_KINDS = JS.KSet"if elseif ? && ||"
+
+function Base.var"@static"(__context__::JL.MacroContext, ex::SyntaxTreeC)
+    mc = __context__.macrocall::SyntaxTreeC
+    if JS.kind(ex) ∉ _STATIC_COND_KINDS
+        push_macro_error!(ex, "invalid @static macro")
+        return JL.@ast(__context__, mc, ex)
+    end
+    x = ex
+    while true
+        k = JS.kind(x)
+        cond = _static_eval_cond(__context__, x[1])
+        cond === nothing && return JL.@ast(__context__, mc, ex)
+        i = xor(cond, k === JS.K"||") ? 2 : 3
+        if i == 2
+            JS.numchildren(x) ≥ 3 && push_inactive_code!(x[3], cond)
+        else
+            push_inactive_code!(x[2], cond)
+            JS.numchildren(x) < 3 && return JL.@ast(__context__, mc, nothing::JS.K"Value")
+        end
+        x = x[i]
+        xk = JS.kind(x)
+        if xk === k || (xk in _STATIC_IF_KINDS && k in _STATIC_IF_KINDS)
+            continue # `elseif` chain, right-nested `&&`/`||`, or nested ternary
+        end
+        return JL.@ast(__context__, mc, x)
+    end
+end
+
+function Base.var"@static"(__context__::JL.MacroContext, args::SyntaxTreeC...)
+    mc = __context__.macrocall::SyntaxTreeC
+    push_macro_error!(mc, "invalid @static macro")
+    isempty(args) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
+    return JL.@ast(__context__, mc, [JS.K"block" args...])
+end
+
+# Returns the condition's value as a `Bool`, or `nothing` (with the issue reported via
+# the sink) when it cannot be statically evaluated. `JL.eval` runs the condition through
+# JuliaLowering's own pipeline, which understands the hygiene (`scope_layer`) annotations
+# macro arguments carry: identifiers a user wrote directly at the macrocall site carry
+# the base layer and resolve in the module given here. (Identifiers spliced in from an
+# outer macro expansion carry layers a fresh lowering context doesn't know — those fail
+# to evaluate and take the recovery path below.) Base lets evaluation errors propagate
+# out of expansion; we recover per the macro issue contract.
+function _static_eval_cond(ctx::JL.MacroContext, cond::SyntaxTreeC)
+    val = try
+        JL.eval(ctx.scope_layer.mod, cond)
+    catch err
+        msg = first(split(sprint(showerror, err), '\n'))
+        push_macro_error!(cond, "@static: failed to evaluate condition: $msg")
+        return nothing
+    end
+    val isa Bool && return val
+    push_macro_error!(cond, "@static: condition did not evaluate to a Bool")
     return nothing
 end

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -2414,6 +2414,25 @@ end
     end
 end
 
+@testset HierarchicalTestSet "inactive code detection" begin
+    # A dropped `@static` branch surfaces as `lowering/inactive-code` at Hint
+    # severity with the `Unnecessary` tag so editors gray out the region.
+    diagnostics = get_lowering_diagnostics("""
+    function f()
+        @static if false
+            inactive_call()
+        else
+            active_call()
+        end
+    end
+    """; code = JETLS.LOWERING_INACTIVE_CODE)
+    d = only(diagnostics)
+    @test d.severity == DiagnosticSeverity.Hint
+    @test d.tags == [DiagnosticTag.Unnecessary]
+    @test d.range.start.line ≤ 2 ≤ d.range.var"end".line # covers `inactive_call()`
+    @test d.range.var"end".line < 4                      # excludes `active_call()`
+end
+
 module soft_scope_module
     global x = 1
 end

--- a/test/utils/test_jl_syntax_macros.jl
+++ b/test/utils/test_jl_syntax_macros.jl
@@ -1243,4 +1243,205 @@ end
     end
 end
 
+module static_eval_module
+const STATIC_COND_FLAG = true
+end
+
+@testset "@static" begin
+    @testset "macro expansion" begin
+        # Taken `if` branch survives as its source block; the dropped branch and the
+        # condition disappear at expansion time.
+        let st1 = jlexpand("@static if true; sin(xxx); end")
+            @test JS.kind(st1) === JS.K"block"
+            @test JS.sourcetext(st1[1]) == "sin(xxx)"
+        end
+
+        # No `else` and a false condition: expands to `nothing`, like Base.
+        let st1 = jlexpand("@static if false; aaa; end")
+            @test JS.kind(st1) === JS.K"Value"
+        end
+
+        # `elseif` chains keep folding until a branch is taken.
+        let st1 = jlexpand("@static if false; aaa; elseif true; bbb; else; ccc; end")
+            @test JS.kind(st1) === JS.K"block"
+            @test JS.sourcetext(st1[1]) == "bbb"
+        end
+        let st1 = jlexpand("@static if false; aaa; elseif false; bbb; else; ccc; end")
+            @test JS.kind(st1) === JS.K"block"
+            @test JS.sourcetext(st1[1]) == "ccc"
+        end
+
+        # Ternary forms, including right-nested chains.
+        let st1 = jlexpand("@static true ? aaa : bbb")
+            @test JS.sourcetext(st1) == "aaa"
+        end
+        let st1 = jlexpand("@static false ? aaa : true ? bbb : ccc")
+            @test JS.sourcetext(st1) == "bbb"
+        end
+
+        # `&&` / `||` short-circuit forms, including right-nested chains.
+        let st1 = jlexpand("@static true && sin(xxx)")
+            @test JS.kind(st1) === JS.K"call"
+            @test JS.sourcetext(st1) == "sin(xxx)"
+        end
+        @test JS.kind(jlexpand("@static false && sin(xxx)")) === JS.K"Value"
+        @test JS.kind(jlexpand("@static true || sin(xxx)")) === JS.K"Value"
+        let st1 = jlexpand("@static false || false || sin(xxx)")
+            @test JS.kind(st1) === JS.K"call"
+            @test JS.sourcetext(st1) == "sin(xxx)"
+        end
+
+        # The condition is evaluated in the macro expansion context module.
+        let st1 = jlexpand(static_eval_module, "@static STATIC_COND_FLAG ? aaa : bbb")
+            @test JS.sourcetext(st1) == "aaa"
+        end
+    end
+
+    @testset "inactive branch hints" begin
+        # Each dropped branch is reported as `lowering/inactive-code` at Hint
+        # severity so clients can gray it out.
+        let diags = collect_macro_diagnostics() do
+                jlexpand("@static if false; aaa; else; bbb; end")
+            end
+            d = only(diags)
+            @test d.severity == JETLS.LSP.DiagnosticSeverity.Hint
+            @test d.code == JETLS.LOWERING_INACTIVE_CODE
+            @test occursin("Inactive `@static` branch", d.msg)
+            @test occursin("`false`", d.msg)
+            @test occursin("aaa", JS.sourcetext(d.node))
+            @test !occursin("bbb", JS.sourcetext(d.node))
+        end
+        let diags = collect_macro_diagnostics() do
+                jlexpand("@static if true; aaa; else; bbb; end")
+            end
+            d = only(diags)
+            @test d.code == JETLS.LOWERING_INACTIVE_CODE
+            @test occursin("`true`", d.msg)
+            @test !occursin("aaa", JS.sourcetext(d.node))
+            @test occursin("bbb", JS.sourcetext(d.node))
+        end
+
+        # No `else` and a false condition: the then-block is still inactive.
+        let diags = collect_macro_diagnostics() do
+                jlexpand("@static if false; aaa; end")
+            end
+            @test occursin("aaa", JS.sourcetext(only(diags).node))
+        end
+
+        # Fully taken conditional: nothing is dropped, nothing is reported.
+        for code in ("@static if true; aaa; end", "@static true && sin(xxx)")
+            @test isempty(collect_macro_diagnostics() do
+                jlexpand(code)
+            end)
+        end
+
+        # `elseif` chains report once per dropped segment.
+        let diags = collect_macro_diagnostics() do
+                jlexpand("@static if false; aaa; elseif true; bbb; else; ccc; end")
+            end
+            @test length(diags) == 2
+            @test occursin("aaa", JS.sourcetext(diags[1].node))
+            @test occursin("ccc", JS.sourcetext(diags[2].node))
+        end
+
+        # Taking an early branch drops the whole remaining chain — including
+        # conditions that were consequently never evaluated — as one range.
+        let diags = collect_macro_diagnostics() do
+                jlexpand("@static if true; aaa; elseif undefined_var_xyz; bbb; end")
+            end
+            d = only(diags)
+            @test d.code == JETLS.LOWERING_INACTIVE_CODE
+            @test occursin("undefined_var_xyz", JS.sourcetext(d.node))
+            @test occursin("bbb", JS.sourcetext(d.node))
+        end
+
+        # Short-circuit and ternary forms.
+        let diags = collect_macro_diagnostics() do
+                jlexpand("@static false && sin(xxx)")
+            end
+            @test occursin("sin(xxx)", JS.sourcetext(only(diags).node))
+        end
+        let diags = collect_macro_diagnostics() do
+                jlexpand("@static true || sin(xxx)")
+            end
+            @test occursin("sin(xxx)", JS.sourcetext(only(diags).node))
+        end
+        let diags = collect_macro_diagnostics() do
+                jlexpand("@static true ? aaa : bbb")
+            end
+            @test occursin("bbb", JS.sourcetext(only(diags).node))
+        end
+    end
+
+    @testset "validation" begin
+        # Non-conditional argument: Base throws `ArgumentError("invalid @static
+        # macro")`; report via sink and flow the argument through.
+        let diags = collect_macro_diagnostics() do
+                @test JS.kind(jlexpand("@static foo(xxx)")) === JS.K"call"
+            end
+            @test length(diags) == 1
+            d = only(diags)
+            @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+            @test occursin("invalid @static macro", d.msg)
+        end
+
+        # Zero arguments and 2+ arguments fall through to the variadic fallback.
+        for code in ("@static", "@static true extra")
+            let diags = collect_macro_diagnostics() do
+                    jlexpand(code)
+                end
+                @test length(diags) == 1
+                d = only(diags)
+                @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+                @test occursin("invalid @static macro", d.msg)
+            end
+        end
+
+        # Unevaluable condition: report via sink and recover with the runtime
+        # conditional so the condition and both branches reach scope analysis.
+        let diags = collect_macro_diagnostics() do
+                st1 = jlexpand("@static if undefined_var_xyz; aaa; else; bbb; end")
+                @test JS.kind(st1) === JS.K"if"
+            end
+            @test length(diags) == 1
+            d = only(diags)
+            @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+            @test occursin("failed to evaluate condition", d.msg)
+        end
+
+        # Non-`Bool` condition: same recovery shape.
+        let diags = collect_macro_diagnostics() do
+                @test JS.kind(jlexpand("@static if 1; aaa; end")) === JS.K"if"
+            end
+            @test length(diags) == 1
+            d = only(diags)
+            @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+            @test occursin("did not evaluate to a Bool", d.msg)
+        end
+    end
+
+    @testset "binding resolution preserves provenance" begin
+        # The taken branch keeps byte-accurate provenance; identifiers in the
+        # dropped branch vanish from the analysis entirely.
+        let res = jlresolve(
+                "staticfunc() = @static VERSION ≥ v\"1.0\" ? sin(xxx) : cos(yyy)")
+            assert_binding_provenance(res, :global, "xxx")
+            assert_no_binding(res, :global, "yyy")
+        end
+    end
+
+    @testset "runtime semantics" begin
+        @test jleval("@static true ? 1 : 2") === 1
+        @test jleval("@static false ? 1 : 2") === 2
+        @test jleval("@static true && 3") === 3
+        @test jleval("@static false && 3") === nothing
+        @test jleval("@static true || 3") === nothing
+        @test jleval("@static false || 3") === 3
+        @test jleval("@static if false; 1; elseif true; 2; else; 3; end") === 2
+        # The dropped branch must never reach lowering: `break` outside a loop
+        # would fail to lower if it survived expansion.
+        @test jleval("@static if true; :taken; else; break; end") === :taken
+    end
+end
+
 end # module test_jl_syntax_macros


### PR DESCRIPTION
Add a new-style macro implementation for `Base.@static`. Like the real macro, the condition is evaluated at expansion time (`JL.eval`'d in `__context__.scope_layer.mod`) and only the taken branch survives, but the surviving branch now keeps fine-grained provenance, so scope resolution and downstream LSP analyses work on identifiers inside `@static` blocks. Conditions that fail to evaluate (or don't produce a `Bool`) are reported via the sink and recovered by flowing the whole conditional through as a runtime conditional.

Each dropped branch is reported as a new `lowering/inactive-code` diagnostic at `Hint` severity with the `Unnecessary` tag, so editors gray out code that is excluded from analysis in the current environment (mirroring rust-analyzer's `inactive-code`). Unlike `lowering/unreachable-code`, no removal action is offered: the branch is intentionally inactive here and may be active in other environments.

To support per-diagnostic codes, `MacroDiagnostic` gains a `code` field and `emit_macro_diagnostics!` emits each entry under its own code. The repo config pins `lowering/inactive-code` back to `hint` severity since the catch-all pattern elevates everything to `warn` for `jetls check`.