### PR TITLE
diagnostic: Suppress phantom type parameter dead stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed false positive `lowering/undef-local-var` diagnostics for variables guarded by negated `@isdefined` conditions, including `&&` and `||` combinations where definedness is guaranteed.
 
+- Fixed false positive `lowering/unused-assignment` diagnostics on phantom `struct` type parameters such as `struct MyVal{T} end`.
+
 ## 2026-06-03
 
 - Commit: [`a42a435`](https://github.com/aviatesk/JETLS.jl/commit/a42a435)

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -710,6 +710,38 @@ function assignment_expression_for_prov(st0::SyntaxTreeC, prov::SyntaxTreeC)
     return first(assignments)
 end
 
+function is_struct_type_parameter_declaration(st0::SyntaxTreeC, prov::SyntaxTreeC)
+    ancestors = byte_ancestors(st0, JS.byte_range(prov))
+    for i = 2:length(ancestors)
+        curly = ancestors[i]
+        JS.kind(curly) === JS.K"curly" || continue
+        is_type_parameter = false
+        for j = 2:JS.numchildren(curly)
+            param = curly[j]
+            pk = JS.kind(param)
+            if (pk === JS.K"<:" || pk === JS.K">:") && JS.numchildren(param) >= 1
+                param = param[1]
+            end
+            if JS.byte_range(prov) ⊆ JS.byte_range(param)
+                is_type_parameter = true
+                break
+            end
+        end
+        is_type_parameter || continue
+        for j = i+1:length(ancestors)
+            parent = ancestors[j]
+            JS.kind(parent) === JS.K"struct" || continue
+            JS.numchildren(parent) >= 2 || continue
+            sig = parent[2]
+            if JS.kind(sig) === JS.K"<:" && JS.numchildren(sig) >= 1
+                sig = sig[1]
+            end
+            same_syntax_range(sig, curly) && return true
+        end
+    end
+    return false
+end
+
 function tail_returned_assignment_kind(
         st0::SyntaxTreeC, assignment::Union{Nothing,SyntaxTreeC}
     )
@@ -937,10 +969,13 @@ function analyze_unused_assignments!(
             provs = JL.flattened_provenance(dead_def_tree)
             is_from_user_ast(provs) || continue
             prov = last(provs)
+            assignment = assignment_expression_for_prov(st0, prov)
+            if assignment === nothing && is_struct_type_parameter_declaration(st0, prov)
+                continue
+            end
             range = jsobj_to_range(prov, fi)
             key = LoweringDiagnosticKey(range, binfo.kind, bn)
             key in reported ? continue : push!(reported, key)
-            assignment = assignment_expression_for_prov(st0, prov)
             tail_kind = tail_returned_assignment_kind(st0, assignment)
             push!(diagnostics, Diagnostic(;
                 range,

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -376,6 +376,10 @@ module EmptyModule end
         @test isempty(get_lowering_diagnostics("struct A end"))
         @test isempty(get_lowering_diagnostics("struct A; x::Int; end"))
         @test isempty(get_lowering_diagnostics("struct A{T}; x::T; end"))
+        @test isempty(get_lowering_diagnostics("struct Phantom{T} end"))
+        @test isempty(get_lowering_diagnostics("struct Phantom{T<:Number} end"))
+        @test isempty(get_lowering_diagnostics("struct Phantom{T,S}; x::T; end"))
+        @test isempty(get_lowering_diagnostics("mutable struct Phantom{T} end"))
         let diagnostics = get_lowering_diagnostics("""
             struct A
                 x::Int


### PR DESCRIPTION
JETLS previously reported `lowering/unused-assignment` on phantom struct type parameters such as `struct MyVal{T} end`, even though introducing a type parameter without fields that mention it is valid Julia code.

Filter unused-assignment diagnostics whose provenance points at a `struct` type parameter declaration and has no user-written assignment expression. This leaves the CFG dead-store analysis unchanged and suppresses only the user-facing false positive.

Added lowering diagnostic coverage for immutable and mutable phantom type parameters, including bounded parameters and partially phantom parameter lists.