### PR TITLE
config: Preserve order of list-valued settings

### DIFF
--- a/.JETLSConfig.toml
+++ b/.JETLSConfig.toml
@@ -1,5 +1,26 @@
 #:schema ./schemas/config-toml.schema.json
 
+# Treat all other diagnostics as warnings (for early detection via jetls check)
+[[diagnostic.patterns]]
+pattern = ".*"
+match_by = "code"
+match_type = "regex"
+severity = "warn"
+path = "src/**/*.jl"
+[[diagnostic.patterns]]
+pattern = ".*"
+match_by = "code"
+match_type = "regex"
+severity = "warn"
+path = "LSP/src/**/*.jl"
+
+[[diagnostic.patterns]]
+pattern = "lowering/inactive-code"
+match_by = "code"
+match_type = "literal" # Outrank code-regex catch-all diagnostic rules
+severity = "hint"
+path = "**/*.jl"
+
 # TODO [JETLS]
 # Need to properly set module context when a single file contains multiple modules (for the new incremental full analysis mode)
 [[diagnostic.patterns]]
@@ -34,27 +55,6 @@ match_by = "message"
 match_type = "regex"
 severity = "off"
 path = "src/testrunner/testrunner-types.jl"
-
-[[diagnostic.patterns]]
-pattern = "lowering/inactive-code"
-match_by = "code"
-match_type = "literal" # Outrank the code-regex catch-all diagnostic rules below
-severity = "hint"
-path = "**/*.jl"
-
-# Treat all other diagnostics as warnings (for early detection via jetls check)
-[[diagnostic.patterns]]
-pattern = ".*"
-match_by = "code"
-match_type = "regex"
-severity = "warn"
-path = "src/**/*.jl"
-[[diagnostic.patterns]]
-pattern = ".*"
-match_by = "code"
-match_type = "regex"
-severity = "warn"
-path = "LSP/src/**/*.jl"
 
 [[initialization_options.analysis_overrides]]
 module_name = "JETLS"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `diagnostic.patterns` order handling so declaration order is preserved after configuration merging. When multiple matching rules have the same priority, later rules now override earlier rules.
+
 - Fixed type information collapsing to `Any` inside closures defined in functions that have default positional arguments or keyword arguments. Hover, inlay hints and other type-aware features now show precise types for such closure bodies and their captured variables.
 
 ## 2026-06-03

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -273,6 +273,8 @@ precedence. The priority order (highest to lowest) is:
 
 This priority strategy allows message-based patterns to override code-based
 patterns, enabling fine-grained control for specific diagnostic instances.
+When multiple matching patterns have the same priority, the later entry takes
+precedence.
 
 Example showing priority:
 

--- a/src/config.jl
+++ b/src/config.jl
@@ -17,24 +17,45 @@ is_config_file(filepath::AbstractString) =
     :(T($(entries...)))
 end
 
+function unique_config_sections_keep_last(config::Vector{T}) where {T<:ConfigSection}
+    seen = Set{Any}()
+    result = T[]
+    sizehint!(result, length(config))
+    for item in Iterators.reverse(config)
+        key = merge_key_value(item)
+        key in seen && continue
+        push!(seen, key)
+        push!(result, item)
+    end
+    return reverse!(result)
+end
+
 function merge_and_track(
         on_difference,
         old_config::Vector{T},
         new_config::Vector{T},
         path::Tuple{Vararg{Symbol}}
     ) where {T<:ConfigSection}
-    old_by_key = Dict(merge_key_value(item) => item for item in old_config)
-    new_by_key = Dict(merge_key_value(item) => item for item in new_config)
+    old_config = unique_config_sections_keep_last(old_config)
+    new_config = unique_config_sections_keep_last(new_config)
+    old_keys = Any[merge_key_value(item) for item in old_config]
+    new_keys = Any[merge_key_value(item) for item in new_config]
+    isequal(old_keys, new_keys) || on_difference(old_keys, new_keys, path)
+
+    old_by_key = Dict{Any,T}(merge_key_value(item) => item for item in old_config)
+    new_keys_set = Set{Any}(new_keys)
     result = T[]
-    for (k, old_item) in old_by_key
-        if haskey(new_by_key, k)
-            push!(result, merge_and_track(on_difference, old_item, new_by_key[k], path))
-        else
-            push!(result, merge_and_track(on_difference, old_item, nothing, path))
-        end
+    sizehint!(result, length(old_config) + length(new_config))
+    for old_item in old_config
+        key = merge_key_value(old_item)
+        key in new_keys_set && continue
+        push!(result, merge_and_track(on_difference, old_item, nothing, path))
     end
-    for (k, new_item) in new_by_key
-        if !haskey(old_by_key, k)
+    for new_item in new_config
+        key = merge_key_value(new_item)
+        if haskey(old_by_key, key)
+            push!(result, merge_and_track(on_difference, old_by_key[key], new_item, path))
+        else
             push!(result, merge_and_track(on_difference, nothing, new_item, path))
         end
     end
@@ -59,7 +80,11 @@ function merge_and_track(
         new_config::Vector{T},
         path::Tuple{Vararg{Symbol}}
     ) where {T<:ConfigSection}
-    return T[merge_and_track(on_difference, nothing, new_item, path) for new_item in new_config]
+    new_config = unique_config_sections_keep_last(new_config)
+    return T[
+        merge_and_track(on_difference, nothing, new_item, path)
+        for new_item in new_config
+    ]
 end
 
 @generated function merge_and_track(

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -213,7 +213,7 @@ function _apply_diagnostic_config(
         is_message_match = pattern_config.match_by == "message"
         specificity = calculate_match_specificity(
             pattern_config.pattern, target, is_message_match)
-        if specificity > best_specificity
+        if specificity != 0 && specificity >= best_specificity
             best_specificity = specificity
             severity = pattern_config.severity
         end

--- a/test/test_config.jl
+++ b/test/test_config.jl
@@ -29,13 +29,11 @@ using JETLS
             pattern1 = JETLS.DiagnosticPattern(r"error1", "code", "regex", 1, nothing, "error1")
             pattern2 = JETLS.DiagnosticPattern(r"error2", "code", "regex", 2, nothing, "error2")
             pattern3 = JETLS.DiagnosticPattern(r"error3", "code", "regex", 3, nothing, "error3")
-            # Same merge key (match_by, match_type, path, __pattern_value__), only severity differs
+            # Same merge key; only severity differs.
             pattern1_updated = JETLS.DiagnosticPattern(r"error1", "code", "regex", 4, nothing, "error1")
 
-            let base = JETLS.JETLSConfig(;
-                    diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern1, pattern2]))
-                overlay = JETLS.JETLSConfig(;
-                    diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern1_updated, pattern3]))
+            let base = JETLS.JETLSConfig(; diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern1, pattern2]))
+                overlay = JETLS.JETLSConfig(; diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern1_updated, pattern3]))
                 merged = JETLS.merge_settings(base, overlay)
                 patterns = JETLS.getobjpath(merged, :diagnostic, :patterns)
                 @test length(patterns) == 3
@@ -46,21 +44,28 @@ using JETLS
             end
 
             let base = JETLS.JETLSConfig(; diagnostic=JETLS.DiagnosticConfig(; patterns=nothing))
-                overlay = JETLS.JETLSConfig(;
-                    diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern1]))
+                overlay = JETLS.JETLSConfig(; diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern1]))
                 merged = JETLS.merge_settings(base, overlay)
                 patterns = JETLS.getobjpath(merged, :diagnostic, :patterns)
                 @test length(patterns) == 1
                 @test patterns[1] == pattern1
             end
 
-            let base = JETLS.JETLSConfig(;
-                    diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern1]))
+            let base = JETLS.JETLSConfig(; diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern1]))
                 overlay = JETLS.JETLSConfig(; diagnostic=JETLS.DiagnosticConfig(; patterns=nothing))
                 merged = JETLS.merge_settings(base, overlay)
                 patterns = JETLS.getobjpath(merged, :diagnostic, :patterns)
                 @test length(patterns) == 1
                 @test patterns[1] == pattern1
+            end
+
+            # Overlay entries come after unmatched base entries in merged order.
+            let base = JETLS.JETLSConfig(; diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern1, pattern2]))
+                overlay = JETLS.JETLSConfig(; diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern3, pattern1_updated]))
+                merged = JETLS.merge_settings(base, overlay)
+                patterns = JETLS.getobjpath(merged, :diagnostic, :patterns)
+                @test [p.__pattern_value__ for p in patterns] == ["error2", "error3", "error1"]
+                @test patterns[end].severity == 4
             end
         end
 
@@ -72,10 +77,8 @@ using JETLS
             pattern_src = JETLS.DiagnosticPattern(r".*", "code", "regex", 2, src_path, ".*")
             pattern_test = JETLS.DiagnosticPattern(r".*", "code", "regex", 0, test_path, ".*")
 
-            let base = JETLS.JETLSConfig(;
-                    diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern_src, pattern_test]))
-                overlay = JETLS.JETLSConfig(;
-                    diagnostic=JETLS.DiagnosticConfig(; patterns=nothing))
+            let base = JETLS.JETLSConfig(; diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern_src, pattern_test]))
+                overlay = JETLS.JETLSConfig(; diagnostic=JETLS.DiagnosticConfig(; patterns=nothing))
                 merged = JETLS.merge_settings(base, overlay)
                 patterns = JETLS.getobjpath(merged, :diagnostic, :patterns)
                 @test length(patterns) == 2
@@ -83,10 +86,8 @@ using JETLS
 
             # Updating only one of them should preserve the other
             pattern_src_updated = JETLS.DiagnosticPattern(r".*", "code", "regex", 1, src_path, ".*")
-            let base = JETLS.JETLSConfig(;
-                    diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern_src, pattern_test]))
-                overlay = JETLS.JETLSConfig(;
-                    diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern_src_updated]))
+            let base = JETLS.JETLSConfig(; diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern_src, pattern_test]))
+                overlay = JETLS.JETLSConfig(; diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern_src_updated]))
                 merged = JETLS.merge_settings(base, overlay)
                 patterns = JETLS.getobjpath(merged, :diagnostic, :patterns)
                 @test length(patterns) == 2
@@ -120,10 +121,8 @@ using JETLS
         let pattern1 = JETLS.DiagnosticPattern(r"error1", "code", "regex", 1, nothing, "error1")
             pattern1_updated = JETLS.DiagnosticPattern(r"error1", "code", "regex", 4, nothing, "error1")
             pattern2 = JETLS.DiagnosticPattern(r"error2", "code", "regex", 2, nothing, "error2")
-            config1 = JETLS.JETLSConfig(;
-                diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern1]))
-            config2 = JETLS.JETLSConfig(;
-                diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern1_updated, pattern2]))
+            config1 = JETLS.JETLSConfig(; diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern1]))
+            config2 = JETLS.JETLSConfig(; diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern1_updated, pattern2]))
             changes = []
             JETLS.track_setting_changes(config1, config2) do old_val, new_val, path
                 push!(changes, (old_val, new_val, path))
@@ -131,6 +130,20 @@ using JETLS
             @test any(changes) do (old_val, new_val, path)
                 path == (:diagnostic, :patterns, :severity) &&
                 old_val == 1 && new_val == 4
+            end
+        end
+
+        # Reordering patterns should invalidate diagnostics caches.
+        let pattern1 = JETLS.DiagnosticPattern(r"error1", "code", "regex", 1, nothing, "error1")
+            pattern2 = JETLS.DiagnosticPattern(r"error2", "code", "regex", 2, nothing, "error2")
+            config1 = JETLS.JETLSConfig(; diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern1, pattern2]))
+            config2 = JETLS.JETLSConfig(; diagnostic=JETLS.DiagnosticConfig(; patterns=[pattern2, pattern1]))
+            changes = []
+            JETLS.track_setting_changes(config1, config2) do old_val, new_val, path
+                push!(changes, (old_val, new_val, path))
+            end
+            @test any(changes) do (_, _, path)
+                path == (:diagnostic, :patterns)
             end
         end
     end

--- a/test/test_diagnostic.jl
+++ b/test/test_diagnostic.jl
@@ -1027,6 +1027,32 @@ end
             @test only(diagnostics).severity == DiagnosticSeverity.Information
         end
 
+        # Later rules win when patterns have the same priority.
+        let diagnostics = [
+                make_test_diagnostic(;
+                    code = JETLS.LOWERING_UNUSED_ARGUMENT_CODE,
+                    severity = DiagnosticSeverity.Error)
+            ]
+            manager = make_test_manager(Dict{String,Any}(
+                "diagnostic" => Dict{String,Any}(
+                    "patterns" => [
+                        Dict{String,Any}(
+                            "pattern" => "lowering/.*",
+                            "match_by" => "code",
+                            "match_type" => "regex",
+                            "severity" => "warn"),
+                        Dict{String,Any}(
+                            "pattern" => "lowering/unused-argument",
+                            "match_by" => "code",
+                            "match_type" => "regex",
+                            "severity" => "hint"),
+                    ])))
+            uri = filepath2uri("/tmp/test.jl")
+            JETLS.apply_diagnostic_config!(diagnostics, manager, uri, nothing)
+            @test length(diagnostics) == 1
+            @test only(diagnostics).severity == DiagnosticSeverity.Hint
+        end
+
         @testset "path matching" begin
             let diagnostics = [
                     make_test_diagnostic(;


### PR DESCRIPTION
Preserve declaration order when merging list-valued configuration sections such as `diagnostic.patterns` across configuration layers.

Use later matching diagnostic rules as the tie-breaker for patterns with the same priority, and document the behavior.