### PR TITLE
release: Preserve non-vendored source entries

### DIFF
--- a/scripts/vendor-deps.jl
+++ b/scripts/vendor-deps.jl
@@ -368,7 +368,9 @@ function update_project_with_vendored_deps(
         end
     end
 
-    project["sources"] = Dict{String, Any}()
+    if !haskey(project, "sources")
+        project["sources"] = Dict{String, Any}()
+    end
 
     if use_local_path
         for (pkg_name, original_uuid) in all_vendored_packages


### PR DESCRIPTION
`vendor-deps.jl --local` rebuilt root `[sources]` from scratch. That dropped source entries for non-vendored direct dependencies, including `Revise`, so the final `Pkg.instantiate()` fell back to General and failed while `Revise` 3.16 was still unreleased.

Keep the existing `[sources]` table when updating the root project. Vendored packages still overwrite their own source entries, while non-vendored entries are preserved.