### PR TITLE
testrunner: Open logs from temp files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed type information collapsing to `Any` inside closures defined in functions that have default positional arguments or keyword arguments. Hover, inlay hints and other type-aware features now show precise types for such closure bodies and their captured variables.
 
+- Fixed TestRunner log viewing to open saved temporary log files instead of relying on `untitled:` buffers, avoiding empty log tabs and mismatched log file paths.
+
 ## 2026-06-03
 
 - Commit: [`a42a435`](https://github.com/aviatesk/JETLS.jl/commit/a42a435)

--- a/src/testrunner/testrunner.jl
+++ b/src/testrunner/testrunner.jl
@@ -710,57 +710,88 @@ function _testrunner_run_testcase(
 end
 
 struct ShowDocumentRequestCaller <: RequestCaller
+    testset_name::String
+    temp_path::String
     uri::URI
-    logs::String
-    context::String
+end
+
+is_testsetinfo_logs_filename_unsafe(c::Char) =
+    isspace(c) || iscntrl(c) ||
+    c in ('%', '/', '\\', '?', '#', '<', '>', ':', '"', '|', '*')
+
+# This builds a filesystem name, not a URI component. Keep Unicode names as-is
+# and let `filepath2uri` percent-encode the final path; putting literal `%XX`
+# escapes in the filename would show up as `%25XX` in `file:` links.
+function testsetinfo_logs_filename(tsn::AbstractString)
+    io = IOBuffer()
+    last_replaced = false
+    for c in tsn
+        if is_testsetinfo_logs_filename_unsafe(c)
+            if !last_replaced
+                print(io, '_')
+                last_replaced = true
+            end
+        else
+            print(io, c)
+            last_replaced = false
+        end
+    end
+    name = strip(String(take!(io)), '_')
+    isempty(name) && (name = "testset")
+    length(name) > 80 && (name = first(name, 80))
+    return "TestRunner_$name.log"
+end
+
+function show_testsetinfo_logs_path_message(
+        server::Server, tsn::String, temp_path::String, uri::URI
+    )
+    return show_info_message(server, """
+    Test logs for $tsn saved temporarily to:
+
+    [$temp_path]($uri)
+
+    This file will be removed when JETLS exits.
+    """)
 end
 
 function open_testsetinfo_logs!(server::Server, tsn::String, logs::String)
-    tsn = rlstrip(tsn, '"')
+    testset_name = String(rlstrip(tsn, '"'))
+    temp_filename = testsetinfo_logs_filename(testset_name)
+    temp_path = joinpath(mktempdir(; cleanup=true), temp_filename)
+    try
+        write(temp_path, logs)
+    catch err
+        return show_error_message(server, "Failed to save test logs: $(sprint(showerror, err))")
+    end
+    uri = filepath2uri(temp_path)
     if supports(server, :window, :showDocument, :support)
-        # Use `window/showDocument` to show logs in untitled editor if supported
-        untitled_name = "TestRunner_$tsn.log"
-        uri = URI(; scheme="untitled", path=untitled_name)
         id = String(gensym(:ShowDocumentRequest))
-        context = "showing test logs"
-        addrequest!(server, id=>ShowDocumentRequestCaller(uri, logs, context))
-        send(server, ShowDocumentRequest(;
+        addrequest!(server, id=>ShowDocumentRequestCaller(testset_name, temp_path, uri))
+        return send(server, ShowDocumentRequest(;
             id,
             params = ShowDocumentParams(;
                 uri,
                 takeFocus = true)))
     else
-        # Fallback: save to temp file
-        temp_filename = "TestRunner_$(tsn)_$(getpid()).log"
-        temp_path = joinpath(mktempdir(; cleanup=false), temp_filename)
-        try
-            write(temp_path, logs)
-        catch err
-            return show_error_message(server, "Failed to save test logs: $(sprint(showerror, err))")
-        end
-        uri = filepath2uri(temp_path)
-        show_info_message(server, """
-        Test logs for $tsn saved to:
-
-        [$temp_path]($uri)
-        """)
+        return show_testsetinfo_logs_path_message(server, testset_name, temp_path, uri)
     end
 end
 
 function handle_show_document_response(
         server::Server, msg::Dict{Symbol,Any}, request_caller::ShowDocumentRequestCaller
     )
+    (; testset_name, temp_path, uri) = request_caller
     if handle_response_error(server, msg, "show document")
+        return show_testsetinfo_logs_path_message(server, testset_name, temp_path, uri)
     elseif haskey(msg, :result)
         result = msg[:result] # ::ShowDocumentResult
-        if haskey(result, "success") && result["success"] === true
-            (; uri, logs, context) = request_caller
-            return set_document_content(server, uri, logs; context)
-        else
+        if !(haskey(result, "success") && result["success"] === true)
             show_error_message(server, "Failed to open document for viewing test logs")
+            return show_testsetinfo_logs_path_message(server, testset_name, temp_path, uri)
         end
     else
         show_error_message(server, "Unexpected response from show document request")
+        return show_testsetinfo_logs_path_message(server, testset_name, temp_path, uri)
     end
 end
 

--- a/test/test_testrunner.jl
+++ b/test/test_testrunner.jl
@@ -95,6 +95,38 @@ end
     end
 end
 
+@testset "testsetinfo_logs_filename" begin
+    let filename = JETLS.testsetinfo_logs_filename("simple")
+        @test filename == "TestRunner_simple.log"
+    end
+
+    let filename = JETLS.testsetinfo_logs_filename("macro expansion content")
+        @test startswith(filename, "TestRunner_")
+        @test endswith(filename, ".log")
+        @test !occursin('%', filename)
+    end
+
+    let filename = JETLS.testsetinfo_logs_filename("a/b ?#%\n")
+        @test startswith(filename, "TestRunner_")
+        @test endswith(filename, ".log")
+        @test filename != "TestRunner_.log"
+        @test !any(c -> occursin(c, filename), ('/', '\\', '%', '?', '#', '\n'))
+    end
+
+    let filename = JETLS.testsetinfo_logs_filename("日本語")
+        @test startswith(filename, "TestRunner_")
+        @test endswith(filename, ".log")
+        @test occursin("日本語", filename)
+        @test !occursin('%', filename)
+    end
+
+    let filename = JETLS.testsetinfo_logs_filename(repeat("a", 100))
+        @test startswith(filename, "TestRunner_")
+        @test endswith(filename, ".log")
+        @test length(filename) <= length("TestRunner_") + 80 + length(".log")
+    end
+end
+
 @testset "testrunner_code_lenses" begin
     let server = JETLS.Server()
         test_code = """
@@ -318,7 +350,6 @@ end
 
         uri = URI("file://runtests.jl")
         fi = JETLS.cache_file_info!(server, uri, 1, test_code)
-        testsetinfos = fi.testsetinfos
 
         # Test action on standalone @test (outside any testset)
         standalone_range = LSP.Range(;


### PR DESCRIPTION
Write TestRunner logs to cleanup-enabled temporary files before opening them with `window/showDocument`.

Use real `file:` URIs because `untitled:` support is client-specific and would require a follow-up workspace edit to populate the buffer. Writing the file first avoids empty log tabs, apply-edit failures, and fallback paths that differ from the files actually written.

Add `testsetinfo_logs_filename` to derive safe log filenames from testset names, with coverage for unsafe characters and truncation.