### PR TITLE
TypeAnnotation: Resolve closure parameter types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed dot completion erroring (or offering nothing) when the prefix sits in code that inference proves unreachable, such as code after a non-returning call. Module and global-const prefixes such as `Base.` now resolve their members there as usual.
 
+- Fixed hover on unannotated local closure parameters showing `Core.OpaqueClosure` internals instead of the inferred argument type.
+
 ## 2026-06-03
 
 - Commit: [`a42a435`](https://github.com/aviatesk/JETLS.jl/commit/a42a435)

--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -156,7 +156,7 @@ import ..JETLS: InferredTreeContext
 
 export InferredTreeContext,
     build_inferred_context_for_range, build_inferred_context_for_tree,
-    get_matches_for_range, get_oc_argtypes_for_range, get_type_for_range,
+    get_matches_for_range, get_type_for_range,
     is_type_annotation_skipped_toplevel
 
 # ASTTypeAnnotator
@@ -1340,19 +1340,40 @@ function collect_lambda_ranges(ctx3::JL.VariableAnalysisContext)
 end
 
 function collect_oc_argtypes_by_binding(inferred_tree::SyntaxTreeC)
+    body_ranges_by_surface = collect_oc_body_ranges_by_surface(inferred_tree)
     oc_argtypes = Dict{Tuple{UnitRange{Int},Symbol},Any}()
     traverse(inferred_tree) do st::SyntaxTreeC
         JS.kind(st) === JS.K"new_opaque_closure" || return nothing
         JS.hasattr(st, :type) || return nothing
         entry = @something oc_argtypes_for_node(st.type, JS.byte_range(st)) return nothing
+        body_ranges = get(Vector{UnitRange{Int}}, body_ranges_by_surface, entry.range)
         for i = 1:length(entry.argnames)
             typ = entry.argtypes[i]
             is_refined_slot(typ) || continue
-            oc_argtypes[(entry.range, entry.argnames[i])] = typ
+            name = entry.argnames[i]
+            oc_argtypes[(entry.range, name)] = typ
+            for body_range in body_ranges
+                oc_argtypes[(body_range, name)] = typ
+            end
         end
         return nothing
     end
     return oc_argtypes
+end
+
+function collect_oc_body_ranges_by_surface(inferred_tree::SyntaxTreeC)
+    body_ranges_by_surface = Dict{UnitRange{Int},Vector{UnitRange{Int}}}()
+    traverse(inferred_tree) do st::SyntaxTreeC
+        JS.kind(st) === JS.K"opaque_closure_method" || return nothing
+        surface_range = JS.byte_range(st)
+        for child in JS.children(st)
+            JS.kind(child) === JS.K"code_info" || continue
+            body_ranges = get!(Vector{UnitRange{Int}}, body_ranges_by_surface, surface_range)
+            push!(body_ranges, JS.byte_range(child))
+        end
+        return nothing
+    end
+    return body_ranges_by_surface
 end
 
 function oc_argtypes_for_node(@nospecialize(typ), rng::UnitRange{Int})
@@ -1756,32 +1777,6 @@ function get_matches_for_range(ctx::InferredTreeContext, rng::UnitRange{<:Intege
     last_call === nothing && return nothing
     JS.hasattr(last_call, :matches) || return nothing
     return last_call.matches::Vector{Core.MethodMatch}
-end
-
-"""
-    get_oc_argtypes_for_range(
-            ctx::InferredTreeContext, rng::UnitRange{<:Integer}
-        ) -> Union{Nothing,Vector{Any}}
-
-Look up the `Core.OpaqueClosure` constructed at surface byte range `rng` — a lambda or
-`do`-block closure routed through [`Closure2Opaque.rewrite_local_closures_to_opaque`](@ref)
-— and return its argument types: one entry per user-visible parameter, with any
-call-site argtype refinement applied (see "Closure argument-type refinement" in the
-[`TypeAnnotation`](@ref) module docstring). Returns `nothing` when no annotated OC
-construction lies at `rng` or its argt isn't a plain `Vararg`-free `Tuple`.
-
-Feature code uses this for parameter-position queries (e.g. inlay hints on unannotated
-lambda parameters), where the value-type query [`get_type_for_range`](@ref) would
-surface the closure's own `OpaqueClosure{…}` type instead.
-"""
-function get_oc_argtypes_for_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
-    for st in get(ctx.by_byte_range, rng, ())
-        JS.kind(st) === JS.K"new_opaque_closure" || continue
-        JS.hasattr(st, :type) || continue
-        argtypes = @something opaque_closure_argtypes(st.type) continue
-        return argtypes
-    end
-    return nothing
 end
 
 function opaque_closure_argtypes(@nospecialize(typ))

--- a/src/inlay-hint.jl
+++ b/src/inlay-hint.jl
@@ -240,6 +240,14 @@ function collect_type_inlay_hints!(
         end
         if JS.kind(node) in JS.KSet"function macro"
             sig_rng = funcdef_sig_range(node)
+            if (sig_rng === nothing && JS.kind(node) === JS.K"function" &&
+                JS.numchildren(node) ≥ 1)
+                # Anonymous `function (args...) ... end` signatures are `K"tuple"`,
+                # not `K"call"`; suppress them like named signatures so the generic
+                # postorder path doesn't duplicate dedicated parameter hints.
+                sig = unwrap_funcdef_sig(node[1])
+                JS.kind(sig) === JS.K"tuple" && (sig_rng = JS.byte_range(sig))
+            end
             sig_rng !== nothing && push!(verbatim_ranges, sig_rng)
         end
         if JS.kind(node) === JS.K"->" && JS.numchildren(node) >= 1
@@ -333,7 +341,7 @@ function collect_type_inlay_hints!(
         # lambdas, anonymous `function (…) … end`, and named local closures. Emitted
         # before the funcdef return-type path's early return so a named local closure
         # gets both its parameter and return-type hints. `emit_lambda_param_hints!`
-        # is a no-op for non-closures (it gates on `get_oc_argtypes_for_range`).
+        # is a no-op when parameter ranges have no inferred types.
         if k in JS.KSet"-> function ="
             emit_lambda_param_hints!(
                 inlay_hints, node, ctx, fi, uri, range, nontrivia_index,
@@ -539,17 +547,12 @@ end
 # `K"->"` (arrow / `do`, bare `K"Identifier"` or `K"tuple"` params), anonymous
 # `function (…) … end` (`K"tuple"` signature), and named local closures /
 # short-form `f(…) = …` (`K"call"` signature, after stripping `where` / return-type
-# wrappers — its head child is the function name and is skipped). Each positional
-# parameter consumes one entry of the constructed `OpaqueClosure`'s argt (from
-# `get_oc_argtypes_for_range`, carrying the call-site argtype refinement):
-# - a simple `K"Identifier"` parameter gets that entry's type directly;
-# - a destructuring pattern (`(a, b)`, `(; a, b)`, …) is one parameter whose argt
-#   entry is the aggregate, so per-component hints come from each leaf's own range
-#   instead (`emit_destructure_var_hints!`, shared with for-loop iteration vars).
+# wrappers — its head child is the function name and is skipped). Each simple
+# `K"Identifier"` parameter is queried by its own source range via `get_type_for_range`;
+# destructuring patterns (`(a, b)`, `(; a, b)`, …) recurse into each leaf instead
+# (`emit_destructure_var_hints!`, shared with for-loop iteration vars).
 # `Any` entries on simple parameters are skipped (an unrefined slot adds no information
-# over the bare name); user-annotated (`K"::"`) parameters are left untouched. A no-op
-# when no OC was constructed at the range (top-level methods, plain assignments), since
-# `get_oc_argtypes_for_range` returns `nothing` there.
+# over the bare name); user-annotated (`K"::"`) parameters are left untouched.
 function emit_lambda_param_hints!(
         inlay_hints::Vector{InlayHint}, lambda::SyntaxTreeC,
         ctx::InferredTreeContext, fi::FileInfo, uri::URI, range::Range,
@@ -557,40 +560,43 @@ function emit_lambda_param_hints!(
         emitted_ranges::Set{UnitRange{Int}}, label_cache::IdDict{Any,String},
         maxdepth::Int, maxwidth::Int, lazy_tooltips::Bool
     )
-    argtypes = @something get_oc_argtypes_for_range(ctx, JS.byte_range(lambda)) return nothing
     JS.numchildren(lambda) >= 1 || return nothing
     sig = lambda[1]
+    k = JS.kind(lambda)
     # `params`: the node whose children (from `start` on) are the positional params.
-    if JS.kind(lambda) === JS.K"->"
+    if k === JS.K"->"
         if JS.kind(sig) === JS.K"Identifier" # no-paren single-parameter form
-            isempty(argtypes) || emit_lambda_param_hint!(
-                inlay_hints, sig, argtypes[1], fi, uri, range, nontrivia_index,
+            emit_lambda_param_hint!(
+                inlay_hints, sig, ctx, fi, uri, range, nontrivia_index,
                 postprocessor, label_cache, maxdepth, maxwidth, lazy_tooltips)
             return nothing
         end
         JS.kind(sig) === JS.K"tuple" || return nothing
         params, start = sig, 1
-    else # `K"function"` / `K"="`
+    elseif k === JS.K"function"
         sig = unwrap_funcdef_sig(sig)
         sk = JS.kind(sig)
-        if sk === JS.K"tuple"
+        if sk === JS.K"tuple" # anonymous `function (args...) ... end`
             params, start = sig, 1
-        elseif sk === JS.K"call"
+        elseif sk === JS.K"call" # named local `function f(args...) ... end`
             params, start = sig, 2 # skip the function name
         else
             return nothing
         end
+    elseif k === JS.K"="
+        sig = unwrap_funcdef_sig(sig)
+        JS.kind(sig) === JS.K"call" || return nothing # only short-form `f(args...) = ...`
+        params, start = sig, 2 # skip the function name
+    else
+        return nothing
     end
-    argi = 0
     for ci = start:JS.numchildren(params)
         p = params[ci]
         pk = JS.kind(p)
         pk === JS.K"parameters" && break # keyword parameters aren't positional
-        argi += 1
-        argi <= length(argtypes) || break
         if pk === JS.K"Identifier"
             emit_lambda_param_hint!(
-                inlay_hints, p, argtypes[argi], fi, uri, range, nontrivia_index,
+                inlay_hints, p, ctx, fi, uri, range, nontrivia_index,
                 postprocessor, label_cache, maxdepth, maxwidth, lazy_tooltips)
         elseif pk === JS.K"tuple" # destructuring pattern — annotate each component
             emit_destructure_var_hints!(
@@ -603,11 +609,12 @@ function emit_lambda_param_hints!(
 end
 
 function emit_lambda_param_hint!(
-        inlay_hints::Vector{InlayHint}, p::SyntaxTreeC, @nospecialize(typ),
+        inlay_hints::Vector{InlayHint}, p::SyntaxTreeC, ctx::InferredTreeContext,
         fi::FileInfo, uri::URI, range::Range, nontrivia_index::Vector{Int},
         postprocessor::LSPostProcessor, label_cache::IdDict{Any,String},
         maxdepth::Int, maxwidth::Int, lazy_tooltips::Bool
     )
+    typ = @something get_type_for_range(ctx, JS.byte_range(p)) return nothing
     typ === Any && return nothing # an unrefined slot adds nothing over the bare name
     should_annotate_type(p, typ) || return nothing
     endpos = offset_to_xy(fi, JS.last_byte(p) + 1)

--- a/test/test_hover.jl
+++ b/test/test_hover.jl
@@ -448,6 +448,16 @@ end
         """, "(argument) y :: Float64")
     end
 
+    @testset "closure parameter binding uses refined argument type" begin
+        hover_test("""
+            let x = rand(Int)
+                y = Some{Any}(x)
+                f = z│ -> z * y.value
+                f(rand())
+            end
+        """, "(argument) z :: Float64"; notpat="OpaqueClosure")
+    end
+
     @testset "closure values format as a function-arrow signature" begin
         # closures get rewritten to `Core.OpaqueClosure` by JETLS' inference
         # pipeline; surface that as `(args...) -> rt` instead of leaking the

--- a/test/test_inlay_hint.jl
+++ b/test/test_inlay_hint.jl
@@ -1582,10 +1582,9 @@ end
             @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
         end
 
-        # No-paren `x -> body`: parameter byte range overlaps with the OC binding's
-        # `PartialOpaque` slot, so the generic path is suppressed (it would emit a
-        # misleading `x::OpaqueClosure{…}` hint); the dedicated parameter hint reads
-        # the refined argt off the constructed OC instead.
+        # No-paren `x -> body`: parameter byte range overlaps with OC construction
+        # scaffolding, so `get_type_for_range` must resolve the parameter binding's
+        # refined argument type instead of surfacing `OpaqueClosure` internals.
         @testset "no-paren anonymous lambda" begin
             code = """
                 let g = x -> 2x


### PR DESCRIPTION
Hovering an unannotated local closure parameter could show noisy `Core.OpaqueClosure` internals instead of the call-site-refined argument type. For example, `f = z -> ...; f(rand())` now reports `z :: Float64` at the parameter position.

Index refined opaque-closure argument types by both the closure surface range and its lowered body range, so `get_type_for_range` can answer parameter binding ranges directly. Type inlay hints now use the same range query instead of the exported
`get_oc_argtypes_for_range` helper, which is removed.