### PR TITLE
LSP: Update protocol definitions for 3.18

### DIFF
--- a/LSP/src/basic-json-structures.jl
+++ b/LSP/src/basic-json-structures.jl
@@ -400,6 +400,10 @@ Represents a location inside a resource, such as a line inside a text file.
     range::Range
 end
 
+@interface LocationUriOnly begin
+    uri::DocumentUri
+end
+
 """
 Represents a link between a source and a target location.
 
@@ -937,6 +941,15 @@ the failure is described by the client capability:
     changeAnnotations::Union{Nothing, Dict{ChangeAnnotationIdentifier, ChangeAnnotation}} = nothing
 end
 
+@interface ChangeAnnotationsSupportOptions begin
+    """
+    Whether the client groups edits with equal labels into tree nodes,
+    for instance all edits labelled with "Changes in Strings" would
+    be a tree node.
+    """
+    groupsOnLabel::Union{Nothing, Bool} = nothing
+end
+
 """
 New in version 3.13: [`ResourceOperationKind`](@ref) and [`FailureHandlingKind`](@ref)
 and the client capability `workspace.workspaceEdit.resourceOperations` as well as
@@ -983,14 +996,7 @@ their support using the following client capability:
 
     - `@since` 3.16.0
     """
-    changeAnnotationSupport::Union{Nothing, @interface begin
-        """
-        Whether the client groups edits with equal labels into tree nodes,
-        for instance all edits labelled with "Changes in Strings" would
-        be a tree node.
-        """
-        groupsOnLabel::Union{Nothing, Bool} = nothing
-    end} = nothing
+    changeAnnotationSupport::Union{Nothing, ChangeAnnotationsSupportOptions} = nothing
 end
 
 # Work Done Progress

--- a/LSP/src/language-features/code-action.jl
+++ b/LSP/src/language-features/code-action.jl
@@ -49,6 +49,13 @@ to the server during initialization.
     RefactorInline = "refactor.inline"
 
     """
+    Base kind for refactoring move actions: 'refactor.move'
+
+    - `@since` 3.18.0
+    """
+    RefactorMove = "refactor.move"
+
+    """
     Base kind for refactoring rewrite actions: 'refactor.rewrite'.
 
     Example rewrite actions:
@@ -85,6 +92,13 @@ to the server during initialization.
     - `@since` 3.17.0
     """
     SourceFixAll = "source.fixAll"
+
+    """
+    Base kind for all code actions applying to the entire notebook's scope.
+
+    - `@since` 3.18.0
+    """
+    Notebook = "notebook"
 end
 
 """
@@ -107,6 +121,44 @@ The reason why code actions were requested.
     Automatic = 2
 end
 
+"""
+Code action tags are extra annotations that tweak the behavior of a code action.
+
+- `@since` 3.18.0
+"""
+@namespace CodeActionTag::Int begin
+    "Marks the code action as LLM-generated."
+    LLMGenerated = 1
+end
+
+@interface ClientCodeActionKindOptions begin
+    """
+    The code action kind values the client supports. When this
+    property exists the client also guarantees that it will
+    handle values outside its set gracefully and falls back
+    to a default value when unknown.
+    """
+    valueSet::Vector{CodeActionKind.Ty}
+end
+
+@interface ClientCodeActionLiteralOptions begin
+    """
+    The code action kind is supported with the following value
+    set.
+    """
+    codeActionKind::ClientCodeActionKindOptions
+end
+
+@interface ClientCodeActionResolveOptions begin
+    "The properties that a client can resolve lazily."
+    properties::Vector{String}
+end
+
+@interface CodeActionTagOptions begin
+    "The tags supported by the client."
+    valueSet::Vector{CodeActionTag.Ty}
+end
+
 @interface CodeActionClientCapabilities begin
     """
     Whether code action supports dynamic registration.
@@ -119,21 +171,7 @@ end
 
     - `@since` 3.8.0
     """
-    codeActionLiteralSupport::Union{Nothing, @interface begin
-        """
-        The code action kind is supported with the following value
-        set.
-        """
-        codeActionKind::(@interface begin
-            """
-            The code action kind values the client supports. When this
-            property exists the client also guarantees that it will
-            handle values outside its set gracefully and falls back
-            to a default value when unknown.
-            """
-            valueSet::Vector{CodeActionKind.Ty}
-        end)
-    end} = nothing
+    codeActionLiteralSupport::Union{Nothing, ClientCodeActionLiteralOptions} = nothing
 
     """
     Whether code action supports the `isPreferred` property.
@@ -164,12 +202,7 @@ end
 
     - `@since` 3.16.0
     """
-    resolveSupport::Union{Nothing, @interface begin
-        """
-        The properties that a client can resolve lazily.
-        """
-        properties::Vector{String}
-    end} = nothing
+    resolveSupport::Union{Nothing, ClientCodeActionResolveOptions} = nothing
 
     """
     Whether the client honors the change annotations in
@@ -181,6 +214,34 @@ end
     - `@since` 3.16.0
     """
     honorsChangeAnnotations::Union{Nothing, Bool} = nothing
+
+    """
+    Whether the client supports documentation for a class of code actions.
+
+    - `@since` 3.18.0
+    """
+    documentationSupport::Union{Nothing, Bool} = nothing
+
+    """
+    Client supports the tag property on a code action. Clients supporting tags
+    have to handle unknown tags gracefully.
+
+    - `@since` 3.18.0
+    """
+    tagSupport::Union{Nothing, CodeActionTagOptions} = nothing
+end
+
+"""
+Documentation for a class of code actions.
+
+- `@since` 3.18.0
+"""
+@interface CodeActionKindDocumentation begin
+    "The kind of the code action being documented."
+    kind::CodeActionKind.Ty
+
+    "Command that is used to display the documentation to the user."
+    command::Command
 end
 
 @interface CodeActionOptions @extends WorkDoneProgressOptions begin
@@ -191,6 +252,13 @@ end
     or the server may list out every specific kind they provide.
     """
     codeActionKinds::Union{Nothing, Vector{CodeActionKind.Ty}} = nothing
+
+    """
+    Static documentation for a class of code actions.
+
+    - `@since` 3.18.0
+    """
+    documentation::Union{Nothing, Vector{CodeActionKindDocumentation}} = nothing
 
     """
     The server provides support to resolve additional
@@ -233,6 +301,20 @@ a code action is run.
     - `@since` 3.17.0
     """
     triggerKind::Union{Nothing, CodeActionTriggerKind.Ty} = nothing
+end
+
+"""
+Captures why the code action is currently disabled.
+
+- `@since` 3.18.0
+"""
+@interface CodeActionDisabled begin
+    """
+    Human readable description of why the code action is currently disabled.
+
+    This is displayed in the code actions UI.
+    """
+    reason::String
 end
 
 """
@@ -291,15 +373,7 @@ the `edit` is applied first, then the `command` is executed.
 
     - `@since` 3.16.0
     """
-    disabled::Union{Nothing, @interface begin
-        """
-        Human readable description of why the code action is currently
-        disabled.
-
-        This is displayed in the code actions UI.
-        """
-        reason::String
-    end} = nothing
+    disabled::Union{Nothing, CodeActionDisabled} = nothing
 
     """
     The workspace edit this code action performs.
@@ -320,6 +394,13 @@ the `edit` is applied first, then the `command` is executed.
     - `@since` 3.16.0
     """
     data::Union{Nothing, LSPAny} = nothing
+
+    """
+    Tags for this code action.
+
+    - `@since` 3.18.0
+    """
+    tags::Union{Nothing, Vector{CodeActionTag.Ty}} = nothing
 end
 
 """

--- a/LSP/src/language-features/completions.jl
+++ b/LSP/src/language-features/completions.jl
@@ -1,3 +1,13 @@
+@interface ServerCompletionItemOptions begin
+    """
+    The server has support for completion item label details when receiving a
+    completion item in a resolve call.
+
+    - `@since` 3.17.0
+    """
+    labelDetailsSupport::Union{Bool, Nothing} = nothing
+end
+
 @interface CompletionOptions @extends WorkDoneProgressOptions begin
     """
     The additional characters, beyond the defaults provided by the client (typically
@@ -39,16 +49,7 @@
 
     - `@since` 3.17.0
     """
-    completionItem::Union{Nothing, @interface begin
-        """
-        The server has support for completion item label
-        details (see also `CompletionItemLabelDetails`) when receiving
-        a completion item in a resolve call.
-
-        - `@since` 3.17.0
-        """
-        labelDetailsSupport::Union{Bool, Nothing} = nothing
-    end} = nothing
+    completionItem::Union{Nothing, ServerCompletionItemOptions} = nothing
 end
 
 @interface CompletionRegistrationOptions @extends TextDocumentRegistrationOptions, CompletionOptions begin
@@ -200,6 +201,14 @@ A special text edit to provide an insert and a replace operation.
     insert::Range
 
     "The range if the replace is requested."
+    replace::Range
+end
+
+"""
+Edit range variant that includes ranges for insert and replace operations.
+"""
+@interface EditRangeWithInsertReplace begin
+    insert::Range
     replace::Range
 end
 
@@ -420,6 +429,80 @@ export GlobalCompletionData, MethodSignatureCompletionData, PropertyCompletionDa
 end
 
 """
+Defines how values from a set of defaults and an individual item will be merged.
+
+- `@since` 3.18.0
+"""
+@namespace ApplyKind::Int begin
+    "The value from the individual item is used instead of the default."
+    Replace = 1
+
+    "The value from the item will be merged with the default."
+    Merge = 2
+end
+
+"""
+Specifies how fields from a completion item should be combined with those from
+`completionList.itemDefaults`.
+
+- `@since` 3.18.0
+"""
+@interface CompletionItemApplyKinds begin
+    """
+    Specifies whether commitCharacters on a completion will replace or be
+    merged with those in `completionList.itemDefaults.commitCharacters`.
+
+    - `@since` 3.18.0
+    """
+    commitCharacters::Union{Nothing, ApplyKind.Ty} = nothing
+
+    """
+    Specifies whether the `data` field on a completion will replace or be
+    merged with data from `completionList.itemDefaults.data`.
+
+    - `@since` 3.18.0
+    """
+    data::Union{Nothing, ApplyKind.Ty} = nothing
+end
+
+@interface CompletionItemDefaults begin
+    """
+    A default commit character set.
+
+    - `@since` 3.17.0
+    """
+    commitCharacters::Union{Vector{String}, Nothing} = nothing
+
+    """
+    A default edit range
+
+    - `@since` 3.17.0
+    """
+    editRange::Union{Range, EditRangeWithInsertReplace, Nothing} = nothing
+
+    """
+    A default insert text format
+
+    - `@since` 3.17.0
+    """
+    insertTextFormat::Union{InsertTextFormat.Ty, Nothing} = nothing
+
+    """
+    A default insert text mode
+
+    - `@since` 3.17.0
+    """
+    insertTextMode::Union{InsertTextMode.Ty, Nothing} = nothing
+
+    """
+    A default data value.
+
+    - `@since` 3.17.0
+    """
+    data::Union{GlobalCompletionData, MethodSignatureCompletionData, PropertyCompletionData, Nothing} = nothing
+end
+
+"""
 Represents a collection of [completion items](#CompletionItem) to be
 presented in the editor.
 """
@@ -448,46 +531,15 @@ presented in the editor.
 
     - `@since` 3.17.0
     """
-    itemDefaults::Union{Nothing, @interface begin
-        """
-        A default commit character set.
+    itemDefaults::Union{Nothing, CompletionItemDefaults} = nothing
 
-        - `@since` 3.17.0
-        """
-        commitCharacters::Union{Vector{String}, Nothing} = nothing
+    """
+    Specifies how fields from a completion item should be combined with those
+    from `completionList.itemDefaults`.
 
-        """
-        A default edit range
-
-        - `@since` 3.17.0
-        """
-        editRange::Union{Range, Nothing, @interface begin
-            insert::Range
-            replace::Range
-        end} = nothing
-
-        """
-        A default insert text format
-
-        - `@since` 3.17.0
-        """
-        insertTextFormat::Union{InsertTextFormat.Ty, Nothing} = nothing
-
-        """
-        A default insert text mode
-
-        - `@since` 3.17.0
-        """
-        insertTextMode::Union{InsertTextMode.Ty, Nothing} = nothing
-
-        """
-        A default data value.
-
-        - `@since` 3.17.0
-        """
-
-        data::Union{GlobalCompletionData, MethodSignatureCompletionData, PropertyCompletionData, Nothing} = nothing
-    end} = nothing
+    - `@since` 3.18.0
+    """
+    applyKind::Union{Nothing, CompletionItemApplyKinds} = nothing
 
     """
     The completion items.
@@ -571,6 +623,115 @@ end
     result::Union{CompletionItem, Nothing}
 end
 
+@interface ClientCompletionItemResolveOptions begin
+    "The properties that a client can resolve lazily."
+    properties::Vector{String}
+end
+
+@interface CompletionItemTagOptions begin
+    "The tags supported by the client."
+    valueSet::Vector{CompletionItemTag.Ty}
+end
+
+@interface ClientCompletionItemInsertTextModeOptions begin
+    valueSet::Vector{InsertTextMode.Ty}
+end
+
+@interface ClientCompletionItemOptions begin
+    """
+    Client supports snippets as insert text.
+    """
+    snippetSupport::Union{Nothing, Bool} = nothing
+
+    """
+    Client supports commit characters on a completion item.
+    """
+    commitCharactersSupport::Union{Nothing, Bool} = nothing
+
+    """
+    Client supports the follow content formats for the documentation
+    property. The order describes the preferred format of the client.
+    """
+    documentationFormat::Union{Nothing, Vector{MarkupKind.Ty}} = nothing
+
+    """
+    Client supports the deprecated property on a completion item.
+    """
+    deprecatedSupport::Union{Nothing, Bool} = nothing
+
+    """
+    Client supports the preselect property on a completion item.
+    """
+    preselectSupport::Union{Nothing, Bool} = nothing
+
+    """
+    Client supports the tag property on a completion item. Clients supporting
+    tags have to handle unknown tags gracefully.
+
+    - `@since` 3.15.0
+    """
+    tagSupport::Union{Nothing, CompletionItemTagOptions} = nothing
+
+    """
+    Client supports insert replace edit to control different behavior if a
+    completion item is inserted in the text or should replace text.
+
+    - `@since` 3.16.0
+    """
+    insertReplaceSupport::Union{Nothing, Bool} = nothing
+
+    """
+    Indicates which properties a client can resolve lazily on a
+    completion item.
+
+    - `@since` 3.16.0
+    """
+    resolveSupport::Union{Nothing, ClientCompletionItemResolveOptions} = nothing
+
+    """
+    The client supports the `insertTextMode` property on
+    a completion item to override the whitespace handling mode
+    as defined by the client (see `insertTextMode`).
+
+    - `@since` 3.16.0
+    """
+    insertTextModeSupport::Union{Nothing, ClientCompletionItemInsertTextModeOptions} = nothing
+
+    """
+    The client has support for completion item label
+    details (see also `CompletionItemLabelDetails`).
+
+    - `@since` 3.17.0
+    """
+    labelDetailsSupport::Union{Nothing, Bool} = nothing
+end
+
+@interface ClientCompletionItemOptionsKind begin
+    """
+    The completion item kind values the client supports. When this
+    property exists the client also guarantees that it will
+    handle values outside its set gracefully and falls back
+    to a default value when unknown.
+    """
+    valueSet::Union{Nothing, Vector{CompletionItemKind.Ty}} = nothing
+end
+
+@interface CompletionListCapabilities begin
+    """
+    The client supports the following itemDefaults on a completion list.
+
+    - `@since` 3.17.0
+    """
+    itemDefaults::Union{Nothing, Vector{String}} = nothing
+
+    """
+    Specifies whether the client supports `CompletionList.applyKind`.
+
+    - `@since` 3.18.0
+    """
+    applyKindSupport::Union{Nothing, Bool} = nothing
+end
+
 @interface CompletionClientCapabilities begin
     """
     Whether completion supports dynamic registration.
@@ -581,108 +742,9 @@ end
     The client supports the following `CompletionItem` specific
     capabilities.
     """
-    completionItem::Union{Nothing, @interface begin
-        """
-        Client supports snippets as insert text.
+    completionItem::Union{Nothing, ClientCompletionItemOptions} = nothing
 
-        A snippet can define tab stops and placeholders with `\$1`, `\$2`
-        and `\${3:foo}`. `\$0` defines the final tab stop, it defaults to
-        the end of the snippet. Placeholders with equal identifiers are
-        linked, that is typing in one will update others too.
-        """
-        snippetSupport::Union{Nothing, Bool} = nothing
-
-        """
-        Client supports commit characters on a completion item.
-        """
-        commitCharactersSupport::Union{Nothing, Bool} = nothing
-
-        """
-        Client supports the follow content formats for the documentation
-        property. The order describes the preferred format of the client.
-        """
-        documentationFormat::Union{Nothing, Vector{MarkupKind.Ty}} = nothing
-
-        """
-        Client supports the deprecated property on a completion item.
-        """
-        deprecatedSupport::Union{Nothing, Bool} = nothing
-
-        """
-        Client supports the preselect property on a completion item.
-        """
-        preselectSupport::Union{Nothing, Bool} = nothing
-
-        """
-        Client supports the tag property on a completion item. Clients
-        supporting tags have to handle unknown tags gracefully. Clients
-        especially need to preserve unknown tags when sending a completion
-        item back to the server in a resolve call.
-
-        - `@since` 3.15.0
-        """
-        tagSupport::Union{Nothing, @interface begin
-            """
-            The tags supported by the client.
-            """
-            valueSet::Vector{CompletionItemTag.Ty}
-        end} = nothing
-
-        """
-        Client supports insert replace edit to control different behavior if
-        a completion item is inserted in the text or should replace text.
-
-        - `@since` 3.16.0
-        """
-        insertReplaceSupport::Union{Nothing, Bool} = nothing
-
-        """
-        Indicates which properties a client can resolve lazily on a
-        completion item. Before version 3.16.0 only the predefined properties
-        `documentation` and `detail` could be resolved lazily.
-
-        - `@since` 3.16.0
-        """
-        resolveSupport::Union{Nothing, @interface begin
-            """
-            The properties that a client can resolve lazily.
-            """
-            properties::Vector{String}
-        end} = nothing
-
-        """
-        The client supports the `insertTextMode` property on
-        a completion item to override the whitespace handling mode
-        as defined by the client (see `insertTextMode`).
-
-        - `@since` 3.16.0
-        """
-        insertTextModeSupport::Union{Nothing, @interface begin
-            valueSet::Vector{InsertTextMode.Ty}
-        end} = nothing
-
-        """
-        The client has support for completion item label
-        details (see also `CompletionItemLabelDetails`).
-
-        - `@since` 3.17.0
-        """
-        labelDetailsSupport::Union{Nothing, Bool} = nothing
-    end} = nothing
-
-    completionItemKind::Union{Nothing, @interface begin
-        """
-        The completion item kind values the client supports. When this
-        property exists the client also guarantees that it will
-        handle values outside its set gracefully and falls back
-        to a default value when unknown.
-
-        If this property is not present the client only supports
-        the completion items kinds from `Text` to `Reference` as defined in
-        the initial version of the protocol.
-        """
-        valueSet::Union{Nothing, Vector{CompletionItemKind.Ty}} = nothing
-    end} = nothing
+    completionItemKind::Union{Nothing, ClientCompletionItemOptionsKind} = nothing
 
     """
     The client supports to send additional context information for a
@@ -704,17 +766,5 @@ end
 
     - `@since` 3.17.0
     """
-    completionList::Union{Nothing, @interface begin
-        """
-        The client supports the following itemDefaults on
-        a completion list.
-
-        The value lists the supported property names of the
-        `CompletionList.itemDefaults` object. If omitted
-        no properties are supported.
-
-        - `@since` 3.17.0
-        """
-        itemDefaults::Union{Nothing, Vector{String}} = nothing
-    end} = nothing
+    completionList::Union{Nothing, CompletionListCapabilities} = nothing
 end

--- a/LSP/src/language-features/document-symbol.jl
+++ b/LSP/src/language-features/document-symbol.jl
@@ -1,3 +1,22 @@
+@interface ClientSymbolKindOptions begin
+    """
+    The symbol kind values the client supports. When this
+    property exists the client also guarantees that it will
+    handle values outside its set gracefully and falls back
+    to a default value when unknown.
+
+    If this property is not present the client only supports
+    the symbol kinds from `File` to `Array` as defined in
+    the initial version of the protocol.
+    """
+    valueSet::Union{Nothing, Vector{SymbolKind.Ty}} = nothing
+end
+
+@interface ClientSymbolTagOptions begin
+    "The tags supported by the client."
+    valueSet::Vector{SymbolTag.Ty}
+end
+
 @interface DocumentSymbolClientCapabilities begin
     """
     Whether document symbol supports dynamic registration.
@@ -8,19 +27,7 @@
     Specific capabilities for the `SymbolKind` in the
     `textDocument/documentSymbol` request.
     """
-    symbolKind::Union{Nothing, @interface begin
-        """
-        The symbol kind values the client supports. When this
-        property exists the client also guarantees that it will
-        handle values outside its set gracefully and falls back
-        to a default value when unknown.
-
-        If this property is not present the client only supports
-        the symbol kinds from `File` to `Array` as defined in
-        the initial version of the protocol.
-        """
-        valueSet::Union{Nothing, Vector{SymbolKind.Ty}} = nothing
-    end} = nothing
+    symbolKind::Union{Nothing, ClientSymbolKindOptions} = nothing
 
     """
     The client supports hierarchical document symbols.
@@ -34,10 +41,7 @@
 
     - `@since` 3.16.0
     """
-    tagSupport::Union{Nothing, @interface begin
-        "The tags supported by the client."
-        valueSet::Vector{SymbolTag.Ty}
-    end} = nothing
+    tagSupport::Union{Nothing, ClientSymbolTagOptions} = nothing
 
     """
     The client supports an additional label presented in the UI when

--- a/LSP/src/language-features/folding-range.jl
+++ b/LSP/src/language-features/folding-range.jl
@@ -16,6 +16,26 @@ A set of predefined range kinds.
     Region = "region"
 end
 
+@interface ClientFoldingRangeKindOptions begin
+    """
+    The folding range kind values the client supports. When this
+    property exists the client also guarantees that it will
+    handle values outside its set gracefully and falls back
+    to a default value when unknown.
+    """
+    valueSet::Union{Nothing, Vector{FoldingRangeKind.Ty}} = nothing
+end
+
+@interface ClientFoldingRangeOptions begin
+    """
+    If set, the client signals that it supports setting collapsedText on
+    folding ranges to display custom labels instead of the default text.
+
+    - `@since` 3.17.0
+    """
+    collapsedText::Union{Nothing, Bool} = nothing
+end
+
 @interface FoldingRangeClientCapabilities begin
     """
     Whether implementation supports dynamic registration for folding range
@@ -44,33 +64,30 @@ end
 
     - `@since` 3.17.0
     """
-    foldingRangeKind::Union{Nothing, @interface begin
-        """
-        The folding range kind values the client supports. When this
-        property exists the client also guarantees that it will
-        handle values outside its set gracefully and falls back
-        to a default value when unknown.
-        """
-        valueSet::Union{Nothing, Vector{FoldingRangeKind.Ty}} = nothing
-    end} = nothing
+    foldingRangeKind::Union{Nothing, ClientFoldingRangeKindOptions} = nothing
 
     """
     Specific options for the folding range.
 
     - `@since` 3.17.0
     """
-    foldingRange::Union{Nothing, @interface begin
-        """
-        If set, the client signals that it supports setting collapsedText on
-        folding ranges to display custom labels instead of the default text.
-
-        - `@since` 3.17.0
-        """
-        collapsedText::Union{Nothing, Bool} = nothing
-    end} = nothing
+    foldingRange::Union{Nothing, ClientFoldingRangeOptions} = nothing
 end
 
 @interface FoldingRangeOptions @extends WorkDoneProgressOptions begin
+end
+
+"""
+Workspace client capabilities specific to folding ranges.
+
+- `@since` 3.18.0
+"""
+@interface FoldingRangeWorkspaceClientCapabilities begin
+    """
+    Whether the client implementation supports a refresh request sent from the
+    server to the client.
+    """
+    refreshSupport::Union{Nothing, Bool} = nothing
 end
 
 @interface FoldingRangeRegistrationOptions @extends TextDocumentRegistrationOptions, FoldingRangeOptions begin
@@ -147,4 +164,20 @@ end
 
 @interface FoldingRangeResponse @extends ResponseMessage begin
     result::Union{Vector{FoldingRange}, Null, Nothing}
+end
+
+"""
+The `workspace/foldingRange/refresh` request is sent from the server to the
+client. Servers can use it to ask clients to refresh the folding ranges
+currently shown in editors.
+
+- `@since` 3.18.0
+"""
+@interface FoldingRangeRefreshRequest @extends RequestMessage begin
+    method::String = "workspace/foldingRange/refresh"
+    params::Nothing = nothing
+end
+
+@interface FoldingRangeRefreshResponse @extends ResponseMessage begin
+    result::Union{Null, Nothing}
 end

--- a/LSP/src/language-features/inlay-hint.jl
+++ b/LSP/src/language-features/inlay-hint.jl
@@ -1,3 +1,8 @@
+@interface ClientInlayHintResolveOptions begin
+    "The properties that a client can resolve lazily."
+    properties::Vector{String}
+end
+
 """
 Inlay hint client capabilities.
 
@@ -13,12 +18,7 @@ Inlay hint client capabilities.
     Indicates which properties a client can resolve lazily on an inlay
     hint.
     """
-    resolveSupport::Union{Nothing, @interface begin
-        """
-        The properties that a client can resolve lazily.
-        """
-        properties::Vector{String}
-    end} = nothing
+    resolveSupport::Union{Nothing, ClientInlayHintResolveOptions} = nothing
 end
 
 """

--- a/LSP/src/language-features/semantic-tokens.jl
+++ b/LSP/src/language-features/semantic-tokens.jl
@@ -75,6 +75,28 @@ end
     tokenModifiers::Vector{String}
 end
 
+@interface ClientSemanticTokensRequestFullDelta begin
+    """
+    The client will send the `textDocument/semanticTokens/full/delta` request
+    if the server provides a corresponding handler.
+    """
+    delta::Union{Nothing, Bool} = nothing
+end
+
+@interface ClientSemanticTokensRequestOptions begin
+    """
+    The client will send the `textDocument/semanticTokens/range` request
+    if the server provides a corresponding handler.
+    """
+    range::Union{Nothing, Bool, @interface begin end} = nothing
+
+    """
+    The client will send the `textDocument/semanticTokens/full` request
+    if the server provides a corresponding handler.
+    """
+    full::Union{Nothing, Bool, ClientSemanticTokensRequestFullDelta} = nothing
+end
+
 @interface SemanticTokensClientCapabilities begin
     """
     Whether implementation supports dynamic registration. If this is set to
@@ -88,25 +110,7 @@ end
     Which requests the client supports and might send to the server
     depending on the server's capability.
     """
-    requests::@interface begin
-        """
-        The client will send the `textDocument/semanticTokens/range` request
-        if the server provides a corresponding handler.
-        """
-        range::Union{Nothing, Bool, @interface begin end} = nothing
-
-        """
-        The client will send the `textDocument/semanticTokens/full` request
-        if the server provides a corresponding handler.
-        """
-        full::Union{Nothing, Bool, @interface begin
-            """
-            The client will send the `textDocument/semanticTokens/full/delta`
-            request if the server provides a corresponding handler.
-            """
-            delta::Union{Nothing, Bool} = nothing
-        end} = nothing
-    end
+    requests::ClientSemanticTokensRequestOptions
 
     """
     The token types that the client supports.
@@ -158,6 +162,14 @@ end
     augmentsSyntaxTokens::Union{Nothing, Bool} = nothing
 end
 
+"""
+Semantic tokens options to support deltas for full documents.
+"""
+@interface SemanticTokensFullDelta begin
+    "The server supports deltas for full documents."
+    delta::Union{Nothing, Bool} = nothing
+end
+
 @interface SemanticTokensOptions @extends WorkDoneProgressOptions begin
     """
     The legend used by the server.
@@ -173,12 +185,7 @@ end
     """
     Server supports providing semantic tokens for a full document.
     """
-    full::Union{Nothing, Bool, @interface begin
-        """
-        The server supports deltas for full documents.
-        """
-        delta::Union{Nothing, Bool} = nothing
-    end} = nothing
+    full::Union{Nothing, Bool, SemanticTokensFullDelta} = nothing
 end
 
 @interface SemanticTokensRegistrationOptions @extends TextDocumentRegistrationOptions, SemanticTokensOptions, StaticRegistrationOptions begin

--- a/LSP/src/lifecycle-messages/initialize.jl
+++ b/LSP/src/lifecycle-messages/initialize.jl
@@ -481,6 +481,242 @@ end
 end
 
 """
+Capabilities relating to events from file operations by the user in the client.
+These events do not come from the file system, they come from user operations
+like renaming a file in the UI.
+
+- `@since` 3.16.0
+"""
+@interface FileOperationClientCapabilities begin
+    """
+    Whether the client supports dynamic registration for file
+    requests/notifications.
+    """
+    dynamicRegistration::Union{Bool, Nothing} = nothing
+
+    "The client has support for sending didCreateFiles notifications."
+    didCreate::Union{Bool, Nothing} = nothing
+
+    "The client has support for sending willCreateFiles requests."
+    willCreate::Union{Bool, Nothing} = nothing
+
+    "The client has support for sending didRenameFiles notifications."
+    didRename::Union{Bool, Nothing} = nothing
+
+    "The client has support for sending willRenameFiles requests."
+    willRename::Union{Bool, Nothing} = nothing
+
+    "The client has support for sending didDeleteFiles notifications."
+    didDelete::Union{Bool, Nothing} = nothing
+
+    "The client has support for sending willDeleteFiles requests."
+    willDelete::Union{Bool, Nothing} = nothing
+end
+
+@interface WorkspaceClientCapabilities begin
+    """
+    The client supports applying batch edits
+    to the workspace by supporting the request
+    'workspace/applyEdit'
+    """
+    applyEdit::Union{Bool, Nothing} = nothing
+
+    """
+    Capabilities specific to `WorkspaceEdit`s
+    """
+    workspaceEdit::Union{WorkspaceEditClientCapabilities, Nothing} = nothing
+
+    """
+    Capabilities specific to the `workspace/didChangeConfiguration`
+    notification.
+    """
+    didChangeConfiguration::Union{DidChangeConfigurationClientCapabilities, Nothing} = nothing
+
+    """
+    Capabilities specific to the `workspace/didChangeWatchedFiles`
+    notification.
+    """
+    didChangeWatchedFiles::Union{DidChangeWatchedFilesClientCapabilities, Nothing} = nothing
+
+    """
+    Capabilities specific to the `workspace/symbol` request.
+    """
+    symbol::Union{WorkspaceSymbolClientCapabilities, Nothing} = nothing
+
+    """
+    Capabilities specific to the `workspace/executeCommand` request.
+    """
+    executeCommand::Union{ExecuteCommandClientCapabilities, Nothing} = nothing
+
+    """
+    The client has support for workspace folders.
+
+    - `@since` 3.6.0
+    """
+    workspaceFolders::Union{Bool, Nothing} = nothing
+
+    """
+    The client supports `workspace/configuration` requests.
+
+    - `@since` 3.6.0
+    """
+    configuration::Union{Bool, Nothing} = nothing
+
+    """
+    Capabilities specific to the semantic token requests scoped to the
+    workspace.
+
+    - `@since` 3.16.0
+    """
+    semanticTokens::Union{SemanticTokensWorkspaceClientCapabilities, Nothing} = nothing
+
+    """
+    Capabilities specific to the code lens requests scoped to the
+    workspace.
+
+    - `@since` 3.16.0
+    """
+    codeLens::Union{CodeLensWorkspaceClientCapabilities, Nothing} = nothing
+
+    """
+    The client has support for file requests/notifications.
+
+    - `@since` 3.16.0
+    """
+    fileOperations::Union{Nothing, FileOperationClientCapabilities} = nothing
+
+    # """
+    # Client workspace capabilities specific to inline values.
+
+    # - `@since` 3.17.0
+    # """
+    # inlineValue::Union{InlineValueWorkspaceClientCapabilities, Nothing} = nothing
+
+    """
+    Client workspace capabilities specific to inlay hints.
+
+    - `@since` 3.17.0
+    """
+    inlayHint::Union{InlayHintWorkspaceClientCapabilities, Nothing} = nothing
+
+    """
+    Client workspace capabilities specific to diagnostics.
+
+    - `@since` 3.17.0.
+    """
+    diagnostics::Union{DiagnosticWorkspaceClientCapabilities, Nothing} = nothing
+
+    """
+    Capabilities specific to the folding range requests scoped to the
+    workspace.
+
+    - `@since` 3.18.0
+    """
+    foldingRange::Union{FoldingRangeWorkspaceClientCapabilities, Nothing} = nothing
+
+    """
+    Capabilities specific to the `workspace/textDocumentContent` request.
+
+    - `@since` 3.18.0
+    """
+    textDocumentContent::Union{TextDocumentContentClientCapabilities, Nothing} = nothing
+end
+
+@interface WindowClientCapabilities begin
+    """
+    It indicates whether the client supports server initiated
+    progress using the `window/workDoneProgress/create` request.
+
+    The capability also controls Whether client supports handling
+    of progress notifications. If set servers are allowed to report a
+    `workDoneProgress` property in the request specific server
+    capabilities.
+
+    - `@since` 3.15.0
+    """
+    workDoneProgress::Union{Bool, Nothing} = nothing
+
+    """
+    Capabilities specific to the showMessage request
+
+    - `@since` 3.16.0
+    """
+    showMessage::Union{ShowMessageRequestClientCapabilities, Nothing} = nothing
+
+    """
+    Client capabilities for the show document request.
+
+    - `@since` 3.16.0
+    """
+    showDocument::Union{ShowDocumentClientCapabilities, Nothing} = nothing
+end
+
+@interface StaleRequestSupportOptions begin
+    "The client will actively cancel the request."
+    cancel::Bool
+
+    """
+    The list of requests for which the client
+    will retry the request if it receives a
+    response with error code `ContentModified`
+    """
+    retryOnContentModified::Vector{String}
+end
+
+"""
+General client capabilities.
+
+- `@since` 3.16.0
+"""
+@interface GeneralClientCapabilities begin
+    """
+    Client capability that signals how the client
+    handles stale requests (e.g. a request
+    for which the client will not process the response
+    anymore since the information is outdated).
+
+    - `@since` 3.17.0
+    """
+    staleRequestSupport::Union{Nothing, StaleRequestSupportOptions} = nothing
+
+    """
+    Client capabilities specific to regular expressions.
+
+    - `@since` 3.16.0
+    """
+    regularExpressions::Union{RegularExpressionsClientCapabilities, Nothing} = nothing
+
+    """
+    Client capabilities specific to the client's markdown parser.
+
+    - `@since` 3.16.0
+    """
+    markdown::Union{MarkdownClientCapabilities, Nothing} = nothing
+
+    """
+    The position encodings supported by the client. Client and server
+    have to agree on the same position encoding to ensure that offsets
+    (e.g. character position in a line) are interpreted the same on both
+    side.
+
+    To keep the protocol backwards compatible the following applies: if
+    the value 'utf-16' is missing from the array of position encodings
+    servers can assume that the client supports UTF-16. UTF-16 is
+    therefore a mandatory encoding.
+
+    If omitted it defaults to ['utf-16'].
+
+    Implementation considerations: since the conversion from one encoding
+    into another requires the content of the file / line the conversion
+    is best done where the file is read which is usually on the server
+    side.
+
+    - `@since` 3.17.0
+    """
+    positionEncodings::Union{Vector{PositionEncodingKind.Ty}, Nothing} = nothing
+end
+
+"""
 `ClientCapabilities` define capabilities for dynamic registration, workspace and text
 document features the client supports. The `experimental` can be used to pass
 experimental capabilities under development. For future compatibility a
@@ -499,130 +735,7 @@ provides text document synchronization (e.g. open, changed and close notificatio
 """
 @interface ClientCapabilities begin
     "Workspace specific client capabilities."
-    workspace::Union{Nothing, @interface begin
-        """
-        The client supports applying batch edits
-        to the workspace by supporting the request
-        'workspace/applyEdit'
-        """
-        applyEdit::Union{Bool, Nothing} = nothing
-
-        """
-        Capabilities specific to `WorkspaceEdit`s
-        """
-        workspaceEdit::Union{WorkspaceEditClientCapabilities, Nothing} = nothing
-
-        """
-        Capabilities specific to the `workspace/didChangeConfiguration`
-        notification.
-        """
-        didChangeConfiguration::Union{DidChangeConfigurationClientCapabilities, Nothing} = nothing
-
-        """
-        Capabilities specific to the `workspace/didChangeWatchedFiles`
-        notification.
-        """
-        didChangeWatchedFiles::Union{DidChangeWatchedFilesClientCapabilities, Nothing} = nothing
-
-        """
-        Capabilities specific to the `workspace/textDocumentContent` request.
-
-        - `@since` 3.18.0
-        """
-        textDocumentContent::Union{TextDocumentContentClientCapabilities, Nothing} = nothing
-
-        """
-        Capabilities specific to the `workspace/symbol` request.
-        """
-        symbol::Union{WorkspaceSymbolClientCapabilities, Nothing} = nothing
-
-        """
-        Capabilities specific to the `workspace/executeCommand` request.
-        """
-        executeCommand::Union{ExecuteCommandClientCapabilities, Nothing} = nothing
-
-        """
-        The client has support for workspace folders.
-
-        - `@since` 3.6.0
-        """
-        workspaceFolders::Union{Bool, Nothing} = nothing
-
-        """
-        The client supports `workspace/configuration` requests.
-
-        - `@since` 3.6.0
-        """
-        configuration::Union{Bool, Nothing} = nothing
-
-        """
-        Capabilities specific to the semantic token requests scoped to the
-        workspace.
-
-        - `@since` 3.16.0
-        """
-        semanticTokens::Union{SemanticTokensWorkspaceClientCapabilities, Nothing} = nothing
-
-        """
-        Capabilities specific to the code lens requests scoped to the
-        workspace.
-
-        - `@since` 3.16.0
-        """
-        codeLens::Union{CodeLensWorkspaceClientCapabilities, Nothing} = nothing
-
-        """
-        # The client has support for file requests/notifications.
-
-        - `@since` 3.16.0
-        """
-        fileOperations::Union{Nothing, @interface begin
-            """
-            Whether the client supports dynamic registration for file
-            requests/notifications.
-            """
-            dynamicRegistration::Union{Bool, Nothing} = nothing
-
-            "The client has support for sending didCreateFiles notifications."
-            didCreate::Union{Bool, Nothing} = nothing
-
-            "The client has support for sending willCreateFiles requests."
-            willCreate::Union{Bool, Nothing} = nothing
-
-            "The client has support for sending didRenameFiles notifications."
-            didRename::Union{Bool, Nothing} = nothing
-
-            "The client has support for sending willRenameFiles requests."
-            willRename::Union{Bool, Nothing} = nothing
-
-            "The client has support for sending didDeleteFiles notifications."
-            didDelete::Union{Bool, Nothing} = nothing
-
-            "The client has support for sending willDeleteFiles requests."
-            willDelete::Union{Bool, Nothing} = nothing
-            end} = nothing
-
-        # """
-        # Client workspace capabilities specific to inline values.
-
-        # - `@since` 3.17.0
-        # """
-        # inlineValue::Union{InlineValueWorkspaceClientCapabilities, Nothing} = nothing
-
-        """
-        Client workspace capabilities specific to inlay hints.
-
-        - `@since` 3.17.0
-        """
-        inlayHint::Union{InlayHintWorkspaceClientCapabilities, Nothing} = nothing
-
-        """
-        Client workspace capabilities specific to diagnostics.
-
-        - `@since` 3.17.0.
-        """
-        diagnostics::Union{DiagnosticWorkspaceClientCapabilities, Nothing} = nothing
-    end} = nothing
+    workspace::Union{WorkspaceClientCapabilities, Nothing} = nothing
 
     "Text document specific client capabilities."
     textDocument::Union{TextDocumentClientCapabilities, Nothing} = nothing
@@ -635,100 +748,30 @@ provides text document synchronization (e.g. open, changed and close notificatio
     notebookDocument::Union{NotebookDocumentClientCapabilities, Nothing} = nothing
 
     "Window specific client capabilities."
-    window::Union{Nothing, @interface begin
-        """
-        It indicates whether the client supports server initiated
-        progress using the `window/workDoneProgress/create` request.
-
-        The capability also controls Whether client supports handling
-        of progress notifications. If set servers are allowed to report a
-        `workDoneProgress` property in the request specific server
-        capabilities.
-
-        - `@since` 3.15.0
-        """
-        workDoneProgress::Union{Bool, Nothing} = nothing
-
-        """
-        Capabilities specific to the showMessage request
-
-        - `@since` 3.16.0
-        """
-        showMessage::Union{ShowMessageRequestClientCapabilities, Nothing} = nothing
-
-        """
-        Client capabilities for the show document request.
-
-        - `@since` 3.16.0
-        """
-        showDocument::Union{ShowDocumentClientCapabilities, Nothing} = nothing
-    end} = nothing
+    window::Union{WindowClientCapabilities, Nothing} = nothing
 
     """
     General client capabilities.
 
     - `@since` 3.16.0
     """
-    general::Union{Nothing, @interface begin
-        """
-        Client capability that signals how the client
-        handles stale requests (e.g. a request
-        for which the client will not process the response
-        anymore since the information is outdated).
-
-        - `@since` 3.17.0
-        """
-        staleRequestSupport::Union{Nothing, @interface begin
-            "The client will actively cancel the request."
-            cancel::Bool
-
-            """
-            The list of requests for which the client
-            will retry the request if it receives a
-            response with error code `ContentModified`
-            """
-            retryOnContentModified::Vector{String}
-        end} = nothing
-
-        """
-        Client capabilities specific to regular expressions.
-
-        - `@since` 3.16.0
-        """
-        regularExpressions::Union{RegularExpressionsClientCapabilities, Nothing} = nothing
-
-        """
-        Client capabilities specific to the client's markdown parser.
-
-        - `@since` 3.16.0
-        """
-        markdown::Union{MarkdownClientCapabilities, Nothing} = nothing
-
-        """
-        The position encodings supported by the client. Client and server
-        have to agree on the same position encoding to ensure that offsets
-        (e.g. character position in a line) are interpreted the same on both
-        side.
-
-        To keep the protocol backwards compatible the following applies: if
-        the value 'utf-16' is missing from the array of position encodings
-        servers can assume that the client supports UTF-16. UTF-16 is
-        therefore a mandatory encoding.
-
-        If omitted it defaults to ['utf-16'].
-
-        Implementation considerations: since the conversion from one encoding
-        into another requires the content of the file / line the conversion
-        is best done where the file is read which is usually on the server
-        side.
-
-        - `@since` 3.17.0
-        """
-        positionEncodings::Union{Vector{PositionEncodingKind.Ty}, Nothing} = nothing
-    end} = nothing
+    general::Union{GeneralClientCapabilities, Nothing} = nothing
 
     "Experimental client capabilities."
     experimental::Union{Any, Nothing} = nothing
+end
+
+"""
+Information about the client
+
+- `@since` 3.15.0
+"""
+@interface ClientInfo begin
+    "The name of the client as defined by the client."
+    name::String
+
+    "The client's version as defined by the client."
+    version::Union{String, Nothing} = nothing
 end
 
 @interface InitializeParams @extends WorkDoneProgressParams begin
@@ -744,13 +787,7 @@ end
 
     - `@since` 3.15.0
     """
-    clientInfo::Union{Nothing, @interface begin
-        "The name of the client as defined by the client."
-        name::String
-
-        "The client's version as defined by the client."
-        version::Union{String, Nothing} = nothing
-    end} = nothing
+    clientInfo::Union{Nothing, ClientInfo} = nothing
 
     """
     The locale the client is currently showing the user interface in.
@@ -823,6 +860,19 @@ The initialize request may only be sent once.
     params::InitializeParams
 end
 
+"""
+Information about the server
+
+- `@since` 3.15.0
+"""
+@interface ServerInfo begin
+    "The name of the server as defined by the server."
+    name::String
+
+    "The server's version as defined by the server."
+    version::Union{String, Nothing} = nothing
+end
+
 @interface InitializeResult begin
     "The capabilities the language server provides."
     capabilities::ServerCapabilities
@@ -832,13 +882,7 @@ end
 
     - `@since` 3.15.0
     """
-    serverInfo::Union{Nothing, @interface begin
-        "The name of the server as defined by the server."
-        name::String
-
-        "The server's version as defined by the server."
-        version::Union{String, Nothing} = nothing
-    end} = nothing
+    serverInfo::Union{Nothing, ServerInfo} = nothing
 end
 
 "Known error codes for an `InitializeErrorCodes`."

--- a/LSP/src/window-features.jl
+++ b/LSP/src/window-features.jl
@@ -47,6 +47,14 @@ end
 # ShowMessage Request
 # ===================
 
+@interface ClientShowMessageActionItemOptions begin
+    """
+    Whether the client supports additional attributes which are preserved and
+    sent back to the server in the request's response.
+    """
+    additionalPropertiesSupport::Union{Nothing, Bool} = nothing
+end
+
 """
 Show message request client capabilities.
 """
@@ -54,14 +62,7 @@ Show message request client capabilities.
     """
     Capabilities specific to the MessageActionItem type.
     """
-    messageActionItem::Union{Nothing, @interface begin
-        """
-        Whether the client supports additional attributes which
-        are preserved and sent back to the server in the
-        request's response.
-        """
-        additionalPropertiesSupport::Union{Nothing, Bool} = nothing
-    end} = nothing
+    messageActionItem::Union{Nothing, ClientShowMessageActionItemOptions} = nothing
 end
 
 @interface MessageActionItem begin

--- a/LSP/src/workspace-features/workspace-symbol.jl
+++ b/LSP/src/workspace-features/workspace-symbol.jl
@@ -1,3 +1,11 @@
+@interface ClientSymbolResolveOptions begin
+    """
+    The properties that a client can resolve lazily. Usually
+    `location.range`.
+    """
+    properties::Vector{String}
+end
+
 @interface WorkspaceSymbolClientCapabilities begin
     """
     Symbol request supports dynamic registration.
@@ -8,19 +16,7 @@
     Specific capabilities for the `SymbolKind` in the `workspace/symbol`
     request.
     """
-    symbolKind::Union{Nothing, @interface begin
-        """
-        The symbol kind values the client supports. When this
-        property exists the client also guarantees that it will
-        handle values outside its set gracefully and falls back
-        to a default value when unknown.
-
-        If this property is not present the client only supports
-        the symbol kinds from `File` to `Array` as defined in
-        the initial version of the protocol.
-        """
-        valueSet::Union{Nothing, Vector{SymbolKind.Ty}} = nothing
-    end} = nothing
+    symbolKind::Union{Nothing, ClientSymbolKindOptions} = nothing
 
     """
     The client supports tags on `SymbolInformation` and `WorkspaceSymbol`.
@@ -28,12 +24,7 @@
 
     - `@since` 3.16.0
     """
-    tagSupport::Union{Nothing, @interface begin
-        """
-        The tags supported by the client.
-        """
-        valueSet::Vector{SymbolTag.Ty}
-    end} = nothing
+    tagSupport::Union{Nothing, ClientSymbolTagOptions} = nothing
 
     """
     The client support partial workspace symbols. The client will send the
@@ -42,13 +33,7 @@
 
     - `@since` 3.17.0 - proposedState
     """
-    resolveSupport::Union{Nothing, @interface begin
-        """
-        The properties that a client can resolve lazily. Usually
-        `location.range`
-        """
-        properties::Vector{String}
-    end} = nothing
+    resolveSupport::Union{Nothing, ClientSymbolResolveOptions} = nothing
 end
 
 @interface WorkspaceSymbolOptions @extends WorkDoneProgressOptions begin
@@ -111,9 +96,7 @@ A special workspace symbol that supports locations without a range.
 
     See also `SymbolInformation.location`.
     """
-    location::Union{Location, @interface begin
-        uri::DocumentUri
-    end}
+    location::Union{Location, LocationUriOnly}
 
     """
     A data entry field that is preserved on a workspace symbol between a

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -16,7 +16,7 @@ const COMPLETION_TRIGGER_CHARACTERS = [
 completion_options() = CompletionOptions(;
     triggerCharacters = COMPLETION_TRIGGER_CHARACTERS,
     resolveProvider = true,
-    completionItem = (;
+    completionItem = ServerCompletionItemOptions(;
         labelDetailsSupport = true))
 
 const COMPLETION_REGISTRATION_ID = "jetls-completion"

--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -317,7 +317,7 @@ function handle_InitializeRequest(
             renameProvider,
             workspaceSymbolProvider,
         ),
-        serverInfo = (;
+        serverInfo = ServerInfo(;
             name = "JETLS",
             version = JETLS_VERSION))
 

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -365,8 +365,8 @@ function with_completion_items(
         capabilities = ClientCapabilities(;
             textDocument = TextDocumentClientCapabilities(;
                 completion = CompletionClientCapabilities(;
-                    completionItem = (;
-                        resolveSupport = (;
+                    completionItem = ClientCompletionItemOptions(;
+                        resolveSupport = ClientCompletionItemResolveOptions(;
                             properties = ["documentation", "detail", "kind", "labelDetails"])
                     )))))
     fi = JETLS.FileInfo(#=version=#0, clean_code, @__FILE__)

--- a/test/test_did_change_watched_files.jl
+++ b/test/test_did_change_watched_files.jl
@@ -7,13 +7,10 @@ include(normpath(pkgdir(JETLS), "test", "setup.jl"))
 
 # `workspace/didChangeWatchedFiles` does not support static registration,
 # so we need to allow dynamic registration here to test it
-const CLIENT_CAPABILITIES = ClientCapabilities(
-    workspace = (;
-        didChangeWatchedFiles = DidChangeWatchedFilesClientCapabilities(
-            dynamicRegistration = true
-        )
-    )
-)
+const CLIENT_CAPABILITIES = ClientCapabilities(;
+    workspace = WorkspaceClientCapabilities(;
+        didChangeWatchedFiles = DidChangeWatchedFilesClientCapabilities(;
+            dynamicRegistration = true)))
 
 const DEBOUNCE_DEFAULT = JETLS.get_config(JETLS.ConfigManager(JETLS.ConfigManagerData()), :full_analysis, :debounce)
 const TESTRUNNER_DEFAULT = JETLS.get_config(JETLS.ConfigManager(JETLS.ConfigManagerData()), :testrunner, :executable)

--- a/test/test_registration.jl
+++ b/test/test_registration.jl
@@ -10,7 +10,7 @@ let capabilities = ClientCapabilities(;
         textDocument = TextDocumentClientCapabilities(;
             completion = CompletionClientCapabilities(;
                 dynamicRegistration = true)))
-    withserver(; capabilities) do (; server, readmsg, id_counter)
+    withserver(; capabilities) do (; server, readmsg)
         state = server.state
         reg = Registered(JETLS.COMPLETION_REGISTRATION_ID, JETLS.COMPLETION_REGISTRATION_METHOD)
 


### PR DESCRIPTION
- Refresh LSP 3.18 definitions to use named spec types
- Replace inline anonymous interfaces across initialize and feature metadata
- Update JETLS call sites and tests for renamed constructors