### PR TITLE
jl-syntax-macros: Add `@lock` new-style stub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed renaming symbols inside Jupyter notebook cells on VS Code, which previously failed with a "The rename edit returned from the server is not valid anymore and cannot be applied." error.
 
+- Fixed scope resolution for identifiers inside `@lock` blocks so language features distinguish bindings introduced in the protected body from surrounding bindings.
+
 ## 2026-06-03
 
 - Commit: [`a42a435`](https://github.com/aviatesk/JETLS.jl/commit/a42a435)

--- a/src/utils/jl-syntax-macros.jl
+++ b/src/utils/jl-syntax-macros.jl
@@ -157,6 +157,7 @@ const NEW_STYLE_MACROCALL_NAMES = (
     "@invokelatest",
     "@kwdef",
     "@label",
+    "@lock",
     "@logmsg",
     "@noinline",
     "@propagate_inbounds",
@@ -226,6 +227,27 @@ end
 
 function Base.var"@inbounds"(__context__::JL.MacroContext, ex::SyntaxTreeC)
     JL.@ast(__context__, ex, ex)
+end
+
+# Keep the lock expression in the enclosing scope, but wrap only the protected
+# body in a local scope to mirror the `try` scope introduced by Base's macro.
+function Base.var"@lock"(
+        __context__::JL.MacroContext, lock::SyntaxTreeC, body::SyntaxTreeC
+    )
+    mc = __context__.macrocall::SyntaxTreeC
+    return JL.@ast(__context__, mc,
+        [JS.K"block"
+            lock
+            [JS.K"let"
+                [JS.K"block"]
+                [JS.K"block" body]]])
+end
+
+function Base.var"@lock"(__context__::JL.MacroContext, args::SyntaxTreeC...)
+    mc = __context__.macrocall::SyntaxTreeC
+    push_macro_error!(mc, "@lock expects exactly two arguments: `lock body`")
+    isempty(args) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
+    return JL.@ast(__context__, mc, [JS.K"block" args...])
 end
 
 # Stub new-style implementation of `Threads.@spawn`. The real macro wraps the

--- a/test/utils/test_jl_syntax_macros.jl
+++ b/test/utils/test_jl_syntax_macros.jl
@@ -204,6 +204,58 @@ end
     end
 end
 
+@testset "@lock" begin
+    @testset "macro expansion" begin
+        let st1 = jlexpand("@lock lk begin x = 1; x end")
+            @test JS.kind(st1) === JS.K"block"
+            @test JS.numchildren(st1) == 2
+            @test JS.sourcetext(st1[1]) == "lk"
+            @test JS.kind(st1[2]) === JS.K"let"
+        end
+    end
+
+    @testset "validation" begin
+        for code in ("@lock", "@lock lk", "@lock lk body extra")
+            let diags = collect_macro_diagnostics() do
+                    jlexpand(code)
+                end
+                @test length(diags) == 1
+                d = only(diags)
+                @test d.severity == JETLS.LSP.DiagnosticSeverity.Error
+                @test occursin("@lock expects exactly two arguments", d.msg)
+            end
+        end
+    end
+
+    @testset "scope isolation + provenance" begin
+        let res = jlresolve("""
+                function f()
+                    @lock lk begin
+                        guarded = 1
+                        guarded
+                    end
+                    guarded
+                end
+                """)
+            assert_binding_provenance(res, :global, "lk")
+            assert_binding_provenance(res, :local, "guarded")
+            assert_binding_provenance(res, :global, "guarded")
+        end
+
+        let res = jlresolve("""
+                function f()
+                    @lock (lk = 1) begin
+                        guarded = 1
+                    end
+                    lk
+                end
+                """)
+            assert_binding_provenance(res, :local, "lk")
+            assert_no_binding(res, :global, "lk")
+        end
+    end
+end
+
 @testset "Threads.@spawn" begin
     @testset "macro expansion" begin
         # Single-argument form: returns the body unchanged.


### PR DESCRIPTION
Add a new-style `@lock` macro stub for scope resolution.

The stub keeps the lock expression in the enclosing scope while isolating bindings introduced in the protected body. This lets LSP features resolve identifiers inside `@lock` blocks without leaking locals outward.

Add focused tests for expansion recovery, protected-body scope isolation, and lock-expression resolution, and document the user-facing fix.