### PR TITLE
inlay-hint: Show inferred types for unannotated closure parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Improved type precision for local closures with untyped parameters (`do x`, `x -> ...`): their parameter types are now inferred from the argument types observed at the closure's call sites instead of degrading to `Any`, so hover, inlay hints and other type-aware features show precise types in closure bodies, in comprehensions, and for results of higher-order calls like `map`. Parameter annotations other than `::Any` are always respected as-is.
 
+- Added inlay type hints for unannotated parameters of local closures, showing the parameter types inferred from the closure's call sites (e.g. `map(xs) do x::Int` for `xs::Vector{Int}`, or `f = x::Union{Float64, Int} -> 2x` when `f` is called with both `Float64` and `Int`).
+  This covers all local-closure forms — arrow and `do`-block lambdas, anonymous and named local closures.
+  Destructuring parameters are annotated per component (e.g. `do (key::String, val::Int)`), consistent with for-loop iteration variables.
+  Parameters whose type cannot be narrowed beyond `Any` are left without a hint.
+
 - JETLS now performs correct scope resolution on identifiers used inside `@static` macrocalls, which previously could yield incorrect results in edge cases.
   Invalid `@static` usage (an unsupported expression shape, or a condition that fails to evaluate to a `Bool`) is now reported in place as `lowering/macro-expansion-error` while the code still flows through to analysis.
 

--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -152,7 +152,7 @@ using ..JETLS: InferredContextCache, InferredContextCacheData, JETLS_DEBUG_LOWER
 import ..JETLS: InferredTreeContext
 
 export InferredTreeContext, build_inferred_context_for_range, get_matches_for_range,
-    get_type_for_range
+    get_oc_argtypes_for_range, get_type_for_range
 
 # ASTTypeAnnotator
 # ================
@@ -1581,6 +1581,12 @@ function tmerge_at_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
     # `Union{T, Method, OpaqueClosure, Type}`. Keep only nodes attributed to the body of
     # the OC at `rng`; outside that scope is scaffolding.
     is_oc_site = any(s -> JS.kind(s) === JS.K"new_opaque_closure", nodes)
+    # Property destructuring in parameter position (`do (; a, b)`) emits a
+    # `getproperty(obj, :a)` whose field-name `K"Symbol"` leaf lands on the binding's
+    # byte range, polluting it to `Union{T, Symbol}`. (Assignment-position `(; a, b) =`
+    # is already handled by `is_synthetic_destructure_stmt` at annotation time.)
+    # Skip the symbol when a binding slot shares the range.
+    has_binding_slot = any(s -> JS.kind(s) === JS.K"slot", nodes)
     typ = nothing
     for st in nodes
         # `K"core"` leaves are lowering-introduced `Core.X` references (e.g. the
@@ -1588,6 +1594,7 @@ function tmerge_at_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
         # the parameter's surface position); users can't write them, so their types
         # (`Const(Any)` etc.) must not leak into surface queries.
         JS.kind(st) === JS.K"core" && continue
+        has_binding_slot && JS.kind(st) === JS.K"Symbol" && continue
         hasproperty(st, :type) || continue
         if is_oc_site && get(ctx.oc_body_scope, st._id, nothing) !== rng
             continue
@@ -1641,6 +1648,39 @@ function get_matches_for_range(ctx::InferredTreeContext, rng::UnitRange{<:Intege
     last_call === nothing && return nothing
     hasproperty(last_call, :matches) || return nothing
     return last_call.matches::Vector{Core.MethodMatch}
+end
+
+"""
+    get_oc_argtypes_for_range(
+            ctx::InferredTreeContext, rng::UnitRange{<:Integer}
+        ) -> Union{Nothing,Vector{Any}}
+
+Look up the `Core.OpaqueClosure` constructed at surface byte range `rng` — a lambda or
+`do`-block closure routed through [`Closure2Opaque.rewrite_local_closures_to_opaque`](@ref)
+— and return its argument types: one entry per user-visible parameter, with any
+call-site argtype refinement applied (see "Closure argument-type refinement" in the
+[`TypeAnnotation`](@ref) module docstring). Returns `nothing` when no annotated OC
+construction lies at `rng` or its argt isn't a plain `Vararg`-free `Tuple`.
+
+Feature code uses this for parameter-position queries (e.g. inlay hints on unannotated
+lambda parameters), where the value-type query [`get_type_for_range`](@ref) would
+surface the closure's own `OpaqueClosure{…}` type instead.
+"""
+function get_oc_argtypes_for_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
+    for st in get(ctx.by_byte_range, rng, ())
+        JS.kind(st) === JS.K"new_opaque_closure" || continue
+        hasproperty(st, :type) || continue
+        oc = Base.unwrap_unionall(CC.widenconst(st.type))
+        oc isa DataType || continue
+        oc.name === Base.typename(Core.OpaqueClosure) || continue
+        argt = oc.parameters[1]
+        argt isa DataType || continue
+        argt <: Tuple || continue
+        params = argt.parameters
+        any(CC.isvarargtype, params) && continue
+        return Any[params...]
+    end
+    return nothing
 end
 
 end # module TypeAnnotation

--- a/src/inlay-hint.jl
+++ b/src/inlay-hint.jl
@@ -245,8 +245,10 @@ function collect_type_inlay_hints!(
             sig_rng !== nothing && push!(verbatim_ranges, sig_rng)
         end
         if JS.kind(node) === JS.K"->" && JS.numchildren(node) >= 1
-            # Lambda parameters are signature syntax; suppress the misleading
-            # OC slot hint for no-paren single-Identifier forms too.
+            # Lambda/`do` parameters are signature syntax, and the OC binding's slot
+            # shares their byte range, so the generic path would emit a misleading
+            # `OpaqueClosure{…}` hint. Suppress it here; dedicated parameter hints
+            # are emitted by the `K"->"` branch of the postorder pass.
             params = node[1]
             if JS.kind(params) in JS.KSet"tuple Identifier"
                 push!(verbatim_ranges, JS.byte_range(params))
@@ -325,6 +327,17 @@ function collect_type_inlay_hints!(
 
         byterng = JS.byte_range(node)
 
+        # Dedicated hints for unannotated local-closure parameters — arrow / `do`
+        # lambdas, anonymous `function (…) … end`, and named local closures. Emitted
+        # before the funcdef return-type path's early return so a named local closure
+        # gets both its parameter and return-type hints. `emit_lambda_param_hints!`
+        # is a no-op for non-closures (it gates on `get_oc_argtypes_for_range`).
+        if k in JS.KSet"-> function ="
+            emit_lambda_param_hints!(
+                inlay_hints, node, ctx, fi, uri, range, nontrivia_index,
+                postprocessor, label_cache, maxdepth, maxwidth, lazy_tooltips)
+        end
+
         # Emit function return hints on the signature, not the full definition.
         if k in JS.KSet"function macro =" && (call_node = funcdef_call_node(node)) !== nothing
             endpos = offset_to_xy(fi, JS.last_byte(call_node) + 1)
@@ -348,7 +361,7 @@ function collect_type_inlay_hints!(
         if k === JS.K"for" && JS.numchildren(node) >= 1
             spec = node[1]
             if JS.kind(spec) === JS.K"=" && JS.numchildren(spec) >= 1
-                emit_for_loop_var_hints!(
+                emit_destructure_var_hints!(
                     inlay_hints, spec[1], ctx, fi, uri, range, nontrivia_index,
                     postprocessor, label_cache, maxdepth, maxwidth, lazy_tooltips)
             end
@@ -357,7 +370,7 @@ function collect_type_inlay_hints!(
         if k in JS.KSet"generator filter"
             spec = comprehension_iter_spec(node)
             if spec !== nothing && JS.numchildren(spec) >= 1
-                emit_for_loop_var_hints!(
+                emit_destructure_var_hints!(
                     inlay_hints, spec[1], ctx, fi, uri, range, nontrivia_index,
                     postprocessor, label_cache, maxdepth, maxwidth, lazy_tooltips)
             end
@@ -491,8 +504,93 @@ function register_for_loop_vars!(callee_ranges::Set{UnitRange{Int}}, lhs::Syntax
     return nothing
 end
 
-# Emit one hint per variable in an iteration LHS, including destructuring forms.
-function emit_for_loop_var_hints!(
+# Emit one hint per unannotated local-closure parameter, for every definition form:
+# `K"->"` (arrow / `do`, bare `K"Identifier"` or `K"tuple"` params), anonymous
+# `function (…) … end` (`K"tuple"` signature), and named local closures /
+# short-form `f(…) = …` (`K"call"` signature, after stripping `where` / return-type
+# wrappers — its head child is the function name and is skipped). Each positional
+# parameter consumes one entry of the constructed `OpaqueClosure`'s argt (from
+# `get_oc_argtypes_for_range`, carrying the call-site argtype refinement):
+# - a simple `K"Identifier"` parameter gets that entry's type directly;
+# - a destructuring pattern (`(a, b)`, `(; a, b)`, …) is one parameter whose argt
+#   entry is the aggregate, so per-component hints come from each leaf's own range
+#   instead (`emit_destructure_var_hints!`, shared with for-loop iteration vars).
+# `Any` entries on simple parameters are skipped (an unrefined slot adds no information
+# over the bare name); user-annotated (`K"::"`) parameters are left untouched. A no-op
+# when no OC was constructed at the range (top-level methods, plain assignments), since
+# `get_oc_argtypes_for_range` returns `nothing` there.
+function emit_lambda_param_hints!(
+        inlay_hints::Vector{InlayHint}, lambda::SyntaxTreeC,
+        ctx::InferredTreeContext, fi::FileInfo, uri::URI, range::Range,
+        nontrivia_index::Vector{Int}, postprocessor::LSPostProcessor,
+        label_cache::IdDict{Any,String}, maxdepth::Int, maxwidth::Int, lazy_tooltips::Bool
+    )
+    argtypes = @something get_oc_argtypes_for_range(ctx, JS.byte_range(lambda)) return nothing
+    JS.numchildren(lambda) >= 1 || return nothing
+    sig = lambda[1]
+    # `params`: the node whose children (from `start` on) are the positional params.
+    if JS.kind(lambda) === JS.K"->"
+        if JS.kind(sig) === JS.K"Identifier" # no-paren single-parameter form
+            isempty(argtypes) || emit_lambda_param_hint!(
+                inlay_hints, sig, argtypes[1], fi, uri, range, nontrivia_index,
+                postprocessor, label_cache, maxdepth, maxwidth, lazy_tooltips)
+            return nothing
+        end
+        JS.kind(sig) === JS.K"tuple" || return nothing
+        params, start = sig, 1
+    else # `K"function"` / `K"="`
+        sig = unwrap_funcdef_sig(sig)
+        sk = JS.kind(sig)
+        if sk === JS.K"tuple"
+            params, start = sig, 1
+        elseif sk === JS.K"call"
+            params, start = sig, 2 # skip the function name
+        else
+            return nothing
+        end
+    end
+    argi = 0
+    for ci = start:JS.numchildren(params)
+        p = params[ci]
+        pk = JS.kind(p)
+        pk === JS.K"parameters" && break # keyword parameters aren't positional
+        argi += 1
+        argi <= length(argtypes) || break
+        if pk === JS.K"Identifier"
+            emit_lambda_param_hint!(
+                inlay_hints, p, argtypes[argi], fi, uri, range, nontrivia_index,
+                postprocessor, label_cache, maxdepth, maxwidth, lazy_tooltips)
+        elseif pk === JS.K"tuple" # destructuring pattern — annotate each component
+            emit_destructure_var_hints!(
+                inlay_hints, p, ctx, fi, uri, range, nontrivia_index,
+                postprocessor, label_cache, maxdepth, maxwidth, lazy_tooltips)
+        end
+    end
+    return nothing
+end
+
+function emit_lambda_param_hint!(
+        inlay_hints::Vector{InlayHint}, p::SyntaxTreeC, @nospecialize(typ),
+        fi::FileInfo, uri::URI, range::Range, nontrivia_index::Vector{Int},
+        postprocessor::LSPostProcessor, label_cache::IdDict{Any,String},
+        maxdepth::Int, maxwidth::Int, lazy_tooltips::Bool
+    )
+    typ === Any && return nothing # an unrefined slot adds nothing over the bare name
+    should_annotate_type(typ) || return nothing
+    endpos = offset_to_xy(fi, JS.last_byte(p) + 1)
+    endpos ∈ range || return nothing
+    emit_type_hint!(
+        inlay_hints, p, typ, fi, uri, nontrivia_index, endpos, postprocessor,
+        label_cache, maxdepth, maxwidth, lazy_tooltips, JS.byte_range(p))
+    return nothing
+end
+
+# Emit one hint per variable in a binding pattern, recursing through destructuring
+# forms (`(a, b)`, nested `(a, (b, c))`, property `(; a, b)`). Each leaf's type is
+# queried at its own byte range. Shared by for-loop / comprehension iteration variables
+# and by destructured closure parameters. `K"..."` (slurp) and `K"::"` (user-annotated)
+# components are left untouched.
+function emit_destructure_var_hints!(
         inlay_hints::Vector{InlayHint}, lhs::SyntaxTreeC,
         ctx::InferredTreeContext, fi::FileInfo, uri::URI, range::Range,
         nontrivia_index::Vector{Int}, postprocessor::LSPostProcessor,
@@ -500,12 +598,12 @@ function emit_for_loop_var_hints!(
     )
     k = JS.kind(lhs)
     if k === JS.K"Identifier"
-        emit_loop_var_hint!(
+        emit_destructure_var_hint!(
             inlay_hints, lhs, ctx, fi, uri, range, nontrivia_index, postprocessor,
             label_cache, maxdepth, maxwidth, lazy_tooltips)
     elseif k in JS.KSet"tuple parameters"
         for child in JS.children(lhs)
-            emit_for_loop_var_hints!(
+            emit_destructure_var_hints!(
                 inlay_hints, child, ctx, fi, uri, range, nontrivia_index, postprocessor,
                 label_cache, maxdepth, maxwidth, lazy_tooltips)
         end
@@ -513,7 +611,7 @@ function emit_for_loop_var_hints!(
     return nothing
 end
 
-function emit_loop_var_hint!(
+function emit_destructure_var_hint!(
         inlay_hints::Vector{InlayHint}, lvar::SyntaxTreeC,
         ctx::InferredTreeContext, fi::FileInfo, uri::URI, range::Range,
         nontrivia_index::Vector{Int}, postprocessor::LSPostProcessor,
@@ -574,7 +672,7 @@ end
 
 # Whether a byte range is contained in user-written syntax that should not get hints.
 in_verbatim_range(byterng::UnitRange{Int}, verbatim_ranges::Set{UnitRange{Int}}) =
-    any(rng::UnitRange{Int} -> byterng ⊆ rng, verbatim_ranges)
+    any(rng -> byterng ⊆ rng, verbatim_ranges)
 
 function emit_type_hint!(
         inlay_hints::Vector{InlayHint}, node::SyntaxTreeC, @nospecialize(typ), fi::FileInfo,

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -886,6 +886,30 @@ end
     # OC construction scaffolding shares its byte range with the user's yield expression
     # for comprehension/`map` lambdas; queries at that range should surface only the body's
     # value type. See `tmerge_at_range`.
+    # Property destructuring in parameter position (`do (; a, b)`) lowers each name to a
+    # `getproperty(obj, :a)` whose field-name `K"Symbol"` leaf lands on the binding's
+    # byte range. `tmerge_at_range` must skip it so the query yields the binding's type,
+    # not `Union{T, Symbol}`. (Assignment-position `(; a, b) = rhs` is already clean via
+    # `is_synthetic_destructure_stmt`.)
+    @testset "property-destructure parameter field-name symbol is not merged" begin
+        let code = """
+            function f(nts::Vector{@NamedTuple{a::Int, b::String}})
+                foreach(nts) do (; a, b)
+                    a, b
+                end
+            end
+            """
+            fi, ctx = type_annotate(code)
+            # Every resolved `a` / `b` (the destructured parameter and its body uses)
+            # must be the clean field type, never `Union{Int, Symbol}`. The signature
+            # annotation occurrences resolve to `nothing` and are filtered out.
+            atypes = filter(!isnothing, query_all_types(fi, ctx, "a"))
+            btypes = filter(!isnothing, query_all_types(fi, ctx, "b"))
+            @test !isempty(atypes) && all(t -> widenconst(t) === Int, atypes)
+            @test !isempty(btypes) && all(t -> widenconst(t) === String, btypes)
+        end
+    end
+
     @testset "OC construction noise at user expression byte range" begin
         @testset "comprehension with typed iterator yield" begin
             let code = "let xs = rand(3); [yld for yld::Float64 in xs]; end"

--- a/test/test_inlay_hint.jl
+++ b/test/test_inlay_hint.jl
@@ -1465,7 +1465,7 @@ end
                 """
             expected = """
                 function with_rt(xs::Vector{Float64})::Float64
-                    f(y)::Float64 = ((xs::Vector{Float64})[1]::Float64 + y::Float64)::Float64
+                    f(y::Float64)::Float64 = ((xs::Vector{Float64})[1]::Float64 + y::Float64)::Float64
                     f(2.0)::Float64
                 end
                 """
@@ -1522,8 +1522,9 @@ end
         end
 
         # No-paren `x -> body`: parameter byte range overlaps with the OC binding's
-        # `PartialOpaque` slot. Without the verbatim-range entry the parameter would pick
-        # up a misleading `x::OpaqueClosure{…}` hint.
+        # `PartialOpaque` slot, so the generic path is suppressed (it would emit a
+        # misleading `x::OpaqueClosure{…}` hint); the dedicated parameter hint reads
+        # the refined argt off the constructed OC instead.
         @testset "no-paren anonymous lambda" begin
             code = """
                 let g = x -> 2x
@@ -1531,8 +1532,184 @@ end
                 end
                 """
             expected = """
-                let g = x -> 2x::Float64
+                let g = x::Float64 -> 2x::Float64
                     g(1.0)
+                end
+                """
+            @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
+        end
+
+        # Multi-call-site lambda: the parameter hint shows the join of the observed
+        # call-site argtypes, matching the signature view the body is inferred under.
+        @testset "multi-call-site lambda parameter" begin
+            code = """
+                function genfunc(x::Float64)
+                    f = x -> 2x
+                    o1 = f(x)
+                    o2 = f(rand(Int))
+                    o1, o2
+                end
+                """
+            expected = """
+                function genfunc(x::Float64)::Tuple{Float64, $Int}
+                    f = x::Union{Float64, $Int} -> 2x::Union{Float64, $Int}
+                    o1 = f(x::Float64)::Float64
+                    o2 = f(rand(Int)::$Int)::$Int
+                    (o1::Float64, o2::$Int)::Tuple{Float64, $Int}
+                end
+                """
+            @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
+        end
+
+        # Parameter hints apply to every local-closure definition form, not just
+        # arrow lambdas: anonymous `function (…) … end`, and named local closures
+        # in both long and short form (the function name is skipped, and the
+        # return-type hint still coexists with the parameter hints).
+        @testset "anonymous function form" begin
+            code = """
+                function outer(s::String)
+                    create = function (key, val, flag::Bool)
+                        key * val
+                    end
+                    create(s, s, true)
+                end
+                """
+            expected = """
+                function outer(s::String)::String
+                    create = function (key::String, val::String, flag::Bool)
+                        (key::String * val::String)::String
+                    end
+                    create(s::String, s::String, true)::String
+                end
+                """
+            @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
+        end
+
+        @testset "named local closure (long form)" begin
+            code = """
+                function outer(s::String)
+                    function inner(key, val)
+                        key * val
+                    end
+                    inner(s, s)
+                end
+                """
+            expected = """
+                function outer(s::String)::String
+                    function inner(key::String, val::String)::String
+                        (key::String * val::String)::String
+                    end
+                    inner(s::String, s::String)::String
+                end
+                """
+            @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
+        end
+
+        @testset "named local closure (short form)" begin
+            code = """
+                function outer(s::String)
+                    inner(key, val) = key * val
+                    inner(s, s)
+                end
+                """
+            expected = """
+                function outer(s::String)::String
+                    inner(key::String, val::String)::String = (key::String * val::String)::String
+                    inner(s::String, s::String)::String
+                end
+                """
+            @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
+        end
+
+        # Top-level methods are not opaque closures, so their parameters get no
+        # call-site-refined hints (only the body uses and return type do).
+        @testset "top-level method parameters stay un-hinted" begin
+            code = """
+                function topf(key, val)
+                    key * val
+                end
+                """
+            expected = """
+                function topf(key, val)::Any
+                    (key::Any * val::Any)::Any
+                end
+                """
+            @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
+        end
+
+        # A destructuring parameter is a single closure argument, but each component
+        # is annotated from its own resolved type (consistent with for-loop iteration
+        # variable destructuring), not from the aggregate argument type.
+        @testset "destructuring parameter (plain)" begin
+            code = """
+                let ps = [1=>"a", 2=>"b"]
+                    foreach(ps) do (k, v)
+                        k, v
+                    end
+                end
+                """
+            expected = """
+                let ps = [1=>"a", 2=>"b"]::Vector{Pair{$Int, String}}
+                    foreach(ps::Vector{Pair{$Int, String}}) do (k::$Int, v::String)
+                        (k::$Int, v::String)::Tuple{$Int, String}
+                    end
+                end
+                """
+            @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
+        end
+
+        @testset "destructuring parameter (nested)" begin
+            code = """
+                let ts = [(1, (2.0, "x"))]
+                    foreach(ts) do (a, (b, c))
+                        a, b, c
+                    end
+                end
+                """
+            expected = """
+                let ts = [(1, (2.0, "x"))]::Vector{Tuple{$Int, Tuple{Float64, String}}}
+                    foreach(ts::Vector{Tuple{$Int, Tuple{Float64, String}}}) do (a::$Int, (b::Float64, c::String))
+                        (a::$Int, b::Float64, c::String)::Tuple{$Int, Float64, String}
+                    end
+                end
+                """
+            @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
+        end
+
+        # Property destructuring (`(; a, b)`) reuses each name as both a binding and a
+        # `getproperty` field-name symbol; the field-name `Symbol` must not pollute the
+        # binding's type (it would otherwise surface as `Union{Int, Symbol}`).
+        @testset "destructuring parameter (property)" begin
+            code = """
+                let nts = [(a=1, b="x")]
+                    foreach(nts) do (; a, b)
+                        a, b
+                    end
+                end
+                """
+            expected = """
+                let nts = [(a=1, b="x")]::Vector{@NamedTuple{a::$Int, b::String}}
+                    foreach(nts::Vector{@NamedTuple{a::$Int, b::String}}) do (; a::$Int, b::String)
+                        (a::$Int, b::String)::Tuple{$Int, String}
+                    end
+                end
+                """
+            @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
+        end
+
+        # A parenthesized two-parameter arrow `(a, b) -> …` is two separate parameters,
+        # not a destructuring of one — each gets its own call-site-refined type.
+        @testset "two-parameter arrow is not destructuring" begin
+            code = """
+                function f(x::Float64)
+                    g = (a, b) -> a + b
+                    g(x, 1) + g(2, 3)
+                end
+                """
+            expected = """
+                function f(x::Float64)::Float64
+                    g = (a::Union{Float64, $Int}, b::$Int) -> (a::Union{Float64, $Int} + b::$Int)::Union{Float64, $Int}
+                    (g(x::Float64, 1)::Float64 + g(2, 3))::Float64
                 end
                 """
             @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
@@ -1577,8 +1754,8 @@ end
             @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
         end
 
-        # Untyped `do x` resolves precisely via closure argument-type refinement,
-        # including `map`'s result element type.
+        # Untyped `do x` resolves precisely via closure argument-type refinement —
+        # the parameter hint, the body, and `map`'s result element type.
         @testset "untyped do-block" begin
             code = """
                 let xs = [1, 2, 3]
@@ -1589,7 +1766,7 @@ end
                 """
             @test apply_inlay_hints(code, get_type_inlay_hints(code)) == """
                 let xs = [1, 2, 3]::Vector{$Int}
-                    map(xs::Vector{$Int}) do x
+                    map(xs::Vector{$Int}) do x::$Int
                         (x::$Int * 2)::$Int
                     end::Vector{$Int}
                 end


### PR DESCRIPTION
Local-closure parameters used to get no type hints at all: their byte range is shared by the OC binding's slot, so the generic emission path was suppressed wholesale to avoid a misleading `x::OpaqueClosure{…}` label.

Emit dedicated parameter hints instead, mirroring the for-loop variable hints. A new TypeAnnotation query (`get_oc_argtypes_for_range`) reads the argument types off the `OpaqueClosure` constructed at the definition's byte range — carrying the call-site argtype refinement — and maps them positionally onto the parameter list. For example:

    function genfunc(x::Float64)
        f = x -> 2x      # f = x::Union{Float64, Int64} -> 2x
        o1 = f(x)
        o2 = f(rand(Int))
        o1, o2
    end

This covers every local-closure definition form: arrow / `do`-block lambdas, anonymous `function (…) … end`, and named local closures (`function f(…) … end` and short-form `f(…) = …`, whose signature name is skipped). Top-level methods and plain assignments construct no OC, so `get_oc_argtypes_for_range` returns nothing and they get no hint.

Destructuring parameters are annotated per component (`do (a::Int, b::String)`), reusing the for-loop destructuring emitter — so the shared helpers are renamed from `emit_for_loop_var_hints!` / `emit_loop_var_hint!` to `emit_destructure_var_hints!` / `emit_destructure_var_hint!`. A destructuring pattern is a single OC argument whose aggregate type is e.g. `Pair{…}`, so each component's type is queried at its own byte range instead of the argt entry.

Property destructuring (`(; a, b)`) in parameter position lowers each name to a `getproperty(obj, :a)` whose field-name `Symbol` lands on the binding's byte range; `tmerge_at_range` now skips that symbol when a binding slot shares the range, so the component resolves to its field type rather than `Union{T, Symbol}`. (Assignment-position `(; a, b) =` was already clean via `is_synthetic_destructure_stmt`.)

User-written parameter annotations are left untouched, and slots that remain `Any` get no hint (the bare name carries the same information).