### PR TITLE
testrunner: Serve logs via workspace/textDocumentContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed type information collapsing to `Any` inside closures defined in functions that have default positional arguments or keyword arguments. Hover, inlay hints and other type-aware features now show precise types for such closure bodies and their captured variables.
 
-- Fixed TestRunner log viewing to open saved temporary log files instead of relying on `untitled:` buffers, avoiding empty log tabs and mismatched log file paths.
+- Fixed TestRunner log viewing to use readonly virtual documents when supported, and cleanup-enabled temporary files otherwise, avoiding empty `untitled:` log tabs and mismatched log file paths.
 
 - Fixed renaming symbols inside Jupyter notebook cells on VS Code, which previously failed with a "The rename edit returned from the server is not valid anymore and cannot be applied." error.
 

--- a/docs/src/testrunner.md
+++ b/docs/src/testrunner.md
@@ -54,6 +54,11 @@ After running tests, the code lens is refreshed as follows:
 > </div>
 > ```
 
+On editors that support [`workspace/textDocumentContent`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#workspace_textDocumentContent)
+(an LSP 3.18 feature), the logs open in a read-only virtual document that
+refreshes in place when you re-run the same testset, so you don't need to reopen
+it. On other editors, the logs open as a temporary file instead.
+
 ### [Code actions](@id testrunner/features/code-actions)
 
 You can trigger test runs via "code actions" that are explicitly requested by the user:

--- a/jetls-client/jetls-client.ts
+++ b/jetls-client/jetls-client.ts
@@ -465,6 +465,13 @@ async function startLanguageServer() {
         notebook: { notebookType: "jupyter-notebook" },
         language: "julia",
       },
+      // Sync `jetls:` virtual documents (e.g. TestRunner logs) so the server is
+      // notified when they are opened/closed. Language features are registered
+      // separately (see `DEFAULT_DOCUMENT_SELECTOR`) and do not target this scheme;
+      // this entry only drives document synchronization.
+      {
+        scheme: "jetls",
+      },
     ],
     synchronize: {
       fileEvents: [

--- a/jetls-client/jetls-client.ts
+++ b/jetls-client/jetls-client.ts
@@ -465,12 +465,13 @@ async function startLanguageServer() {
         notebook: { notebookType: "jupyter-notebook" },
         language: "julia",
       },
-      // Sync `jetls:` virtual documents (e.g. TestRunner logs) so the server is
-      // notified when they are opened/closed. Language features are registered
-      // separately (see `DEFAULT_DOCUMENT_SELECTOR`) and do not target this scheme;
-      // this entry only drives document synchronization.
+      // Sync the server-provided virtual documents (`jetls-*` schemes, e.g.
+      // TestRunner logs) so the server is notified when they are opened/closed.
+      // Language features are registered separately (see `DEFAULT_DOCUMENT_SELECTOR`)
+      // and do not target these schemes; this only drives document synchronization.
+      // Each new view's scheme must be listed here to receive sync notifications.
       {
-        scheme: "jetls",
+        scheme: "jetls-testrunner-logs",
       },
     ],
     synchronize: {

--- a/jetls-client/jetls-client.ts
+++ b/jetls-client/jetls-client.ts
@@ -526,6 +526,10 @@ async function startLanguageServer() {
     serverOptions,
     clientOptions,
   );
+  // `workspace/textDocumentContent` is still exposed as a proposed
+  // vscode-languageclient feature. JETLS sends the supported `jetls` scheme
+  // in its server capability or dynamic registration.
+  languageClient.registerProposedFeatures();
 
   statusBarItem.text = "$(sync~spin) Loading JETLS ...";
   statusBarItem.tooltip =

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -119,6 +119,7 @@ include("notebook.jl")
 include("analysis/full-analysis.jl")
 include("registration.jl")
 include("apply-edit.jl")
+include("text-document-content.jl")
 include("execute-command.jl")
 include("signature-help.jl")
 include("completions.jl")
@@ -414,6 +415,8 @@ function handle_response_message(
         handle_code_lens_refresh_response(server, msg, request_caller)
     elseif request_caller isa DiagnosticRefreshRequestCaller
         handle_diagnostic_refresh_response(server, msg, request_caller)
+    elseif request_caller isa TextDocumentContentRefreshCaller
+        handle_text_document_content_refresh_response(server, msg, request_caller)
     elseif request_caller isa FormattingProgressCaller
         handle_formatting_progress_response(server, msg, request_caller, cancel_flag)
     elseif request_caller isa RangeFormattingProgressCaller
@@ -499,6 +502,8 @@ function handle_request_message(server::Server, @nospecialize(msg), cancel_flag:
         handle_PrepareRenameRequest(server, msg, cancel_flag)
     elseif msg isa ExecuteCommandRequest
         handle_ExecuteCommandRequest(server, msg)
+    elseif msg isa TextDocumentContentRequest
+        handle_TextDocumentContentRequest(server, msg)
     elseif JETLS_DEV_MODE
         if isdefined(msg, :method)
             _id = getfield(msg, :method)

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -80,8 +80,12 @@ end
 
 function handle_DidOpenTextDocumentNotification(server::Server, msg::DidOpenTextDocumentNotification)
     textDocument = msg.params.textDocument
-    @assert textDocument.languageId == "julia"
     uri = textDocument.uri
+    # `jetls:` documents are server-provided, read-only virtual documents
+    # (`workspace/textDocumentContent`). Spec-conformant clients may still sync them,
+    # but they carry no Julia source, so the Julia-only path below must not run.
+    uri.scheme == TEXT_DOCUMENT_CONTENT_SCHEME && return nothing
+    @assert textDocument.languageId == "julia"
     parsed_stream = ParseStream!(textDocument.text)
     cache_file_info!(server, uri, textDocument.version, parsed_stream)
     cache_saved_file_info!(server.state, uri, parsed_stream)
@@ -92,6 +96,9 @@ end
 function handle_DidChangeTextDocumentNotification(server::Server, msg::DidChangeTextDocumentNotification)
     (; textDocument, contentChanges) = msg.params
     uri = textDocument.uri
+    # Read-only `jetls:` virtual documents never carry user edits to sync (see
+    # `handle_DidOpenTextDocumentNotification`).
+    uri.scheme == TEXT_DOCUMENT_CONTENT_SCHEME && return nothing
     for contentChange in contentChanges
         @assert contentChange.range === contentChange.rangeLength === nothing # since `change = TextDocumentSyncKind.Full`
     end
@@ -127,6 +134,9 @@ end
 
 function handle_DidCloseTextDocumentNotification(server::Server, msg::DidCloseTextDocumentNotification)
     uri = msg.params.textDocument.uri
+    # `jetls:` virtual documents are never tracked in the Julia caches (see
+    # `handle_DidOpenTextDocumentNotification`), so skip the file-backed cleanup.
+    uri.scheme == TEXT_DOCUMENT_CONTENT_SCHEME && return nothing
     store!(server.state.file_cache) do cache
         Base.delete(cache, uri), nothing
     end

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -85,7 +85,7 @@ function handle_DidOpenTextDocumentNotification(server::Server, msg::DidOpenText
     # (`workspace/textDocumentContent`); they carry no Julia source, so skip the
     # Julia-only path below. Record that the view is open so subsequent content
     # updates refresh it.
-    uri.scheme == TEXT_DOCUMENT_CONTENT_SCHEME &&
+    is_text_document_content_uri(uri) &&
         return mark_text_document_content_opened!(server, uri)
     @assert textDocument.languageId == "julia"
     parsed_stream = ParseStream!(textDocument.text)
@@ -100,7 +100,7 @@ function handle_DidChangeTextDocumentNotification(server::Server, msg::DidChange
     uri = textDocument.uri
     # Read-only `jetls:` virtual documents never carry user edits to sync (see
     # `handle_DidOpenTextDocumentNotification`).
-    uri.scheme == TEXT_DOCUMENT_CONTENT_SCHEME && return nothing
+    is_text_document_content_uri(uri) && return nothing
     for contentChange in contentChanges
         @assert contentChange.range === contentChange.rangeLength === nothing # since `change = TextDocumentSyncKind.Full`
     end
@@ -139,7 +139,7 @@ function handle_DidCloseTextDocumentNotification(server::Server, msg::DidCloseTe
     # `jetls:` virtual documents are never tracked in the Julia caches (see
     # `handle_DidOpenTextDocumentNotification`), so skip the file-backed cleanup;
     # just record that the view closed so we stop refreshing it.
-    uri.scheme == TEXT_DOCUMENT_CONTENT_SCHEME &&
+    is_text_document_content_uri(uri) &&
         return mark_text_document_content_closed!(server, uri)
     store!(server.state.file_cache) do cache
         Base.delete(cache, uri), nothing

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -82,9 +82,11 @@ function handle_DidOpenTextDocumentNotification(server::Server, msg::DidOpenText
     textDocument = msg.params.textDocument
     uri = textDocument.uri
     # `jetls:` documents are server-provided, read-only virtual documents
-    # (`workspace/textDocumentContent`). Spec-conformant clients may still sync them,
-    # but they carry no Julia source, so the Julia-only path below must not run.
-    uri.scheme == TEXT_DOCUMENT_CONTENT_SCHEME && return nothing
+    # (`workspace/textDocumentContent`); they carry no Julia source, so skip the
+    # Julia-only path below. Record that the view is open so subsequent content
+    # updates refresh it.
+    uri.scheme == TEXT_DOCUMENT_CONTENT_SCHEME &&
+        return mark_text_document_content_opened!(server, uri)
     @assert textDocument.languageId == "julia"
     parsed_stream = ParseStream!(textDocument.text)
     cache_file_info!(server, uri, textDocument.version, parsed_stream)
@@ -135,8 +137,10 @@ end
 function handle_DidCloseTextDocumentNotification(server::Server, msg::DidCloseTextDocumentNotification)
     uri = msg.params.textDocument.uri
     # `jetls:` virtual documents are never tracked in the Julia caches (see
-    # `handle_DidOpenTextDocumentNotification`), so skip the file-backed cleanup.
-    uri.scheme == TEXT_DOCUMENT_CONTENT_SCHEME && return nothing
+    # `handle_DidOpenTextDocumentNotification`), so skip the file-backed cleanup;
+    # just record that the view closed so we stop refreshing it.
+    uri.scheme == TEXT_DOCUMENT_CONTENT_SCHEME &&
+        return mark_text_document_content_closed!(server, uri)
     store!(server.state.file_cache) do cache
         Base.delete(cache, uri), nothing
     end

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -81,12 +81,8 @@ end
 function handle_DidOpenTextDocumentNotification(server::Server, msg::DidOpenTextDocumentNotification)
     textDocument = msg.params.textDocument
     uri = textDocument.uri
-    # `jetls:` documents are server-provided, read-only virtual documents
-    # (`workspace/textDocumentContent`); they carry no Julia source, so skip the
-    # Julia-only path below. Record that the view is open so subsequent content
-    # updates refresh it.
     is_text_document_content_uri(uri) &&
-        return mark_text_document_content_opened!(server, uri)
+        return mark_text_document_content_opened!(server, uri) # turn on the `opened` flag
     @assert textDocument.languageId == "julia"
     parsed_stream = ParseStream!(textDocument.text)
     cache_file_info!(server, uri, textDocument.version, parsed_stream)
@@ -98,8 +94,7 @@ end
 function handle_DidChangeTextDocumentNotification(server::Server, msg::DidChangeTextDocumentNotification)
     (; textDocument, contentChanges) = msg.params
     uri = textDocument.uri
-    # Read-only `jetls:` virtual documents never carry user edits to sync (see
-    # `handle_DidOpenTextDocumentNotification`).
+    # Read-only `jetls-*:` virtual documents never carry user edits to sync, so just ignore it.
     is_text_document_content_uri(uri) && return nothing
     for contentChange in contentChanges
         @assert contentChange.range === contentChange.rangeLength === nothing # since `change = TextDocumentSyncKind.Full`
@@ -136,11 +131,8 @@ end
 
 function handle_DidCloseTextDocumentNotification(server::Server, msg::DidCloseTextDocumentNotification)
     uri = msg.params.textDocument.uri
-    # `jetls:` virtual documents are never tracked in the Julia caches (see
-    # `handle_DidOpenTextDocumentNotification`), so skip the file-backed cleanup;
-    # just record that the view closed so we stop refreshing it.
     is_text_document_content_uri(uri) &&
-        return mark_text_document_content_closed!(server, uri)
+        return mark_text_document_content_closed!(server, uri) # turn off the `opened` flag
     store!(server.state.file_cache) do cache
         Base.delete(cache, uri), nothing
     end

--- a/src/execute-command.jl
+++ b/src/execute-command.jl
@@ -99,10 +99,7 @@ function execute_testrunner_run_testset_command(server::Server, msg::ExecuteComm
                 result = nothing,
                 error = request_failed_error(error_msg)))
     end
-    return send(server,
-        ExecuteCommandResponse(;
-            id = msg.id,
-            result = null))
+    return send(server, ExecuteCommandResponse(; id = msg.id, result = null))
 end
 
 function execute_testrunner_run_testcase_command(server::Server, msg::ExecuteCommandRequest)
@@ -118,20 +115,16 @@ function execute_testrunner_run_testcase_command(server::Server, msg::ExecuteCom
                 result = nothing,
                 error = request_failed_error(error_msg)))
     end
-    return send(server,
-        ExecuteCommandResponse(;
-            id = msg.id,
-            result = null))
+    return send(server, ExecuteCommandResponse(; id = msg.id, result = null))
 end
 
 function execute_testrunner_open_logs_command(server::Server, msg::ExecuteCommandRequest)
-    tsn = @tryparsearg server msg[1]::String
-    logs = @tryparsearg server msg[2]::String
-    open_testsetinfo_logs!(server, tsn, logs)
-    return send(server,
-        ExecuteCommandResponse(;
-            id = msg.id,
-            result = null))
+    source_uri = URI(@tryparsearg server msg[1]::String)
+    idx = @tryparsearg server msg[2]::Int
+    tsn = @tryparsearg server msg[3]::String
+    logs = @tryparsearg server msg[4]::String
+    open_testsetinfo_logs!(server, tsn, logs; source_uri, testset_index=idx)
+    return send(server, ExecuteCommandResponse(; id = msg.id, result = null))
 end
 
 function execute_testrunner_clear_result_command(server::Server, msg::ExecuteCommandRequest)
@@ -139,10 +132,7 @@ function execute_testrunner_clear_result_command(server::Server, msg::ExecuteCom
     idx = @tryparsearg server msg[2]::Int
     tsn = @tryparsearg server msg[3]::String
     try_clear_testrunner_result!(server, uri, idx, tsn)
-    return send(server,
-        ExecuteCommandResponse(;
-            id = msg.id,
-            result = null))
+    return send(server, ExecuteCommandResponse(; id = msg.id, result = null))
 end
 
 function execute_show_message_command(server::Server, msg::ExecuteCommandRequest)
@@ -161,8 +151,5 @@ function execute_show_message_command(server::Server, msg::ExecuteCommandRequest
     end
     send(server, ShowMessageNotification(;
         params = ShowMessageParams(; type, message)))
-    return send(server,
-        ExecuteCommandResponse(;
-            id = msg.id,
-            result = null))
+    return send(server, ExecuteCommandResponse(; id = msg.id, result = null))
 end

--- a/src/execute-command.jl
+++ b/src/execute-command.jl
@@ -122,8 +122,13 @@ function execute_testrunner_open_logs_command(server::Server, msg::ExecuteComman
     source_uri = URI(@tryparsearg server msg[1]::String)
     idx = @tryparsearg server msg[2]::Int
     tsn = @tryparsearg server msg[3]::String
-    logs = @tryparsearg server msg[4]::String
-    open_testsetinfo_logs!(server, tsn, logs; source_uri, testset_index=idx)
+    logs = get_testsetinfo_logs(server.state, source_uri, idx)
+    if logs === nothing
+        show_warning_message(server,
+            "The test result is no longer available. Re-run the testset to view its logs.")
+    else
+        open_testsetinfo_logs!(server, tsn, logs; source_uri, testset_index=idx)
+    end
     return send(server, ExecuteCommandResponse(; id = msg.id, result = null))
 end
 

--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -270,6 +270,18 @@ function handle_InitializeRequest(
         end
     end
 
+    if !supports_text_document_content(server)
+        textDocumentContent = nothing
+    elseif supports(server, :workspace, :textDocumentContent, :dynamicRegistration)
+        textDocumentContent = nothing # will be registered dynamically
+    else
+        textDocumentContent = text_document_content_options()
+        if JETLS_DEV_MODE
+            @info "Registering 'workspace/textDocumentContent' with `InitializeResponse`"
+        end
+    end
+    workspace = textDocumentContent === nothing ? nothing : WorkspaceOptions(; textDocumentContent)
+
     positionEncodings = getcapability(state, :general, :positionEncodings)
     if isnothing(positionEncodings) || isempty(positionEncodings)
         positionEncoding = PositionEncodingKind.UTF16
@@ -316,6 +328,7 @@ function handle_InitializeRequest(
             semanticTokensProvider,
             renameProvider,
             workspaceSymbolProvider,
+            workspace,
         ),
         serverInfo = ServerInfo(;
             name = "JETLS",
@@ -574,6 +587,13 @@ function handle_InitializedNotification(server::Server)
         push!(registrations, workspace_symbol_registration(server))
         if JETLS_DEV_MODE
             @info "Dynamically registering 'workspace/symbol' upon `InitializedNotification`"
+        end
+    end
+
+    if supports(server, :workspace, :textDocumentContent, :dynamicRegistration)
+        push!(registrations, text_document_content_registration())
+        if JETLS_DEV_MODE
+            @info "Dynamically registering 'workspace/textDocumentContent' upon `InitializedNotification`"
         end
     end
 

--- a/src/testrunner/testrunner.jl
+++ b/src/testrunner/testrunner.jl
@@ -944,6 +944,12 @@ function try_clear_testrunner_result!(server::Server, uri::URI, idx::Int, tsn::S
     end
     updated || return nothing
 
+    # Drop the cached log content for this testset; its result no longer exists.
+    if supports_text_document_content(server)
+        log_uri = testsetinfo_logs_content_uri(uri, idx, String(rlstrip(tsn, '"')))
+        delete_text_document_content!(server, log_uri)
+    end
+
     if clear_extra_diagnostics!(server, TestsetDiagnosticsKey(uri, tsn, idx))
         notify_diagnostics!(server; ensure_cleared=uri)
     end

--- a/src/testrunner/testrunner.jl
+++ b/src/testrunner/testrunner.jl
@@ -164,7 +164,7 @@ function testrunner_code_lenses!(
                 arguments = run_arguments)
             push!(code_lenses, CodeLens(; range, command))
         end
-        logs_arguments = Any[uri, idx, tsn, prev_result.logs]
+        logs_arguments = Any[uri, idx, tsn]
         let command = Command(;
                 title = TESTRUNNER_OPEN_LOGS_TITLE,
                 command = COMMAND_TESTRUNNER_OPEN_LOGS,
@@ -228,7 +228,7 @@ function testrunner_testset_code_actions!(
                 arguments = run_arguments)
             push!(code_actions, CodeAction(; title, command))
         end
-        logs_arguments = Any[uri, idx, tsn, prev_result.logs]
+        logs_arguments = Any[uri, idx, tsn]
         let title = TESTRUNNER_OPEN_LOGS_TITLE
             command = Command(;
                 title,
@@ -396,12 +396,8 @@ function show_testrunner_result_in_message(server::Server, result::TestRunnerRes
     id = String(gensym(:ShowMessageRequest))
     addrequest!(server, id=>request_caller)
 
-    send(server, ShowMessageRequest(;
-        id,
-        params = ShowMessageRequestParams(;
-            type = msg_type,
-            message,
-            actions)))
+    params = ShowMessageRequestParams(; type = msg_type, message, actions)
+    send(server, ShowMessageRequest(; id, params))
 end
 
 function handle_test_runner_message_response2(
@@ -743,6 +739,17 @@ end
 function testsetinfo_logs_content_uri(source_uri::URI, idx::Int, tsn::AbstractString)
     query = LSP.URIs2.escapeuri((source=string(source_uri), index=idx, name=tsn))
     return URI(; scheme = TESTRUNNER_LOGS_SCHEME, path = "/testrunner/logs", query)
+end
+
+# Look up the logs of the testset at `idx` in `uri`. Returns `nothing` if the file or
+# its result is gone (e.g. cleared, or the file changed since the code lens / action
+# that carries this `idx` was generated), so the caller can degrade gracefully.
+function get_testsetinfo_logs(state::ServerState, uri::URI, idx::Int)
+    fi = @something get_file_info(state, uri) return nothing
+    is_testsetinfo_valid(fi, idx) || return nothing
+    testsetinfo = fi.testsetinfos[idx]
+    isdefined(testsetinfo, :result) || return nothing
+    return testsetinfo.result.result.logs
 end
 
 function show_testsetinfo_logs_path_message(

--- a/src/testrunner/testrunner.jl
+++ b/src/testrunner/testrunner.jl
@@ -162,35 +162,27 @@ function testrunner_code_lenses!(
                 title = "$TESTRUNNER_RERUN_TITLE $tsn $summary",
                 command = COMMAND_TESTRUNNER_RUN_TESTSET,
                 arguments = run_arguments)
-            push!(code_lenses, CodeLens(;
-                range,
-                command))
+            push!(code_lenses, CodeLens(; range, command))
         end
-        logs_arguments = Any[tsn, prev_result.logs]
+        logs_arguments = Any[uri, idx, tsn, prev_result.logs]
         let command = Command(;
                 title = TESTRUNNER_OPEN_LOGS_TITLE,
                 command = COMMAND_TESTRUNNER_OPEN_LOGS,
                 arguments = logs_arguments)
-            push!(code_lenses, CodeLens(;
-                range,
-                command))
+            push!(code_lenses, CodeLens(; range, command))
         end
         let command = Command(;
                 title = TESTRUNNER_CLEAR_RESULT_TITLE,
                 command = COMMAND_TESTRUNNER_CLEAR_RESULT,
                 arguments = clear_arguments)
-            push!(code_lenses, CodeLens(;
-                range,
-                command))
+            push!(code_lenses, CodeLens(; range, command))
         end
     else
         command = Command(;
             title = "$TESTRUNNER_RUN_TITLE $tsn",
             command = COMMAND_TESTRUNNER_RUN_TESTSET,
             arguments = run_arguments)
-        push!(code_lenses, CodeLens(;
-            range,
-            command))
+        push!(code_lenses, CodeLens(; range, command))
     end
     return code_lenses
 end
@@ -236,7 +228,7 @@ function testrunner_testset_code_actions!(
                 arguments = run_arguments)
             push!(code_actions, CodeAction(; title, command))
         end
-        logs_arguments = Any[tsn, prev_result.logs]
+        logs_arguments = Any[uri, idx, tsn, prev_result.logs]
         let title = TESTRUNNER_OPEN_LOGS_TITLE
             command = Command(;
                 title,
@@ -447,7 +439,7 @@ function handle_test_runner_message_response4(
                 show_error_message(server, error_msg)
             end
         elseif title == TESTRUNNER_OPEN_LOGS_TITLE
-            open_testsetinfo_logs!(server, testset_name, logs)
+            open_testsetinfo_logs!(server, testset_name, logs; source_uri=uri, testset_index=idx)
         elseif title == TESTRUNNER_CLEAR_RESULT_TITLE
             try_clear_testrunner_result!(server, uri, idx, testset_name)
         else
@@ -578,6 +570,11 @@ function _testrunner_run_testset(
         # Simply show only the option to open logs
         show_testrunner_result_in_message(server, result, #=title=#tsn)
         return ret
+    end
+
+    if supports_text_document_content(server)
+        log_uri = testsetinfo_logs_content_uri(uri, idx, String(rlstrip(tsn, '"')))
+        update_text_document_content!(server, log_uri, result.logs)
     end
 
     if !isempty(result.diagnostics)
@@ -711,8 +708,9 @@ end
 
 struct ShowDocumentRequestCaller <: RequestCaller
     testset_name::String
-    temp_path::String
     uri::URI
+    temp_path::Union{Nothing,String}
+    logs::Union{Nothing,String}
 end
 
 is_testsetinfo_logs_filename_unsafe(c::Char) =
@@ -742,6 +740,11 @@ function testsetinfo_logs_filename(tsn::AbstractString)
     return "TestRunner_$name.log"
 end
 
+function testsetinfo_logs_content_uri(source_uri::URI, idx::Int, tsn::AbstractString)
+    query = LSP.URIs2.escapeuri((source=string(source_uri), index=idx, name=tsn))
+    return URI(; scheme = TEXT_DOCUMENT_CONTENT_SCHEME, path = "/testrunner/logs", query)
+end
+
 function show_testsetinfo_logs_path_message(
         server::Server, tsn::String, temp_path::String, uri::URI
     )
@@ -754,44 +757,81 @@ function show_testsetinfo_logs_path_message(
     """)
 end
 
-function open_testsetinfo_logs!(server::Server, tsn::String, logs::String)
+function open_testsetinfo_logs!(
+        server::Server, tsn::String, logs::String;
+        source_uri::Union{Nothing,URI} = nothing,
+        testset_index::Union{Nothing,Int} = nothing
+    )
     testset_name = String(rlstrip(tsn, '"'))
-    temp_filename = testsetinfo_logs_filename(testset_name)
-    temp_path = joinpath(mktempdir(; cleanup=true), temp_filename)
-    try
-        write(temp_path, logs)
-    catch err
-        return show_error_message(server, "Failed to save test logs: $(sprint(showerror, err))")
-    end
-    uri = filepath2uri(temp_path)
-    if supports(server, :window, :showDocument, :support)
+    if (source_uri !== nothing && testset_index !== nothing &&
+        supports_text_document_content(server) &&
+        supports(server, :window, :showDocument, :support))
+        uri = testsetinfo_logs_content_uri(source_uri, testset_index, testset_name)
+        update_text_document_content!(server, uri, logs)
         id = String(gensym(:ShowDocumentRequest))
-        addrequest!(server, id=>ShowDocumentRequestCaller(testset_name, temp_path, uri))
+        addrequest!(server, id=>ShowDocumentRequestCaller(testset_name, uri, nothing, logs))
         return send(server, ShowDocumentRequest(;
             id,
             params = ShowDocumentParams(;
                 uri,
                 takeFocus = true)))
     else
-        return show_testsetinfo_logs_path_message(server, testset_name, temp_path, uri)
+        return open_testsetinfo_logs_tempfile!(server, testset_name, logs)
     end
+end
+
+function open_testsetinfo_logs_tempfile!(server::Server, tsn::String, logs::String)
+    saved = @something save_testsetinfo_logs_tempfile(server, tsn, logs) return nothing
+    (; temp_path, uri) = saved
+    if supports(server, :window, :showDocument, :support)
+        id = String(gensym(:ShowDocumentRequest))
+        addrequest!(server, id=>ShowDocumentRequestCaller(tsn, uri, temp_path, nothing))
+        return send(server, ShowDocumentRequest(;
+            id,
+            params = ShowDocumentParams(;
+                uri,
+                takeFocus = true)))
+    else
+        return show_testsetinfo_logs_path_message(server, tsn, temp_path, uri)
+    end
+end
+
+function save_testsetinfo_logs_tempfile(server::Server, tsn::String, logs::String)
+    temp_filename = testsetinfo_logs_filename(tsn)
+    temp_path = joinpath(mktempdir(; cleanup=true), temp_filename)
+    try
+        write(temp_path, logs)
+    catch err
+        show_error_message(server, "Failed to save test logs: $(sprint(showerror, err))")
+        return nothing
+    end
+    return (; temp_path, uri = filepath2uri(temp_path))
 end
 
 function handle_show_document_response(
         server::Server, msg::Dict{Symbol,Any}, request_caller::ShowDocumentRequestCaller
     )
-    (; testset_name, temp_path, uri) = request_caller
+    (; testset_name, uri, temp_path, logs) = request_caller
     if handle_response_error(server, msg, "show document")
-        return show_testsetinfo_logs_path_message(server, testset_name, temp_path, uri)
+        temp_path !== nothing &&
+            return show_testsetinfo_logs_path_message(server, testset_name, temp_path, uri)
+        logs !== nothing && return open_testsetinfo_logs_tempfile!(server, testset_name, logs)
     elseif haskey(msg, :result)
         result = msg[:result] # ::ShowDocumentResult
-        if !(haskey(result, "success") && result["success"] === true)
+        if haskey(result, "success") && result["success"] === true
+            uri.scheme == TEXT_DOCUMENT_CONTENT_SCHEME &&
+                return mark_text_document_content_opened!(server, uri)
+        else
             show_error_message(server, "Failed to open document for viewing test logs")
-            return show_testsetinfo_logs_path_message(server, testset_name, temp_path, uri)
+            temp_path !== nothing &&
+                return show_testsetinfo_logs_path_message(server, testset_name, temp_path, uri)
+            logs !== nothing && return open_testsetinfo_logs_tempfile!(server, testset_name, logs)
         end
     else
         show_error_message(server, "Unexpected response from show document request")
-        return show_testsetinfo_logs_path_message(server, testset_name, temp_path, uri)
+        temp_path !== nothing &&
+            return show_testsetinfo_logs_path_message(server, testset_name, temp_path, uri)
+        logs !== nothing && return open_testsetinfo_logs_tempfile!(server, testset_name, logs)
     end
 end
 

--- a/src/testrunner/testrunner.jl
+++ b/src/testrunner/testrunner.jl
@@ -742,7 +742,7 @@ end
 
 function testsetinfo_logs_content_uri(source_uri::URI, idx::Int, tsn::AbstractString)
     query = LSP.URIs2.escapeuri((source=string(source_uri), index=idx, name=tsn))
-    return URI(; scheme = TEXT_DOCUMENT_CONTENT_SCHEME, path = "/testrunner/logs", query)
+    return URI(; scheme = TESTRUNNER_LOGS_SCHEME, path = "/testrunner/logs", query)
 end
 
 function show_testsetinfo_logs_path_message(
@@ -819,7 +819,7 @@ function handle_show_document_response(
     elseif haskey(msg, :result)
         result = msg[:result] # ::ShowDocumentResult
         if haskey(result, "success") && result["success"] === true
-            uri.scheme == TEXT_DOCUMENT_CONTENT_SCHEME &&
+            is_text_document_content_uri(uri) &&
                 return mark_text_document_content_opened!(server, uri)
         else
             show_error_message(server, "Failed to open document for viewing test logs")

--- a/src/testrunner/testrunner.jl
+++ b/src/testrunner/testrunner.jl
@@ -767,14 +767,10 @@ function open_testsetinfo_logs!(
         supports_text_document_content(server) &&
         supports(server, :window, :showDocument, :support))
         uri = testsetinfo_logs_content_uri(source_uri, testset_index, testset_name)
-        update_text_document_content!(server, uri, logs)
         id = String(gensym(:ShowDocumentRequest))
         addrequest!(server, id=>ShowDocumentRequestCaller(testset_name, uri, nothing, logs))
-        return send(server, ShowDocumentRequest(;
-            id,
-            params = ShowDocumentParams(;
-                uri,
-                takeFocus = true)))
+        params = ShowDocumentParams(; uri, takeFocus = true)
+        return send(server, ShowDocumentRequest(; id, params))
     else
         return open_testsetinfo_logs_tempfile!(server, testset_name, logs)
     end
@@ -813,26 +809,19 @@ function handle_show_document_response(
     )
     (; testset_name, uri, temp_path, logs) = request_caller
     if handle_response_error(server, msg, "show document")
-        temp_path !== nothing &&
-            return show_testsetinfo_logs_path_message(server, testset_name, temp_path, uri)
-        logs !== nothing && return open_testsetinfo_logs_tempfile!(server, testset_name, logs)
     elseif haskey(msg, :result)
         result = msg[:result] # ::ShowDocumentResult
         if haskey(result, "success") && result["success"] === true
-            is_text_document_content_uri(uri) &&
-                return mark_text_document_content_opened!(server, uri)
+            return
         else
             show_error_message(server, "Failed to open document for viewing test logs")
-            temp_path !== nothing &&
-                return show_testsetinfo_logs_path_message(server, testset_name, temp_path, uri)
-            logs !== nothing && return open_testsetinfo_logs_tempfile!(server, testset_name, logs)
         end
     else
         show_error_message(server, "Unexpected response from show document request")
-        temp_path !== nothing &&
-            return show_testsetinfo_logs_path_message(server, testset_name, temp_path, uri)
-        logs !== nothing && return open_testsetinfo_logs_tempfile!(server, testset_name, logs)
     end
+    temp_path !== nothing &&
+        return show_testsetinfo_logs_path_message(server, testset_name, temp_path, uri)
+    logs !== nothing && return open_testsetinfo_logs_tempfile!(server, testset_name, logs)
 end
 
 struct TestRunnerTestsetProgressCaller <: RequestCaller
@@ -944,7 +933,6 @@ function try_clear_testrunner_result!(server::Server, uri::URI, idx::Int, tsn::S
     end
     updated || return nothing
 
-    # Drop the cached log content for this testset; its result no longer exists.
     if supports_text_document_content(server)
         log_uri = testsetinfo_logs_content_uri(uri, idx, String(rlstrip(tsn, '"')))
         delete_text_document_content!(server, log_uri)

--- a/src/text-document-content.jl
+++ b/src/text-document-content.jl
@@ -1,0 +1,77 @@
+const TEXT_DOCUMENT_CONTENT_REGISTRATION_ID = "jetls-text-document-content"
+const TEXT_DOCUMENT_CONTENT_REGISTRATION_METHOD = "workspace/textDocumentContent"
+const TEXT_DOCUMENT_CONTENT_SCHEME = "jetls"
+
+struct TextDocumentContentRefreshCaller <: RequestCaller
+    uri::URI
+end
+
+supports_text_document_content(server::Server) =
+    getcapability(server, :workspace, :textDocumentContent) !== nothing
+
+function text_document_content_options()
+    return TextDocumentContentOptions(; schemes = String[TEXT_DOCUMENT_CONTENT_SCHEME])
+end
+
+function text_document_content_registration()
+    return Registration(;
+        id = TEXT_DOCUMENT_CONTENT_REGISTRATION_ID,
+        method = TEXT_DOCUMENT_CONTENT_REGISTRATION_METHOD,
+        registerOptions = TextDocumentContentRegistrationOptions(;
+            schemes = String[TEXT_DOCUMENT_CONTENT_SCHEME]))
+end
+
+function get_text_document_content(state::ServerState, uri::URI)
+    entry = get(load(state.text_document_content_cache), uri, nothing)
+    entry === nothing && return nothing
+    return entry.text
+end
+
+function update_text_document_content!(server::Server, uri::URI, text::String)
+    should_refresh = store!(server.state.text_document_content_cache) do data
+        old_entry = get(data, uri, nothing)
+        opened = old_entry !== nothing && old_entry.opened
+        new_data = Base.PersistentDict(data, uri => TextDocumentContentEntry(text, opened))
+        return new_data, opened
+    end
+    should_refresh && request_text_document_content_refresh!(server, uri)
+    return nothing
+end
+
+function mark_text_document_content_opened!(server::Server, uri::URI)
+    return store!(server.state.text_document_content_cache) do data
+        entry = @something get(data, uri, nothing) return data, nothing
+        new_data = Base.PersistentDict(data, uri => TextDocumentContentEntry(entry.text, true))
+        return new_data, nothing
+    end
+end
+
+function request_text_document_content_refresh!(server::Server, uri::URI)
+    supports_text_document_content(server) || return nothing
+    id = String(gensym(:TextDocumentContentRefreshRequest))
+    addrequest!(server, id=>TextDocumentContentRefreshCaller(uri))
+    return send(server, TextDocumentContentRefreshRequest(;
+        id,
+        params = TextDocumentContentRefreshParams(; uri)))
+end
+
+function handle_TextDocumentContentRequest(server::Server, msg::TextDocumentContentRequest)
+    uri = msg.params.uri
+    if uri.scheme != TEXT_DOCUMENT_CONTENT_SCHEME
+        return send(server, TextDocumentContentResponse(; id = msg.id, result = null))
+    end
+    text = get_text_document_content(server.state, uri)
+    text === nothing && return send(server, TextDocumentContentResponse(;
+        id = msg.id,
+        result = null))
+    return send(server, TextDocumentContentResponse(;
+        id = msg.id,
+        result = TextDocumentContentResult(; text)))
+end
+
+function handle_text_document_content_refresh_response(
+        server::Server, msg::Dict{Symbol,Any}, ::TextDocumentContentRefreshCaller
+    )
+    handle_response_error(server, msg, "refresh text document content")
+    return nothing
+end

--- a/src/text-document-content.jl
+++ b/src/text-document-content.jl
@@ -46,6 +46,21 @@ function mark_text_document_content_opened!(server::Server, uri::URI)
     end
 end
 
+function mark_text_document_content_closed!(server::Server, uri::URI)
+    return store!(server.state.text_document_content_cache) do data
+        entry = @something get(data, uri, nothing) return data, nothing
+        new_data = Base.PersistentDict(data, uri => TextDocumentContentEntry(entry.text, false))
+        return new_data, nothing
+    end
+end
+
+function delete_text_document_content!(server::Server, uri::URI)
+    return store!(server.state.text_document_content_cache) do data
+        haskey(data, uri) || return data, nothing
+        return Base.delete(data, uri), nothing
+    end
+end
+
 function request_text_document_content_refresh!(server::Server, uri::URI)
     supports_text_document_content(server) || return nothing
     id = String(gensym(:TextDocumentContentRefreshRequest))

--- a/src/text-document-content.jl
+++ b/src/text-document-content.jl
@@ -1,6 +1,14 @@
 const TEXT_DOCUMENT_CONTENT_REGISTRATION_ID = "jetls-text-document-content"
 const TEXT_DOCUMENT_CONTENT_REGISTRATION_METHOD = "workspace/textDocumentContent"
-const TEXT_DOCUMENT_CONTENT_SCHEME = "jetls"
+
+# Each `workspace/textDocumentContent` view gets its own scheme so document selectors
+# can enable language features per view: TestRunner logs need none, while future
+# Julia-code views (macro expansion, type annotations, `code_typed`, …) will want
+# semantic tokens, go-to-definition, etc. New views add their scheme here.
+const TESTRUNNER_LOGS_SCHEME = "jetls-testrunner-logs"
+const TEXT_DOCUMENT_CONTENT_SCHEMES = String[TESTRUNNER_LOGS_SCHEME]
+
+is_text_document_content_uri(uri::URI) = uri.scheme in TEXT_DOCUMENT_CONTENT_SCHEMES
 
 struct TextDocumentContentRefreshCaller <: RequestCaller
     uri::URI
@@ -10,7 +18,7 @@ supports_text_document_content(server::Server) =
     getcapability(server, :workspace, :textDocumentContent) !== nothing
 
 function text_document_content_options()
-    return TextDocumentContentOptions(; schemes = String[TEXT_DOCUMENT_CONTENT_SCHEME])
+    return TextDocumentContentOptions(; schemes = TEXT_DOCUMENT_CONTENT_SCHEMES)
 end
 
 function text_document_content_registration()
@@ -18,7 +26,7 @@ function text_document_content_registration()
         id = TEXT_DOCUMENT_CONTENT_REGISTRATION_ID,
         method = TEXT_DOCUMENT_CONTENT_REGISTRATION_METHOD,
         registerOptions = TextDocumentContentRegistrationOptions(;
-            schemes = String[TEXT_DOCUMENT_CONTENT_SCHEME]))
+            schemes = TEXT_DOCUMENT_CONTENT_SCHEMES))
 end
 
 function get_text_document_content(state::ServerState, uri::URI)
@@ -72,7 +80,7 @@ end
 
 function handle_TextDocumentContentRequest(server::Server, msg::TextDocumentContentRequest)
     uri = msg.params.uri
-    if uri.scheme != TEXT_DOCUMENT_CONTENT_SCHEME
+    if !is_text_document_content_uri(uri)
         return send(server, TextDocumentContentResponse(; id = msg.id, result = null))
     end
     text = get_text_document_content(server.state, uri)

--- a/src/text-document-content.jl
+++ b/src/text-document-content.jl
@@ -73,9 +73,8 @@ function request_text_document_content_refresh!(server::Server, uri::URI)
     supports_text_document_content(server) || return nothing
     id = String(gensym(:TextDocumentContentRefreshRequest))
     addrequest!(server, id=>TextDocumentContentRefreshCaller(uri))
-    return send(server, TextDocumentContentRefreshRequest(;
-        id,
-        params = TextDocumentContentRefreshParams(; uri)))
+    params = TextDocumentContentRefreshParams(; uri)
+    return send(server, TextDocumentContentRefreshRequest(; id, params))
 end
 
 function handle_TextDocumentContentRequest(server::Server, msg::TextDocumentContentRequest)
@@ -83,10 +82,10 @@ function handle_TextDocumentContentRequest(server::Server, msg::TextDocumentCont
     if !is_text_document_content_uri(uri)
         return send(server, TextDocumentContentResponse(; id = msg.id, result = null))
     end
-    text = get_text_document_content(server.state, uri)
-    text === nothing && return send(server, TextDocumentContentResponse(;
-        id = msg.id,
-        result = null))
+    text = @something get_text_document_content(server.state, uri) begin
+        return send(server,
+            TextDocumentContentResponse(; id = msg.id, result = null))
+    end
     return send(server, TextDocumentContentResponse(;
         id = msg.id,
         result = TextDocumentContentResult(; text)))

--- a/src/types.jl
+++ b/src/types.jl
@@ -829,6 +829,13 @@ const ConfigManager = LWContainer{ConfigManagerData, LWStats}
 const UnsyncedFileCacheData = Base.PersistentDict{URI,FileInfo}
 const UnsyncedFileCache = LWContainer{UnsyncedFileCacheData, LWStats}
 
+struct TextDocumentContentEntry
+    text::String
+    opened::Bool
+end
+const TextDocumentContentCacheData = Base.PersistentDict{URI,TextDocumentContentEntry}
+const TextDocumentContentCache = LWContainer{TextDocumentContentCacheData, LWStats}
+
 const CurrentlyHandled = Dict{MessageId, CancelFlag}
 const HandledHistory = FixedSizeQueue{MessageId}
 
@@ -854,6 +861,7 @@ mutable struct ServerState
     const document_symbol_cache::DocumentSymbolCache
     const binding_occurrences_cache::BindingOccurrencesCache
     const per_file_diagnostics_cache::PerFileDiagnosticsCache
+    const text_document_content_cache::TextDocumentContentCache
     const analysis_manager::AnalysisManager
     const extra_diagnostics::ExtraDiagnostics
     const currently_handled::CurrentlyHandled
@@ -886,6 +894,7 @@ mutable struct ServerState
             #=document_symbol_cache=# DocumentSymbolCache(),
             #=binding_occurrences_cache=# BindingOccurrencesCache(),
             #=per_file_diagnostics_cache=# PerFileDiagnosticsCache(),
+            #=text_document_content_cache=# TextDocumentContentCache(),
             #=analysis_manager=# AnalysisManager(),
             #=extra_diagnostics=# ExtraDiagnostics(),
             #=currently_handled=# CurrentlyHandled(),

--- a/test/test_testrunner.jl
+++ b/test/test_testrunner.jl
@@ -226,7 +226,11 @@ end
         logs_lens = code_lenses[2]
         @test logs_lens.command.title == JETLS.TESTRUNNER_OPEN_LOGS_TITLE
         @test logs_lens.command.command == JETLS.COMMAND_TESTRUNNER_OPEN_LOGS
-        @test logs_lens.command.arguments == [uri, 1, tsn1, result.logs]
+        @test logs_lens.command.arguments == [uri, 1, tsn1]
+        # logs are looked up server-side rather than carried in the command arguments
+        @test JETLS.get_testsetinfo_logs(server.state, uri, 1) == result.logs
+        @test JETLS.get_testsetinfo_logs(server.state, uri, 2) === nothing
+        @test JETLS.get_testsetinfo_logs(server.state, URI("file:///none.jl"), 1) === nothing
 
         clear_lens = code_lenses[3]
         @test clear_lens.command.title == JETLS.TESTRUNNER_CLEAR_RESULT_TITLE
@@ -361,7 +365,7 @@ end
 
         @test code_actions[2].title == JETLS.TESTRUNNER_OPEN_LOGS_TITLE
         @test code_actions[2].command.command == JETLS.COMMAND_TESTRUNNER_OPEN_LOGS
-        @test code_actions[2].command.arguments == [uri, 1, tsn, result.logs]
+        @test code_actions[2].command.arguments == [uri, 1, tsn]
 
         @test code_actions[3].title == JETLS.TESTRUNNER_CLEAR_RESULT_TITLE
         @test code_actions[3].command.command == JETLS.COMMAND_TESTRUNNER_CLEAR_RESULT

--- a/test/test_testrunner.jl
+++ b/test/test_testrunner.jl
@@ -164,15 +164,6 @@ end
     @test JETLS.get_file_info(server.state, juri) === nothing
     @test JETLS.load(server.state.text_document_content_cache)[juri].opened
 
-    chg_msg = DidChangeTextDocumentNotification(; params = DidChangeTextDocumentParams(;
-        textDocument = VersionedTextDocumentIdentifier(; uri=juri, version=2),
-        contentChanges = TextDocumentContentChangeEvent[
-            TextDocumentContentChangeEvent(; text="ignored\n")]))
-    @test JETLS.handle_DidChangeTextDocumentNotification(server, chg_msg) === nothing
-    @test JETLS.get_file_info(server.state, juri) === nothing
-    # read-only: didChange does not overwrite the server-held content
-    @test JETLS.get_text_document_content(server.state, juri) == "logs\n"
-
     close_msg = DidCloseTextDocumentNotification(; params = DidCloseTextDocumentParams(;
         textDocument = TextDocumentIdentifier(; uri=juri)))
     @test JETLS.handle_DidCloseTextDocumentNotification(server, close_msg) === nothing

--- a/test/test_testrunner.jl
+++ b/test/test_testrunner.jl
@@ -2,7 +2,7 @@ module test_testrunner
 
 using Test
 using JETLS
-using JETLS: JS, JL
+using JETLS: JL, JS
 using JETLS.LSP
 using JETLS.LSP.URIs2
 
@@ -127,6 +127,25 @@ end
     end
 end
 
+@testset "testsetinfo_logs_content" begin
+    let uri = URI("file:///runtests.jl"), testset_name = "日本語"
+        log_uri = JETLS.testsetinfo_logs_content_uri(uri, 1, testset_name)
+        @test log_uri == JETLS.testsetinfo_logs_content_uri(uri, 1, testset_name)
+        @test log_uri != JETLS.testsetinfo_logs_content_uri(uri, 2, testset_name)
+        @test log_uri.scheme == JETLS.TEXT_DOCUMENT_CONTENT_SCHEME
+        @test log_uri.path == "/testrunner/logs"
+    end
+
+    let server = JETLS.Server(), uri = URI(; scheme="jetls", path="/test")
+        JETLS.update_text_document_content!(server, uri, "old logs")
+        @test JETLS.get_text_document_content(server.state, uri) == "old logs"
+        JETLS.mark_text_document_content_opened!(server, uri)
+        JETLS.update_text_document_content!(server, uri, "new logs")
+        @test JETLS.get_text_document_content(server.state, uri) == "new logs"
+        @test JETLS.load(server.state.text_document_content_cache)[uri].opened
+    end
+end
+
 @testset "testrunner_code_lenses" begin
     let server = JETLS.Server()
         test_code = """
@@ -183,8 +202,7 @@ end
         logs_lens = code_lenses[2]
         @test logs_lens.command.title == JETLS.TESTRUNNER_OPEN_LOGS_TITLE
         @test logs_lens.command.command == JETLS.COMMAND_TESTRUNNER_OPEN_LOGS
-        @test length(logs_lens.command.arguments) == 2
-        @test logs_lens.command.arguments[1] == tsn1
+        @test logs_lens.command.arguments == [uri, 1, tsn1, result.logs]
 
         clear_lens = code_lenses[3]
         @test clear_lens.command.title == JETLS.TESTRUNNER_CLEAR_RESULT_TITLE
@@ -319,8 +337,7 @@ end
 
         @test code_actions[2].title == JETLS.TESTRUNNER_OPEN_LOGS_TITLE
         @test code_actions[2].command.command == JETLS.COMMAND_TESTRUNNER_OPEN_LOGS
-        @test length(code_actions[2].command.arguments) == 2
-        @test code_actions[2].command.arguments[1] == tsn
+        @test code_actions[2].command.arguments == [uri, 1, tsn, result.logs]
 
         @test code_actions[3].title == JETLS.TESTRUNNER_CLEAR_RESULT_TITLE
         @test code_actions[3].command.command == JETLS.COMMAND_TESTRUNNER_CLEAR_RESULT

--- a/test/test_testrunner.jl
+++ b/test/test_testrunner.jl
@@ -146,6 +146,30 @@ end
     end
 end
 
+@testset "jetls scheme excluded from document synchronization" begin
+    # Spec-conformant clients may sync `jetls:` virtual documents. The Julia-only
+    # sync handlers must not run for them (no crash on the non-`julia` languageId,
+    # no `FileInfo` pollution).
+    server = JETLS.Server()
+    juri = URI(; scheme="jetls", path="/testrunner/logs", query="source=x&index=1&name=ts")
+
+    open_msg = DidOpenTextDocumentNotification(; params = DidOpenTextDocumentParams(;
+        textDocument = TextDocumentItem(; uri=juri, languageId="log", version=1, text="logs\n")))
+    @test JETLS.handle_DidOpenTextDocumentNotification(server, open_msg) === nothing
+    @test JETLS.get_file_info(server.state, juri) === nothing
+
+    chg_msg = DidChangeTextDocumentNotification(; params = DidChangeTextDocumentParams(;
+        textDocument = VersionedTextDocumentIdentifier(; uri=juri, version=2),
+        contentChanges = TextDocumentContentChangeEvent[
+            TextDocumentContentChangeEvent(; text="new logs\n")]))
+    @test JETLS.handle_DidChangeTextDocumentNotification(server, chg_msg) === nothing
+    @test JETLS.get_file_info(server.state, juri) === nothing
+
+    close_msg = DidCloseTextDocumentNotification(; params = DidCloseTextDocumentParams(;
+        textDocument = TextDocumentIdentifier(; uri=juri)))
+    @test JETLS.handle_DidCloseTextDocumentNotification(server, close_msg) === nothing
+end
+
 @testset "testrunner_code_lenses" begin
     let server = JETLS.Server()
         test_code = """

--- a/test/test_testrunner.jl
+++ b/test/test_testrunner.jl
@@ -143,31 +143,40 @@ end
         JETLS.update_text_document_content!(server, uri, "new logs")
         @test JETLS.get_text_document_content(server.state, uri) == "new logs"
         @test JETLS.load(server.state.text_document_content_cache)[uri].opened
+        JETLS.mark_text_document_content_closed!(server, uri)
+        @test !JETLS.load(server.state.text_document_content_cache)[uri].opened
+        JETLS.delete_text_document_content!(server, uri)
+        @test JETLS.get_text_document_content(server.state, uri) === nothing
     end
 end
 
-@testset "jetls scheme excluded from document synchronization" begin
+@testset "jetls document synchronization (track open/close, no Julia analysis)" begin
     # Spec-conformant clients may sync `jetls:` virtual documents. The Julia-only
-    # sync handlers must not run for them (no crash on the non-`julia` languageId,
-    # no `FileInfo` pollution).
+    # sync path must not run for them (no crash on the non-`julia` languageId, no
+    # `FileInfo` pollution); instead open/close is tracked to drive content refreshes.
     server = JETLS.Server()
     juri = URI(; scheme="jetls", path="/testrunner/logs", query="source=x&index=1&name=ts")
+    JETLS.update_text_document_content!(server, juri, "logs\n")
 
     open_msg = DidOpenTextDocumentNotification(; params = DidOpenTextDocumentParams(;
         textDocument = TextDocumentItem(; uri=juri, languageId="log", version=1, text="logs\n")))
     @test JETLS.handle_DidOpenTextDocumentNotification(server, open_msg) === nothing
     @test JETLS.get_file_info(server.state, juri) === nothing
+    @test JETLS.load(server.state.text_document_content_cache)[juri].opened
 
     chg_msg = DidChangeTextDocumentNotification(; params = DidChangeTextDocumentParams(;
         textDocument = VersionedTextDocumentIdentifier(; uri=juri, version=2),
         contentChanges = TextDocumentContentChangeEvent[
-            TextDocumentContentChangeEvent(; text="new logs\n")]))
+            TextDocumentContentChangeEvent(; text="ignored\n")]))
     @test JETLS.handle_DidChangeTextDocumentNotification(server, chg_msg) === nothing
     @test JETLS.get_file_info(server.state, juri) === nothing
+    # read-only: didChange does not overwrite the server-held content
+    @test JETLS.get_text_document_content(server.state, juri) == "logs\n"
 
     close_msg = DidCloseTextDocumentNotification(; params = DidCloseTextDocumentParams(;
         textDocument = TextDocumentIdentifier(; uri=juri)))
     @test JETLS.handle_DidCloseTextDocumentNotification(server, close_msg) === nothing
+    @test !JETLS.load(server.state.text_document_content_cache)[juri].opened
 end
 
 @testset "testrunner_code_lenses" begin

--- a/test/test_testrunner.jl
+++ b/test/test_testrunner.jl
@@ -132,11 +132,11 @@ end
         log_uri = JETLS.testsetinfo_logs_content_uri(uri, 1, testset_name)
         @test log_uri == JETLS.testsetinfo_logs_content_uri(uri, 1, testset_name)
         @test log_uri != JETLS.testsetinfo_logs_content_uri(uri, 2, testset_name)
-        @test log_uri.scheme == JETLS.TEXT_DOCUMENT_CONTENT_SCHEME
+        @test log_uri.scheme == JETLS.TESTRUNNER_LOGS_SCHEME
         @test log_uri.path == "/testrunner/logs"
     end
 
-    let server = JETLS.Server(), uri = URI(; scheme="jetls", path="/test")
+    let server = JETLS.Server(), uri = URI(; scheme=JETLS.TESTRUNNER_LOGS_SCHEME, path="/test")
         JETLS.update_text_document_content!(server, uri, "old logs")
         @test JETLS.get_text_document_content(server.state, uri) == "old logs"
         JETLS.mark_text_document_content_opened!(server, uri)
@@ -155,7 +155,7 @@ end
     # sync path must not run for them (no crash on the non-`julia` languageId, no
     # `FileInfo` pollution); instead open/close is tracked to drive content refreshes.
     server = JETLS.Server()
-    juri = URI(; scheme="jetls", path="/testrunner/logs", query="source=x&index=1&name=ts")
+    juri = URI(; scheme=JETLS.TESTRUNNER_LOGS_SCHEME, path="/testrunner/logs", query="source=x&index=1&name=ts")
     JETLS.update_text_document_content!(server, juri, "logs\n")
 
     open_msg = DidOpenTextDocumentNotification(; params = DidOpenTextDocumentParams(;


### PR DESCRIPTION
## Summary

Serve TestRunner logs as read-only **virtual documents** via the LSP 3.18 `workspace/textDocumentContent` request, instead of writing them to temporary files or `untitled:` buffers.
This avoids leaving stale files on disk and lets an already-open log tab update in place when a testset is re-run, while keeping a temp-file fallback for clients that don't support the feature.

## Motivation

TestRunner logs were previously written to a temp file (and before that, an `untitled:` buffer) and opened with `window/showDocument`. That:
- leaves a stale file on disk, and
- cannot reflect new results once the log tab is open — re-running a testset spawned a fresh file instead of updating the one already on screen.

## What changed

### `testrunner: Serve logs via textDocumentContent`
- A content cache maps each per-testset log URI to its text and an `opened` flag, and answers `workspace/textDocumentContent` requests.
- The provider is advertised statically in `InitializeResponse`, or via dynamic registration on `InitializedNotification`.
- Re-running a testset updates the cache and, once a log has been opened, sends `workspace/textDocumentContent/refresh` so the open tab updates in place.
- Retains a cleanup-enabled temp-file fallback for clients lacking `workspace/textDocumentContent` / `window/showDocument`, degrading further to showing the saved log path as a message.

### `lsp: Skip jetls documents in text-sync handlers`
Spec-conformant clients may send `didOpen`/`didChange`/`didClose` for these virtual documents (the spec even anticipates "subsequent open notifications"). The text-sync handlers assumed every synced document is Julia source (`@assert languageId == "julia"`, parse/analyze, file-backed cleanup), which crashed the handler or polluted the Julia caches. The handlers now skip the scheme, keeping the sync path Julia-only.

### `testrunner: Track jetls log open/close via sync, evict on clear`
- `didOpen`/`didClose` now mark the cached content opened/closed, so refreshes stop once the log view is closed (previously `opened` was set from the `window/showDocument` response and never reset). `didChange` is ignored since the documents are read-only.
- The VS Code client syncs the scheme so it sends those notifications; language features are registered separately and do not target the scheme.
- Clearing a test result now evicts the cached log content for that testset.

### `lsp: Use per-view schemes for textDocumentContent`
- Each view gets its own scheme under a `jetls-<view>` convention; logs use `jetls-testrunner-logs`. This lets document selectors enable language features per view, so planned Julia-code views (macro expansion, type annotations, `code_typed`, …) can opt into semantic tokens / go-to-definition while plain output (logs) stays excluded. A `TEXT_DOCUMENT_CONTENT_SCHEMES` set and an `is_text_document_content_uri` predicate back the content provider and the sync-handler guards.

## Client support

`workspace/textDocumentContent` is a recently-added LSP feature (added in LSP 3.18), so the bundled VS Code client enables `registerProposedFeatures()` and lists the scheme in its `documentSelector` (for document synchronization only — language features are registered separately).