### PR TITLE
Fast-fail `get_file_info` for non-syncable document URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed language feature registrations so JETLS only targets supported Julia document URI schemes (`file:` and `untitled:`). This prevents virtual documents from unsupported schemes from triggering diagnostics, code actions, and other file-backed features.
 
+- Fixed language feature requests for unsupported document URIs (e.g. virtual documents, or any request from clients that ignore the registered document selectors) blocking for up to 10 seconds before returning an empty result; such requests now return immediately.
+
 - Fixed `diagnostic.patterns` order handling so declaration order is preserved after configuration merging. When multiple matching rules have the same priority, later rules now override earlier rules.
 
 - Fixed type information collapsing to `Any` inside closures defined in functions that have default positional arguments or keyword arguments. Hover, inlay hints and other type-aware features now show precise types for such closure bodies and their captured variables.

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -194,6 +194,9 @@ function get_file_info(
         timeout::Float64 = @static(JETLS_TEST_MODE ? 1.0 : 10.),
         cancelled_error_data = nothing
     )
+    # No `didOpen` will arrive for a URI that cannot be backed by a `FileInfo`,
+    # so polling would only waste the full timeout before returning `nothing`.
+    may_have_file_info(s, uri) || return nothing
     start = time()
     request_id = objectid(cancel_flag) # Each request uses a unique `cancel_flag`, so this objectid can be used as a request-unique ID
     while true
@@ -219,6 +222,21 @@ function get_file_info(
 end
 get_file_info(s::ServerState, t::TextDocumentIdentifier, cancel_flag::AbstractCancelFlag; kwargs...) =
     get_file_info(s, t.uri, cancel_flag; kwargs...)
+
+"""
+    may_have_file_info(s::ServerState, uri::URI) -> Bool
+
+Return `true` if `uri` could ever be backed by a `FileInfo`, i.e. it is a saved (`file:`)
+or unsaved (`untitled:`/`buffer:`) document, or an already-registered notebook cell.
+Any other URI (e.g. server-provided `jetls:` virtual documents, or requests from clients
+that ignore the registered document selectors) can never receive a `FileInfo`, so the
+polling [`get_file_info`](@ref) returns early instead of blocking until its timeout.
+"""
+function may_have_file_info(s::ServerState, uri::URI)
+    uri.scheme == "file" && return true
+    isunsaveduri(uri) && return true
+    return get_notebook_uri_for_cell(s, uri) !== nothing
+end
 
 """
     get_saved_file_info(s::ServerState, uri::URI) -> fi::Union{Nothing,SavedFileInfo}


### PR DESCRIPTION
The polling `get_file_info` (used by request handlers) waits up to the full timeout (10s in production) for a `FileInfo` to appear before returning `nothing`. For a URI that can never be backed by a `FileInfo` — a server-provided virtual document, or any document a client requests despite the registered document selectors — no `didOpen` ever arrives, so the handler thread blocks for the entire timeout only to return an empty result.

Add `may_have_file_info` and short-circuit at the top of the polling `get_file_info`: only `file:`/`untitled:`/`buffer:` documents and already-registered notebook cells can obtain a `FileInfo`. Notebook cells are matched via the cell->notebook mapping rather than a scheme literal, since the cell scheme is client-defined (`file:` in tests, `vscode-notebook-cell:` in VS Code).

This complements the client-side document selector restriction from aviatesk/JETLS.jl#741: the selectors ask well-behaved clients not to send such requests, while this guards against clients that ignore them.