### PR TITLE
dev-mode: Run server loop to a fixed world

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -72,10 +72,13 @@ JETLS has a development mode that can be enabled through the `JETLS_DEV_MODE`
 [preference](https://github.com/JuliaPackaging/Preferences.jl).
 When this mode is enabled, the language server enables several features to aid
 in development:
-- Automatic loading of Revise when starting the server, allowing changes to be
-  applied without restarting
-- Uses `@invokelatest` in message handling to ensure that changes made by Revise
-  are reflected without terminating the `runserver` loop
+- Automatic loading of Revise when starting the server
+- Pins message handling to a server world age, so full-analysis can inspect
+  revised JETLS methods without changing the running server machinery
+- Applies Revise before Revise-based full-analysis, rather than on every
+  received LSP message
+- Watches `.JETLS_REVISE`; creating or touching this file applies Revise and
+  advances the running server world without restarting the server
 
 Note that error handling behavior (whether errors are caught or propagated) is
 controlled by `JETLS_TEST_MODE`, not `JETLS_DEV_MODE`.

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -27,11 +27,27 @@ function show_setup_info(msg)
     @info msg Sys.BINDIR pkgdir(JETLS) Threads.nthreads() JETLS_VERSION JETLS_DEV_MODE JETLS_TEST_MODE JETLS_DEBUG_LOWERING
 end
 
+const server_world_age = Ref{UInt}(typemax(UInt))
+
+"""
+    advance_server_world!()
+
+Pin JETLS server dispatch to the current world age.
+"""
+advance_server_world!() = (server_world_age[] = Base.get_world_counter(); nothing)
+
+call_in_server_world(@nospecialize(f), args...; kwargs...) =
+    Base.invoke_in_world(server_world_age[], f, args...; kwargs...)
+
+push_init_hook!(advance_server_world!)
+
 if JETLS_DEV_MODE
     using Revise: Revise
 else
     const Revise = nothing
 end
+
+revise_now!() = JETLS_DEV_MODE && Revise.revise()
 
 using LSP
 using LSP: LSP

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -161,15 +161,11 @@ include("did-change-watched-files.jl")
 include("initialize.jl")
 
 """
-    runserver([callback,] in::IO, out::IO; client_process_id=nothing) -> exit_code::Int
-    runserver([callback,] endpoint::Endpoint; client_process_id=nothing) -> exit_code::Int
-    runserver([callback,] server::Server; client_process_id=nothing) -> exit_code::Int
+    runserver(in::IO, out::IO; client_process_id=nothing) -> exit_code::Int
+    runserver(endpoint::Endpoint; client_process_id=nothing) -> exit_code::Int
+    runserver(server::Server; client_process_id=nothing) -> exit_code::Int
 
 Run the JETLS language server with the specified input/output streams or endpoint.
-
-The `callback` function is invoked on each message sent or received, with the
-signature `callback(event::Symbol, msg)` where `event` is either `:sent` or
-`:received`. If not specified, a no-op callback is used.
 
 When given IO streams, the function creates an `Endpoint` and then a `ServerState`
 before entering the message handling loop. The function returns after receiving an
@@ -211,9 +207,8 @@ allowing the caller side to safely `exit` this Julia process.
 """
 const self_shutdown_token = SelfShutdownNotification()
 
-runserver(args...; kwargs...) = runserver(Returns(nothing), args...; kwargs...) # no callback specified
-runserver(callback, in::IO, out::IO; kwargs...) = runserver(callback, Endpoint(in, out); kwargs...)
-runserver(callback, endpoint::Endpoint; kwargs...) = runserver(Server(callback, endpoint); kwargs...)
+runserver(in::IO, out::IO; kwargs...) = runserver(Endpoint(in, out); kwargs...)
+runserver(endpoint::Endpoint; kwargs...) = runserver(Server(endpoint); kwargs...)
 function runserver(
         server::Server;
         client_process_id::Union{Nothing,Int} = nothing,

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -901,6 +901,7 @@ function analyze_package_with_revise(
 
     haskey(Revise.pkgdatas, pkgid) || Revise.watch_package(pkgid)
     haskey(Revise.pkgdatas, pkgid) || error(lazy"Package $(pkgid.name) is not analyzable by Revise")
+    revise_now!()
 
     # If Revise hasn't instantiated signatures yet, populate that cache here
     pkgdata = Revise.pkgdatas[pkgid]

--- a/src/app/cli-check.jl
+++ b/src/app/cli-check.jl
@@ -366,7 +366,7 @@ function run_check(args::Vector{String})
 end
 
 function start_cli_server(root_path::AbstractString)
-    server = Server(; suppress_notifications=true, cli_mode=true)
+    server = Server(; cli_mode=true)
 
     # Normalize via URI round-trip so the casing of `state.root_path` matches
     # paths reconstructed from URIs (lowercase drive letter on Windows).

--- a/src/app/cli-serve.jl
+++ b/src/app/cli-serve.jl
@@ -149,15 +149,7 @@ function run_serve(args::Vector{String})
     @with_cli_LOAD_PATH begin
         if JETLS_DEV_MODE
             global currently_running
-            currently_running = server = Server(endpoint) do s::Symbol, x
-                @nospecialize x
-                # allow Revise to apply changes with the dev mode enabled
-                if s === :received
-                    if !(x isa ShutdownRequest || x isa ExitNotification)
-                        Revise.revise()
-                    end
-                end
-            end
+            currently_running = server = Server(Returns(nothing), endpoint)
             runserver_task = let client_process_id=client_process_id, transport=transport
                 Threads.@spawn :interactive runserver(server; client_process_id, transport)
             end

--- a/src/app/cli-serve.jl
+++ b/src/app/cli-serve.jl
@@ -149,7 +149,7 @@ function run_serve(args::Vector{String})
     @with_cli_LOAD_PATH begin
         if JETLS_DEV_MODE
             global currently_running
-            currently_running = server = Server(Returns(nothing), endpoint)
+            currently_running = server = Server(endpoint)
             runserver_task = let client_process_id=client_process_id, transport=transport
                 Threads.@spawn :interactive runserver(server; client_process_id, transport)
             end

--- a/src/did-change-watched-files.jl
+++ b/src/did-change-watched-files.jl
@@ -3,32 +3,40 @@ const DID_CHANGE_WATCHED_FILES_REGISTRATION_METHOD = "workspace/didChangeWatched
 
 const CONFIG_FILE = ".JETLSConfig.toml"
 const PROFILE_TRIGGER_FILE = ".JETLSProfile"
+const SERVER_REVISE_TRIGGER_FILE = ".JETLS_REVISE"
 
 function did_change_watched_files_registration(server::Server)
     state = server.state
     isdefined(state, :root_path) || return nothing
     root_uri = filepath2uri(state.root_path)
+    watchers = FileSystemWatcher[
+        FileSystemWatcher(;
+            globPattern = RelativePattern(;
+                baseUri = root_uri,
+                pattern = CONFIG_FILE),
+            kind = WatchKind.Create | WatchKind.Change | WatchKind.Delete),
+        FileSystemWatcher(;
+            globPattern = RelativePattern(;
+                baseUri = root_uri,
+                pattern = PROFILE_TRIGGER_FILE),
+            kind = WatchKind.Create),
+        FileSystemWatcher(;
+            globPattern = RelativePattern(;
+                baseUri = root_uri,
+                pattern = "**/*.jl"),
+            kind = WatchKind.Create | WatchKind.Change | WatchKind.Delete),
+    ]
+    if JETLS_DEV_MODE
+        push!(watchers, FileSystemWatcher(;
+            globPattern = RelativePattern(;
+                baseUri = root_uri,
+                pattern = SERVER_REVISE_TRIGGER_FILE),
+            kind = WatchKind.Create | WatchKind.Change))
+    end
     Registration(;
         id = DID_CHANGE_WATCHED_FILES_REGISTRATION_ID,
         method = DID_CHANGE_WATCHED_FILES_REGISTRATION_METHOD,
-        registerOptions = DidChangeWatchedFilesRegistrationOptions(;
-            watchers = FileSystemWatcher[
-                FileSystemWatcher(;
-                    globPattern = RelativePattern(;
-                        baseUri = root_uri,
-                        pattern = CONFIG_FILE),
-                    kind = WatchKind.Create | WatchKind.Change | WatchKind.Delete),
-                FileSystemWatcher(;
-                    globPattern = RelativePattern(;
-                        baseUri = root_uri,
-                        pattern = PROFILE_TRIGGER_FILE),
-                    kind = WatchKind.Create),
-                FileSystemWatcher(;
-                    globPattern = RelativePattern(;
-                        baseUri = root_uri,
-                        pattern = "**/*.jl"),
-                    kind = WatchKind.Create | WatchKind.Change | WatchKind.Delete),
-            ]))
+        registerOptions = DidChangeWatchedFilesRegistrationOptions(; watchers))
 end
 
 # For dynamic registrations during development
@@ -118,8 +126,16 @@ function delete_file_config!(on_difference, manager::ConfigManager, filepath::Ab
 end
 
 is_profile_trigger_file(path::AbstractString) = endswith(path, PROFILE_TRIGGER_FILE)
-
+is_server_revise_trigger_file(path::AbstractString) = endswith(path, SERVER_REVISE_TRIGGER_FILE)
 is_jl_file(path::AbstractString) = endswith(path, ".jl")
+
+function handle_server_revise_trigger!(server::Server, trigger_path::AbstractString)
+    JETLS_DEV_MODE || return show_warning_message(server,  ".JETLS_REVISE requires dev mode")
+    revise_now!()
+    advance_server_world!()
+    show_info_message(server, "JETLS server world advanced: $trigger_path")
+    request_delete_file(server, filepath2uri(trigger_path))
+end
 
 function handle_DidChangeWatchedFilesNotification(server::Server, msg::DidChangeWatchedFilesNotification)
     for change in msg.params.changes
@@ -128,6 +144,8 @@ function handle_DidChangeWatchedFilesNotification(server::Server, msg::DidChange
             handle_config_file_change!(server, changed_path, change.type)
         elseif is_profile_trigger_file(changed_path) && change.type == FileChangeType.Created
             trigger_profile!(server, changed_path)
+        elseif is_server_revise_trigger_file(changed_path) && change.type != FileChangeType.Deleted
+            handle_server_revise_trigger!(server, changed_path)
         elseif is_jl_file(changed_path)
             handle_jl_file_change!(server, change)
         end

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -53,9 +53,7 @@ function cache_file_info!(
 
     invalidate_per_file_caches!(state, uri)
 
-    if !state.suppress_notifications && any_deleted
-        notify_diagnostics!(server; ensure_cleared=uri)
-    end
+    any_deleted && notify_diagnostics!(server; ensure_cleared=uri)
 
     return fi
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -898,7 +898,6 @@ mutable struct ServerState
     const currently_registered::CurrentlyRegistered
     const config_manager::ConfigManager
     const completion_resolver_info::CompletionResolverInfo
-    const suppress_notifications::Bool
     # When true, skip workspace-boundary guards intended for the LSP flow.
     # Files in CLI mode are explicitly named on the command line, so the
     # `state.root_path`-based "is this file inside the workspace?" check in
@@ -912,7 +911,7 @@ mutable struct ServerState
     root_path::String
     root_env_path::String
     init_params::InitializeParams
-    function ServerState(; suppress_notifications::Bool=false, cli_mode::Bool=false)
+    function ServerState(; cli_mode::Bool=false)
         return new(
             #=file_cache=# FileCache(),
             #=saved_file_cache=# SavedFileCache(),
@@ -931,7 +930,6 @@ mutable struct ServerState
             #=currently_registered=# CurrentlyRegistered(),
             #=config_manager=# ConfigManager(),
             #=completion_resolver_info=# CompletionResolverInfo(nothing),
-            suppress_notifications,
             cli_mode,
             #=encoding=# PositionEncodingKind.UTF16, # initialize with UTF16 (for tests)
             #=init_options=# DEFAULT_INIT_OPTIONS, # initialize with defaults
@@ -958,22 +956,14 @@ struct Server
     callback::Union{Nothing,ServerMessageRecorder}
     function Server(
             endpoint::Endpoint;
-            suppress_notifications::Bool = false,
             cli_mode::Bool = false,
             callback::Union{Nothing,ServerMessageRecorder} = nothing
         )
         return new(
             endpoint,
-            ServerState(; suppress_notifications, cli_mode),
+            ServerState(; cli_mode),
             Channel{Any}(Inf),
             callback)
     end
 end
-function Server(; # used by tests
-    suppress_notifications::Bool = true,
-    cli_mode::Bool = false,
-    callback::Union{Nothing,ServerMessageRecorder} = nothing)
-    return Server(
-        Endpoint(IOBuffer(), IOBuffer());
-        suppress_notifications, cli_mode, callback)
-end
+Server(; kwargs...) = Server(Endpoint(IOBuffer(), IOBuffer()); kwargs...) # used by tests

--- a/src/types.jl
+++ b/src/types.jl
@@ -939,21 +939,41 @@ mutable struct ServerState
     end
 end
 
-struct Server{Callback}
-    endpoint::Endpoint
-    callback::Callback
-    state::ServerState
-    message_queue::Channel{Any}
-    function Server(
-            callback::Callback, endpoint::Endpoint;
-            suppress_notifications::Bool=false, cli_mode::Bool=false
-        ) where Callback
-        return new{Callback}(
-            endpoint,
-            callback,
-            ServerState(; suppress_notifications, cli_mode),
-            Channel{Any}(Inf))
+struct ServerMessageRecorder
+    received_queue::Channel{Any}
+    sent_queue::Channel{Any}
+end
+function (callback::ServerMessageRecorder)(s::Symbol, @nospecialize(msg))
+    if s === :received
+        put!(callback.received_queue, msg)
+    elseif s === :sent
+        put!(callback.sent_queue, msg)
     end
 end
-Server(; suppress_notifications::Bool=true, cli_mode::Bool=false) = # used for tests
-    Server(Returns(nothing), Endpoint(IOBuffer(), IOBuffer()); suppress_notifications, cli_mode)
+
+struct Server
+    endpoint::Endpoint
+    state::ServerState
+    message_queue::Channel{Any}
+    callback::Union{Nothing,ServerMessageRecorder}
+    function Server(
+            endpoint::Endpoint;
+            suppress_notifications::Bool = false,
+            cli_mode::Bool = false,
+            callback::Union{Nothing,ServerMessageRecorder} = nothing
+        )
+        return new(
+            endpoint,
+            ServerState(; suppress_notifications, cli_mode),
+            Channel{Any}(Inf),
+            callback)
+    end
+end
+function Server(; # used by tests
+    suppress_notifications::Bool = true,
+    cli_mode::Bool = false,
+    callback::Union{Nothing,ServerMessageRecorder} = nothing)
+    return Server(
+        Endpoint(IOBuffer(), IOBuffer());
+        suppress_notifications, cli_mode, callback)
+end

--- a/src/utils/general.jl
+++ b/src/utils/general.jl
@@ -160,17 +160,17 @@ end
 """
     @tryinvokelatest f(args...; kwargs...)
 
-Safely invoke a function with the latest method definitions and automatic error handling.
+Safely invoke a function in the server world with automatic error handling.
 
-This macro combines the functionality of `@invokelatest` and `try`-`catch` error handling,
+This macro combines pinned server-world dispatch and `try`-`catch` error handling,
 providing a robust way to call functions in the JETLS server environment where:
-- Methods that are called from unrevisable loop may be updated by Revise.jl during development
+- Methods that are called from unrevisable loops may be updated by Revise.jl during development
 - Errors should be logged but not crash the server (in non-test mode)
 
 The macro's behavior depends on the JETLS execution mode:
-- `JETLS_DEV_MODE=true`: Wraps the call with `@invokelatest` to ensure Revise.jl
-  changes are reflected without restarting the server
-- `JETLS_DEV_MODE=false`: Direct function call without `@invokelatest`
+- `JETLS_DEV_MODE=true`: Wraps the call with `call_in_server_world` so running server
+  code stays pinned until `advance_server_world!` is called
+- `JETLS_DEV_MODE=false`: Direct function call
 - `JETLS_TEST_MODE=true`: No `try`-`catch` wrapping, allowing errors to propagate for testing
 - `JETLS_TEST_MODE=false`: Wraps the call in `try`-`catch` to log errors without crashing
 """
@@ -184,9 +184,10 @@ macro tryinvokelatest(ex)
     isempty(kwargs) || push!(callex.args, Expr(:parameters, kwargs...))
     push!(callex.args, args...)
     callex = if JETLS_DEV_MODE
-        # `@invokelatest` for allowing changes maded by Revise to be reflected without
-        # terminating the `runserver` loop
-        :(@invokelatest $(callex))
+        worldex = Expr(:call, :call_in_server_world, f)
+        isempty(kwargs) || push!(worldex.args, Expr(:parameters, kwargs...))
+        push!(worldex.args, args...)
+        worldex
     else
         callex
     end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -52,14 +52,7 @@ function withserver(f;
     received_queue = Channel{Any}(Inf)
     sent_queue = Channel{Any}(Inf)
     endpoint = Endpoint(in_pipe.out, out_pipe.in)
-    server = Server(endpoint) do s::Symbol, x
-        @nospecialize x
-        if s === :received
-            put!(received_queue, x)
-        elseif s === :sent
-            put!(sent_queue, x)
-        end
-    end
+    server = Server(endpoint; callback=JETLS.ServerMessageRecorder(received_queue, sent_queue))
     runserver_task = Threads.@spawn :interactive runserver(server)
     id_counter = Ref(0)
     old_env = Pkg.project().path


### PR DESCRIPTION
JETLS development mode previously ran Revise from the LSP receive callback and dispatched handlers with `@invokelatest`. When JETLS analyzed itself, ordinary requests could update both the analyzed code and the running language-server machinery to the latest methods.

Add a server world age captured at initialization and route dev-mode handler dispatch through `Base.invoke_in_world`. Apply Revise before Revise-based full analysis so the analysis snapshot sees updated package methods without changing the running server code. Add a `.JETLS_REVISE` watched-file trigger to apply Revise and explicitly advance the server world when needed.

This does not isolate mutable globals or existing server state.
Structural changes to running server objects may still require a restart.