### PR TITLE
TypeAnnotation: Refine Filter predicate closures

### DIFF
--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -102,7 +102,7 @@ Untyped closure parameters (`do x`, `x -> ...`) have no declared types to feed t
 body's signature-view inference, so a single pass would annotate such bodies against
 `Tuple{Any,…}`. Instead, [`infer_toplevel_tree`](@ref) runs up to
 `MAX_OC_REFINEMENT_PASSES` inference passes: each pass records OC argtypes observed
-at calls and `Base.Generator` construction sites (`record_oc_argtype_observation!`,
+at calls and iterator adaptor construction sites (`record_oc_argtype_observation!`,
 keyed by body byte range), and the next pass substitutes the per-slot join into the
 declared-`Any` slots of the OC's argt (`refine_partial_opaque_argt`) before the eager
 body inference runs. Body
@@ -468,21 +468,23 @@ function CC.abstract_call_opaque_closure(
         si::CC.StmtInfo, sv::CC.AbsIntState, check::Bool)
 end
 
-# `Generator(f, iter)` invokes `f` as iteration advances. In nested generators,
-# such as multi-`for` comprehensions lowered through `Flatten`, that invocation is
-# mediated by iterator machinery, so the `PartialOpaque` call hook may not observe
-# it. Treat the construction as observing `f` at the iterator element type.
+# `Generator(f, iter)` and `Filter(f, iter)` invoke `f` as iteration advances. In
+# nested iterator pipelines, that invocation is mediated by iterator machinery, so
+# the `PartialOpaque` call hook may not observe it. Treat construction as observing
+# `f` at the iterator element type.
 function CC.abstract_call_gf_by_type(
         interp::ASTTypeAnnotator, @nospecialize(func), arginfo::CC.ArgInfo,
         si::CC.StmtInfo, @nospecialize(atype), sv::CC.AbsIntState, max_methods::Int
     )
-    func === Base.Generator && record_generator_argtype_observation!(interp, arginfo)
+    if func === Base.Generator || func === Base.Iterators.Filter
+        record_iterator_argtype_observation!(interp, arginfo)
+    end
     return @invoke CC.abstract_call_gf_by_type(
         interp::CC.AbstractInterpreter, func::Any, arginfo::CC.ArgInfo,
         si::CC.StmtInfo, atype::Any, sv::CC.AbsIntState, max_methods::Int)
 end
 
-function record_generator_argtype_observation!(
+function record_iterator_argtype_observation!(
         interp::ASTTypeAnnotator, arginfo::CC.ArgInfo
     )
     argtypes = arginfo.argtypes

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -580,8 +580,8 @@ end
                 end
             end
 
-            # A multi-`for` comprehension lowers to nested generator closures.
-            # Requires `record_generator_argtype_observation!`'s synthetic observation recording.
+            # A multi-`for` comprehension lowers to nested iterator closures.
+            # Requires synthetic observations at iterator adaptor construction sites.
             @testset "multi-`for` comprehension inner variable" begin
                 let code = """
                     let xs = [1, 2, 3], ys = [1.0]
@@ -595,6 +595,18 @@ end
                     @test widenconst(get_type_for_range(ctx, first(yrng):first(yrng))) === Float64
                     @test widenconst(get_type_for_range(ctx, range_of(code, "x + y"))) === Float64
                     @test widenconst(get_type_for_range(ctx, range_of(code, "[x + y for x in xs for y in ys]"))) === Vector{Float64}
+                end
+
+                let code = """
+                    let xs = [1, 2, 3], ys = [1.0, -1.0]
+                        [x + y for x in xs for y in ys if y > 0]
+                    end
+                    """
+                    _, ctx = type_annotate(code)
+                    crng = range_of(code, " y > 0")
+                    @test widenconst(get_type_for_range(
+                        ctx, (first(crng)+1):(first(crng)+1))) === Float64
+                    @test widenconst(get_type_for_range(ctx, crng)) === Bool
                 end
             end
 

--- a/test/test_hover.jl
+++ b/test/test_hover.jl
@@ -427,6 +427,14 @@ end
         """, "(argument) y :: Float64")
     end
 
+    @testset "multi-for comprehension filter variable" begin
+        hover_test("""
+            let xs = [1, 2, 3], ys = [1.0, -1.0]
+                [x + y for x in xs for y in ys if y│ > 0]
+            end
+        """, "(argument) y :: Float64")
+    end
+
     @testset "closure values format as a function-arrow signature" begin
         # closures get rewritten to `Core.OpaqueClosure` by JETLS' inference
         # pipeline; surface that as `(args...) -> rt` instead of leaking the

--- a/test/test_inlay_hint.jl
+++ b/test/test_inlay_hint.jl
@@ -982,6 +982,19 @@ end
                     end
                     """
             end
+
+            # `if cond` on an inner generator adds a filter predicate OC.
+            let code = """
+                    let xs = [1, 2, 3], ys = [1.0, -1.0]
+                        [x + y for x in xs for y in ys if y > 0]
+                    end
+                    """
+                @test apply_inlay_hints(code, get_type_inlay_hints(code)) == """
+                    let xs = [1, 2, 3]::Vector{$Int}, ys = [1.0, -1.0]::Vector{Float64}
+                        [(x::$Int + y::Float64)::Float64 for x::$Int in xs::Vector{$Int} for y::Float64 in ys::Vector{Float64} if (y::Float64 > 0)::Bool]::Vector{Float64}
+                    end
+                    """
+            end
         end
 
         @testset "typed iter var" begin


### PR DESCRIPTION
Filtered multi-`for` comprehensions could infer an iteration variable at the binding and yield positions while leaving the same variable as `Any` inside the filter predicate. For example:

    [x + y for x in xs for y in ys if y > 0]

`y` in `x + y` could be `Float64`, but `y` in `y > 0` stayed imprecise.

Treat `Base.Iterators.Filter(f, iter)` construction like `Base.Generator(f, iter)` for closure-argument refinement. The construction records a synthetic observation of `f` at the iterator upper-bound element type, so the predicate opaque closure is re-inferred with the same argument type as the filtered iterator elements.

Regression tests cover direct type queries, inlay hints, and hover for filtered multi-`for` comprehensions.