### PR TITLE
lsp: Restrict document selectors by scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed language feature registrations so JETLS only targets supported Julia document URI schemes (`file:` and `untitled:`). This prevents virtual documents from unsupported schemes from triggering diagnostics, code actions, and other file-backed features.
+
 - Fixed `diagnostic.patterns` order handling so declaration order is preserved after configuration merging. When multiple matching rules have the same priority, later rules now override earlier rules.
 
 - Fixed type information collapsing to `Any` inside closures defined in functions that have default positional arguments or keyword arguments. Hover, inlay hints and other type-aware features now show precise types for such closure bodies and their captured variables.

--- a/src/utils/lsp.jl
+++ b/src/utils/lsp.jl
@@ -20,7 +20,8 @@ overlap(rng1::Range, rng2::Range) = max(rng1.start, rng2.start) <= min(rng1.var"
 @define_override_constructor LSP.TextEdit
 
 const DEFAULT_DOCUMENT_SELECTOR = DocumentFilter[
-    DocumentFilter(; language = "julia")
+    DocumentFilter(; language = "julia", scheme = "file"),
+    DocumentFilter(; language = "julia", scheme = "untitled"),
 ]
 
 """


### PR DESCRIPTION
Limit `DEFAULT_DOCUMENT_SELECTOR` to `file:` and `untitled:` Julia documents. This keeps file-backed language features from being registered for unsupported virtual documents such as `jetls:` buffers.

Also documents the user-visible behavior change in `CHANGELOG.md`.