### PR TITLE
diagnostic: Add inferred `TypeError` reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 > This disables analysis for matched files. Basic features like completion still might work, but most LSP features will be unfunctional.
 > Note that `analysis_overrides` is provided as a temporary workaround and may be removed or changed at any time. A proper fix is being worked on.
 
+### Breaking
+
+- `inference/non-boolean-cond` is now reported as `inference/type-error/non-bool-cond`. Existing diagnostic pattern configurations that match the old code continue to apply for now, but this compatibility support may be removed in a future release.
+
+### Added
+
+- Added the `inference/type-error/type-assert` diagnostic for type assertions that inference can prove will fail, such as `x::Int` when `x` is inferred as `Float64`.
+
+### Changed
+
+- `inference/type-error/*` now groups diagnostics for the subset of runtime `TypeError` cases that JETLS can infer, including non-`Bool` conditions and statically failing type assertions. Users can ignore or reconfigure this family together with a regex code match such as `^inference/type-error/`.
+
 ## 2026-06-26
 
 - Commit: [`0d67c12`](https://github.com/aviatesk/JETLS.jl/commit/0d67c12)

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -125,7 +125,8 @@ Here is a summary table of the diagnostics explained in this section:
 | [`inference/field-error`](@ref diagnostic/reference/inference/field-error)                                     | `Warning`             | `JETLS/save`  | Access to non-existent struct fields                   |
 | [`inference/bounds-error`](@ref diagnostic/reference/inference/bounds-error)                                   | `Warning`             | `JETLS/save`  | Out-of-bounds field access by index                    |
 | [`inference/method-error`](@ref diagnostic/reference/inference/method-error)                                   | `Warning`             | `JETLS/save`  | No matching method found for function calls            |
-| [`inference/non-boolean-cond`](@ref diagnostic/reference/inference/non-boolean-cond)                           | `Warning`             | `JETLS/save`  | Non-boolean value used in boolean context              |
+| [`inference/type-error/type-assert`](@ref diagnostic/reference/inference/type-error/type-assert)               | `Warning`             | `JETLS/save`  | Type assertion failures                                |
+| [`inference/type-error/non-bool-cond`](@ref diagnostic/reference/inference/type-error/non-bool-cond)           | `Warning`             | `JETLS/save`  | Non-boolean value used in boolean context              |
 | [`testrunner/test-failure`](@ref diagnostic/reference/testrunner/test-failure)                                 | `Error`               | `JETLS/extra` | Test failures from TestRunner integration              |
 
 ### [Syntax diagnostic (`syntax/*`)](@id diagnostic/reference/syntax)
@@ -1098,7 +1099,28 @@ function union_split_method_error(x::Union{Int,String})
 end
 ```
 
-#### [Non-boolean condition (`inference/non-boolean-cond`)](@id diagnostic/reference/inference/non-boolean-cond)
+#### [Type assertion error (`inference/type-error/type-assert`)](@id diagnostic/reference/inference/type-error/type-assert)
+
+**Default severity:** `Warning`
+
+Type assertions that are guaranteed to fail. Julia raises a `TypeError` at
+runtime when a value does not satisfy a type assertion like `x::T`.
+
+Example:
+
+```julia
+let x = rand()
+    o = x::Int  # TypeError: in typeassert, expected Int64, got a value of type Float64
+                # (JETLS inference/type-error/type-assert)
+    o
+end
+```
+
+This diagnostic is reported when inference can prove that the asserted value's
+inferred type has no overlap with the asserted type. Type assertions that may
+succeed for some runtime values are not reported.
+
+#### [Non-boolean condition (`inference/type-error/non-bool-cond`)](@id diagnostic/reference/inference/type-error/non-bool-cond)
 
 **Default severity:** `Warning`
 
@@ -1112,7 +1134,7 @@ Examples:
 function non_boolean_example()
     x = 1
     if x  # non-boolean `Int64` found in boolean context
-          # (JETLS inference/non-boolean-cond)
+          # (JETLS inference/type-error/non-bool-cond)
         return "truthy"
     end
 end
@@ -1124,7 +1146,7 @@ When union-split types include non-boolean branches:
 function find_zero(xs::Vector{Union{Missing,Int}})
     for i in eachindex(xs)
         xs[i] == 0 && return i  # non-boolean `Missing` found in boolean context (1/2 union split)
-                                # (JETLS inference/non-boolean-cond)
+                                # (JETLS inference/type-error/non-bool-cond)
     end
 end
 ```
@@ -1137,7 +1159,7 @@ end
     ```julia
     function check(x, y::AbstractString)
         x == :flag || error("x is invalid")  # non-boolean `Missing` found in boolean context (1/2 union split)
-                                             # (JETLS inference/non-boolean-cond)
+                                             # (JETLS inference/type-error/non-bool-cond)
         return println(y)
     end
     ```
@@ -1148,6 +1170,13 @@ end
     - Adding a `::Bool` return type annotation to the comparison
       expression if you know `x` will never be `missing`
       (e.g. `(x == :flag)::Bool`).
+
+##### [Legacy diagnostic code (`inference/non-boolean-cond`)](@id diagnostic/reference/inference/non-boolean-cond)
+
+`inference/non-boolean-cond` is a deprecated code alias for
+`inference/type-error/non-bool-cond`. It is kept for existing documentation
+links and diagnostic pattern configurations for now, but this compatibility
+support may be removed in a future release.
 
 ### [TestRunner diagnostic (`testrunner/*`)](@id diagnostic/reference/testrunner)
 

--- a/src/analysis/Analyzer.jl
+++ b/src/analysis/Analyzer.jl
@@ -2,7 +2,7 @@ module Analyzer
 
 export LSAnalyzer, inference_error_report_severity, inference_error_report_stack, reset_report_target_modules!
 export BoundsErrorReport, FieldErrorReport, MethodErrorReport, NonBooleanCondErrorReport,
-    UndefVarErrorReport
+    TypeAssertErrorReport, TypeErrorReport, UndefVarErrorReport
 
 using Core.IR
 using JET.JETInterface
@@ -363,13 +363,14 @@ end
 Abstract type for error reports analyzed by [`LSAnalyzer`](@ref).
 
 Subtypes:
-- `UndefVarErrorReport`: Undefined variables (global only, undefined static parameters is not analyzed currently)
-- `FieldErrorReport`: Access to non-existent struct fields
-- `BoundsErrorReport`: Out-of-bounds field access by index
-- `MethodErrorReport`: Method dispatch errors
-- `NonBooleanCondErrorReport`: Non-boolean value used in boolean context
+- `UndefVarErrorReport`: Undefined global bindings (corresponding to `UndefVarError`)
+- `FieldErrorReport`: Access to non-existent struct fields (corresponding to `FieldError`)
+- `BoundsErrorReport`: Out-of-bounds field access by index (corresponding to `BoundsError`)
+- `MethodErrorReport`: Method dispatch errors (corresponding to `MethodError`)
+- `TypeErrorReport`: Type errors (corresponding to `TypeError`)
 """
 abstract type LSErrorReport <: InferenceErrorReport end
+abstract type TypeErrorReport <: LSErrorReport end
 
 # UndefVarErrorReport
 # -------------------
@@ -454,6 +455,55 @@ JETInterface.print_report_message(io::IO, r::BoundsErrorReport) =
 inference_error_report_stack_impl(r::BoundsErrorReport) = (length(r.vst)-r.vst_offset):-1:1
 inference_error_report_severity_impl(::BoundsErrorReport) = DiagnosticSeverity.Warning
 
+# TypeAssertErrorReport
+# ---------------------
+
+@jetreport struct TypeAssertErrorReport <: TypeErrorReport
+    @nospecialize expected
+    @nospecialize actual
+    union_split::Int
+    vst_offset::Int
+end
+inference_error_report_stack_impl(r::TypeAssertErrorReport) = (length(r.vst)-r.vst_offset):-1:1
+inference_error_report_severity_impl(::TypeAssertErrorReport) = DiagnosticSeverity.Warning
+
+function JETInterface.print_report_message(io::IO, r::TypeAssertErrorReport)
+    print(io, "TypeError: in `typeassert`, expected `", r.expected, "`, got ")
+    print_type_error_got(io, r.actual)
+    if r.union_split != 0
+        print(io, " (", 1, '/', r.union_split, " union split)")
+    end
+end
+
+function print_type_error_got(io::IO, @nospecialize(actual))
+    if CC.isType(actual)
+        print(io, actual)
+    else
+        print(io, "a value of type `", actual, '`')
+    end
+end
+
+function report_typeassert_error!(
+        analyzer::LSAnalyzer, sv::CC.InferenceState, argtypes::Vector{Any}, offset::Int
+    )
+    length(argtypes) == 2 || return false
+    valtyp, asserttyp = argtypes
+
+    expected = CC.instanceof_tfunc(asserttyp, true)[1]
+    if expected === Union{}
+        actual = CC.widenconst(asserttyp)
+        actual === Union{} && return false
+        add_new_report!(analyzer, sv.result, TypeAssertErrorReport(sv, Type, actual, 0, offset))
+        return true
+    end
+
+    actual = CC.widenconst(valtyp)
+    actual === Union{} && return false
+    CC.hasintersect(actual, expected) && return false
+    add_new_report!(analyzer, sv.result, TypeAssertErrorReport(sv, expected, actual, 0, offset))
+    return true
+end
+
 function report_builtin_error!(
         analyzer::LSAnalyzer, sv::CC.InferenceState, @nospecialize(f), argtypes::Vector{Any},
         @nospecialize(ret), offset::Int
@@ -465,6 +515,8 @@ function report_builtin_error!(
             report_fieldaccess!(analyzer, sv, setfield!, argtypes, offset)
         elseif f === fieldtype
             report_fieldaccess!(analyzer, sv, fieldtype, argtypes, offset)
+        elseif f === Core.typeassert
+            report_typeassert_error!(analyzer, sv, argtypes, offset)
         end
     end
 end
@@ -617,7 +669,7 @@ end
 # NonBooleanCondErrorReport
 # -------------------------
 
-@jetreport struct NonBooleanCondErrorReport <: LSErrorReport
+@jetreport struct NonBooleanCondErrorReport <: TypeErrorReport
     @nospecialize t # ::Union{Type, Vector{Type}}
     union_split::Int
     uncovered::Bool

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -169,6 +169,14 @@ function calculate_match_specificity(
     return specificity
 end
 
+function diagnostic_code_match_specificity(pattern::Union{Regex,String}, code::String)
+    specificity = calculate_match_specificity(pattern, code, #=is_message_match=#false)
+    for alias in get(DIAGNOSTIC_CODE_ALIASES, code, String[])
+        specificity = max(specificity, calculate_match_specificity(pattern, alias, #=is_message_match=#false))
+    end
+    return specificity
+end
+
 function _apply_diagnostic_config(
         diagnostic::Diagnostic, manager::ConfigManager, uri::URI,
         root_path::Union{Nothing,String}
@@ -209,10 +217,13 @@ function _apply_diagnostic_config(
         if globpath !== nothing && !occursin(globpath, path_for_glob)
             continue
         end
-        target = pattern_config.match_by == "message" ? get_raw_message(diagnostic) : code
         is_message_match = pattern_config.match_by == "message"
-        specificity = calculate_match_specificity(
-            pattern_config.pattern, target, is_message_match)
+        specificity = if is_message_match
+            target = get_raw_message(diagnostic)
+            calculate_match_specificity(pattern_config.pattern, target, is_message_match)
+        else
+            diagnostic_code_match_specificity(pattern_config.pattern, code)
+        end
         if specificity != 0 && specificity >= best_specificity
             best_specificity = specificity
             severity = pattern_config.severity
@@ -437,8 +448,10 @@ function inference_error_report_code(@nospecialize report::JET.InferenceErrorRep
         return INFERENCE_BOUNDS_ERROR_CODE
     elseif report isa MethodErrorReport
         return INFERENCE_METHOD_ERROR_CODE
+    elseif report isa TypeAssertErrorReport
+        return INFERENCE_TYPE_ERROR_TYPE_ASSERT_CODE
     elseif report isa NonBooleanCondErrorReport
-        return INFERENCE_NON_BOOLEAN_COND_CODE
+        return INFERENCE_TYPE_ERROR_NON_BOOL_COND_CODE
     end
     error(lazy"No diagnostic code is defined for report: $report")
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -527,7 +527,9 @@ const INFERENCE_UNDEF_STATIC_PARAM_CODE = "inference/undef-static-param" # curre
 const INFERENCE_FIELD_ERROR_CODE = "inference/field-error"
 const INFERENCE_BOUNDS_ERROR_CODE = "inference/bounds-error"
 const INFERENCE_METHOD_ERROR_CODE = "inference/method-error"
-const INFERENCE_NON_BOOLEAN_COND_CODE = "inference/non-boolean-cond"
+const INFERENCE_TYPE_ERROR_NON_BOOL_COND_CODE = "inference/type-error/non-bool-cond"
+const INFERENCE_TYPE_ERROR_TYPE_ASSERT_CODE = "inference/type-error/type-assert"
+const DEPRECATED_INFERENCE_NON_BOOLEAN_COND_CODE = "inference/non-boolean-cond"
 const TESTRUNNER_TEST_FAILURE_CODE = "testrunner/test-failure"
 
 const ALL_DIAGNOSTIC_CODES = Set{String}(String[
@@ -555,9 +557,16 @@ const ALL_DIAGNOSTIC_CODES = Set{String}(String[
     INFERENCE_FIELD_ERROR_CODE,
     INFERENCE_BOUNDS_ERROR_CODE,
     INFERENCE_METHOD_ERROR_CODE,
-    INFERENCE_NON_BOOLEAN_COND_CODE,
+    INFERENCE_TYPE_ERROR_NON_BOOL_COND_CODE,
+    INFERENCE_TYPE_ERROR_TYPE_ASSERT_CODE,
     TESTRUNNER_TEST_FAILURE_CODE,
 ])
+
+const DIAGNOSTIC_CODE_ALIASES = Dict{String,Vector{String}}(
+    INFERENCE_TYPE_ERROR_NON_BOOL_COND_CODE => String[
+        DEPRECATED_INFERENCE_NON_BOOLEAN_COND_CODE,
+    ],
+)
 
 struct DiagnosticPattern <: ConfigSection
     pattern::Union{Regex,String}

--- a/test/analysis/test_Analyzer.jl
+++ b/test/analysis/test_Analyzer.jl
@@ -238,6 +238,115 @@ end
     end
 end
 
+@testset "TypeErrorReport" begin
+    @testset "TypeAssertErrorReport" begin
+        let result = analyze_call((Int,)) do x
+                x::Int
+            end
+            @test isempty(get_reports(result))
+        end
+        let result = analyze_call((Any,)) do x
+                x::Int
+            end
+            @test isempty(get_reports(result))
+        end
+
+        let result = analyze_call() do
+                let x = rand()
+                    o = x::Int
+                    o
+                end
+            end
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa TypeAssertErrorReport
+            @test r.expected === Int && r.actual === Float64 && r.union_split == 0
+            @test sprint(JETLS.JET.print_report_message, r) == "TypeError: in `typeassert`, expected `Int64`, got a value of type `Float64`"
+        end
+
+        let result = analyze_call() do
+                (Int)::String
+            end
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa TypeAssertErrorReport
+            @test r.expected === String && r.actual === Type{Int} && r.union_split == 0
+            @test sprint(JETLS.JET.print_report_message, r) == "TypeError: in `typeassert`, expected `String`, got Type{Int64}"
+        end
+
+        let result = analyze_call((Union{Int,Float64},)) do x
+                x::Int
+            end
+            @test isempty(get_reports(result))
+        end
+    end
+
+    @testset "NonBooleanCondErrorReport" begin
+        # no report for boolean condition
+        let result = analyze_call((Bool,)) do x
+                x ? 1 : 2
+            end
+            @test isempty(get_reports(result))
+        end
+        let result = analyze_call((Bool,)) do x
+                if x; 1; else; 2; end
+            end
+            @test isempty(get_reports(result))
+        end
+        let result = analyze_call((Bool,)) do x
+                x && return 1
+            end
+            @test isempty(get_reports(result))
+        end
+
+        # basic non-boolean condition
+        let result = analyze_call((Int,)) do x
+                x ? 1 : 2
+            end
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa NonBooleanCondErrorReport && r.union_split == 0
+        end
+        let result = analyze_call((Int,)) do x
+                if x; 1; else; 2; end
+            end
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa NonBooleanCondErrorReport && r.union_split == 0
+        end
+        let result = analyze_call((Int,)) do x
+                x && return 1
+            end
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa NonBooleanCondErrorReport && r.union_split == 0
+        end
+
+        # union split case: only one branch is non-boolean
+        let result = analyze_call((Union{Bool,Int},)) do x
+                x ?  1 : 2
+            end
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa NonBooleanCondErrorReport && r.union_split == 2 && length(r.t) == 1
+        end
+
+        # JuliaLang/julia#61526
+        let result = analyze_call((Vector{String},String,)) do xs, x
+                x in tuple(xs) ? 0 : 1
+            end
+            reports = get_reports(result)
+            @test isempty(reports)
+        end
+    end
+end
+
 @testset "report_target_modules" begin
     let result = analyze_call(; report_target_modules=()) do
             TestTargetModule.func()
@@ -315,69 +424,6 @@ end
             sin(1, 2)
         end
         @test isempty(get_reports(result))
-    end
-end
-
-@testset "NonBooleanCondErrorReport" begin
-    # no report for boolean condition
-    let result = analyze_call((Bool,)) do x
-            x ? 1 : 2
-        end
-        @test isempty(get_reports(result))
-    end
-    let result = analyze_call((Bool,)) do x
-            if x; 1; else; 2; end
-        end
-        @test isempty(get_reports(result))
-    end
-    let result = analyze_call((Bool,)) do x
-            x && return 1
-        end
-        @test isempty(get_reports(result))
-    end
-
-    # basic non-boolean condition
-    let result = analyze_call((Int,)) do x
-            x ? 1 : 2
-        end
-        reports = get_reports(result)
-        @test length(reports) == 1
-        r = only(reports)
-        @test r isa NonBooleanCondErrorReport && r.union_split == 0
-    end
-    let result = analyze_call((Int,)) do x
-            if x; 1; else; 2; end
-        end
-        reports = get_reports(result)
-        @test length(reports) == 1
-        r = only(reports)
-        @test r isa NonBooleanCondErrorReport && r.union_split == 0
-    end
-    let result = analyze_call((Int,)) do x
-            x && return 1
-        end
-        reports = get_reports(result)
-        @test length(reports) == 1
-        r = only(reports)
-        @test r isa NonBooleanCondErrorReport && r.union_split == 0
-    end
-
-    # union split case: only one branch is non-boolean
-    let result = analyze_call((Union{Bool,Int},)) do x
-            x ?  1 : 2
-        end
-        reports = get_reports(result)
-        @test length(reports) == 1
-        r = only(reports)
-        @test r isa NonBooleanCondErrorReport && r.union_split == 2 && length(r.t) == 1
-    end
-
-    # JuliaLang/julia#61526
-    let result = analyze_call((Vector{String},String,)) do xs, x
-            x in tuple(xs) ? 0 : 1
-        end
-        reports = get_reports(result)
-        @test isempty(reports)
     end
 end
 


### PR DESCRIPTION
Add `inference/type-error/type-assert` to report type assertions that JETLS can prove will fail, such as `x::Int` when `x` is inferred as `Float64`. As part of introducing this `TypeError` diagnostic family, move non-`Bool` condition reports under `inference/type-error/non-bool-cond`.

Implement this with a new `TypeErrorReport` family and a `TypeAssertErrorReport` emitted from the `Core.typeassert` builtin path when inference determines the call returns `Union{}`. Diagnostic code matching also checks deprecated aliases so existing `inference/non-boolean-cond` patterns continue to apply for now.

Tests cover the new type assertion reports, message printing, the non-`Bool` condition diagnostic code, and diagnostic config compatibility. The deprecated alias support may be removed in a future release.