### PR TITLE
formatting: Support ranges formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
                           # (JETLS lowering/unconstrained-static-parameter)
   ```
 
+- Added support for the LSP 3.18 `textDocument/rangesFormatting` request so clients that advertise `textDocument.rangeFormatting.rangesSupport` can format multiple ranges in a single request.
+
 ### Changed
 
 - JETLS now performs correct scope resolution on identifiers used inside `@static` macrocalls, which previously could yield incorrect results in edge cases.

--- a/LSP/src/language-features/formatting.jl
+++ b/LSP/src/language-features/formatting.jl
@@ -28,21 +28,21 @@ Value-object describing what options formatting should use.
     """
     Trim trailing whitespace on a line.
 
-    @since 3.15.0
+    - @since 3.15.0
     """
     trimTrailingWhitespace::Union{Nothing, Bool} = nothing
 
     """
     Insert a newline character at the end of the file if one does not exist.
 
-    @since 3.15.0
+    - @since 3.15.0
     """
     insertFinalNewline::Union{Nothing, Bool} = nothing
 
     """
     Trim all newlines after the final newline at the end of the file.
 
-    @since 3.15.0
+    - @since 3.15.0
     """
     trimFinalNewlines::Union{Nothing, Bool} = nothing
 end
@@ -77,9 +77,22 @@ end
     Whether formatting supports dynamic registration.
     """
     dynamicRegistration::Union{Nothing, Bool} = nothing
+
+    """
+    Whether the client supports formatting multiple ranges at once.
+
+    - @since 3.18.0
+    """
+    rangesSupport::Union{Nothing, Bool} = nothing
 end
 
 @interface DocumentRangeFormattingOptions @extends WorkDoneProgressOptions begin
+    """
+    Whether the server supports formatting multiple ranges at once.
+
+    - @since 3.18.0
+    """
+    rangesSupport::Union{Nothing, Bool} = nothing
 end
 
 @interface DocumentRangeFormattingRegistrationOptions @extends TextDocumentRegistrationOptions, DocumentRangeFormattingOptions begin
@@ -112,6 +125,32 @@ format a given range in a document.
 end
 
 @interface DocumentRangeFormattingResponse @extends ResponseMessage begin
+    result::Union{Vector{TextEdit}, Null, Nothing}
+end
+
+@interface DocumentRangesFormattingParams @extends WorkDoneProgressParams begin
+    """
+    The document to format.
+    """
+    textDocument::TextDocumentIdentifier
+
+    """
+    The ranges to format.
+    """
+    ranges::Vector{Range}
+
+    """
+    The format options.
+    """
+    options::FormattingOptions
+end
+
+@interface DocumentRangesFormattingRequest @extends RequestMessage begin
+    method::String = "textDocument/rangesFormatting"
+    params::DocumentRangesFormattingParams
+end
+
+@interface DocumentRangesFormattingResponse @extends ResponseMessage begin
     result::Union{Vector{TextEdit}, Null, Nothing}
 end
 

--- a/docs/src/formatting.md
+++ b/docs/src/formatting.md
@@ -8,8 +8,13 @@ executables.
 ## [Features](@id formatting/features)
 
 - **Document formatting**: Format entire Julia files
-- **Range formatting**: Format selected code regions (Runic and custom
-  formatters only)
+  (`textDocument/formatting`)
+- **Range formatting**: Format one selected region
+  (`textDocument/rangeFormatting`; Runic and custom formatters only)
+- **Multiple range formatting**: Format multiple selected regions in one
+  LSP 3.18 request (`textDocument/rangesFormatting`). This is advertised only
+  when the client supports `textDocument.rangeFormatting.rangesSupport`, and is
+  available for Runic and custom formatters only.
 - **Progress notifications**: Visual feedback during formatting operations
   for clients that support work done progress
 
@@ -54,7 +59,8 @@ In this case, JETLS will look for the `runic` executable and use it to perform
 formatting.
 
 This is the default setting and doesn't require explicit configuration.
-Runic supports both document and range formatting.
+Runic supports document formatting, single range formatting, and multiple
+range formatting via repeated `--lines=START:END` arguments.
 
 ### [Preset `"JuliaFormatter"`](@id formatting/configuration/juliaformatter)
 
@@ -72,7 +78,7 @@ editor client (such as tab size) when available.
 
 !!! warning
     Note that JuliaFormatter currently, as of v2.2.0, only supports full
-    document formatting, not range formatting.
+    document formatting, not range formatting or multiple range formatting.
 
 ### [Custom formatter](@id formatting/configuration/custom)
 
@@ -89,9 +95,9 @@ code to stdout, following the same interface as `runic`:
   read the entire Julia source code from stdin, format it completely, and
   write the formatted result to stdout. The exit code should be 0 on success.
 - `executable_range`: Command for range formatting. The formatter should
-  accept a `--lines=START:END` argument to format only the specified line
-  range. It should read the entire document code from stdin and write the
-  _entire document code_ to stdout with only the specified region formatted.
+  accept one or more `--lines=START:END` arguments to format only the specified
+  line ranges. It should read the entire document code from stdin and write the
+  _entire document code_ to stdout with only the specified regions formatted.
   The rest of the document must remain unchanged.
 
 ## [Troubleshooting](@id formatting/troubleshooting)

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -418,6 +418,8 @@ function handle_response_message(
         handle_formatting_progress_response(server, msg, request_caller, cancel_flag)
     elseif request_caller isa RangeFormattingProgressCaller
         handle_range_formatting_progress_response(server, msg, request_caller, cancel_flag)
+    elseif request_caller isa RangesFormattingProgressCaller
+        handle_ranges_formatting_progress_response(server, msg, request_caller, cancel_flag)
     elseif request_caller isa ReferencesProgressCaller
         handle_references_progress_response(server, msg, request_caller, cancel_flag)
     elseif request_caller isa RenameProgressCaller
@@ -489,6 +491,8 @@ function handle_request_message(server::Server, @nospecialize(msg), cancel_flag:
         handle_DocumentFormattingRequest(server, msg, cancel_flag)
     elseif msg isa DocumentRangeFormattingRequest
         handle_DocumentRangeFormattingRequest(server, msg, cancel_flag)
+    elseif msg isa DocumentRangesFormattingRequest
+        handle_DocumentRangesFormattingRequest(server, msg, cancel_flag)
     elseif msg isa RenameRequest
         handle_RenameRequest(server, msg, cancel_flag)
     elseif msg isa PrepareRenameRequest

--- a/src/formatting.jl
+++ b/src/formatting.jl
@@ -24,6 +24,16 @@ struct RangeFormattingProgressCaller <: RequestCaller
 end
 cancellable_token_impl(caller::RangeFormattingProgressCaller) = caller.token
 
+struct RangesFormattingProgressCaller <: RequestCaller
+    uri::URI
+    ranges::Vector{Range}
+    options::FormattingOptions
+    msg_id::MessageId
+    token::ProgressToken
+    cancel_flag::CancelFlag
+end
+cancellable_token_impl(caller::RangesFormattingProgressCaller) = caller.token
+
 function formatting_options(server::Server)
     return DocumentFormattingOptions(;
         workDoneProgress = supports(server, :window, :workDoneProgress))
@@ -38,9 +48,14 @@ function formatting_registration(server::Server)
             workDoneProgress = supports(server, :window, :workDoneProgress)))
 end
 
+function ranges_formatting_supported(server::Server)
+    return supports(server, :textDocument, :rangeFormatting, :rangesSupport)
+end
+
 function range_formatting_options(server::Server)
     return DocumentRangeFormattingOptions(;
-        workDoneProgress = supports(server, :window, :workDoneProgress))
+        workDoneProgress = supports(server, :window, :workDoneProgress),
+        rangesSupport = ranges_formatting_supported(server) ? true : nothing)
 end
 
 function range_formatting_registration(server::Server)
@@ -49,7 +64,8 @@ function range_formatting_registration(server::Server)
         method = RANGE_FORMATTING_REGISTRATION_METHOD,
         registerOptions = DocumentRangeFormattingRegistrationOptions(;
             documentSelector = DEFAULT_DOCUMENT_SELECTOR,
-            workDoneProgress = supports(server, :window, :workDoneProgress)))
+            workDoneProgress = supports(server, :window, :workDoneProgress),
+            rangesSupport = ranges_formatting_supported(server) ? true : nothing))
 end
 
 # For dynamic registrations during development
@@ -294,59 +310,161 @@ function range_format_result(
         return exe
     end
 
-    return format_file(state, exe, uri, fi, range, options, formatter)
+    return format_file(state, exe, uri, fi, Range[range], options, formatter)
+end
+
+function handle_DocumentRangesFormattingRequest(
+        server::Server, msg::DocumentRangesFormattingRequest, cancel_flag::CancelFlag
+    )
+    uri = msg.params.textDocument.uri
+    ranges = msg.params.ranges
+    options = msg.params.options
+
+    workDoneToken = msg.params.workDoneToken
+    if workDoneToken !== nothing
+        do_ranges_format_with_progress(
+            server, uri, ranges, options, msg.id, workDoneToken, cancel_flag)
+    elseif supports(server, :window, :workDoneProgress)
+        id = String(gensym(:WorkDoneProgressCreateRequest_rangesFormatting))
+        token = String(gensym(:RangesFormattingProgress))
+        addrequest!(server,
+            id => RangesFormattingProgressCaller(
+                uri, ranges, options, msg.id, token, cancel_flag))
+        params = WorkDoneProgressCreateParams(; token)
+        send(server, WorkDoneProgressCreateRequest(; id, params))
+    else
+        do_ranges_format(server, uri, ranges, options, msg.id, cancel_flag)
+    end
+
+    return nothing
+end
+
+function handle_ranges_formatting_progress_response(
+        server::Server, msg::Dict{Symbol, Any},
+        request_caller::RangesFormattingProgressCaller,
+        progress_cancel_flag::CancelFlag
+    )
+    if handle_response_error(server, msg, "create work done progress")
+        return
+    end
+    (; uri, ranges, options, msg_id, token, cancel_flag) = request_caller
+    combined_flag = CombinedCancelFlag(cancel_flag, progress_cancel_flag)
+    do_ranges_format_with_progress(
+        server, uri, ranges, options, msg_id, token, combined_flag)
+end
+
+function do_ranges_format_with_progress(
+        server::Server, uri::URI, ranges::Vector{Range}, options::FormattingOptions,
+        msg_id::MessageId, token::ProgressToken, cancel_flag::AbstractCancelFlag
+    )
+    send_progress(server, token,
+        WorkDoneProgressBegin(; title = "Formatting document ranges", cancellable = true))
+    completed = false
+    try
+        do_ranges_format(server, uri, ranges, options, msg_id, cancel_flag)
+        completed = true
+    finally
+        send_progress(server, token,
+            WorkDoneProgressEnd(;
+                message = "Document ranges formatting " *
+                          (completed ? "completed" : "failed")))
+    end
+end
+
+function do_ranges_format(
+        server::Server, uri::URI, ranges::Vector{Range}, options::FormattingOptions,
+        msg_id::MessageId, cancel_flag::AbstractCancelFlag
+    )
+    result = ranges_format_result(server.state, uri, ranges, options, cancel_flag)
+    if isnothing(result)
+        return send(server, DocumentRangesFormattingResponse(; id = msg_id, result = null))
+    elseif result isa ResponseError
+        return send(server,
+            DocumentRangesFormattingResponse(;
+                id = msg_id,
+                result = nothing,
+                error = result))
+    else
+        return send(server, DocumentRangesFormattingResponse(; id = msg_id, result))
+    end
+end
+
+function ranges_format_result(
+        state::ServerState, uri::URI, ranges::Vector{Range}, options::FormattingOptions,
+        cancel_flag::AbstractCancelFlag
+    )
+    isempty(ranges) && return TextEdit[]
+
+    result = @something get_file_info(state, uri, cancel_flag) return nothing
+    result isa ResponseError && return result
+    fi = result
+
+    formatter = get_config(state, :formatter)
+    exe = get_formatter_executable(formatter, true)
+    if exe isa ResponseError
+        return exe
+    end
+
+    return format_file(state, exe, uri, fi, ranges, options, formatter)
+end
+
+function range_lines(range::Range)
+    startline = Int(range.start.line + 1)
+    endline = Int(range.var"end".line + 1)
+    return "$startline:$endline"
 end
 
 function format_file(
-        state::ServerState, exe::String, uri::URI, fi::FileInfo, range::Union{Range,Nothing},
+        state::ServerState, exe::String, uri::URI, fi::FileInfo,
+        ranges::Union{Vector{Range},Nothing},
         options::FormattingOptions, formatter::FormatterConfig
     )
-    cell_text = get_cell_text(state, uri)
-    text = cell_text !== nothing ? cell_text : document_text(fi)
-    lines = if range !== nothing
-        startline = Int(range.start.line + 1)
-        endline = Int(range.var"end".line + 1)
-        "$startline:$endline"
-    else
-        nothing
+    if ranges !== nothing && isempty(ranges)
+        return TextEdit[]
     end
 
-    newText = @something run_formatter(exe, text, lines, uri, options, formatter) begin
-        return request_failed_error("Formatter returned an error. See server logs for details.")
+    cell_text = get_cell_text(state, uri)
+    text = cell_text !== nothing ? cell_text : document_text(fi)
+    line_ranges = ranges === nothing ? nothing : map(range_lines, ranges)
+
+    formatter_result = run_formatter(exe, text, line_ranges, uri, options, formatter)
+    newText = @something formatter_result begin
+        return request_failed_error(
+            "Formatter returned an error. See server logs for details.")
     end
-    edit_range = cell_text !== nothing ? cell_range(cell_text, fi.encoding) : document_range(fi)
+    edit_range = if cell_text !== nothing
+        cell_range(cell_text, fi.encoding)
+    else
+        document_range(fi)
+    end
     return TextEdit[TextEdit(; range = edit_range, newText)]
 end
 
 function run_formatter(
-        exe::String, text::AbstractString, lines::Union{Nothing,AbstractString},
+        exe::String, text::AbstractString, line_ranges::Union{Nothing,Vector{String}},
         uri::URI, options::FormattingOptions, formatter::FormatterConfig
     )
+    line_args = line_ranges === nothing ?
+        String[] : ["--lines=$line_range" for line_range in line_ranges]
     cmd = if formatter isa String
         # Preset formatter: "Runic" or "JuliaFormatter"
         if formatter == "Runic"
-            if isnothing(lines)
+            if isempty(line_args)
                 `$exe`
             else
-                `$exe --lines=$lines`
+                `$exe $(line_args)`
             end
         elseif formatter == "JuliaFormatter"
             # JuliaFormatter doesn't support range formatting
             # (should not reach here due to earlier validation)
-            if isnothing(lines)
+            if line_ranges === nothing
                 tabSize = options.tabSize
                 filepath = uri2filepath(uri)
                 if filepath !== nothing
                     config_dir = dirname(filepath)
-                    if tabSize !== nothing
-                        `$exe --indent=$(Int(tabSize)) --prioritize-config-file --config-dir=$config_dir`
-                    else
-                        `$exe --config-dir=$config_dir`
-                    end
-                elseif tabSize !== nothing
-                    `$exe --indent=$(Int(tabSize))`
+                    `$exe --indent=$(Int(tabSize)) --prioritize-config-file --config-dir=$config_dir`
                 else
-                    `$exe`
+                    `$exe --indent=$(Int(tabSize))`
                 end
             else
                 return nothing
@@ -357,10 +475,10 @@ function run_formatter(
     else # Custom formatter
         formatter = formatter::CustomFormatterConfig
         # Assume custom formatters use the same interface as Runic
-        if isnothing(lines)
+        if isempty(line_args)
             `$exe`
         else
-            `$exe --lines=$lines`
+            `$exe $(line_args)`
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,6 +47,7 @@ end
     @testset "semantic tokens" include("test_semantic_tokens.jl")
     @testset "lowering diagnostic" include("test_lowering_diagnostic.jl")
     @testset "code action" include("test_code_action.jl")
+    @testset "formatting" include("test_formatting.jl")
     @testset "diagnostic" include("test_diagnostic.jl")
     @testset "did-change-watched-files" include("test_did_change_watched_files.jl")
     @testset "rename" include("test_rename.jl")

--- a/test/test_formatting.jl
+++ b/test/test_formatting.jl
@@ -1,0 +1,167 @@
+module test_formatting
+
+include("setup.jl")
+
+using Test
+using JETLS
+using JETLS.LSP
+using JETLS.URIs2
+
+function make_range(
+        start_line::Int, start_character::Int, end_line::Int, end_character::Int
+    )
+    return Range(;
+        start = Position(; line = start_line, character = start_character),
+        var"end" = Position(; line = end_line, character = end_character))
+end
+
+function formatting_options()
+    return FormattingOptions(; tabSize = 4, insertSpaces = true)
+end
+
+function ranges_formatting_capabilities()
+    return ClientCapabilities(;
+        textDocument = TextDocumentClientCapabilities(;
+            rangeFormatting = DocumentRangeFormattingClientCapabilities(;
+                rangesSupport = true)))
+end
+
+function store_lsp_config!(server::JETLS.Server, config::JETLS.JETLSConfig)
+    JETLS.store!(server.state.config_manager) do old_data::JETLS.ConfigManagerData
+        new_data = JETLS.ConfigManagerData(old_data; lsp_config = config)
+        return new_data, nothing
+    end
+end
+
+function write_passthrough_formatter(tempdir::AbstractString)
+    exe = joinpath(tempdir, "passthrough-formatter")
+    args_file = joinpath(tempdir, "formatter-args.txt")
+    write(exe,
+        "#!/bin/sh\n" *
+        ": > \"\$JETLS_TEST_FORMATTER_ARGS\"\n" *
+        "for arg do\n" *
+        "    printf '%s\\n' \"\$arg\" >> \"\$JETLS_TEST_FORMATTER_ARGS\"\n" *
+        "done\n" *
+        "cat\n")
+    chmod(exe, 0o755)
+    return (; exe, args_file)
+end
+
+function with_passthrough_formatter(f, tempdir::AbstractString)
+    (; exe, args_file) = write_passthrough_formatter(tempdir)
+    return withenv("JETLS_TEST_FORMATTER_ARGS" => args_file) do
+        f(exe, args_file)
+    end
+end
+
+function configure_formatter!(server::JETLS.Server, exe::AbstractString)
+    return store_lsp_config!(server, JETLS.JETLSConfig(;
+        formatter = JETLS.CustomFormatterConfig(exe, exe)))
+end
+
+function cache_test_file!(server::JETLS.Server, uri::URI, text::AbstractString)
+    return JETLS.cache_file_info!(server, uri, 1, text)
+end
+
+@testset "textDocument/formatting handler" begin
+    @static if Sys.iswindows()
+        @test_skip "shell-script-backed formatter test is Unix-only"
+    else
+        mktempdir() do tempdir
+            text = "a=1\nb=2\n"
+            uri = filepath2uri(joinpath(tempdir, "test.jl"))
+
+            with_passthrough_formatter(tempdir) do exe, args_file
+                withserver() do (; server, writereadmsg, id_counter)
+                    configure_formatter!(server, exe)
+                    cache_test_file!(server, uri, text)
+
+                    request = DocumentFormattingRequest(;
+                        id = id_counter[] += 1,
+                        params = DocumentFormattingParams(;
+                            textDocument = TextDocumentIdentifier(; uri),
+                            options = formatting_options()))
+                    (; raw_res) = writereadmsg(request)
+
+                    @test raw_res isa DocumentFormattingResponse
+                    @test raw_res.result isa Vector{TextEdit}
+                    @test length(raw_res.result) == 1
+                    @test raw_res.result[1].newText == text
+                    @test readlines(args_file) == String[]
+                end
+            end
+        end
+    end
+end
+
+@testset "textDocument/rangeFormatting handler" begin
+    @static if Sys.iswindows()
+        @test_skip "shell-script-backed formatter test is Unix-only"
+    else
+        mktempdir() do tempdir
+            text = "a=1\nb=2\nc=3\n"
+            uri = filepath2uri(joinpath(tempdir, "test.jl"))
+            range = make_range(1, 0, 2, 3)
+
+            with_passthrough_formatter(tempdir) do exe, args_file
+                withserver() do (; server, writereadmsg, id_counter)
+                    configure_formatter!(server, exe)
+                    cache_test_file!(server, uri, text)
+
+                    request = DocumentRangeFormattingRequest(;
+                        id = id_counter[] += 1,
+                        params = DocumentRangeFormattingParams(;
+                            textDocument = TextDocumentIdentifier(; uri),
+                            range,
+                            options = formatting_options()))
+                    (; raw_res) = writereadmsg(request)
+
+                    @test raw_res isa DocumentRangeFormattingResponse
+                    @test raw_res.result isa Vector{TextEdit}
+                    @test length(raw_res.result) == 1
+                    @test raw_res.result[1].newText == text
+                    @test readlines(args_file) == ["--lines=2:3"]
+                end
+            end
+        end
+    end
+end
+
+@testset "textDocument/rangesFormatting handler" begin
+    @static if Sys.iswindows()
+        @test_skip "shell-script-backed formatter test is Unix-only"
+    else
+        mktempdir() do tempdir
+            text = "a=1\nb=2\nc=3\nd=4\n"
+            uri = filepath2uri(joinpath(tempdir, "test.jl"))
+            ranges = Range[
+                make_range(0, 0, 1, 3),
+                make_range(3, 0, 3, 3),
+            ]
+
+            with_passthrough_formatter(tempdir) do exe, args_file
+                withserver(; capabilities = ranges_formatting_capabilities()) do argnt
+                    (; server, writereadmsg, id_counter) = argnt
+                    configure_formatter!(server, exe)
+                    cache_test_file!(server, uri, text)
+
+                    request = DocumentRangesFormattingRequest(;
+                        id = id_counter[] += 1,
+                        params = DocumentRangesFormattingParams(;
+                            textDocument = TextDocumentIdentifier(; uri),
+                            ranges,
+                            options = formatting_options()))
+                    (; raw_res) = writereadmsg(request)
+
+                    @test raw_res isa DocumentRangesFormattingResponse
+                    @test raw_res.result isa Vector{TextEdit}
+                    @test length(raw_res.result) == 1
+                    @test raw_res.result[1].newText == text
+                    @test readlines(args_file) == ["--lines=1:2", "--lines=4:4"]
+                end
+            end
+        end
+    end
+end
+
+end # module test_formatting


### PR DESCRIPTION
Add LSP 3.18 `textDocument/rangesFormatting` support and advertise `rangesSupport` only when the client advertises the matching capability.

This lets clients submit disjoint formatting ranges in one request instead of issuing sequential `textDocument/rangeFormatting` requests. Keeping the ranges together lets the formatter see the original document and avoids request ordering and intermediate-edit coordinate drift concerns on the client side.

JETLS maps multiple LSP ranges to repeated formatter `--lines` arguments. This matches Runic’s CLI, which supports multiple `--lines` options, and extends the existing custom formatter convention that range formatters accept Runic-compatible `--lines` arguments. JuliaFormatter continues to reject range formatting.

Add focused tests for document formatting, single-range formatting, and multiple-range formatting.