### PR TITLE
formatting: Support range formatting for the JuliaFormatter preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - JETLS now performs correct scope resolution on identifiers used inside `@static` macrocalls, which previously could yield incorrect results in edge cases.
   Invalid `@static` usage (an unsupported expression shape, or a condition that fails to evaluate to a `Bool`) is now reported in place as `lowering/macro-expansion-error` while the code still flows through to analysis.
 
+- The `"JuliaFormatter"` preset now supports `textDocument/rangeFormatting` and `textDocument/rangesFormatting`, which previously failed with a "JuliaFormatter does not support range formatting" error. This requires [JuliaFormatter v2.7.0](https://github.com/JuliaEditorSupport/JuliaFormatter.jl/releases/tag/v2.7.0) or later. See [the formatter integration docs](https://aviatesk.github.io/JETLS.jl/release/formatting/#formatting/prerequisites) for setup.
+
 - Allows scope resolution for identifiers inside `@lock` blocks so language features distinguish bindings introduced in the protected body from surrounding bindings.
 
 - Signature help now uses LSP 3.18 `activeParameter: null` for clients that support it, so editors can avoid highlighting a stale parameter after all known keywords have already been filled.

--- a/docs/src/formatting.md
+++ b/docs/src/formatting.md
@@ -10,11 +10,10 @@ executables.
 - **Document formatting**: Format entire Julia files
   (`textDocument/formatting`)
 - **Range formatting**: Format one selected region
-  (`textDocument/rangeFormatting`; Runic and custom formatters only)
+  (`textDocument/rangeFormatting`)
 - **Multiple range formatting**: Format multiple selected regions in one
   LSP 3.18 request (`textDocument/rangesFormatting`). This is advertised only
-  when the client supports `textDocument.rangeFormatting.rangesSupport`, and is
-  available for Runic and custom formatters only.
+  when the client supports `textDocument.rangeFormatting.rangesSupport`.
 - **Progress notifications**: Visual feedback during formatting operations
   for clients that support work done progress
 
@@ -59,8 +58,9 @@ In this case, JETLS will look for the `runic` executable and use it to perform
 formatting.
 
 This is the default setting and doesn't require explicit configuration.
-Runic supports document formatting, single range formatting, and multiple
-range formatting via repeated `--lines=START:END` arguments.
+Runic supports document formatting (`textDocument/formatting`), single range
+formatting (`textDocument/rangeFormatting`), and multiple range formatting
+(`textDocument/rangesFormatting`).
 
 ### [Preset `"JuliaFormatter"`](@id formatting/configuration/juliaformatter)
 
@@ -76,9 +76,15 @@ file is found in your project, `jlfmt` will use those settings.
 Otherwise, it uses default settings with formatting options provided by the
 editor client (such as tab size) when available.
 
-!!! warning
-    Note that JuliaFormatter currently, as of v2.2.0, only supports full
-    document formatting, not range formatting or multiple range formatting.
+JuliaFormatter supports document formatting (`textDocument/formatting`), single
+range formatting (`textDocument/rangeFormatting`), and multiple range formatting
+(`textDocument/rangesFormatting`).
+
+!!! note
+    Range formatting (and multiple range formatting) requires
+    [JuliaFormatter v2.7.0](https://github.com/JuliaEditorSupport/JuliaFormatter.jl/releases/tag/v2.7.0)
+    or later, which adds the `--lines` flag to the `jlfmt` CLI.
+    Range formatting requests fail with earlier versions.
 
 ### [Custom formatter](@id formatting/configuration/custom)
 
@@ -91,14 +97,16 @@ executable_range = "/path/to/custom-range-formatter"
 Custom formatters should accept Julia code via stdin and output formatted
 code to stdout, following the same interface as `runic`:
 
-- `executable`: Command for full document formatting. The formatter should
-  read the entire Julia source code from stdin, format it completely, and
-  write the formatted result to stdout. The exit code should be 0 on success.
-- `executable_range`: Command for range formatting. The formatter should
-  accept one or more `--lines=START:END` arguments to format only the specified
-  line ranges. It should read the entire document code from stdin and write the
-  _entire document code_ to stdout with only the specified regions formatted.
-  The rest of the document must remain unchanged.
+- `executable`: Command for document formatting (`textDocument/formatting`).
+  The formatter should read the entire Julia source code from stdin, format it
+  completely, and write the formatted result to stdout. The exit code should be
+  0 on success.
+- `executable_range`: Command for single and multiple range formatting
+  (`textDocument/rangeFormatting` and `textDocument/rangesFormatting`). The
+  formatter should accept one or more `--lines=START:END` arguments to format
+  only the specified line ranges. It should read the entire document code from
+  stdin and write the _entire document code_ to stdout with only the specified
+  regions formatted. The rest of the document must remain unchanged.
 
 ## [Troubleshooting](@id formatting/troubleshooting)
 

--- a/src/formatting.jl
+++ b/src/formatting.jl
@@ -171,25 +171,16 @@ function get_formatter_executable(formatter::FormatterConfig, for_range::Bool)
                 "Unknown formatter preset \"$formatter\". " *
                 "Valid presets are: \"Runic\", \"JuliaFormatter\". " *
                 "For custom formatters, use [formatter.custom] configuration.")
-
-        if for_range && formatter == "JuliaFormatter"
-            return request_failed_error(
-                "JuliaFormatter does not support range formatting. " *
-                "Please use document formatting instead or configure a custom " *
-                "formatter with `executable_range`.")
+        additional_msg = if formatter == "JuliaFormatter"
+            install_instruction_message(executable, JULIAFORMATTER_INSTALLATION_URL)
+        elseif formatter == "Runic"
+            install_instruction_message(executable, RUNIC_INSTALLATION_URL)
         else
-            additional_msg = if formatter == "JuliaFormatter"
-                install_instruction_message(executable, JULIAFORMATTER_INSTALLATION_URL)
-            elseif formatter == "Runic"
-                install_instruction_message(executable, RUNIC_INSTALLATION_URL)
-            else
-                check_settings_message(:formatter)
-            end
-
-            exe_path = @something Sys.which(executable) return request_failed_error(
-                app_notfound_message(executable) * additional_msg)
-            return exe_path
+            check_settings_message(:formatter)
         end
+        exe_path = @something Sys.which(executable) return request_failed_error(
+            app_notfound_message(executable) * additional_msg)
+        return exe_path
     else # Custom formatter
         formatter = formatter::CustomFormatterConfig
         if for_range
@@ -426,8 +417,13 @@ function format_file(
 
     formatter_result = run_formatter(exe, text, line_ranges, uri, options, formatter)
     newText = @something formatter_result begin
-        return request_failed_error(
-            "Formatter returned an error. See server logs for details.")
+        msg = "Formatter returned an error. See server logs for details."
+        if line_ranges !== nothing && formatter == "JuliaFormatter"
+            # `jlfmt` only learned `--lines` in v2.7.0, so an older executable
+            # fails the range request; hint at the version requirement.
+            msg *= " Note that range formatting requires JuliaFormatter v2.7.0 or later."
+        end
+        return request_failed_error(msg)
     end
     edit_range = if cell_text !== nothing
         cell_range(cell_text, fi.encoding)
@@ -443,42 +439,7 @@ function run_formatter(
     )
     line_args = line_ranges === nothing ?
         String[] : ["--lines=$line_range" for line_range in line_ranges]
-    cmd = if formatter isa String
-        # Preset formatter: "Runic" or "JuliaFormatter"
-        if formatter == "Runic"
-            if isempty(line_args)
-                `$exe`
-            else
-                `$exe $(line_args)`
-            end
-        elseif formatter == "JuliaFormatter"
-            # JuliaFormatter doesn't support range formatting
-            # (should not reach here due to earlier validation)
-            if line_ranges === nothing
-                tabSize = options.tabSize
-                filepath = uri2filepath(uri)
-                if filepath !== nothing
-                    config_dir = dirname(filepath)
-                    `$exe --indent=$(Int(tabSize)) --prioritize-config-file --config-dir=$config_dir`
-                else
-                    `$exe --indent=$(Int(tabSize))`
-                end
-            else
-                return nothing
-            end
-        else # Unknown preset (should not reach here)
-            return nothing
-        end
-    else # Custom formatter
-        formatter = formatter::CustomFormatterConfig
-        # Assume custom formatters use the same interface as Runic
-        if isempty(line_args)
-            `$exe`
-        else
-            `$exe $(line_args)`
-        end
-    end
-
+    cmd = @something formatter_command(exe, line_args, uri, options, formatter) return nothing
     proc = open(cmd; read = true, write = true)
     write(proc, text)
     close(proc.in)
@@ -490,4 +451,33 @@ function run_formatter(
     ret = read(proc)
     close(proc)
     return String(ret)
+end
+
+# Build the formatter command line. `line_args` is a (possibly empty) list of
+# `--lines=START:END` arguments; when empty the whole document is formatted.
+function formatter_command(
+        exe::String, line_args::Vector{String},
+        uri::URI, options::FormattingOptions, formatter::FormatterConfig
+    )
+    if formatter isa String
+        # Preset formatter: "Runic" or "JuliaFormatter"
+        if formatter == "Runic"
+            return `$exe $(line_args)`
+        elseif formatter == "JuliaFormatter"
+            tabSize = Int(options.tabSize)
+            filepath = uri2filepath(uri)
+            if filepath !== nothing
+                config_dir = dirname(filepath)
+                return `$exe --indent=$tabSize --prioritize-config-file --config-dir=$config_dir $(line_args)`
+            else
+                return `$exe --indent=$tabSize $(line_args)`
+            end
+        else # Unknown preset (should not reach here)
+            return nothing
+        end
+    else # Custom formatter
+        formatter = formatter::CustomFormatterConfig
+        # Assume custom formatters use the same interface as Runic
+        return `$exe $(line_args)`
+    end
 end


### PR DESCRIPTION
The `"JuliaFormatter"` preset previously rejected range formatting requests with a "JuliaFormatter does not support range formatting" error. It now forwards the selected line ranges to `jlfmt` via repeated `--lines=START:END` arguments, so both
`textDocument/rangeFormatting` and `textDocument/rangesFormatting` work with this preset.

This requires JuliaFormatter v2.7.0 or later, which added the `--lines` CLI flag. When an older `jlfmt` fails a range request, the error message now hints at that version requirement.