### PR TITLE
code-action: Add a type annotation code view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added a macro expansion view that shows expanded macro code in a read-only document — served through the LSP 3.18 `workspace/textDocumentContent` request, or a temporary-file fallback for clients without that capability. It is triggered through code actions: one expands the macro call under the cursor, and one recursively expands every macro in the enclosing top-level form.
   See the [Macro expansion code view](https://aviatesk.github.io/JETLS.jl/release/features/#features/code-views/macro-expansion) page for details.
 
+- Added a type annotation view that shows a top-level form with its inferred types applied as explicit `::T` annotations in a read-only document — served through the LSP 3.18 `workspace/textDocumentContent` request, or a temporary-file fallback for clients without that capability. It is triggered through a code action on the enclosing top-level form.
+  See the [Type annotation code view](https://aviatesk.github.io/JETLS.jl/release/features/#features/code-views/type-annotations) page for details.
+
 - Added [`lowering/inactive-code`](https://aviatesk.github.io/JETLS.jl/release/diagnostic/#diagnostic/reference/lowering/inactive-code) diagnostic that marks `@static` branches not taken in the current environment (e.g. a Windows-only branch when analyzing on macOS) at `Hint` severity with the `Unnecessary` tag, so editors gray out code that is excluded from analysis.
 
 - Added [`lowering/unconstrained-static-parameter`](https://aviatesk.github.io/JETLS.jl/release/diagnostic/#diagnostic/reference/lowering/unconstrained-static-parameter) diagnostic that warns when a method declares a static parameter that does not appear in the type of any function parameter, so its value cannot be deduced when the method is called.

--- a/docs/src/features.md
+++ b/docs/src/features.md
@@ -831,6 +831,8 @@ JETLS provides code actions for quick fixes and refactoring, including:
   [TestRunner code actions](@ref testrunner/features/code-actions)
 - Expand macro calls via
   [macro expansion views](@ref features/code-views/macro-expansion)
+- View inferred types as
+  [type annotations](@ref features/code-views/type-annotations)
 
 A few representative examples:
 
@@ -972,6 +974,64 @@ To read like hand-written code, the view trims hygiene noise: it strips
 context (or to an exported `Base`/`Core` name) as bare symbols (so the
 expansions above show `throw`/`AssertionError`, not `Base.throw`). If
 expansion throws, the error trace is shown instead.
+
+### [Type annotations](@id features/code-views/type-annotations)
+
+**Show inferred type annotations** opens a read-only view of the enclosing
+top-level form with JETLS's [type inlay hints](@ref features/inlay-hint/types)
+spliced into the source as explicit `::T` annotations — every expression
+(parameter uses, intermediate results, the return value) carries its inferred
+type. Unlike the inline hints, which are transient editor decorations, the
+result is an annotated copy of the code as ordinary buffer text: you can
+select, scroll, search, and copy it like any other document.
+
+For example, consider this function:
+
+```julia
+function summarize(xs::Vector{Int}, label)
+    total = sum(xs)
+    first_pos_even = findfirst(xs) do x
+        x > 0 && iseven(x)
+    end
+    sample = if first_pos_even === nothing
+        missing
+    else
+        xs[first_pos_even]
+    end
+    return (
+        label,
+        total,
+        sample,
+    )
+end
+```
+
+The resulting annotated copy surfaces several related inference results at
+once: the do-block argument `x` is inferred as `Int64`, the predicate
+expression as `Bool`, `findfirst` returns `Union{Nothing, Int64}`, the `else`
+branch narrows the index to `Int64`, and the untyped `label` propagates to the
+final `Tuple{Any, Int64, Union{Missing, Int64}}` return type:
+
+```julia
+# Inferred type annotations at summary.jl:1
+
+function summarize(xs::Vector{Int}, label)::Tuple{Any, Int64, Union{Missing, Int64}}
+    total = sum(xs::Vector{Int64})::Int64
+    first_pos_even = findfirst(xs::Vector{Int64}) do x::Int64
+        ((x::Int64 > 0)::Bool && iseven(x::Int64)::Bool)::Bool
+    end::Union{Nothing, Int64}
+    sample = if (first_pos_even::Union{Nothing, Int64} === nothing)::Bool
+        missing
+    else
+        (xs::Vector{Int64})[first_pos_even::Int64]::Int64
+    end::Union{Missing, Int64}
+    return (
+        label::Any,
+        total::Int64,
+        sample::Union{Missing, Int64},
+    )::Tuple{Any, Int64, Union{Missing, Int64}}
+end
+```
 
 ## [Formatting](@id features/formatting)
 

--- a/src/code-action.jl
+++ b/src/code-action.jl
@@ -64,6 +64,7 @@ function handle_CodeActionRequest(
             fi = result
             testrunner_code_actions!(code_actions, uri, fi, msg.params.range)
             macro_expansion_code_actions!(code_actions, server, uri, fi, msg.params.range)
+            type_annotation_code_actions!(code_actions, server, uri, fi, msg.params.range)
         end
         # When the file info is unavailable (`isnothing(result)`), skip the kindless actions
         # but still return any quickfix actions accumulated above, since those are derived
@@ -94,26 +95,42 @@ function macro_expansion_code_actions!(
     # `@doc` (a docstring) wraps the whole documented form; its expansion is just
     # doc-registration machinery, so don't offer it as a macro view.
     if macrocall !== nothing && !is_doc0_any(macrocall)
-        push_macro_expansion_action!(code_actions,
+        push_code_view_action!(code_actions, COMMAND_OPEN_MACRO_EXPANSION,
             "Show macro expansion for `$(macrocall_name(macrocall))`",
             macro_expansion_content_uri(uri, macrocall))
     end
     toplevel = lowerable_toplevel_at(st0_top, first(byte_range))
     if toplevel !== nothing && toplevel_contains_macrocall(toplevel)
-        push_macro_expansion_action!(code_actions,
+        push_code_view_action!(code_actions, COMMAND_OPEN_MACRO_EXPANSION,
             "Expand all macros in this top-level form",
             macro_expansion_content_uri(uri, toplevel; toplevel=true))
     end
     return code_actions
 end
 
-function push_macro_expansion_action!(
-        code_actions::Vector{Union{CodeAction,Command}}, title::String, content_uri::URI)
+# Offer on any lowerable top-level form that type-annotation features do not skip.
+# No annotations appear if nothing was inferred (e.g. a literal-bound assignment).
+function type_annotation_code_actions!(
+        code_actions::Vector{Union{CodeAction,Command}}, server::Server, uri::URI,
+        fi::FileInfo, range::Range
+    )
+    supports(server, :window, :showDocument, :support) || return code_actions
+    st0_top = build_syntax_tree(fi)
+    byte_range = range_to_byte_range(fi, range; collapse_empty = true)
+    tree = @something lowerable_toplevel_at(st0_top, first(byte_range)) return code_actions
+    is_type_annotation_skipped_toplevel(tree) && return code_actions
+    push_code_view_action!(code_actions, COMMAND_OPEN_TYPE_ANNOTATION,
+        "Show inferred type annotations", type_annotation_content_uri(uri, tree))
+    return code_actions
+end
+
+function push_code_view_action!(
+        code_actions::Vector{Union{CodeAction,Command}},
+        command::String, title::String, content_uri::URI)
     push!(code_actions, CodeAction(;
         title,
         command = Command(;
-            title,
-            command = COMMAND_OPEN_MACRO_EXPANSION,
+            title, command,
             arguments = Any[string(content_uri)])))
     return code_actions
 end

--- a/src/code-views.jl
+++ b/src/code-views.jl
@@ -234,3 +234,91 @@ function request_open_macro_expansion(server::Server, content_uri::URI)
         #=label=# "macro expansion", #=tempfile_name=# "macro-expanded.jl",
         ProduceText(() -> macro_expansion_text(server, content_uri)))
 end
+
+# Type annotation view
+# --------------------
+# Renders a lowerable top-level form with JETLS's type inlay hints spliced into
+# the source as explicit `::T` annotations, so the inferred types read inline.
+# The URI encodes the source document and the form's byte range.
+
+const TYPE_ANNOTATION_CONTENT_PATH = "/type-annotated.jl"
+
+function type_annotation_content_uri(source_uri::URI, tree::SyntaxTreeC)
+    range = JS.byte_range(tree)
+    query = join((
+        "source=$(LSP.URIs2.escapeuri(string(source_uri)))",
+        "start=$(first(range))",
+        "stop=$(last(range))",
+    ), '&')
+    return URI(;
+        scheme = TYPE_ANNOTATION_SCHEME,
+        path = TYPE_ANNOTATION_CONTENT_PATH,
+        query)
+end
+
+function collect_type_annotation_hints(
+        state::ServerState, fi::FileInfo, uri::URI, tree::SyntaxTreeC
+    )
+    startpos = offset_to_xy(fi, JS.first_byte(tree))
+    endpos = offset_to_xy(fi, JS.last_byte(tree) + 1)
+    tree_range = Range(; start = startpos, var"end" = endpos)
+    (; context_module, postprocessor, world) = get_context_info(state, uri, startpos)
+    ctx = @something build_inferred_context_for_tree(tree, context_module;
+        world, caller="type_annotation", cache=fi.inferred_context_cache) return nothing
+    hints = InlayHint[]
+    # Unlike the glanceable inline hints, a written-out view shows the full
+    # inferred type rather than a `…`-clipped one, so truncation is disabled.
+    # Only the labels are spliced in, so `lazy_tooltips=true` skips the otherwise
+    # eager (and here discarded) tooltip formatting.
+    collect_type_inlay_hints!(hints, tree, ctx, fi, uri, tree_range, postprocessor;
+        maxdepth = typemax(Int), maxwidth = typemax(Int), lazy_tooltips = true)
+    return hints
+end
+
+function type_annotation_text(server::Server, content_uri::URI)
+    params = parse_text_document_content_query(content_uri)
+    source = @something get(params, "source", nothing) begin
+        return "Missing `source` parameter.\n"
+    end
+    start = @something tryparse(Int, get(params, "start", "")) begin
+        return "Invalid `start` parameter.\n"
+    end
+    stop = @something tryparse(Int, get(params, "stop", "")) begin
+        return "Invalid `stop` parameter.\n"
+    end
+    source_uri = URI(source)
+    fi = @something get_file_info(server.state, source_uri) begin
+        return "Source document is not available: $(string(source_uri))\n"
+    end
+    st0_top = build_syntax_tree(fi)
+    tree = @something find_toplevel_tree_by_range(st0_top, start:stop) begin
+        return "Top-level form is no longer available: $(string(source_uri))\n"
+    end
+    line = Int(offset_to_xy(fi, JS.first_byte(tree)).line) + 1
+    src = JS.sourcetext(tree)
+    hints = @something try
+        collect_type_annotation_hints(server.state, fi, source_uri, tree)
+    catch
+        nothing
+    end begin
+        io = IOBuffer()
+        println(io, "# Failed to infer type annotations at ", fi.filename, ":", line)
+        println(io)
+        print(io, src)
+        endswith(src, '\n') || println(io)
+        return String(take!(io))
+    end
+    annotated = apply_inlay_hints(fi, src, JS.first_byte(tree), hints)
+    io = IOBuffer()
+    println(io, "# Inferred type annotations at ", fi.filename, ":", line)
+    println(io)
+    print(io, annotated)
+    endswith(annotated, '\n') || println(io)
+    return String(take!(io))
+end
+
+function request_open_type_annotation(server::Server, content_uri::URI)
+    return open_text_document_content!(server, content_uri,
+        #=label=# "type annotations", #=tempfile_name=# "type-annotated.jl",
+        ProduceText(() -> type_annotation_text(server, content_uri)))
+end

--- a/src/execute-command.jl
+++ b/src/execute-command.jl
@@ -7,6 +7,7 @@ const COMMAND_TESTRUNNER_CLEAR_RESULT = "jetls.testrunner.clearResult"
 const COMMAND_TESTRUNNER_OPEN_LOGS = "jetls.testrunner.openLogs"
 const COMMAND_SHOW_MESSAGE = "jetls.showMessage"
 const COMMAND_OPEN_MACRO_EXPANSION = "jetls.openMacroExpansion"
+const COMMAND_OPEN_TYPE_ANNOTATION = "jetls.openTypeAnnotation"
 
 const SUPPORTED_COMMANDS = [
     COMMAND_TESTRUNNER_RUN_TESTSET,
@@ -15,6 +16,7 @@ const SUPPORTED_COMMANDS = [
     COMMAND_TESTRUNNER_CLEAR_RESULT,
     COMMAND_SHOW_MESSAGE,
     COMMAND_OPEN_MACRO_EXPANSION,
+    COMMAND_OPEN_TYPE_ANNOTATION,
 ]
 
 function execute_command_options()
@@ -50,6 +52,8 @@ function handle_ExecuteCommandRequest(server::Server, msg::ExecuteCommandRequest
         return execute_show_message_command(server, msg)
     elseif command == COMMAND_OPEN_MACRO_EXPANSION
         return execute_open_macro_expansion_command(server, msg)
+    elseif command == COMMAND_OPEN_TYPE_ANNOTATION
+        return execute_open_type_annotation_command(server, msg)
     end
     return send(server,
         invalid_execute_command_response(msg, "Unknown execution command: $command"))
@@ -147,6 +151,12 @@ end
 function execute_open_macro_expansion_command(server::Server, msg::ExecuteCommandRequest)
     uri = URI(@tryparsearg server msg[1]::String)
     request_open_macro_expansion(server, uri)
+    return send(server, ExecuteCommandResponse(; id = msg.id, result = null))
+end
+
+function execute_open_type_annotation_command(server::Server, msg::ExecuteCommandRequest)
+    uri = URI(@tryparsearg server msg[1]::String)
+    request_open_type_annotation(server, uri)
     return send(server, ExecuteCommandResponse(; id = msg.id, result = null))
 end
 

--- a/src/inlay-hint.jl
+++ b/src/inlay-hint.jl
@@ -780,3 +780,33 @@ function resolve_inlay_hint(
     tooltip = format_type_inlay_hint_tooltip(rawtyp, postprocessor)
     return InlayHint(hint; tooltip)
 end
+
+# Render `hints` into `src` — the source spanning `base_byte:…` of `fi` — by
+# inserting each hint's label (with any padding) at the byte offset it points
+# at, and return the annotated text. Shared by the type-annotation code view
+# and the inlay-hint tests; only `String` labels are spliced.
+function apply_inlay_hints(
+        fi::FileInfo, src::AbstractString, base_byte::Integer, hints::Vector{InlayHint}
+    )
+    inserts = Tuple{Int,String}[]
+    for hint in hints
+        hint.label isa String || continue
+        offset = xy_to_offset(fi, hint.position) - base_byte + 1
+        1 ≤ offset ≤ ncodeunits(src) + 1 || continue
+        text = hint.label
+        something(hint.paddingLeft, false) && (text = " " * text)
+        something(hint.paddingRight, false) && (text = text * " ")
+        push!(inserts, (offset, text))
+    end
+    isempty(inserts) && return String(src)
+    sort!(inserts; by=first)
+    io = IOBuffer()
+    prev = 1
+    for (offset, text) in inserts
+        print(io, SubString(src, prev, prevind(src, offset)))
+        print(io, text)
+        prev = offset
+    end
+    print(io, SubString(src, prev))
+    return String(take!(io))
+end

--- a/src/text-document-content.jl
+++ b/src/text-document-content.jl
@@ -3,11 +3,16 @@ const TEXT_DOCUMENT_CONTENT_REGISTRATION_METHOD = "workspace/textDocumentContent
 
 # Each `workspace/textDocumentContent` view gets its own scheme so document selectors
 # can enable language features per view: TestRunner logs need none, while Julia-code
-# views (macro expansion, and future `code_typed`, type annotations, …) can opt into
+# views (macro expansion, type annotations, and future `code_typed`, …) can opt into
 # semantic tokens, go-to-definition, etc. New views add their scheme here.
 const TESTRUNNER_LOGS_SCHEME = "jetls-testrunner-logs"
 const MACRO_EXPANSION_SCHEME = "jetls-macro-expansion"
-const TEXT_DOCUMENT_CONTENT_SCHEMES = String[TESTRUNNER_LOGS_SCHEME, MACRO_EXPANSION_SCHEME]
+const TYPE_ANNOTATION_SCHEME = "jetls-type-annotation"
+const TEXT_DOCUMENT_CONTENT_SCHEMES = String[
+    TESTRUNNER_LOGS_SCHEME,
+    MACRO_EXPANSION_SCHEME,
+    TYPE_ANNOTATION_SCHEME,
+]
 
 is_text_document_content_uri(uri::URI) = uri.scheme in TEXT_DOCUMENT_CONTENT_SCHEMES
 
@@ -103,9 +108,13 @@ function handle_TextDocumentContentRequest(server::Server, msg::TextDocumentCont
     if !is_text_document_content_uri(uri)
         return send(server, TextDocumentContentResponse(; id = msg.id, result = null))
     end
+    # Code views are computed on demand from the request URI rather than cached.
     if uri.scheme == MACRO_EXPANSION_SCHEME
-        # Computed on demand from the request URI rather than served from the cache.
         text = macro_expansion_text(server, uri)
+        return send(server, TextDocumentContentResponse(;
+            id = msg.id, result = TextDocumentContentResult(; text)))
+    elseif uri.scheme == TYPE_ANNOTATION_SCHEME
+        text = type_annotation_text(server, uri)
         return send(server, TextDocumentContentResponse(;
             id = msg.id, result = TextDocumentContentResult(; text)))
     end

--- a/test/test_code_views.jl
+++ b/test/test_code_views.jl
@@ -37,6 +37,16 @@ function toplevel_expansion_testcase(text::AbstractString)
     return (; server, uri, fi, tree, content_uri)
 end
 
+function type_annotation_testcase(text::AbstractString)
+    server = server_with_show_document_support()
+    uri = filepath2uri(joinpath(pkgdir(JETLS), "test", "annotate_testcase.jl"))
+    fi = JETLS.cache_file_info!(server, uri, 1, text)
+    st0 = JETLS.build_syntax_tree(fi)
+    tree = @something JETLS.lowerable_toplevel_at(st0, 1) error("missing toplevel tree")
+    content_uri = JETLS.type_annotation_content_uri(uri, tree)
+    return (; server, uri, fi, tree, content_uri)
+end
+
 @testset "macro expansion content" begin
     let case = macroexpand_testcase("@time 1 + 2\n")
         content_uri = JETLS.URI(string(case.content_uri))
@@ -194,6 +204,65 @@ end
         titles = String[a.title for a in actions]
         @test "Expand all macros in this top-level form" in titles
         @test !has_callsite(actions)
+    end
+end
+
+@testset "type annotation content" begin
+    let case = type_annotation_testcase("function f(a, b)\n    return a + b\nend\n")
+        content_uri = JETLS.URI(string(case.content_uri))
+        params = JETLS.parse_text_document_content_query(content_uri)
+        @test params["source"] == string(case.uri)
+
+        text = JETLS.type_annotation_text(case.server, content_uri)
+        @test occursin("Inferred type annotations", text)
+        @test occursin("annotate_testcase.jl:1", text)
+        # the original source is preserved; annotations are spliced in additively
+        @test occursin("function f(a, b)", text)
+        # untyped parameters infer to `Any`, applied as `::Any`
+        @test occursin("::Any", text)
+    end
+
+    let case = type_annotation_testcase("@__undefined_macro_for_test__ xyz\n")
+        content_uri = JETLS.URI(string(case.content_uri))
+        text = JETLS.type_annotation_text(case.server, content_uri)
+        @test occursin("Failed to infer type annotations", text)
+        @test occursin("annotate_testcase.jl:1", text)
+        @test occursin("@__undefined_macro_for_test__ xyz", text)
+    end
+end
+
+@testset "type annotation code action" begin
+    let case = type_annotation_testcase("function f(a, b)\n    return a + b\nend\n")
+        actions = Union{CodeAction,Command}[]
+        range = Range(;
+            start = Position(; line = 0, character = 0),
+            var"end" = Position(; line = 0, character = 0))
+        JETLS.type_annotation_code_actions!(
+            actions, case.server, case.uri, case.fi, range)
+        titles = String[a.title for a in actions]
+        action = actions[findfirst(==("Show inferred type annotations"), titles)]
+        @test action.command.command == JETLS.COMMAND_OPEN_TYPE_ANNOTATION
+        @test only(action.command.arguments) == string(case.content_uri)
+    end
+    full_range() = Range(;
+        start = Position(; line = 0, character = 0),
+        var"end" = Position(; line = 0, character = 0))
+    # not offered on declaration forms with no inferable values
+    for code in ("using Base\n", "import Base: map\n", "export foo, bar\n",
+                 "public baz\n", "abstract type A end\n", "primitive type P 8 end\n")
+        case = type_annotation_testcase(code)
+        actions = Union{CodeAction,Command}[]
+        JETLS.type_annotation_code_actions!(
+            actions, case.server, case.uri, case.fi, full_range())
+        @test isempty(actions)
+    end
+    # still offered on `struct` (inner constructors have inferable bodies)
+    let case = type_annotation_testcase(
+            "struct Point\n    x::Int\n    Point(x::Int) = new(x + 1)\nend\n")
+        actions = Union{CodeAction,Command}[]
+        JETLS.type_annotation_code_actions!(
+            actions, case.server, case.uri, case.fi, full_range())
+        @test "Show inferred type annotations" in String[a.title for a in actions]
     end
 end
 

--- a/test/test_inlay_hint.jl
+++ b/test/test_inlay_hint.jl
@@ -8,34 +8,11 @@ using JETLS.URIs2
 include(normpath(pkgdir(JETLS), "test", "setup.jl"))
 include(normpath(pkgdir(JETLS), "test", "jsjl-utils.jl"))
 
-# Inserts each `hint.label` at its `position` in `code` and returns the
-# resulting text, mirroring how an editor renders the hint (honouring
-# `paddingLeft` / `paddingRight`). ASCII-only — LSP `Position.character` is
-# treated as a byte index into the line. Hints on the same position are
-# inserted in their original (traversal) order.
+# Render `hints` into `code` via the shared `JETLS.apply_inlay_hints` helper
+# (the whole document starts at byte 1).
 function apply_inlay_hints(code::AbstractString, hints::Vector{InlayHint})
-    by_line = Dict{Int,Vector{InlayHint}}()
-    for h in hints
-        push!(get!(() -> InlayHint[], by_line, h.position.line), h)
-    end
-    out = IOBuffer()
-    lines = split(code, '\n'; keepempty=true)
-    for (i, line) in enumerate(lines)
-        s = String(line)
-        line_hints = sort(get(by_line, i-1, InlayHint[]); by = h -> h.position.character)
-        cursor = 0
-        for h in line_hints
-            c = h.position.character
-            print(out, s[cursor+1:c])
-            something(h.paddingLeft, false) && print(out, ' ')
-            print(out, h.label)
-            something(h.paddingRight, false) && print(out, ' ')
-            cursor = c
-        end
-        print(out, s[cursor+1:end])
-        i < length(lines) && print(out, '\n')
-    end
-    return String(take!(out))
+    fi = JETLS.FileInfo(1, code, @__FILE__)
+    return JETLS.apply_inlay_hints(fi, code, 1, hints)
 end
 
 function get_syntactic_inlay_hints(


### PR DESCRIPTION
Add a "Show inferred type annotations" code action on any lowerable top-level form. It opens a read-only view of the form with JETLS's inferred types spliced into the source as explicit `::T` annotations — parameter uses, intermediate results, and the return value — so the inferred types can be read inline without hovering.

The view reuses the type-inlay-hint machinery: it collects the same hints (with truncation disabled for full types) and splices their labels into the form's source via a shared `apply_inlay_hints` helper, now also used by the inlay-hint tests. It is served through the existing code-view infrastructure (`jetls-type-annotation` scheme, `textDocumentContent` with a temp-file fallback).