### PR TITLE
TypeAnnotatoin: Avoid bottom for static-param signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed type annotation results for methods whose signature contains static parameters such as `f(a::Vector{T}) where {T}` so reachable calls like `copy(a)` no longer collapse to `Union{}`. (Closed https://github.com/aviatesk/JETLS.jl/issues/764)
+
 - Fixed the names introduced by `import`/`using`/`export`/`public` statements nested in a block (e.g. version-gated imports) not being recognized by document highlight, find references, rename, and semantic tokens.
 
 ## 2026-06-18

--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -1129,7 +1129,7 @@ function resolve_method_argtypes(
     argtypes = Vector{Any}(undef, nargs)
     for i = 1:nargs
         argtypes[i] = i <= length(inner_args) ?
-            eval_to_type(inner_args[i], src, context_module, world) : Any
+            eval_method_sig_type(inner_args[i], src, context_module, world) : Any
     end
     return argtypes
 end
@@ -1142,8 +1142,7 @@ function resolve_ssa_stmt(@nospecialize(expr), src::CodeInfo)
 end
 
 function svec_call_args(@nospecialize(expr))
-    expr isa Expr || return nothing
-    expr.head === :call || return nothing
+    Meta.isexpr(expr, :call) || return nothing
     length(expr.args) >= 1 || return nothing
     callee = expr.args[1]
     callee isa GlobalRef || return nothing
@@ -1151,28 +1150,40 @@ function svec_call_args(@nospecialize(expr))
     return @view expr.args[2:end]
 end
 
-function eval_to_type(
+function eval_method_sig_type(
         @nospecialize(expr), src::CodeInfo, context_module::Module, world::UInt
     )
-    val = eval_to_value(expr, src, context_module, world)
+    val = eval_method_sig_value(expr, src, context_module, world)
     val isa TypeVar && return val.ub
     return val isa Type ? val : Any
 end
 
 # Returns `nothing` when any leaf reference fails to resolve (e.g. undefined
 # synthetic name); callers must treat that as "could not statically evaluate".
-function eval_to_value(
+function eval_method_sig_value(
         @nospecialize(expr), src::CodeInfo, context_module::Module, world::UInt
     )
+    return eval_method_sig_value(expr, src, context_module, world, length(src.code) + 1)
+end
+
+function eval_method_sig_value(
+        @nospecialize(expr), src::CodeInfo, context_module::Module, world::UInt,
+        stmt_limit::Int
+    )
     if expr isa SSAValue
-        return eval_to_value(resolve_ssa_stmt(expr, src), src, context_module, world)
+        1 <= expr.id <= length(src.code) || return nothing
+        return eval_method_sig_value(src.code[expr.id], src, context_module, world, expr.id)
+    elseif expr isa SlotNumber
+        return eval_method_sig_slot_value(expr, src, context_module, world, stmt_limit)
     elseif expr isa GlobalRef
         return resolve_globalref(expr, world)
-    elseif expr isa Expr && expr.head === :call
-        f = @something eval_to_value(expr.args[1], src, context_module, world) return nothing
+    elseif Meta.isexpr(expr, :call)
+        f = @something eval_method_sig_value(
+            expr.args[1], src, context_module, world, stmt_limit) return nothing
         cargs = Any[]
         for i = 2:length(expr.args)
-            v = @something eval_to_value(expr.args[i], src, context_module, world) return nothing
+            v = @something eval_method_sig_value(
+                expr.args[i], src, context_module, world, stmt_limit) return nothing
             push!(cargs, v)
         end
         try
@@ -1185,6 +1196,22 @@ function eval_to_value(
     end
     # Self-evaluating literal (Number, String, Symbol, Bool, ...).
     return expr
+end
+
+function eval_method_sig_slot_value(
+        slot::SlotNumber, src::CodeInfo, context_module::Module, world::UInt,
+        stmt_limit::Int
+    )
+    found = nothing
+    for i = 1:min(stmt_limit - 1, length(src.code))
+        stmt = src.code[i]
+        if Meta.isexpr(stmt, :(=)) && length(stmt.args) == 2 && stmt.args[1] === slot
+            found === nothing || return nothing
+            found = Pair{Int,Any}(i, stmt.args[2])
+        end
+    end
+    i, rhs = @something found return nothing
+    return eval_method_sig_value(rhs, src, context_module, world, i)
 end
 
 function resolve_globalref(g::GlobalRef, world::UInt)

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -209,6 +209,20 @@ end
         end
     end
 
+    @testset "does not bottom on static-parameter method body" begin
+        let code = """
+            function copy_parametric(a::Vector{T}) where {T}
+                _ = copy(a)
+                return 0
+            end
+            """
+            _, ctx = type_annotate(code)
+            copy_type = widenconst(get_type_for_range(ctx, range_of(code, "copy(a)")))
+            @test copy_type !== Union{}
+            @test widenconst(get_type_for_range(ctx, range_of_kind(code, JS.K"function"))) === Int
+        end
+    end
+
     # Kwarg lowering produces three `:method` 3-arg statements (kwbody,
     # public, kwcall); the user's body lives in kwbody and we expect its
     # user-named slots to resolve.

--- a/test/test_inlay_hint.jl
+++ b/test/test_inlay_hint.jl
@@ -1352,8 +1352,8 @@ end
         end
 
         # `where` bounds are user-written signature syntax and should be skipped.
-        # The `::Any` body hints below come from the current TypeAnnotation-side
-        # static-parameter limitation, not from the inlay-hint pass.
+        # Body hints may still use the static parameter upper bounds recovered by
+        # the TypeAnnotation-side method-signature evaluator.
         @testset "where-clause type parameters" begin
             @testset "long-form" begin
                 code = """
@@ -1363,7 +1363,7 @@ end
                     """
                 expected = """
                     function func(x::T)::Any where {T <: Number}
-                        return 2x::Any
+                        return 2x::Number
                     end
                     """
                 @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
@@ -1375,8 +1375,8 @@ end
                     end
                     """
                 expected = """
-                    function f(x::T, y::S)::Tuple{Any, Any} where {T <: Number, S <: AbstractString}
-                        return (x::Any, y::Any)::Tuple{Any, Any}
+                    function f(x::T, y::S)::Tuple{Number, AbstractString} where {T <: Number, S <: AbstractString}
+                        return (x::Number, y::AbstractString)::Tuple{Number, AbstractString}
                     end
                     """
                 @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
@@ -1386,7 +1386,7 @@ end
                     add(x::T, y::T) where {T <: Real} = x + y
                     """
                 expected = """
-                    add(x::T, y::T)::Any where {T <: Real} = (x::Any + y::Any)::Any
+                    add(x::T, y::T)::Any where {T <: Real} = (x::Real + y::Real)::Any
                     """
                 @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
             end


### PR DESCRIPTION
Type annotations could report `Union{}` for method bodies whose signature contains static parameters, such as `copy(a)` inside `f(a::Vector{T}) where {T}`. This made the call and function return annotations bottom out even though the body is reachable.

Restrict the lowered-signature evaluator to method signature svecs and recover slot-bound `TypeVar`s only from a single prior assignment. Ambiguous or unresolved slots still fail closed and fall back to `Any`, avoiding fake types like `Vector{:(_1)}`.

Added a TypeAnnotation regression test for `copy(::Vector{T})`. Static-parameter precision is still limited, so this change only prevents spurious bottom annotations rather than recovering `Vector{T}`.

Fixes aviatesk/JETLS.jl#764.