### PR TITLE
inlay-hint: Type inlay hint enhancements

### DIFF
--- a/src/inlay-hint.jl
+++ b/src/inlay-hint.jl
@@ -317,6 +317,10 @@ function collect_type_inlay_hints!(
         if JS.kind(node) in JS.KSet"using import"
             push!(verbatim_ranges, JS.byte_range(node))
         end
+        # `K"inert"` wraps literal symbol contents and dot-property names.
+        if JS.kind(node) === JS.K"inert"
+            push!(verbatim_ranges, JS.byte_range(node))
+        end
     end
 
     traverse(st0, #=postorder=#true) do node::SyntaxTreeC
@@ -398,7 +402,7 @@ function collect_type_inlay_hints!(
         k !== JS.K"macrocall" && byterng in callee_ranges && return nothing
         typ = get_type_for_range(ctx, byterng)
         typ === nothing && return nothing
-        should_annotate_type(typ) || return nothing
+        should_annotate_type(node, typ) || return nothing
 
         # Wrap forms where `::T` would otherwise bind to the wrong expression,
         # or where trailing field/index access must stay outside the assertion.
@@ -487,7 +491,34 @@ function funcdef_sig_range(funcdef::SyntaxTreeC)
     return JS.byte_range(sig)
 end
 
-should_annotate_type(@nospecialize(typ)) = !(typ isa Core.Const)
+function should_annotate_type(node::SyntaxTreeC, @nospecialize(typ))
+    typ isa Core.Const || return true
+    val = typ.val
+    is_const_literal_node(node, val) && return false
+    is_const_binding_value(val) && return false
+    return true
+end
+
+function is_const_literal_node(node::SyntaxTreeC, @nospecialize(val))
+    k = JS.kind(node)
+    JS.is_literal(k) && return true
+    k === JS.K"inert" && return true
+    if k === JS.K"Identifier"
+        name = get_name_val(node)
+        if name isa String
+            return identifier_spells_const_value(name, val)
+        end
+    end
+    return false
+end
+
+function identifier_spells_const_value(name::String, @nospecialize val)
+    return (name == "nothing" && val === nothing) ||
+        (name == "missing" && val === missing)
+end
+
+is_const_binding_value(@nospecialize val) =
+    val isa Type || val isa Function || val isa Module
 
 # Register both variables and destructuring wrappers so the regular postorder
 # pass doesn't emit duplicate or wrapper-level iteration hints.
@@ -578,7 +609,7 @@ function emit_lambda_param_hint!(
         maxdepth::Int, maxwidth::Int, lazy_tooltips::Bool
     )
     typ === Any && return nothing # an unrefined slot adds nothing over the bare name
-    should_annotate_type(typ) || return nothing
+    should_annotate_type(p, typ) || return nothing
     endpos = offset_to_xy(fi, JS.last_byte(p) + 1)
     endpos ∈ range || return nothing
     emit_type_hint!(
@@ -624,7 +655,7 @@ function emit_destructure_var_hint!(
     byterng = JS.byte_range(lvar)
     byterng in emitted_ranges && return nothing
     ltyp = @something get_type_for_range(ctx, byterng) return nothing
-    should_annotate_type(ltyp) || return nothing
+    should_annotate_type(lvar, ltyp) || return nothing
     endpos = offset_to_xy(fi, JS.last_byte(lvar) + 1)
     endpos ∈ range || return nothing
     emit_type_hint!(

--- a/src/inlay-hint.jl
+++ b/src/inlay-hint.jl
@@ -739,10 +739,10 @@ function emit_type_hint!(
         truncate_typstr(postprocessor(typstr), maxdepth, maxwidth)
     end
     tooltip = data = nothing
-    if lazy_tooltips && should_lazy_resolve_tooltip(rawtyp)
+    if lazy_tooltips && should_lazy_resolve_tooltip(typ, rawtyp)
         data = LSP.TypeInlayHintData(uri, fi.version, first(type_range), last(type_range))
     else
-        tooltip = format_type_inlay_hint_tooltip(rawtyp, postprocessor)
+        tooltip = format_type_inlay_hint_tooltip(typ, postprocessor)
     end
     push!(inlay_hints, InlayHint(;
         position = endpos,
@@ -762,11 +762,12 @@ function first_token_byte(node::SyntaxTreeC, nontrivia_index::Vector{Int})
     return nontrivia_index[idx]
 end
 
-# Lazy tooltip resolution avoids allocating full `show` output for complex types,
-# but serializing `TypeInlayHintData` is more expensive than sending short
-# tooltips. Keep simple scalar-like types eager and defer parameterized, alias,
-# union, and other potentially expensive type displays.
-function should_lazy_resolve_tooltip(@nospecialize rawtyp)
+# Lazy tooltip resolution avoids allocating full `show` output for complex types
+# and extended lattice elements, but serializing `TypeInlayHintData` is more
+# expensive than sending short tooltips. Keep simple scalar-like types eager and
+# defer parameterized, alias, union, and other potentially expensive displays.
+function should_lazy_resolve_tooltip(@nospecialize(typ), @nospecialize(rawtyp))
+    typ !== rawtyp && return true
     rawtyp === Union{} && return false
     rawtyp isa DataType && isempty(rawtyp.parameters) && return false
     rawtyp isa TypeVar && return false
@@ -774,14 +775,31 @@ function should_lazy_resolve_tooltip(@nospecialize rawtyp)
 end
 
 # Explain `Union{}` hints, which otherwise look like obscure valid syntax.
-function format_type_inlay_hint_tooltip(@nospecialize(rawtyp), postprocessor::LSPostProcessor)
+function format_type_inlay_hint_tooltip(
+        @nospecialize(typ), postprocessor::LSPostProcessor;
+        include_lattice::Bool = false
+    )
+    rawtyp = CC.widenconst(typ)
     if rawtyp === Union{}
         value = "`Union{}` — this expression provably never produces a value (always throws, or is unreachable)."
     else
         full_typstr = postprocessor(sprint(show, rawtyp))
         value = "```julia\n$full_typstr\n```"
     end
+    if include_lattice && typ !== rawtyp
+        value *= "\n\n---\n\n" * format_lattice_element_detail(typ)
+    end
     return MarkupContent(; kind = MarkupKind.Markdown, value)
+end
+
+function format_lattice_element_detail(@nospecialize(typ))
+    lattice_str = try
+        sprint(show, typ)
+    catch
+        typ_typstr = sprint(show, typeof(typ))
+        return "Failed to display inferred extended lattice element of type `$typ_typstr`."
+    end
+    return "```julia\n$lattice_str\n```"
 end
 
 # Resolve a lazy type-hint tooltip by recomputing the type for the source range
@@ -807,8 +825,7 @@ function resolve_inlay_hint(
         st0_top, context_module, type_range;
         world, caller="inlayHint/resolve", cache=fi.inferred_context_cache) return hint
     typ = @something get_type_for_range(ctx, type_range) return hint
-    rawtyp = CC.widenconst(typ)
-    tooltip = format_type_inlay_hint_tooltip(rawtyp, postprocessor)
+    tooltip = format_type_inlay_hint_tooltip(typ, postprocessor; include_lattice = true)
     return InlayHint(hint; tooltip)
 end
 

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -170,6 +170,8 @@ function lookup_doc_for_binding(binfo::JL.BindingInfo, @nospecialize(sig), world
     return lookup_doc_for_binding(mod, Symbol(binfo.name), sig, world)
 end
 
+is_doc_binding_value(@nospecialize(v)) = v isa Function || v isa Module || v isa Type
+
 """
     lookup_doc_for_value(v, sig, world::UInt) -> Markdown.MD | Nothing
 
@@ -185,7 +187,7 @@ to keep. For documentable values that nonetheless carry no docstring,
 [`lookup_doc_stripped`](@ref) handles the placeholder removal.
 """
 function lookup_doc_for_value(@nospecialize(v), @nospecialize(sig), world::UInt)
-    v isa Function || v isa Module || v isa Type || return nothing
+    is_doc_binding_value(v) || return nothing
     try
         if sig === nothing
             return lookup_doc_stripped(v, world)

--- a/src/utils/general.jl
+++ b/src/utils/general.jl
@@ -294,7 +294,21 @@ function truncate_typstr(str::String, maxdepth::Int, maxwidth::Int)
         str = Base.type_depth_limit(str, 0; maxdepth)
     end
     lastindex(str) <= maxwidth && return str
-    return Base.type_depth_limit(str, maxwidth)
+    limited = Base.type_depth_limit(str, maxwidth)
+    isempty(limited) || return limited
+    return truncate_flat_typstr(str, maxwidth)
+end
+
+function truncate_flat_typstr(str::String, maxwidth::Int)
+    maxwidth <= 1 && return "…"
+    nchars = length(str)
+    nchars <= maxwidth && return str
+    nkeep = maxwidth - 1
+    prefix_len = max(1, nkeep ÷ 2)
+    suffix_len = nkeep - prefix_len
+    prefix = first(str, prefix_len)
+    suffix = suffix_len == 0 ? "" : last(str, suffix_len)
+    return prefix * "…" * suffix
 end
 
 function typstr_within_depth_limit(str::String, maxdepth::Int)

--- a/test/test_inlay_hint.jl
+++ b/test/test_inlay_hint.jl
@@ -460,6 +460,24 @@ end
         @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
     end
 
+    @testset "const-propagated expressions" begin
+        code = """
+            let x = 42
+                y = sin(x)
+                z = cos(y)
+                return z
+            end
+            """
+        expected = """
+            let x = 42
+                y = sin(x::$Int)::Float64
+                z = cos(y::Float64)::Float64
+                return z::Float64
+            end
+            """
+        @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
+    end
+
     @testset "range filtering" begin
         code = "let x = [1, 2, 3]\n" *
             "    sum(x)\n" *
@@ -831,7 +849,7 @@ end
             expected = """
                 let xs = rand(3)::Vector{Float64}
                     for x::Float64 = xs::Vector{Float64}
-                        println(x::Float64)
+                        println(x::Float64)::Nothing
                     end
                 end
                 """
@@ -848,7 +866,7 @@ end
             expected = """
                 let xs = String["a", "b"]::Vector{String}
                     for s::String in xs::Vector{String}
-                        print(s::String)
+                        print(s::String)::Nothing
                     end
                 end
                 """
@@ -867,7 +885,7 @@ end
             expected = """
                 let xs = rand(3)::Vector{Float64}
                     for (i::$Int, x::Float64) in enumerate(xs::Vector{Float64})::Enumerate{Vector{Float64}}
-                        println(i::$Int, x::Float64)
+                        println(i::$Int, x::Float64)::Nothing
                     end
                 end
                 """
@@ -883,9 +901,9 @@ end
                 end
                 """
             expected = """
-                let xs = Some{$Int}[Some(1)]::Vector{Some{$Int}}
+                let xs = Some{$Int}[Some(1)::Some{$Int}]::Vector{Some{$Int}}
                     for (; value::$Int) in xs::Vector{Some{$Int}}
-                        println(value::$Int)
+                        println(value::$Int)::Nothing
                     end
                 end
                 """
@@ -1066,8 +1084,8 @@ end
                 let x = rand()::Float64
                     r = (0 < x::Float64 < 1)::Bool
                     if (r::Bool && rand(Bool)::Bool)::Bool || rand(Bool)::Bool
-                        println(r::Bool)
-                    end
+                        println(r::Bool)::Nothing
+                    end::Nothing
                 end
                 """
             @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
@@ -1148,8 +1166,8 @@ end
                 function f(x::Union{Int, Nothing})::Union{Nothing, String}
                     out = if (x::Union{Nothing, $Int} isa Int)::Bool
                         return string(x::$Int; base = 16)::String
-                    end
-                    out
+                    end::Nothing
+                    out::Nothing
                 end
                 """
             @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
@@ -1172,8 +1190,8 @@ end
                 function g(b::Bool, c::Bool)::Union{Nothing, $Int, String}
                     out = if b
                         return if c; 1; else; "x"; end::Union{$Int, String}
-                    end
-                    out
+                    end::Nothing
+                    out::Nothing
                 end
                 """
             @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
@@ -1523,7 +1541,7 @@ end
                 """
             expected = """
                 let g = x::Float64 -> 2x::Float64
-                    g(1.0)
+                    g(1.0)::Float64
                 end
                 """
             @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
@@ -1639,10 +1657,10 @@ end
                 end
                 """
             expected = """
-                let ps = [1=>"a", 2=>"b"]::Vector{Pair{$Int, String}}
+                let ps = [(1=>"a")::Pair{$Int, String}, (2=>"b")::Pair{$Int, String}]::Vector{Pair{$Int, String}}
                     foreach(ps::Vector{Pair{$Int, String}}) do (k::$Int, v::String)
                         (k::$Int, v::String)::Tuple{$Int, String}
-                    end
+                    end::Nothing
                 end
                 """
             @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
@@ -1657,10 +1675,10 @@ end
                 end
                 """
             expected = """
-                let ts = [(1, (2.0, "x"))]::Vector{Tuple{$Int, Tuple{Float64, String}}}
+                let ts = [(1, (2.0, "x")::Tuple{Float64, String})::Tuple{$Int, Tuple{Float64, String}}]::Vector{Tuple{$Int, Tuple{Float64, String}}}
                     foreach(ts::Vector{Tuple{$Int, Tuple{Float64, String}}}) do (a::$Int, (b::Float64, c::String))
                         (a::$Int, b::Float64, c::String)::Tuple{$Int, Float64, String}
-                    end
+                    end::Nothing
                 end
                 """
             @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
@@ -1678,10 +1696,10 @@ end
                 end
                 """
             expected = """
-                let nts = [(a=1, b="x")]::Vector{@NamedTuple{a::$Int, b::String}}
+                let nts = [(a=1, b="x")::@NamedTuple{a::$Int, b::String}]::Vector{@NamedTuple{a::$Int, b::String}}
                     foreach(nts::Vector{@NamedTuple{a::$Int, b::String}}) do (; a::$Int, b::String)
                         (a::$Int, b::String)::Tuple{$Int, String}
-                    end
+                    end::Nothing
                 end
                 """
             @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
@@ -1699,7 +1717,7 @@ end
             expected = """
                 function f(x::Float64)::Float64
                     g = (a::Union{Float64, $Int}, b::$Int) -> (a::Union{Float64, $Int} + b::$Int)::Union{Float64, $Int}
-                    (g(x::Float64, 1)::Float64 + g(2, 3))::Float64
+                    (g(x::Float64, 1)::Float64 + g(2, 3)::$Int)::Float64
                 end
                 """
             @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
@@ -1840,7 +1858,7 @@ end
         expected = """
             function f()::$Int
                 x::$Int = 1
-                return x
+                return x::$Int
             end
             """
         @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
@@ -1871,10 +1889,10 @@ end
         end
     end
 
-    # `Const` types (e.g. `x = println` makes both binding and reference
-    # `Const(println)`) are filtered by `should_annotate_type`, so the
-    # source is unchanged — no `typeof(println)` leaks through.
-    @testset "Const types are not annotated" begin
+    # `Const` callables (e.g. `x = println` makes both binding and reference
+    # `Const(println)`) are filtered by `should_annotate_type`, so the source
+    # is unchanged — no `typeof(println)` leaks through.
+    @testset "Const callables are not annotated" begin
         code = """
             let x = println
                 x

--- a/test/test_inlay_hint.jl
+++ b/test/test_inlay_hint.jl
@@ -10,6 +10,9 @@ include(normpath(pkgdir(JETLS), "test", "jsjl-utils.jl"))
 
 struct LongTypeNameForInlayHintTruncation end
 
+struct ThrowingShowForInlayHint end
+Base.show(::IO, ::ThrowingShowForInlayHint) = error("show failed")
+
 # Render `hints` into `code` via the shared `JETLS.apply_inlay_hints` helper
 # (the whole document starts at byte 1).
 function apply_inlay_hints(code::AbstractString, hints::Vector{InlayHint})
@@ -462,24 +465,6 @@ end
         @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
     end
 
-    @testset "const-propagated expressions" begin
-        code = """
-            let x = 42
-                y = sin(x)
-                z = cos(y)
-                return z
-            end
-            """
-        expected = """
-            let x = 42
-                y = sin(x::$Int)::Float64
-                z = cos(y::Float64)::Float64
-                return z::Float64
-            end
-            """
-        @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
-    end
-
     @testset "range filtering" begin
         code = "let x = [1, 2, 3]\n" *
             "    sum(x)\n" *
@@ -550,6 +535,53 @@ end
         @test resolved.tooltip isa MarkupContent
         @test resolved.tooltip.kind == MarkupKind.Markdown
         @test resolved.tooltip.value == "```julia\nLinearAlgebra.Adjoint{Float64, Matrix{Float64}}\n```"
+    end
+
+    @testset "const-propagated expressions" begin
+        code = """
+            let x = 42
+                y = sin(x)
+                z = cos(y)
+                return z
+            end
+            """
+        expected = """
+            let x = 42
+                y = sin(x::$Int)::Float64
+                z = cos(y::Float64)::Float64
+                return z::Float64
+            end
+            """
+        hints = get_type_inlay_hints(code)
+        @test apply_inlay_hints(code, hints) == expected
+        @test all(hints) do h
+            !(h.tooltip isa MarkupContent) || !occursin("\n---\n", h.tooltip.value)
+        end
+
+        server, lazy_hints = get_lazy_type_inlay_hints(code)
+        @test apply_inlay_hints(code, lazy_hints) == expected
+        hint = first(filter(lazy_hints) do h
+            h.data isa TypeInlayHintData && occursin("Float64", h.label)
+        end)
+        @test hint.tooltip === nothing
+        resolved = JETLS.resolve_inlay_hint(server.state, hint)
+        @test resolved.tooltip isa MarkupContent
+        @test occursin("```julia\nFloat64\n```", resolved.tooltip.value)
+        @test occursin("\n---\n", resolved.tooltip.value)
+        @test occursin("Core.Const", resolved.tooltip.value)
+    end
+
+    @testset "lattice tooltip ignores show errors" begin
+        tooltip = JETLS.format_type_inlay_hint_tooltip(
+            Core.Const(ThrowingShowForInlayHint()), JETLS.LSPostProcessor();
+            include_lattice = true)
+        @test tooltip isa MarkupContent
+        @test occursin("ThrowingShowForInlayHint", tooltip.value)
+        @test occursin("\n---\n", tooltip.value)
+        @test occursin(
+            "Failed to display inferred extended lattice element of type",
+            tooltip.value)
+        @test occursin("`Core.Const`", tooltip.value)
     end
 
     @testset "operator expressions" begin

--- a/test/test_inlay_hint.jl
+++ b/test/test_inlay_hint.jl
@@ -8,6 +8,8 @@ using JETLS.URIs2
 include(normpath(pkgdir(JETLS), "test", "setup.jl"))
 include(normpath(pkgdir(JETLS), "test", "jsjl-utils.jl"))
 
+struct LongTypeNameForInlayHintTruncation end
+
 # Render `hints` into `code` via the shared `JETLS.apply_inlay_hints` helper
 # (the whole document starts at byte 1).
 function apply_inlay_hints(code::AbstractString, hints::Vector{InlayHint})
@@ -514,6 +516,25 @@ end
             "end\n"
         @test apply_inlay_hints(code, hints) == expected
         @test length(JETLS.load(cache)) == 1
+    end
+
+    @testset "long flat type names are middle-truncated" begin
+        code = """
+            let ltnflt = LongTypeNameForInlayHintTruncation()
+                ltnflt
+            end
+            """
+        expected = """
+            let ltnflt = LongTypeNameForInlayHintTruncation()::LongTypeN…Truncation
+                ltnflt::LongTypeN…Truncation
+            end
+            """
+        _, hints = get_lazy_type_inlay_hints(code, @__MODULE__)
+        @test apply_inlay_hints(code, hints) == expected
+        hint = only(filter(hints) do h
+            h.data isa TypeInlayHintData && h.position.line == 1
+        end)
+        @test hint.label == "::LongTypeN…Truncation"
     end
 
     @testset "lazy tooltip resolution" begin

--- a/test/utils/test_general.jl
+++ b/test/utils/test_general.jl
@@ -55,6 +55,9 @@ end
             # collapses the outermost `{...}`.
             @test JETLS.truncate_typstr(s, typemax(Int), 20) == "Tuple{…}"
         end
+        let s = "LongTypeNameForInlayHintTruncation"
+            @test JETLS.truncate_typstr(s, typemax(Int), 20) == "LongTypeN…Truncation"
+        end
     end
 
     @testset "passes compose" begin


### PR DESCRIPTION
## Summary

This PR improves type inlay hints in three related areas:

- type hints are now shown for useful const-propagated inference results,
- lazy-resolved tooltips can expose the original inferred lattice element,
- long flat type names are truncated without collapsing the label.

Together, these changes make type inlay hints more complete while keeping the inline label focused on the widened type.

## Details

### Show hints for const-propagated results

Type inlay hints previously filtered out every `Core.Const` result. This could hide useful hints for expressions whose values were propagated through local bindings and calls, for example:

```julia
let x = 42
    y = sin(x)
    z = cos(y)
    return z
end
```

JETLS now widens non-literal `Core.Const` results and shows the widened type in the inline hint:
```julia
let x = 42
    y = sin(x::Int64)::Float64
    z = cos(y::Float64)::Float64
    return z::Float64
end
```

Literal syntax and const bindings to `Type`, `Function`, or `Module` are still suppressed to avoid noisy hints such as `typeof(sin)`.

### Expose inferred lattice details in lazy tooltips

The inline label continues to show the widened type. When the client supports lazy tooltip resolution, the resolved tooltip now also includes the original inferred lattice element when it contains more information than the widened type.

For example, a label can remain:

```julia
::Float64
```

while the resolved tooltip includes the corresponding `Core.Const(-0.9165215479156338)` value below a separator.

Eager tooltips still show only the widened type. If displaying the extended lattice element fails, the tooltip reports that failure and includes `typeof(typ)` instead of failing the request.

### Improve truncation of long flat type names

Long type names without type parameters were not handled well by the previous structural truncation path. In particular, `Base.type_depth_limit` can return an empty string for flat names that cannot be shortened structurally, which could produce labels that look like only `::`.

Flat long type names now use middle truncation, preserving both the start and end of the name, for example:

```text
LongTypeNameForInlayHintTruncation
```

becomes:

```text
LongTypeN…Truncation
```
