### PR TITLE
deps: Update JuliaSyntax and JuliaLowering revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > This disables analysis for matched files. Basic features like completion still might work, but most LSP features will be unfunctional.
 > Note that `analysis_overrides` is provided as a temporary workaround and may be removed or changed at any time. A proper fix is being worked on.
 
+### Changed
+
+- Updated JuliaSyntax.jl and JuliaLowering.jl dependency revisions to latest,
+  fixing several lowering-related bugs.
+
 ### Fixed
 
 - Fixed hover on symbol literals such as `:foo` to show the literal expression (`:foo :: Symbol`) instead of the bare name with internal `Core.Const` details.

--- a/Project.toml
+++ b/Project.toml
@@ -27,8 +27,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [sources]
 Compiler = {rev = "avi/JETLS-Compiler-head", subdir = "Compiler", url = "https://github.com/JuliaLang/julia"}
 JET = {rev = "f423d6f3", url = "https://github.com/aviatesk/JET.jl"}
-JuliaLowering = {rev = "8900f185f2", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
-JuliaSyntax = {rev = "8900f185f2", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
+JuliaLowering = {rev = "600fa49487", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
+JuliaSyntax = {rev = "600fa49487", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
 LSP = {path = "LSP"}
 
 [compat]

--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -1687,6 +1687,10 @@ nodes appropriately; see the source of each helper for the rationale behind its 
 function get_type_for_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
     binding_typ = get(ctx.oc_argument_binding_types, rng, nothing)
     binding_typ === nothing || return binding_typ
+    if is_oc_construction_site(ctx, rng)
+        typ = type_for_oc_body_return_at_range(ctx, rng)
+        typ === nothing || return typ
+    end
     surface_kind = surface_kind_at_range(ctx, rng)
     if surface_kind === JS.K"macrocall"
         return type_for_macroexpansion(ctx, rng)
@@ -1852,15 +1856,38 @@ function type_for_funcdef(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
     return typ
 end
 
+is_oc_construction_site(ctx::InferredTreeContext, rng::UnitRange{<:Integer}) =
+    any(s -> JS.kind(s) === JS.K"new_opaque_closure", get(ctx.by_byte_range, rng, ()))
+
+function type_for_oc_body_return_at_range(
+        ctx::InferredTreeContext, rng::UnitRange{<:Integer}
+    )
+    typ = nothing
+    lo = searchsortedfirst(ctx.return_first_bytes, first(rng))
+    for i in lo:length(ctx.return_first_bytes)
+        first_byte = ctx.return_first_bytes[i]
+        first_byte > last(rng) && break
+        st = ctx.return_nodes[i]
+        JS.last_byte(st) <= last(rng) || continue
+        get(ctx.oc_body_scope, st._id, nothing) === rng || continue
+        JS.hasattr(st, :type) || continue
+        ntyp = st.type
+        typ = typ === nothing ? ntyp : CC.tmerge(ntyp, typ)
+    end
+    return typ
+end
+
 function tmerge_at_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
     nodes = get(ctx.by_byte_range, rng, ())
     # When `OpaqueClosure` construction occurs at `rng` (most often a comprehension/
     # `map`/`filter` auto-generated lambda whose source bytes coincide with the user's
     # yield expression), the construction scaffolding — OC method object, argt/rt_lb svec,
     # OC binding — would otherwise `tmerge` into the user-visible value and surface as
-    # `Union{T, Method, OpaqueClosure, Type}`. Keep only nodes attributed to the body of
-    # the OC at `rng`; outside that scope is scaffolding.
-    is_oc_site = any(s -> JS.kind(s) === JS.K"new_opaque_closure", nodes)
+    # `Union{T, Method, OpaqueClosure, Type}`. Prefer the OC body's return type when
+    # available; it summarizes the user-visible value without mixing in synthetic typed-
+    # iterator conversion checks. Otherwise keep only nodes attributed to the body of the
+    # OC at `rng`; outside that scope is scaffolding.
+    is_oc_site = is_oc_construction_site(ctx, rng)
     # Property destructuring in parameter position (`do (; a, b)`) emits a
     # `getproperty(obj, :a)` whose field-name `K"Symbol"` leaf lands on the binding's
     # byte range, polluting it to `Union{T, Symbol}`. (Assignment-position `(; a, b) =`

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -1098,6 +1098,22 @@ end
             end
         end
 
+        @testset "comprehension with typed iterator branching body" begin
+            let code = "let xs = [1, 2, 3]; [(x > 0 ? x : -x) for x::Int in xs]; end"
+                _, ctx = type_annotate(code)
+                body_rng = range_of(code, "x > 0 ? x : -x")
+                @test widenconst(get_type_for_range(ctx, body_rng)) === Int
+            end
+        end
+
+        @testset "comprehension with typed iterator block body" begin
+            let code = "let xs = [1, 2, 3]; [begin z = x; z end for x::Int in xs]; end"
+                _, ctx = type_annotate(code)
+                body_rng = range_of(code, "begin z = x; z end")
+                @test widenconst(get_type_for_range(ctx, body_rng)) === Int
+            end
+        end
+
         @testset "comprehension with destructured tuple yield" begin
             let code = """
                 let xs = rand(3), ys = rand(3)


### PR DESCRIPTION
Update the JuliaSyntax and JuliaLowering revisions used by JETLS. The newer JuliaLowering checkout changes typed generator lowering, so queries for typed comprehension bodies such as `[x for x::Int in xs]` can otherwise surface intermediate type-checking results in type annotations and inlay hints.

Adjust `TypeAnnotation` to treat opaque-closure construction ranges as body-result queries when a scoped closure return value is available. This keeps the yielded expression annotated with its source-level value while leaving annotations for inner expressions such as `y`, `z`, and `sin(y)` intact.

Adds TypeAnnotation coverage for typed iterator bodies with branching and block-form expressions.