### PR TITLE
hover: Show lattice details in type headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   Destructuring parameters are annotated per component (e.g. `do (key::String, val::Int)`), consistent with for-loop iteration variables.
   Parameters whose type cannot be narrowed beyond `Any` are left without a hint.
 
+- Hover headers now include inferred lattice details as a Julia comment when the displayed type hides more precise information.
+
 - JETLS now performs correct scope resolution on identifiers used inside `@static` macrocalls, which previously could yield incorrect results in edge cases.
   Invalid `@static` usage (an unsupported expression shape, or a condition that fails to evaluate to a `Bool`) is now reported in place as `lowering/macro-expansion-error` while the code still flows through to analysis.
 

--- a/src/hover.jl
+++ b/src/hover.jl
@@ -102,7 +102,7 @@ function get_hover(
     display_rng = JS.byte_range(display_node)
     ctx = build_inferred_context_for_range(st0_top, context_module, display_rng;
         world, caller="get_hover", cache=fi.inferred_context_cache)
-    type_str = typ = nothing
+    type_str = typ = display_typ = nothing
     if ctx !== nothing
         display_typ = get_type_for_range(ctx, display_rng)
         if display_typ !== nothing
@@ -152,10 +152,18 @@ function get_hover(
         return nothing
     end
 
+    lattice_detail = type_str === nothing || display_typ === nothing ? nothing :
+        hover_lattice_detail(display_typ)
     io = IOBuffer()
     if show_header
         println(io, "```julia")
-        type_str === nothing ? println(io, header) : println(io, header, " :: ", postprocessor(type_str))
+        if type_str === nothing
+            println(io, header)
+        else
+            print(io, header, " :: ", postprocessor(type_str))
+            lattice_detail !== nothing && print(io, "  ", lattice_detail)
+            println(io)
+        end
         println(io, "```")
     end
     if !isempty(docs)
@@ -192,6 +200,15 @@ binding_kind_label(kind::Symbol) =
     kind === :argument ? "(argument)" :
     kind === :static_parameter ? "(static parameter)" :
     kind === :local ? "(local)" : "(global)"
+
+function hover_lattice_detail(@nospecialize(typ))
+    # `hover_type_string` already formats `PartialOpaque` as a closure shape, hiding
+    # the underlying `OpaqueClosure` internals. Do not re-append the raw lattice
+    # element as a comment and expose the internal representation again.
+    typ isa Core.PartialOpaque && return nothing
+    typ === CC.widenconst(typ) && return nothing
+    return format_lattice_element_comment(typ)
+end
 
 # Convert a lattice element from `get_type_for_range` into a string suitable for display
 # in a hover. Returns `nothing` for implementation-detail lattice elements that the user

--- a/src/inlay-hint.jl
+++ b/src/inlay-hint.jl
@@ -792,16 +792,6 @@ function format_type_inlay_hint_tooltip(
     return MarkupContent(; kind = MarkupKind.Markdown, value)
 end
 
-function format_lattice_element_detail(@nospecialize(typ))
-    lattice_str = try
-        sprint(show, typ)
-    catch
-        typ_typstr = sprint(show, typeof(typ))
-        return "Failed to display inferred extended lattice element of type `$typ_typstr`."
-    end
-    return "```julia\n$lattice_str\n```"
-end
-
 # Resolve a lazy type-hint tooltip by recomputing the type for the source range
 # stored in `hint.data`, leaving stale or already-resolved hints unchanged.
 function resolve_inlay_hint(

--- a/src/utils/general.jl
+++ b/src/utils/general.jl
@@ -325,6 +325,33 @@ function typstr_within_depth_limit(str::String, maxdepth::Int)
     return true
 end
 
+function format_lattice_element_detail(@nospecialize(typ))
+    lattice_str = @something try_show_lattice_element(typ) begin
+        return failed_lattice_element_detail(typ)
+    end
+    return "```julia\n$lattice_str\n```"
+end
+
+function format_lattice_element_comment(@nospecialize(typ))
+    lattice_str = @something try_show_lattice_element(typ) begin
+        return "# " * failed_lattice_element_detail(typ)
+    end
+    return "# " * replace(lattice_str, '\n' => " ")
+end
+
+function try_show_lattice_element(@nospecialize(typ))
+    return try
+        sprint(show, typ)
+    catch
+        nothing
+    end
+end
+
+function failed_lattice_element_detail(@nospecialize(typ))
+    typ_typstr = sprint(show, typeof(typ))
+    return "Failed to display inferred extended lattice element of type `$typ_typstr`."
+end
+
 rlstrip(s::AbstractString, args...) = lstrip(rstrip(s, args...), args...)
 
 struct LSPostProcessor

--- a/test/test_hover.jl
+++ b/test/test_hover.jl
@@ -221,6 +221,19 @@ end
             context_module = @__MODULE__)
     end
 
+    @testset "extended lattice detail" begin
+        text = """
+            let x = 42
+                y = sin(x)
+                y│
+            end
+            """
+        clean_text, positions = JETLS.get_text_and_positions(text)
+        result = get_hover(clean_text, only(positions))
+        @test result isa Hover
+        @test occursin("(local) y :: Float64  # Core.Const", result.contents.value)
+    end
+
     @testset "module alias resolves through DocsBinding helper" begin
         hover_test("B│.sin(42)", JETLS.lsrender(@doc Base);
             context_module = M_base_alias)


### PR DESCRIPTION
Hover headers now show inferred extended lattice elements as Julia comments when the displayed type has been widened. This surfaces cases like `Core.Const(...)` without replacing the concise type header.

The lattice rendering helper is shared with type inlay tooltip details, with a separate comment formatter for hover. `Core.PartialOpaque` remains hidden in hover lattice details so closure hovers keep the user-facing arrow signature instead of exposing `OpaqueClosure` internals.