### PR TITLE
inlay-hint: Wrap type-hint tooltip in `MarkupContent` for markdown

### DIFF
--- a/src/inlay-hint.jl
+++ b/src/inlay-hint.jl
@@ -641,10 +641,12 @@ end
 # Explain `Union{}` hints, which otherwise look like obscure valid syntax.
 function format_type_inlay_hint_tooltip(@nospecialize(rawtyp), postprocessor::LSPostProcessor)
     if rawtyp === Union{}
-        return "`Union{}` — this expression provably never produces a value (always throws, or is unreachable)."
+        value = "`Union{}` — this expression provably never produces a value (always throws, or is unreachable)."
+    else
+        full_typstr = postprocessor(sprint(show, rawtyp))
+        value = "```julia\n$full_typstr\n```"
     end
-    full_typstr = postprocessor(sprint(show, rawtyp))
-    return "```julia\n$full_typstr\n```"
+    return MarkupContent(; kind = MarkupKind.Markdown, value)
 end
 
 # Resolve a lazy type-hint tooltip by recomputing the type for the source range

--- a/test/test_inlay_hint.jl
+++ b/test/test_inlay_hint.jl
@@ -531,7 +531,9 @@ end
         @test hint.data isa TypeInlayHintData
         resolved = JETLS.resolve_inlay_hint(server.state, hint)
         @test resolved.label == hint.label
-        @test resolved.tooltip == "```julia\nLinearAlgebra.Adjoint{Float64, Matrix{Float64}}\n```"
+        @test resolved.tooltip isa MarkupContent
+        @test resolved.tooltip.kind == MarkupKind.Markdown
+        @test resolved.tooltip.value == "```julia\nLinearAlgebra.Adjoint{Float64, Matrix{Float64}}\n```"
     end
 
     @testset "operator expressions" begin
@@ -1693,8 +1695,9 @@ end
         union_hints = filter(h -> occursin("::Union{}", h.label), hints)
         @test !isempty(union_hints)
         for h in union_hints
-            @test h.tooltip isa AbstractString
-            @test occursin("provably never produces a value", h.tooltip)
+            @test h.tooltip isa MarkupContent
+            @test h.tooltip.kind == MarkupKind.Markdown
+            @test occursin("provably never produces a value", h.tooltip.value)
         end
     end
 


### PR DESCRIPTION
`format_type_inlay_hint_tooltip` returned a plain `String` containing markdown, but per the LSP spec a plain `string` tooltip is rendered as plaintext by spec-compliant clients (e.g. VSCode), so the ` ```julia ` fences leaked as literal text. Wrapping the value in `MarkupContent` with `kind = MarkupKind.Markdown` makes it render as markdown.

No client capability check is needed: `InlayHintClientCapabilities` defines no markup-format field for the tooltip (unlike hover's `contentFormat`), so `string | MarkupContent` is unconditional.