### PR TITLE
TypeAnnotation: Fix nested closure captures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed type annotation for nested local closures that capture values already captured by an enclosing closure.
+
 - Fixed type annotation results for methods whose signature contains static parameters such as `f(a::Vector{T}) where {T}` so reachable calls like `copy(a)` no longer collapse to `Union{}`. (Closed https://github.com/aviatesk/JETLS.jl/issues/764)
 
 - Fixed the names introduced by `import`/`using`/`export`/`public` statements nested in a block (e.g. version-gated imports) not being recognized by document highlight, find references, rename, and semantic tokens.

--- a/Project.toml
+++ b/Project.toml
@@ -27,8 +27,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [sources]
 Compiler = {rev = "avi/JETLS-Compiler-head", subdir = "Compiler", url = "https://github.com/JuliaLang/julia"}
 JET = {rev = "763ae6b0", url = "https://github.com/aviatesk/JET.jl"}
-JuliaLowering = {rev = "523e98135d", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
-JuliaSyntax = {rev = "523e98135d", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
+JuliaLowering = {rev = "8900f185f2", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
+JuliaSyntax = {rev = "8900f185f2", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
 LSP = {path = "LSP"}
 
 [compat]

--- a/test/analysis/test_Closure2Opaque.jl
+++ b/test/analysis/test_Closure2Opaque.jl
@@ -234,6 +234,17 @@ end
         @test val == [11.0, 21.0, 12.0, 22.0, 13.0, 23.0]
         @test count_opaque_closures(tree) == 2
     end
+
+    let (val, tree) = rewrite_lower_eval("""
+            let watched = Set(["src/A.jl"]), batches = [["src/A.jl", "src/B.jl"]]
+                only(map(batches) do changed_files
+                    any(path -> path in watched, changed_files)
+                end)
+            end
+            """)
+        @test val === true
+        @test count_opaque_closures(tree) == 2
+    end
 end
 
 @testset "do-block as map argument" begin

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -532,6 +532,30 @@ end
             end
         end
 
+        @testset "nested closure captures enclosing capture" begin
+            let code = """
+                function has_watched_change()
+                    watched = Set(["src/A.jl"])
+                    batches = [["src/A.jl", "src/B.jl"]]
+                    only(map(batches) do changed_files
+                        any(path -> path in watched, changed_files)
+                    end)
+                end
+                """
+                _, ctx = type_annotate(code)
+                any_expr = "any(path -> path in watched, changed_files)"
+                map_expr = "map(batches) do changed_files\n" *
+                    "        any(path -> path in watched, changed_files)\n" *
+                    "    end"
+                any_call = range_of(code, any_expr)
+                map_call = range_of(code, map_expr)
+                only_call = range_of(code, "only($map_expr)")
+                @test widenconst(get_type_for_range(ctx, any_call)) === Bool
+                @test widenconst(get_type_for_range(ctx, map_call)) === Vector{Bool}
+                @test widenconst(get_type_for_range(ctx, only_call)) === Bool
+            end
+        end
+
         # Closure argument-type refinement (see the `TypeAnnotation` module docstring):
         # untyped closure parameters get their signature inferred from the join of
         # observed call-site argtypes across inference passes, instead of degrading


### PR DESCRIPTION
Type annotation previously failed or lost results for nested local closures that capture a value already captured by an enclosing closure.

Type annotation previously failed for nested local closures like:
```julia
let watched = Set(["src/A.jl"])
    batches = [["src/A.jl", "src/B.jl"]]
    only(map(batches) do changed_files
        any(path -> path in watched, changed_files)
    end)
end
```
`Closure2Opaque` rewrites both the outer `do` block and the inner `path -> ...` closure to opaque closures. Before the JuliaLowering fix, lowering that rewritten tree failed because the inner opaque closure captured `watched` through the enclosing closure.

Update the JuliaLowering and JuliaSyntax source revisions to include the nested opaque-closure capture fix, and add regression coverage for both `Closure2Opaque` lowering and the full `TypeAnnotation` pipeline.