### PR TITLE
TypeAnnotation: Annotate comprehension binding vars

### DIFF
--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -1161,17 +1161,18 @@ end
 
 """
     InferredTreeContext(
-            inferred_tree::SyntaxTreeC, st3::SyntaxTreeC,
-            surface_kind_index::Dict{UnitRange{Int},JS.Kind},
+            inferred_tree::SyntaxTreeC, ctx3::JL.VariableAnalysisContext,
+            st3::SyntaxTreeC, surface_kind_index::Dict{UnitRange{Int},JS.Kind},
             macrocall_types::Dict{UnitRange{Int},Vector{Any}}
         ) -> ctx::InferredTreeContext
 
 [`TypeAnnotation`](@ref) pipeline step 3: wrap an annotated `inferred_tree` (from
-[`infer_toplevel_tree`](@ref)) plus the post-scope-resolution `st3` (from
+[`infer_toplevel_tree`](@ref)) plus the post-scope-resolution `ctx3` / `st3` (from
 [`get_inferrable_tree`](@ref)) and provenance indexes built before pruning,
 yielding a query handle that [`get_type_for_range`](@ref) and friends can answer
 in \$O(1)\$ per call (or \$O(log N)\$ for the branching case).
 
+`ctx3` supplies closure argument binding ranges for parameter-position queries.
 `st3` (rather than the surface tree) is needed to identify byte ranges of
 *user-written* `K"return"` surface forms, which `type_for_branching` looks up
 to filter user returns out of the value type of an enclosing branching
@@ -1187,7 +1188,7 @@ as new queries demand different indexes.
 See the [`TypeAnnotation`](@ref) module docstring for the full pipeline.
 """
 function InferredTreeContext(
-        inferred_tree::SyntaxTreeC, st3::SyntaxTreeC,
+        inferred_tree::SyntaxTreeC, ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC,
         surface_kind_index::Dict{UnitRange{Int},JS.Kind},
         macrocall_types::Dict{UnitRange{Int},Vector{Any}}
     )
@@ -1217,11 +1218,12 @@ function InferredTreeContext(
 
     oc_body_scope = Dict{Int,UnitRange{Int}}()
     populate_oc_body_scope!(oc_body_scope, inferred_tree, nothing)
+    oc_argument_binding_types = collect_oc_argument_binding_types(ctx3, inferred_tree)
 
     return InferredTreeContext(
         inferred_tree, surface_kind_index, by_byte_range,
         macrocall_types, return_first_bytes, return_nodes,
-        user_return_form_ranges, oc_body_scope)
+        user_return_form_ranges, oc_body_scope, oc_argument_binding_types)
 end
 
 # The surface kinds `get_type_for_range` selects a lookup strategy for. When several
@@ -1286,6 +1288,65 @@ function populate_oc_body_scope!(
         end
     end
     return
+end
+
+function collect_oc_argument_binding_types(
+        ctx3::JL.VariableAnalysisContext, inferred_tree::SyntaxTreeC
+    )
+    oc_argtypes = collect_oc_argtypes_by_binding(inferred_tree)
+    binding_types = Dict{UnitRange{Int},Any}()
+    isempty(oc_argtypes) && return binding_types
+    lambda_ranges = collect_lambda_ranges(ctx3)
+    for binfo in ctx3.bindings.info
+        binfo.kind === :argument || continue
+        binfo.is_internal && continue
+        lambda_range = get(lambda_ranges, binfo.lambda_id, nothing)
+        lambda_range === nothing && continue
+        name = binfo.name
+        name isa AbstractString || continue
+        typ = get(oc_argtypes, (lambda_range, Symbol(name)), nothing)
+        typ === nothing && continue
+        binding = SyntaxTreeC(ctx3.graph, binfo.node_id)
+        JS.kind(binding) === JS.K"BindingId" || continue
+        binding_types[JS.byte_range(binding)] = typ
+    end
+    return binding_types
+end
+
+function collect_lambda_ranges(ctx3::JL.VariableAnalysisContext)
+    ranges = Dict{Int,UnitRange{Int}}()
+    for scope in ctx3.scopes
+        node = SyntaxTreeC(ctx3.graph, scope.node_id)
+        JS.kind(node) === JS.K"lambda" || continue
+        ranges[scope.lambda_id] = JS.byte_range(node)
+    end
+    return ranges
+end
+
+function collect_oc_argtypes_by_binding(inferred_tree::SyntaxTreeC)
+    oc_argtypes = Dict{Tuple{UnitRange{Int},Symbol},Any}()
+    traverse(inferred_tree) do st::SyntaxTreeC
+        JS.kind(st) === JS.K"new_opaque_closure" || return nothing
+        hasproperty(st, :type) || return nothing
+        entry = @something oc_argtypes_for_node(st.type, JS.byte_range(st)) return nothing
+        for i = 1:length(entry.argnames)
+            typ = entry.argtypes[i]
+            is_refined_slot(typ) || continue
+            oc_argtypes[(entry.range, entry.argnames[i])] = typ
+        end
+        return nothing
+    end
+    return oc_argtypes
+end
+
+function oc_argtypes_for_node(@nospecialize(typ), rng::UnitRange{Int})
+    typ isa CC.PartialOpaque || return nothing
+    source = typ.source
+    source isa Method || return nothing
+    argnames = (Base.method_argnames(source)[2:end]...,)
+    argtypes = @something opaque_closure_argtypes(typ) return nothing
+    length(argnames) == length(argtypes) || return nothing
+    return (; range = rng, argnames, argtypes)
 end
 
 # `st3` (not `st0`) so `K"return"`s introduced by macro expansion are picked up.
@@ -1377,7 +1438,7 @@ function build_inferred_context(
     inferred = @something infer_toplevel_tree(ctx3, st3, st0, context_module; world) return nothing
     # `JS.prune` minimizes provenance, so collect query-dispatch indexes first.
     surface_kind_index, macrocall_types = collect_provenance_indexes(inferred)
-    return InferredTreeContext(JS.prune(inferred), st3, surface_kind_index, macrocall_types)
+    return InferredTreeContext(JS.prune(inferred), ctx3, st3, surface_kind_index, macrocall_types)
 end
 
 """
@@ -1407,6 +1468,8 @@ nodes appropriately; see the source of each helper for the rationale behind its 
 | everything else                                        | `tmerge_at_range`            |
 """
 function get_type_for_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
+    binding_typ = get(ctx.oc_argument_binding_types, rng, nothing)
+    binding_typ === nothing || return binding_typ
     surface_kind = surface_kind_at_range(ctx, rng)
     if surface_kind === JS.K"macrocall"
         return type_for_macroexpansion(ctx, rng)
@@ -1670,17 +1733,22 @@ function get_oc_argtypes_for_range(ctx::InferredTreeContext, rng::UnitRange{<:In
     for st in get(ctx.by_byte_range, rng, ())
         JS.kind(st) === JS.K"new_opaque_closure" || continue
         hasproperty(st, :type) || continue
-        oc = Base.unwrap_unionall(CC.widenconst(st.type))
-        oc isa DataType || continue
-        oc.name === Base.typename(Core.OpaqueClosure) || continue
-        argt = oc.parameters[1]
-        argt isa DataType || continue
-        argt <: Tuple || continue
-        params = argt.parameters
-        any(CC.isvarargtype, params) && continue
-        return Any[params...]
+        argtypes = @something opaque_closure_argtypes(st.type) continue
+        return argtypes
     end
     return nothing
+end
+
+function opaque_closure_argtypes(@nospecialize(typ))
+    oc = Base.unwrap_unionall(CC.widenconst(typ))
+    oc isa DataType || return nothing
+    oc.name === Base.typename(Core.OpaqueClosure) || return nothing
+    argt = oc.parameters[1]
+    argt isa DataType || return nothing
+    argt <: Tuple || return nothing
+    params = argt.parameters
+    any(CC.isvarargtype, params) && return nothing
+    return Any[params...]
 end
 
 end # module TypeAnnotation

--- a/src/inlay-hint.jl
+++ b/src/inlay-hint.jl
@@ -335,7 +335,7 @@ function collect_type_inlay_hints!(
         if k in JS.KSet"-> function ="
             emit_lambda_param_hints!(
                 inlay_hints, node, ctx, fi, uri, range, nontrivia_index,
-                postprocessor, label_cache, maxdepth, maxwidth, lazy_tooltips)
+                postprocessor, emitted_ranges, label_cache, maxdepth, maxwidth, lazy_tooltips)
         end
 
         # Emit function return hints on the signature, not the full definition.
@@ -363,7 +363,8 @@ function collect_type_inlay_hints!(
             if JS.kind(spec) === JS.K"=" && JS.numchildren(spec) >= 1
                 emit_destructure_var_hints!(
                     inlay_hints, spec[1], ctx, fi, uri, range, nontrivia_index,
-                    postprocessor, label_cache, maxdepth, maxwidth, lazy_tooltips)
+                    postprocessor, emitted_ranges, label_cache, maxdepth, maxwidth,
+                    lazy_tooltips)
             end
         end
         # Emit per-variable hints and skip the comprehension lowering node.
@@ -372,7 +373,8 @@ function collect_type_inlay_hints!(
             if spec !== nothing && JS.numchildren(spec) >= 1
                 emit_destructure_var_hints!(
                     inlay_hints, spec[1], ctx, fi, uri, range, nontrivia_index,
-                    postprocessor, label_cache, maxdepth, maxwidth, lazy_tooltips)
+                    postprocessor, emitted_ranges, label_cache, maxdepth, maxwidth,
+                    lazy_tooltips)
             end
             return nothing
         end
@@ -523,7 +525,8 @@ function emit_lambda_param_hints!(
         inlay_hints::Vector{InlayHint}, lambda::SyntaxTreeC,
         ctx::InferredTreeContext, fi::FileInfo, uri::URI, range::Range,
         nontrivia_index::Vector{Int}, postprocessor::LSPostProcessor,
-        label_cache::IdDict{Any,String}, maxdepth::Int, maxwidth::Int, lazy_tooltips::Bool
+        emitted_ranges::Set{UnitRange{Int}}, label_cache::IdDict{Any,String},
+        maxdepth::Int, maxwidth::Int, lazy_tooltips::Bool
     )
     argtypes = @something get_oc_argtypes_for_range(ctx, JS.byte_range(lambda)) return nothing
     JS.numchildren(lambda) >= 1 || return nothing
@@ -563,7 +566,8 @@ function emit_lambda_param_hints!(
         elseif pk === JS.K"tuple" # destructuring pattern — annotate each component
             emit_destructure_var_hints!(
                 inlay_hints, p, ctx, fi, uri, range, nontrivia_index,
-                postprocessor, label_cache, maxdepth, maxwidth, lazy_tooltips)
+                postprocessor, emitted_ranges, label_cache, maxdepth, maxwidth,
+                lazy_tooltips)
         end
     end
     return nothing
@@ -594,18 +598,19 @@ function emit_destructure_var_hints!(
         inlay_hints::Vector{InlayHint}, lhs::SyntaxTreeC,
         ctx::InferredTreeContext, fi::FileInfo, uri::URI, range::Range,
         nontrivia_index::Vector{Int}, postprocessor::LSPostProcessor,
-        label_cache::IdDict{Any,String}, maxdepth::Int, maxwidth::Int, lazy_tooltips::Bool
+        emitted_ranges::Set{UnitRange{Int}}, label_cache::IdDict{Any,String},
+        maxdepth::Int, maxwidth::Int, lazy_tooltips::Bool
     )
     k = JS.kind(lhs)
     if k === JS.K"Identifier"
         emit_destructure_var_hint!(
             inlay_hints, lhs, ctx, fi, uri, range, nontrivia_index, postprocessor,
-            label_cache, maxdepth, maxwidth, lazy_tooltips)
+            emitted_ranges, label_cache, maxdepth, maxwidth, lazy_tooltips)
     elseif k in JS.KSet"tuple parameters"
         for child in JS.children(lhs)
             emit_destructure_var_hints!(
                 inlay_hints, child, ctx, fi, uri, range, nontrivia_index, postprocessor,
-                label_cache, maxdepth, maxwidth, lazy_tooltips)
+                emitted_ranges, label_cache, maxdepth, maxwidth, lazy_tooltips)
         end
     end
     return nothing
@@ -615,9 +620,11 @@ function emit_destructure_var_hint!(
         inlay_hints::Vector{InlayHint}, lvar::SyntaxTreeC,
         ctx::InferredTreeContext, fi::FileInfo, uri::URI, range::Range,
         nontrivia_index::Vector{Int}, postprocessor::LSPostProcessor,
-        label_cache::IdDict{Any,String}, maxdepth::Int, maxwidth::Int, lazy_tooltips::Bool,
+        emitted_ranges::Set{UnitRange{Int}}, label_cache::IdDict{Any,String},
+        maxdepth::Int, maxwidth::Int, lazy_tooltips::Bool,
     )
     byterng = JS.byte_range(lvar)
+    byterng in emitted_ranges && return nothing
     ltyp = @something get_type_for_range(ctx, byterng) return nothing
     should_annotate_type(ltyp) || return nothing
     endpos = offset_to_xy(fi, JS.last_byte(lvar) + 1)
@@ -625,6 +632,7 @@ function emit_destructure_var_hint!(
     emit_type_hint!(
         inlay_hints, lvar, ltyp, fi, uri, nontrivia_index, endpos, postprocessor,
         label_cache, maxdepth, maxwidth, lazy_tooltips, byterng)
+    push!(emitted_ranges, byterng)
     return nothing
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -83,6 +83,8 @@ struct InferredTreeContext
     # inside an outer OC body (e.g. multi-`for` comprehension, closure-of-closure) is
     # filtered when querying at the inner OC's range.
     oc_body_scope::Dict{Int,UnitRange{Int}}
+    # Refined OC argument types keyed by argument binding byte range.
+    oc_argument_binding_types::Dict{UnitRange{Int},Any}
 end
 
 const InferredContextCacheKey = Tuple{Module,UInt,UnitRange{Int}}

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -589,6 +589,10 @@ end
                     end
                     """
                     _, ctx = type_annotate(code)
+                    xrng = range_of(code, "x in")
+                    yrng = range_of(code, "y in")
+                    @test widenconst(get_type_for_range(ctx, first(xrng):first(xrng))) === Int
+                    @test widenconst(get_type_for_range(ctx, first(yrng):first(yrng))) === Float64
                     @test widenconst(get_type_for_range(ctx, range_of(code, "x + y"))) === Float64
                     @test widenconst(get_type_for_range(ctx, range_of(code, "[x + y for x in xs for y in ys]"))) === Vector{Float64}
                 end

--- a/test/test_hover.jl
+++ b/test/test_hover.jl
@@ -419,6 +419,14 @@ end
         """, "(local) y :: Int")
     end
 
+    @testset "multi-for comprehension iteration binding" begin
+        hover_test("""
+            let xs = [1, 2, 3], ys = [1.0]
+                [x + y for x in xs for y│ in ys]
+            end
+        """, "(argument) y :: Float64")
+    end
+
     @testset "closure values format as a function-arrow signature" begin
         # closures get rewritten to `Core.OpaqueClosure` by JETLS' inference
         # pipeline; surface that as `(args...) -> rt` instead of leaking the

--- a/test/test_inlay_hint.jl
+++ b/test/test_inlay_hint.jl
@@ -940,7 +940,7 @@ end
                     """
                 @test apply_inlay_hints(code, get_type_inlay_hints(code)) == """
                     let xs = rand(3)::Vector{Float64}
-                        [2x::Float64 for x in xs::Vector{Float64}]::Vector{Float64}
+                        [2x::Float64 for x::Float64 in xs::Vector{Float64}]::Vector{Float64}
                     end
                     """
             end
@@ -965,7 +965,7 @@ end
                     """
                 @test apply_inlay_hints(code, get_type_inlay_hints(code)) == """
                     let xs = [1, 2, 3]::Vector{$Int}
-                        [x for x in xs::Vector{$Int} if (x::$Int > 0)::Bool]::Vector{$Int}
+                        [x for x::$Int in xs::Vector{$Int} if (x::$Int > 0)::Bool]::Vector{$Int}
                     end
                     """
             end
@@ -978,7 +978,7 @@ end
                     """
                 @test apply_inlay_hints(code, get_type_inlay_hints(code)) == """
                     let xs = [1, 2, 3]::Vector{$Int}, ys = [1.0]::Vector{Float64}
-                        [(x::$Int + y::Float64)::Float64 for x::$Int in xs::Vector{$Int} for y in ys::Vector{Float64}]::Vector{Float64}
+                        [(x::$Int + y::Float64)::Float64 for x::$Int in xs::Vector{$Int} for y::Float64 in ys::Vector{Float64}]::Vector{Float64}
                     end
                     """
             end


### PR DESCRIPTION
Comprehension variables could be inferred precisely at use sites while remaining imprecise at their binding positions. For example, in

    [x + y for x in xs for y in ys]

`y` in `x + y` could resolve to `Float64`, but the `for y in ys` binding did not have the same type for hover or inlay hints. This was most visible for multi-`for` comprehensions, where the inner generator is represented as an opaque closure.

Fix this by mapping refined opaque-closure argument types back to the source binding ranges recorded by `ctx3`. Refined `new_opaque_closure` argument types are paired with scope-resolved closure arguments by lambda range and argument name, so the query uses binding information instead of reconstructing surface `for` syntax or relying on lowered scaffolding.

Also thread `emitted_ranges` through dedicated destructuring and iteration inlay hints. This prevents generator/filter traversal paths from emitting duplicate labels for the same binding.

Add regression coverage for direct type queries, hover, and inlay hints.