### PR TITLE
notebook: Track per-cell versions so rename edits apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed TestRunner log viewing to open saved temporary log files instead of relying on `untitled:` buffers, avoiding empty log tabs and mismatched log file paths.
 
+- Fixed renaming symbols inside Jupyter notebook cells on VS Code, which previously failed with a "The rename edit returned from the server is not valid anymore and cannot be applied." error.
+
 ## 2026-06-03
 
 - Commit: [`a42a435`](https://github.com/aviatesk/JETLS.jl/commit/a42a435)

--- a/src/notebook.jl
+++ b/src/notebook.jl
@@ -16,6 +16,23 @@ get_notebook_uri_for_cell(state::ServerState, cell_uri::URI, default=nothing) =
 canonical_cache_uri(state::ServerState, uri::URI) =
     get_notebook_uri_for_cell(state, uri, uri)
 
+"""
+    notebook_cell_version(state::ServerState, cell_uri::URI) -> Union{Int,Nothing}
+
+Return the client-tracked text-document version of the notebook cell identified by
+`cell_uri`, or `nothing` if `cell_uri` is not a known notebook cell. This is the per-cell
+version the client expects in edits, as opposed to the notebook-document version stored in
+the cell's concat-source `FileInfo`.
+"""
+function notebook_cell_version(state::ServerState, cell_uri::URI)
+    notebook_uri = @something get_notebook_uri_for_cell(state, cell_uri) return nothing
+    notebook_info = @something get_notebook_info(state, notebook_uri) return nothing
+    for cell in notebook_info.cells
+        cell.uri == cell_uri && return cell.version
+    end
+    return nothing
+end
+
 function concatenate_cells(cells::Vector{NotebookCellInfo})
     source = ""
     cell_ranges = CellRange[]
@@ -52,12 +69,16 @@ function cache_notebook_saved_file_info!(server::Server, notebook_uri::URI, note
     end
 end
 
+# Cells inserted via a structure change carry no text/version of their own; those arrive
+# separately in `structure.didOpen` and get filled in during cell reconstruction from the
+# `cell_texts`/`cell_versions` maps (see `handle_DidChangeNotebookDocumentNotification`).
 cells_from_lsp(cells::Vector{NotebookCell}) =
-    NotebookCellInfo[NotebookCellInfo(cell.document, cell.kind, "") for cell in cells]
+    NotebookCellInfo[NotebookCellInfo(cell.document, cell.kind, 0, "") for cell in cells]
 
 function apply_cell_structure_change!(
         cells::Vector{NotebookCellInfo},
         cell_texts::Dict{URI,String},
+        cell_versions::Dict{URI,Int},
         structure::NotebookDocumentChangeEventCellsStructure
     )
     array_change = structure.array
@@ -74,12 +95,14 @@ function apply_cell_structure_change!(
     if did_open !== nothing
         for doc in did_open
             cell_texts[doc.uri] = doc.text
+            cell_versions[doc.uri] = doc.version
         end
     end
     did_close = structure.didClose
     if did_close !== nothing
         for doc in did_close
             delete!(cell_texts, doc.uri)
+            delete!(cell_versions, doc.uri)
         end
     end
 end
@@ -88,7 +111,7 @@ function apply_cell_data_change!(cells::Vector{NotebookCellInfo}, data::Vector{N
     for updated_cell in data
         for (i, cell) in enumerate(cells)
             if cell.uri == updated_cell.document
-                cells[i] = NotebookCellInfo(updated_cell.document, updated_cell.kind, cell.text)
+                cells[i] = NotebookCellInfo(updated_cell.document, updated_cell.kind, cell.version, cell.text)
                 break
             end
         end
@@ -101,11 +124,13 @@ end
 # `NotebookDocumentSyncOptions` does not provide an equivalent option for cell text content.
 function apply_cell_text_change!(
         cell_texts::Dict{URI,String},
+        cell_versions::Dict{URI,Int},
         text_content::Vector{NotebookDocumentChangeEventCellsTextContentItem},
         encoding::PositionEncodingKind.Ty
     )
     for content_change in text_content
         doc_uri = content_change.document.uri
+        cell_versions[doc_uri] = content_change.document.version
         current_text = get(cell_texts, doc_uri, "")
         for change_event in content_change.changes
             if change_event.range === nothing
@@ -126,8 +151,10 @@ function handle_DidOpenNotebookDocumentNotification(
     notebook_doc = msg.params.notebookDocument
     notebook_uri = notebook_doc.uri
     cell_texts = Dict{URI,String}(doc.uri => doc.text for doc in msg.params.cellTextDocuments)
+    cell_versions = Dict{URI,Int}(doc.uri => doc.version for doc in msg.params.cellTextDocuments)
     cells = NotebookCellInfo[
-        NotebookCellInfo(cell.document, cell.kind, get(cell_texts, cell.document, ""))
+        NotebookCellInfo(cell.document, cell.kind,
+            get(cell_versions, cell.document, 0), get(cell_texts, cell.document, ""))
         for cell in notebook_doc.cells]
     concat = concatenate_cells(cells)
     notebook_info = NotebookInfo(
@@ -161,16 +188,18 @@ function handle_DidChangeNotebookDocumentNotification(
         end
         cells = copy(notebook_info.cells)
         cell_texts = Dict{URI,String}(cell.uri => cell.text for cell in cells)
+        cell_versions = Dict{URI,Int}(cell.uri => cell.version for cell in cells)
         if cells_change !== nothing
             structure = cells_change.structure
-            structure !== nothing && apply_cell_structure_change!(cells, cell_texts, structure)
+            structure !== nothing && apply_cell_structure_change!(cells, cell_texts, cell_versions, structure)
             data = cells_change.data
             data !== nothing && apply_cell_data_change!(cells, data)
             text_content = cells_change.textContent
-            text_content !== nothing && apply_cell_text_change!(cell_texts, text_content, notebook_info.encoding)
+            text_content !== nothing && apply_cell_text_change!(cell_texts, cell_versions, text_content, notebook_info.encoding)
         end
         updated_cells = NotebookCellInfo[
-            NotebookCellInfo(cell.uri, cell.kind, get(cell_texts, cell.uri, cell.text))
+            NotebookCellInfo(cell.uri, cell.kind,
+                get(cell_versions, cell.uri, cell.version), get(cell_texts, cell.uri, cell.text))
             for cell in cells]
         concat = concatenate_cells(updated_cells)
         new_notebook_info = NotebookInfo(notebook_info;

--- a/src/rename.jl
+++ b/src/rename.jl
@@ -6,6 +6,16 @@ function is_macrocall_use_site(fi::FileInfo, tree)
     return !iszero(fb) && fi.parsed_stream.textbuf[fb] == UInt8('@')
 end
 
+# Resolve the document version to attach to a `TextDocumentEdit` targeting `edit_uri`.
+# For a notebook cell the concat-source `FileInfo.version` (passed as `fallback`) is the
+# *notebook* version, which does not match the client's per-cell version and makes the
+# client reject the whole edit; use the cell's own version instead. For regular files
+# `edit_uri` is not a notebook cell, so `fallback` (the file's version) is used as-is.
+function rename_edit_version(state::ServerState, edit_uri::URI, fallback::Union{Int,Null})
+    cell_version = notebook_cell_version(state, edit_uri)
+    return cell_version === nothing ? fallback : cell_version
+end
+
 struct RenameProgressCaller <: RequestCaller
     uri::URI
     fi::FileInfo
@@ -237,7 +247,7 @@ function local_binding_rename(
         documentChanges = TextDocumentEdit[
             TextDocumentEdit(;
                 textDocument = OptionalVersionedTextDocumentIdentifier(;
-                    uri = edit_uri, version = fi.version),
+                    uri = edit_uri, version = rename_edit_version(state, edit_uri, fi.version)),
                 edits)
             for (edit_uri, edits) in edits_by_uri]
         result = WorkspaceEdit(; documentChanges)
@@ -364,7 +374,7 @@ function collect_global_rename_edits!(
         if changes isa Vector{TextDocumentEdit}
             for (edit_uri, edits) in edits_by_uri
                 textDocument = OptionalVersionedTextDocumentIdentifier(;
-                    uri = edit_uri, version)
+                    uri = edit_uri, version = rename_edit_version(state, edit_uri, version))
                 push!(changes, TextDocumentEdit(; textDocument, edits))
             end
         else
@@ -492,7 +502,8 @@ function file_rename(
     textEdit = TextEdit(; range, newText = newName)
 
     if supports(server, :workspace, :workspaceEdit, :documentChanges)
-        textDocument = OptionalVersionedTextDocumentIdentifier(; uri, fi.version)
+        textDocument = OptionalVersionedTextDocumentIdentifier(;
+            uri, version = rename_edit_version(state, uri, fi.version))
         textDocumentEdit = TextDocumentEdit(; textDocument, edits = [textEdit])
         result = WorkspaceEdit(; documentChanges = [textDocumentEdit, renameFile])
     else

--- a/src/types.jl
+++ b/src/types.jl
@@ -169,6 +169,13 @@ end
 struct NotebookCellInfo
     uri::URI
     kind::LSP.NotebookCellKind.Ty
+    """
+    The client-tracked text-document version of this cell. Each notebook cell is an
+    independent text document with its own version counter, distinct from the enclosing
+    `NotebookInfo.version` (the notebook-document version). This per-cell version is what
+    the client expects in `OptionalVersionedTextDocumentIdentifier` for cell edits.
+    """
+    version::Int
     text::String
 end
 

--- a/test/test_notebook.jl
+++ b/test/test_notebook.jl
@@ -89,6 +89,15 @@ function make_InlayHintRequest(id::Int, uri::URI, range::Range)
             range))
 end
 
+function make_RenameRequest(id::Int, uri::URI, position::Position, newName::AbstractString)
+    return RenameRequest(;
+        id,
+        params = RenameParams(;
+            textDocument = TextDocumentIdentifier(; uri),
+            position,
+            newName = String(newName)))
+end
+
 @testset "notebook end to end" begin
     mktempdir() do tempdir; Pkg.activate(tempdir) do
         Pkg.add("Example"; io=devnull)
@@ -445,6 +454,45 @@ end
                 @test edit.range.var"end".line == 3
                 @test edit.range.var"end".character == 19
                 @test edit.newText == "function myfunc(y)\n    y + 1\nend\nresult = myfunc(42)"
+            end
+        end
+    end
+end
+
+@testset "notebook rename keeps per-cell document version" begin
+    mktempdir() do tempdir
+        notebook_uri = filepath2uri(normpath(tempdir, "test.ipynb"))
+        # Rename only emits versioned `TextDocumentEdit`s when the client advertises
+        # `workspaceEdit.documentChanges`.
+        capabilities = ClientCapabilities(;
+            workspace = WorkspaceClientCapabilities(;
+                workspaceEdit = WorkspaceEditClientCapabilities(; documentChanges = true)))
+        withserver(; capabilities) do (; writereadmsg, id_counter)
+            cell_uri = make_cell_uri(tempdir, 1)
+            # Open at notebook version 5; the cell text document stays at version 1. The two
+            # differ on purpose so the rename edit's version is unambiguously the cell's.
+            let cells = NotebookCell[NotebookCell(; kind = NotebookCellKind.Code, document = cell_uri)]
+                cell_texts = Dict{URI,String}(cell_uri => "function foo(yy)\n    return yy + yy\nend")
+                writereadmsg(
+                    make_DidOpenNotebookDocumentNotification(notebook_uri, cells, cell_texts; version = 5))
+            end
+
+            # Renaming the local `yy` must return an edit carrying the *cell* version (1),
+            # not the notebook version (5) — sending the notebook version is what made the
+            # client reject the edit as "not valid anymore".
+            let id = id_counter[] += 1
+                pos = Position(; line = 0, character = 13) # `yy` parameter, cell-local
+                (; raw_res) = writereadmsg(make_RenameRequest(id, cell_uri, pos, "ww"))
+                @test raw_res isa RenameResponse
+                @test raw_res.result isa WorkspaceEdit
+                documentChanges = raw_res.result.documentChanges
+                @test documentChanges isa Vector && length(documentChanges) == 1
+                tde = documentChanges[1]
+                @test tde isa TextDocumentEdit
+                @test tde.textDocument.uri == cell_uri
+                @test tde.textDocument.version == 1
+                @test length(tde.edits) == 3
+                @test all(e -> e.newText == "ww", tde.edits)
             end
         end
     end


### PR DESCRIPTION
Renaming a symbol inside a Jupyter notebook cell failed in VS Code with "The rename edit returned from the server is not valid anymore and cannot be applied." JETLS represents a notebook as a single concat-source `FileInfo` whose `version` is the *notebook* document version, and the rename handlers stamped that version onto every `OptionalVersionedTextDocumentIdentifier`, including ones keyed by cell URIs. Each notebook cell is an independent text document with its own version counter on the client, so the version never matched and the editor rejected the whole edit.

Track each cell's text-document version in `NotebookCellInfo`, populated from the version fields in the `cellTextDocuments`, `structure.didOpen`, and `textContent` parts of the notebook sync notifications. The new `rename_edit_version` helper resolves the per-cell version for cell URIs (and falls back to `FileInfo.version` for regular files), and `local_binding_rename`,
`collect_global_rename_edits!`, and `file_rename` now use it.