### PR TITLE
completions: Fix property completion broken by incomplete dot-access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed stale methods from previous script or notebook analyses lingering after re-analysis or occasionally triggering `Method ... already disabled` cleanup errors.
 
+- Fixed property completion (`obj.`) returning no suggestions in some contexts where the incomplete dot-access prevented type inference, such as inside `try`/`catch` blocks or on the right-hand side of an assignment (`out = obj.`).
+
 ## 2026-06-23
 
 - Commit: [`35c3262`](https://github.com/aviatesk/JETLS.jl/commit/35c3262)

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -151,6 +151,34 @@ function get_inferred_ctx!(comp_ctx::CompletionCtx; caller::AbstractString)
     return comp_ctx.inferred_ctx[] = ctx
 end
 
+# Property completion only needs the prefix type. Build inference from a virtual
+# source where the cursor's incomplete `.partial` accessor is removed, instead of
+# teaching generic AST repair every parser-recovery shape around `prefix.│`.
+function get_dotprefix_inferred_ctx(
+        comp_ctx::CompletionCtx, dotprefix::SyntaxTreeC; caller::AbstractString
+    )
+    hole_start = JS.last_byte(dotprefix) + 1
+    hole_end = property_completion_hole_end(comp_ctx.fi, comp_ctx.offset, hole_start)
+    textbuf = copy(comp_ctx.fi.parsed_stream.textbuf)
+    if hole_start ≤ hole_end
+        deleteat!(textbuf, hole_start:hole_end)
+    end
+    virtual_fi = FileInfo(comp_ctx.fi.version, textbuf, comp_ctx.fi.filename, comp_ctx.fi.encoding)
+    virtual_st0_top = build_syntax_tree(virtual_fi)
+    virtual_st0 = @something lowerable_toplevel_at(virtual_st0_top, JS.first_byte(dotprefix)) return nothing
+    return build_inferred_context_for_tree(virtual_st0, comp_ctx.context_module;
+        world=comp_ctx.world, caller, cache=nothing)
+end
+
+function property_completion_hole_end(fi::FileInfo, offset::Int, hole_start::Int)
+    hole_end = max(hole_start - 1, offset - 1)
+    tok = @something token_at_offset(fi.parsed_stream, offset) return hole_end
+    if JS.kind(tok) === JS.K"Identifier" && JS.first_byte(tok) ≥ hole_start
+        hole_end = max(hole_end, JS.last_byte(tok))
+    end
+    return hole_end
+end
+
 function get_cursor_bindings_cached!(comp_ctx::CompletionCtx)
     isassigned(comp_ctx.cursor_bindings) && return comp_ctx.cursor_bindings[]
     cbs = cursor_bindings(comp_ctx.st0_top, comp_ctx.offset, comp_ctx.context_module;
@@ -311,7 +339,7 @@ function global_completions!(
     dotprefix = select_dotprefix_identifier(st0_top, comp_ctx.offset)
     if !isnothing(dotprefix)
         rng = JS.byte_range(dotprefix)
-        ctx = get_inferred_ctx!(comp_ctx; caller="global_completions!")
+        ctx = get_dotprefix_inferred_ctx(comp_ctx, dotprefix; caller="global_completions!")
         prefixtyp = ctx === nothing ? nothing : get_type_for_range(ctx, rng)
         # A `Union{}` prefix type is uninformative (the prefix throws or is dead code);
         # treat it like `nothing` so module/const prefixes such as `Base.` still complete.

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -600,6 +600,46 @@ end
         @test cnt[] == 1
     end
 
+    let text = """
+        function func(c::Bool, r::Regex)
+            try
+                r.│
+                if c
+                    return nothing
+                end
+            catch
+            end
+        end
+        """
+        cnt = Ref(0)
+        with_completion_items(text; context=dot_context) do (; result)
+            labels = Set(it.label for it in only_props(result.items))
+            @test labels == Set(String.(fieldnames(Regex)))
+            cnt[] += 1
+        end
+        @test cnt[] == 1
+    end
+
+    let text = """
+        function func(c::Bool, r::Regex)
+            try
+                out = r.│
+                if c
+                    return nothing
+                end
+            catch
+            end
+        end
+        """
+        cnt = Ref(0)
+        with_completion_items(text; context=dot_context) do (; result)
+            labels = Set(it.label for it in only_props(result.items))
+            @test labels == Set(String.(fieldnames(Regex)))
+            cnt[] += 1
+        end
+        @test cnt[] == 1
+    end
+
     # Untyped prefix: no useful type to query, so no property completions.
     let text = """
         function bar(x)


### PR DESCRIPTION
Property completion (`obj.`) previously returned no suggestions in some contexts where the incomplete `prefix.│` accessor at the cursor prevented type inference of the prefix, such as inside `try`/`catch` blocks or on the right-hand side of an assignment (`out = obj.`).

Introduce `get_dotprefix_inferred_ctx`, which builds the inferred context from a virtual source where the cursor's incomplete `.partial` accessor is removed, instead of relying on generic AST repair to handle every parser-recovery shape around `prefix.│`. The helper `property_completion_hole_end` computes the byte range to delete (the dangling dot plus any partially-typed identifier under the cursor). Since property completion only needs the prefix type, this narrower virtual-source approach sidesteps the fragile recovery cases that previously broke inference.

Add tests covering `r.│` and `out = r.│` inside a `try`/`catch` block.