### PR TITLE
LSP: Cover notebook cells and `buffer:` buffers in document selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fixed language feature registrations so JETLS only targets supported Julia document URI schemes (`file:` and `untitled:`). This prevents virtual documents from unsupported schemes from triggering diagnostics, code actions, and other file-backed features.
+- Fixed language feature registrations so JETLS only targets supported Julia documents — saved files (`file:`), unsaved buffers (`untitled:` and `buffer:`), and notebook cells — while still keeping virtual documents from unsupported schemes (e.g. `jetls:`) from triggering diagnostics, code actions, and other file-backed features.
 
 - Fixed `diagnostic.patterns` order handling so declaration order is preserved after configuration merging. When multiple matching rules have the same priority, later rules now override earlier rules.
 

--- a/LSP/src/URIs2/URIs2.jl
+++ b/LSP/src/URIs2/URIs2.jl
@@ -5,7 +5,8 @@
 # TODO Move this under LSP.jl?
 module URIs2
 
-export @uri_str, URI, filename2uri, filepath2uri, isunsavedfile, isunsaveduri, uri2filename, uri2filepath
+export @uri_str, UNSAVED_DOCUMENT_SCHEMES, URI, filename2uri, filepath2uri, isunsavedfile,
+    isunsaveduri, uri2filename, uri2filepath
 
 using StructTypes: StructTypes
 

--- a/LSP/src/URIs2/uri-helpers.jl
+++ b/LSP/src/URIs2/uri-helpers.jl
@@ -45,7 +45,16 @@ function get_unsaved_scheme(filename::AbstractString)
     return nothing
 end
 
-isunsaveduri(uri::URI) = uri.scheme == "untitled" || uri.scheme == "buffer"
+"""
+    UNSAVED_DOCUMENT_SCHEMES
+
+URI schemes editors use for in-memory/unsaved buffers. LSP has no first-class representation
+for unsaved documents, so each client picks its own scheme: `untitled:` (VSCode convention)
+and `buffer:` (SublimeText convention).
+"""
+const UNSAVED_DOCUMENT_SCHEMES = ("untitled", "buffer")
+
+isunsaveduri(uri::URI) = uri.scheme in UNSAVED_DOCUMENT_SCHEMES
 
 function filename2uri(filename::AbstractString)
     unsaved_scheme = get_unsaved_scheme(filename)

--- a/src/utils/lsp.jl
+++ b/src/utils/lsp.jl
@@ -21,13 +21,18 @@ overlap(rng1::Range, rng2::Range) = max(rng1.start, rng2.start) <= min(rng1.var"
 
 const DEFAULT_DOCUMENT_SELECTOR = DocumentFilter[
     TextDocumentFilterLanguage(; language = "julia", scheme = "file"),
-    TextDocumentFilterLanguage(; language = "julia", scheme = "untitled"),
+    [TextDocumentFilterLanguage(; language = "julia", scheme) for scheme in UNSAVED_DOCUMENT_SCHEMES]...,
+    # Notebook cells carry a client-defined URI scheme (e.g. `vscode-notebook-cell:`),
+    # so match them by notebook membership and cell language rather than by scheme.
+    NotebookCellTextDocumentFilter(; notebook = "*", language = "julia"),
 ]
 
 """
-    create_source_location_link(uri::URI, showtext::Union{Nothing,AbstractString}=nothing;
-                                line::Union{Integer,Nothing}=nothing,
-                                character::Union{Integer,Nothing}=nothing)
+    create_source_location_link(
+            uri::URI, showtext::Union{Nothing,AbstractString} = nothing;
+            line::Union{Integer,Nothing} = nothing,
+            character::Union{Integer,Nothing} = nothing
+        ) -> String
 
 Create a markdown-style link to a source location that can be displayed in LSP clients.
 
@@ -71,10 +76,11 @@ create_source_location_link(uri; line=42)
 # Returns: "[/path/to/file.jl:42](file:///path/to/file.jl#L42)"
 ```
 """
-function create_source_location_link(uri::URI,
-                                     showtext::Union{Nothing,AbstractString}=nothing;
-                                     line::Union{Integer,Nothing}=nothing,
-                                     character::Union{Integer,Nothing}=nothing)
+function create_source_location_link(
+        uri::URI, showtext::Union{Nothing,AbstractString} = nothing;
+        line::Union{Integer,Nothing} = nothing,
+        character::Union{Integer,Nothing} = nothing
+    )
     linktext = string(uri)
     if line !== nothing
         linktext *= "#L$line"


### PR DESCRIPTION
aviatesk/JETLS.jl#741 narrowed `DEFAULT_DOCUMENT_SELECTOR` to `file:`/`untitled:` Julia documents, which inadvertently dropped two other supported document kinds and stopped language features (completion, hover, …) from firing
for them:

- Notebook cells, whose cell URIs use a client-defined scheme (e.g. `vscode-notebook-cell:` in VSCode), so the pre-#741 catch-all `language = "julia"` filter used to match them.
- SublimeText's unsaved buffers, which use the `buffer:` scheme.

Match notebook cells with a `NotebookCellTextDocumentFilter` (by notebook membership and cell language rather than by URI scheme, since the scheme is client-defined), and add `buffer:` alongside `untitled:`.

The unsaved-buffer schemes are now derived from a single source, `UNSAVED_DOCUMENT_SCHEMES`, which `isunsaveduri` also consumes, so the document selector and `isunsaveduri` can no longer drift apart.