### PR TITLE
signature-help: Support no active parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - JETLS now performs correct scope resolution on identifiers used inside `@static` macrocalls, which previously could yield incorrect results in edge cases.
   Invalid `@static` usage (an unsupported expression shape, or a condition that fails to evaluate to a `Bool`) is now reported in place as `lowering/macro-expansion-error` while the code still flows through to analysis.
 
+- Signature help now uses LSP 3.18 `activeParameter: null` for clients that support it, so editors can avoid highlighting a stale parameter after all known keywords have already been filled.
+
 ### Fixed
 
 - Fixed `diagnostic.patterns` order handling so declaration order is preserved after configuration merging. When multiple matching rules have the same priority, later rules now override earlier rules.

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -294,7 +294,8 @@ end
 function make_siginfo(
         m::Method, ca::CallArgs, world::UInt,
         active_arg::Union{Nothing,Bool,Int}, argtypes::Vector{Any};
-        postprocessor::LSPostProcessor = LSPostProcessor()
+        postprocessor::LSPostProcessor = LSPostProcessor(),
+        no_active_parameter_support::Bool = false
     )
     msig = @something get_sig_str(m, ca, world)
     msig = postprocessor(msig)
@@ -325,6 +326,7 @@ function make_siginfo(
     maybe_var_kwp = kwp_i <= length(params) && JS.kind(params[end]) === JS.K"..." ?
         lastindex(params) : nothing
     kwp_map = find_kws(params, kwp_i; sig=true)
+    noActiveParameter = no_active_parameter_support ? null : nothing
 
     # Map active arg to active param, or nothing
     activeParameter =
@@ -346,12 +348,19 @@ function make_siginfo(
                         break
                     end
                 end
-                active_kw
+                if isnothing(active_kw)
+                    noActiveParameter
+                else
+                    active_kw
+                end
             else
-                # If the given positional argument list is larger than the positional parameter
-                # list, then use the position of the last parameter position, which is likely a
-                # vararg parameter, otherwise use the exact argument position.
-                max(1, ca.kw_i ≥ kwp_i ? kwp_i-1 : ca.kw_i)
+                if isempty(params)
+                    noActiveParameter
+                else
+                    # If the argument list is larger than the positional parameter list,
+                    # use the last parameter position, which is likely a vararg parameter.
+                    max(1, ca.kw_i ≥ kwp_i ? kwp_i-1 : ca.kw_i)
+                end
             end
         elseif active_arg in keys(ca.pos_map)
             lb, ub = get(ca.pos_map, active_arg, (1, nothing))
@@ -371,7 +380,11 @@ function make_siginfo(
             else
                 # we don't have a backwards mapping
                 out = get(kwp_map, kwname.name_val, nothing)
-                isnothing(out) ? maybe_var_kwp : out
+                if isnothing(out)
+                    isnothing(maybe_var_kwp) ? noActiveParameter : maybe_var_kwp
+                else
+                    out
+                end
             end
         else
             JETLS_DEBUG_LOWERING && @info "No active arg" active_arg ca.args[active_arg]
@@ -381,11 +394,21 @@ function make_siginfo(
     parameters = ParameterInformation[]
     for (i, param) in enumerate(params)
         isactive = !isnothing(activeParameter) && activeParameter == i
-        active_argtree = isactive && checkbounds(Bool, ca.args, activeParameter) ? ca.args[activeParameter] : nothing
-        active_argtype = isactive && checkbounds(Bool, argtypes, activeParameter) ? argtypes[activeParameter] : nothing
+        active_argtree = if isactive && checkbounds(Bool, ca.args, activeParameter)
+            ca.args[activeParameter]
+        else
+            nothing
+        end
+        active_argtype = if isactive && checkbounds(Bool, argtypes, activeParameter)
+            argtypes[activeParameter]
+        else
+            nothing
+        end
         push!(parameters, make_paraminfo(param, active_argtree, active_argtype, postprocessor))
     end
-    isnothing(activeParameter) || (activeParameter -= 1) # shift to 0-based
+    if activeParameter isa Int
+        activeParameter = UInt(activeParameter - 1) # shift to 0-based
+    end
     return SignatureInformation(; label, documentation, parameters, activeParameter)
 end
 
@@ -562,7 +585,8 @@ end
 function cursor_siginfos(
         fi::FileInfo, b::Int, context_module::Module;
         world::UInt = Base.get_world_counter(),
-        postprocessor::LSPostProcessor = LSPostProcessor()
+        postprocessor::LSPostProcessor = LSPostProcessor(),
+        no_active_parameter_support::Bool = false
     )
     st0 = build_syntax_tree(fi)
     call = cursor_call(fi.parsed_stream, st0, b)
@@ -614,7 +638,8 @@ function cursor_siginfos(
     for match in matches
         m = match.method
         compatible_method(m, ca, world) || continue
-        siginfo = make_siginfo(m, ca, world, active_arg, argtypes′; postprocessor)
+        siginfo = make_siginfo(m, ca, world, active_arg, argtypes′;
+            postprocessor, no_active_parameter_support)
         if siginfo !== nothing
             push!(out, siginfo)
         end
@@ -640,7 +665,10 @@ function handle_SignatureHelpRequest(
     pos = adjust_position(state, uri, msg.params.position)
     (; context_module, world, postprocessor) = get_context_info(state, uri, pos)
     b = xy_to_offset(fi, pos)
-    signatures = cursor_siginfos(fi, b, context_module; world, postprocessor)
+    no_active_parameter_support = supports(state,
+        :textDocument, :signatureHelp, :signatureInformation, :noActiveParameterSupport)
+    signatures = cursor_siginfos(fi, b, context_module;
+        world, postprocessor, no_active_parameter_support)
     activeSignature = activeParameter = nothing
     return send(server,
         SignatureHelpResponse(;

--- a/test/test_signature_help.jl
+++ b/test/test_signature_help.jl
@@ -8,13 +8,17 @@ using JETLS.URIs2
 # siginfos(context_module, code) -> siginfos
 # nsigs(context_module, code) -> n
 
-function siginfos(context_module::Module, code::AbstractString; kwargs...)
+function siginfos(
+        context_module::Module, code::AbstractString;
+        no_active_parameter_support::Bool=false,
+        kwargs...
+    )
     clean_code, positions = JETLS.get_text_and_positions(code; kwargs...)
     @assert length(positions) == 1 "siginfos requires exactly one cursor marker"
     position = only(positions)
     fi = JETLS.FileInfo(0, clean_code, @__FILE__)
     b = JETLS.xy_to_offset(fi, position)
-    return JETLS.cursor_siginfos(fi, b, context_module)
+    return JETLS.cursor_siginfos(fi, b, context_module; no_active_parameter_support)
 end
 
 n_si(args...) = length(siginfos(args...))
@@ -213,10 +217,14 @@ module M_highlight
 f(a0, a1, a2, va3...; kw4=0, kw5=0, kws6...) = 0
 f1(x, xs...) = 0
 kwfunc(; kw0, kw1, kws2...) = nothing
+noargs() = nothing
+fixedkw(; kw0, kw1) = nothing
 end
 function active_parameter(context_module::Module, code::AbstractString; kwargs...)
     si = siginfos(context_module, code; kwargs...)
-    Int(@something only(si).activeParameter return nothing)
+    activeParameter = @something only(si).activeParameter return nothing
+    activeParameter isa JETLS.LSP.Null && return activeParameter
+    return Int(activeParameter)
 end
 @testset "Active param highlighting" begin
     @test 0 == active_parameter(M_highlight, "f(│)")
@@ -268,6 +276,14 @@ end
 
     # unrecognized kwarg forms should not crash and return something
     @test siginfos(M_highlight, "f(0, 1, 2; a.b=1│)") isa Vector
+
+    @test nothing === active_parameter(M_highlight, "noargs(│)")
+    @test JETLS.LSP.null === active_parameter(M_highlight, "noargs(│)"; no_active_parameter_support=true)
+    @test 0 == active_parameter(M_highlight, "fixedkw(; kw0=nothing│, kw1=missing, )")
+    @test 1 == active_parameter(M_highlight, "fixedkw(; kw0=nothing, kw1=missing│, )")
+    @test nothing === active_parameter(M_highlight, "fixedkw(; kw0, kw1, │)")
+    @test JETLS.LSP.null === active_parameter(M_highlight, "fixedkw(; kw0, kw1, │)"; no_active_parameter_support=true)
+    @test JETLS.LSP.null === active_parameter(M_highlight, "fixedkw(; fake│)"; no_active_parameter_support=true)
 end
 
 module M_nested


### PR DESCRIPTION
Use LSP 3.18 `activeParameter: null` when the client advertises `noActiveParameterSupport` and no signature parameter is active.

Also convert computed active parameter indices to `UInt` before constructing `SignatureInformation`, matching the updated LSP type.