### PR TITLE
deps: Bump JuliaSyntax revision

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,8 +27,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [sources]
 Compiler = {rev = "avi/JETLS-Compiler-head", subdir = "Compiler", url = "https://github.com/JuliaLang/julia"}
 JET = {rev = "12005c72", url = "https://github.com/aviatesk/JET.jl"}
-JuliaLowering = {rev = "080834e338", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
-JuliaSyntax = {rev = "080834e338", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
+JuliaLowering = {rev = "5a2b7c5708", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
+JuliaSyntax = {rev = "5a2b7c5708", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
 LSP = {path = "LSP"}
 
 [compat]

--- a/src/analysis/Interpreter.jl
+++ b/src/analysis/Interpreter.jl
@@ -4,9 +4,8 @@ export LSInterpreter
 
 using JuliaSyntax: JuliaSyntax as JS
 using JET: CC, JET, JuliaInterpreter
-using ..JETLS:
-    AnalysisRequest, JETLS, JETLS_DEV_MODE, Server,
-    is_cancelled, send_progress, yield_to_endpoint
+using ..JETLS: AnalysisRequest, JETLS, JETLS_DEV_MODE, Server,
+    get_source_text, is_cancelled, send_progress, yield_to_endpoint
 using ..JETLS.URIs2
 using ..JETLS.LSP
 using ..JETLS.Analyzer
@@ -266,7 +265,7 @@ function JET.try_read_file(interp::LSInterpreter, _include_context::Module, file
         if isempty(parsed_stream.diagnostics)
             return fi.syntax_node
         else
-            return String(JS.sourcetext(parsed_stream))
+            return String(get_source_text(parsed_stream))
         end
     end
     # fallback to the default file-system-based include

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -744,7 +744,7 @@ function should_insert_spaces_around_equal(fi::FileInfo, ca::CallArgs)
         tok = @something next_tok(tok) continue
         JS.is_whitespace(this(tok)) || continue
         tok = @something next_tok(tok) continue
-        JS.is_plain_equals(this(tok)) || continue
+        JS.kind(this(tok)) === JS.K"=" || continue
         tok = @something next_tok(tok) continue
         JS.is_whitespace(this(tok)) || continue
         has_whitespaces += 1

--- a/src/formatting.jl
+++ b/src/formatting.jl
@@ -78,9 +78,6 @@ end
 #     method = RANGE_FORMATTING_REGISTRATION_METHOD))
 # register(currently_running, range_formatting_registration(currently_running))
 
-document_text(fi::FileInfo) = JS.sourcetext(fi.parsed_stream)
-document_range(fi::FileInfo) = jsobj_to_range(fi.parsed_stream, fi)
-
 function get_cell_text(state::ServerState, cell_uri::URI)
     notebook_uri = @something get_notebook_uri_for_cell(state, cell_uri) return nothing
     notebook_info = @something get_notebook_info(state, notebook_uri) return nothing

--- a/src/inlay-hint.jl
+++ b/src/inlay-hint.jl
@@ -271,8 +271,8 @@ function collect_type_inlay_hints!(
             end
         end
         if JS.kind(node) === JS.K"unknown_head" && JS.numchildren(node) >= 1
-            # Compound assignment (`op=`) lowering introduces operator
-            # references that pollute the LHS byte range.
+            # Compound assignments parse as `K"unknown_head"` with the operator in
+            # `name_val`; lowering introduces references that pollute the LHS range.
             push!(callee_ranges, JS.byte_range(node[1]))
         end
         # Postfix `'` (adjoint): the operand's hint at end-of-operand would

--- a/src/testrunner/testrunner.jl
+++ b/src/testrunner/testrunner.jl
@@ -535,7 +535,7 @@ function _testrunner_run_testset(
     test_env_path = find_uri_env_path(server.state, uri)
     root_path = testrunner_root_path(server.state, uri)
     cmd = testrunner_cmd(executable, filepath, tsn, tsl, test_env_path, root_path)
-    source = JS.sourcetext(fi.parsed_stream)
+    source = String(document_text(fi))
     testrunnerproc = open(pipeline(cmd; stdin=IOBuffer(source)); read=true)
 
     result = try
@@ -833,7 +833,7 @@ function testrunner_run_testcase_from_uri(server::Server, uri::URI, tcl::Int, tc
         return "File is no longer available in the editor"
     end
     filepath = uri2filename(uri)
-    source = JS.sourcetext(fi.parsed_stream)
+    source = String(document_text(fi))
 
     if supports(server, :window, :workDoneProgress)
         id = String(gensym(:WorkDoneProgressCreateRequest_testrunner))
@@ -842,7 +842,7 @@ function testrunner_run_testcase_from_uri(server::Server, uri::URI, tcl::Int, tc
         params = WorkDoneProgressCreateParams(; token)
         send(server, WorkDoneProgressCreateRequest(; id, params))
     else
-        testrunner_run_testcase(server, uri, tcl, tct, filepath, String(source))
+        testrunner_run_testcase(server, uri, tcl, tct, filepath, source)
     end
     return nothing
 end

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -21,6 +21,10 @@ function build_syntax_tree(fi::FileInfo)
     return copy_syntax_tree(fi.syntax_tree0)
 end
 
+get_source_text(ps::JS.ParseStream) = JS.sourcetext(JS.SourceFile(ps))
+document_text(fi::FileInfo) = get_source_text(fi.parsed_stream)
+document_range(fi::FileInfo) = jsobj_to_range(fi.parsed_stream, fi)
+
 @static if JL.DEBUG
     function ensure_jl_source_attr!(graph::JS.SyntaxGraph)
         attrs = getfield(graph, :attributes)
@@ -97,7 +101,7 @@ Currently handled:
 
 Not yet handled because the malformed shape needs more than a child-collapse:
 
-- `K"->"`, `K"if"`, `K"for"`, compound-assignment `K"op="` — either a
+- `K"->"`, `K"if"`, `K"for"`, compound-assignment `K"unknown_head"` — either a
   structural rewrite or context-aware reasoning is required.
 
 Add new branches in [`_repair_node`](@ref) when these cause downstream

--- a/test/test_inlay_hint.jl
+++ b/test/test_inlay_hint.jl
@@ -672,8 +672,8 @@ end
             @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
         end
 
-        # `op=` lowers to `K"unknown_head"`, which is in the skip set; the
-        # rewritten operator (`+`) and its LHS reference don't leak hints, so
+        # Compound assignments parse as `K"unknown_head"`, which is in the skip set;
+        # lowering-introduced operator and LHS references don't leak hints, so
         # the `inside += 1` line stays unannotated even though the surrounding
         # expressions get annotated normally.
         @testset "compound assignment emits nothing" begin


### PR DESCRIPTION
Adapt completion handler for newer JuliaSyntax, while updating comments for current compound-assignment syntax trees.

Also use `SourceFile` to avoid `ParseStream` deprecations.