### PR TITLE
completions: Fix dot completion on `Union{}`-typed prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - JETLS now performs correct scope resolution on identifiers used inside `@static` macrocalls, which previously could yield incorrect results in edge cases.
   Invalid `@static` usage (an unsupported expression shape, or a condition that fails to evaluate to a `Bool`) is now reported in place as `lowering/macro-expansion-error` while the code still flows through to analysis.
 
+- Allows scope resolution for identifiers inside `@lock` blocks so language features distinguish bindings introduced in the protected body from surrounding bindings.
+
 - Signature help now uses LSP 3.18 `activeParameter: null` for clients that support it, so editors can avoid highlighting a stale parameter after all known keywords have already been filled.
+
+- Changed TestRunner log viewing to use readonly virtual documents when supported, and cleanup-enabled temporary files otherwise, avoiding empty `untitled:` log tabs and mismatched log file paths.
 
 ### Fixed
 
@@ -82,11 +86,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed type information collapsing to `Any` inside closures defined in functions that have default positional arguments or keyword arguments. Hover, inlay hints and other type-aware features now show precise types for such closure bodies and their captured variables.
 
-- Fixed TestRunner log viewing to use readonly virtual documents when supported, and cleanup-enabled temporary files otherwise, avoiding empty `untitled:` log tabs and mismatched log file paths.
-
 - Fixed renaming symbols inside Jupyter notebook cells on VS Code, which previously failed with a "The rename edit returned from the server is not valid anymore and cannot be applied." error.
 
-- Fixed scope resolution for identifiers inside `@lock` blocks so language features distinguish bindings introduced in the protected body from surrounding bindings.
+- Fixed dot completion erroring (or offering nothing) when the prefix sits in code that inference proves unreachable, such as code after a non-returning call. Module and global-const prefixes such as `Base.` now resolve their members there as usual.
 
 ## 2026-06-03
 

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -314,7 +314,9 @@ function global_completions!(
         rng = JS.byte_range(dotprefix)
         ctx = get_inferred_ctx!(comp_ctx; caller="global_completions!")
         prefixtyp = ctx === nothing ? nothing : get_type_for_range(ctx, rng)
-        if prefixtyp === nothing
+        # A `Union{}` prefix type is uninformative (the prefix throws or is dead code);
+        # treat it like `nothing` so module/const prefixes such as `Base.` still complete.
+        if prefixtyp === nothing || prefixtyp === Union{}
             prefixtyp = resolve_global_const(context_module, dotprefix, world)
         end
         # Module prefix → enumerate that module's globals below.
@@ -477,6 +479,7 @@ end
 
 function union_components(@nospecialize(prefixtyp))
     typ = CC.widenconst(prefixtyp)
+    typ === Union{} && return Any[]
     return typ isa Union ? Base.uniontypes(typ) : Any[typ]
 end
 

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -614,6 +614,42 @@ end
         @test cnt[] == 1
     end
 
+    # A `Union{}`-typed prefix that isn't a resolvable global const (here a
+    # `Bottom`-returning call): the `resolve_global_const` fallback yields `nothing`,
+    # so no properties are offered and we don't fall through to global/local completions.
+    let text = """
+        function bar()
+            error("unreachable").│
+        end
+        """
+        cnt = Ref(0)
+        with_completion_items(text; context=dot_context) do (; result)
+            @test isempty(result.items)
+            cnt[] += 1
+        end
+        @test cnt[] == 1
+    end
+
+    # A `Union{}`-typed prefix that *is* a resolvable global const recovers module completions
+    # via the `resolve_global_const` fallback. Here `Base` sits in a dead branch, so its
+    # inferred type is `Union{}`, yet `Base.` still completes.
+    let text = """
+        function bar()
+            c = false
+            if c
+                Base.│
+            end
+        end
+        """
+        cnt = Ref(0)
+        with_completion_items(text; context=dot_context) do (; result)
+            labels = Set(it.label for it in result.items)
+            @test "isexpr" in labels   # Base member → module completion fired
+            cnt[] += 1
+        end
+        @test cnt[] == 1
+    end
+
     # `r.│` sitting inside a call's argument list (parser inserts an error
     # in the property-name slot, so the dot subtree must be repaired before
     # lowering can resolve `r`'s type).


### PR DESCRIPTION
When the dot prefix's inferred type is `Union{}` — which happens for prefixes in code that inference proves unreachable, such as a platform-specific branch dead on the host OS or code after a non-returning call — `global_completions!` now treats it like an unknown type and falls back to `resolve_global_const`. Module and global-const prefixes such as `Base.` therefore resolve their members as usual instead of erroring in the property path
(`Tuple{T,Union{}}` construction) or offering nothing.

The `union_components` `Union{}` guard is kept for the residual case where `widenconst(prefixtyp)` is `Union{}` but the prefix itself is a non-`Union{}` lattice element.