### PR TITLE
analysis: Support newer Compiler APIs (1.12.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `inference/type-error/*` now groups diagnostics for the subset of runtime `TypeError` cases that JETLS can infer, including non-`Bool` conditions and statically failing type assertions. Users can ignore or reconfigure this family together with a regex code match such as `^inference/type-error/`.
 
+- Updated Compiler.jl API compatibility for the incoming Julia 1.12.7 release while retaining support for Julia pre-1.12.6 Compiler.jl APIs.
+
 ## 2026-06-26
 
 - Commit: [`0d67c12`](https://github.com/aviatesk/JETLS.jl/commit/0d67c12)

--- a/src/analysis/Analyzer.jl
+++ b/src/analysis/Analyzer.jl
@@ -264,14 +264,12 @@ end # @static if VERSION ≥ v"1.12.2"
 # Analysis injections
 # ===================
 
-function CC.abstract_call_gf_by_type(
-        analyzer::LSAnalyzer, @nospecialize(func), arginfo::CC.ArgInfo, si::CC.StmtInfo,
-        @nospecialize(atype), sv::CC.InferenceState, max_methods::Int
+function report_method_error_after_call!(
+        analyzer::LSAnalyzer, ret::CC.Future, arginfo::CC.ArgInfo,
+        @nospecialize(atype), sv::CC.InferenceState
     )
-    ret = @invoke CC.abstract_call_gf_by_type(analyzer::ToplevelAbstractAnalyzer,
-        func::Any, arginfo::CC.ArgInfo, si::CC.StmtInfo, atype::Any, sv::CC.InferenceState, max_methods::Int)
     if !should_analyze(analyzer, sv)
-        return ret
+        return nothing
     end
     atype′ = Ref{Any}(atype)
     function after_abstract_call_gf_by_type(analyzer′::LSAnalyzer, sv′::CC.InferenceState)
@@ -284,7 +282,35 @@ function CC.abstract_call_gf_by_type(
     else
         push!(sv.tasks, after_abstract_call_gf_by_type)
     end
+    return nothing
+end
+
+@static if hasmethod(CC.abstract_call_gf_by_type,
+        Tuple{CC.AbstractInterpreter, Any, CC.ArgInfo, CC.StmtInfo, Any,
+              Union{Vector{CC.VarState}, Nothing}, CC.AbsIntState, Int})
+function CC.abstract_call_gf_by_type(
+        analyzer::LSAnalyzer, @nospecialize(func), arginfo::CC.ArgInfo,
+        si::CC.StmtInfo, @nospecialize(atype), vtypes::Union{Vector{CC.VarState},Nothing},
+        sv::CC.InferenceState, max_methods::Int
+    )
+    ret = @invoke CC.abstract_call_gf_by_type(
+        analyzer::ToplevelAbstractAnalyzer, func::Any, arginfo::CC.ArgInfo,
+        si::CC.StmtInfo, atype::Any, vtypes::Union{Vector{CC.VarState},Nothing},
+        sv::CC.InferenceState, max_methods::Int)
+    report_method_error_after_call!(analyzer, ret, arginfo, atype, sv)
     return ret
+end
+else
+function CC.abstract_call_gf_by_type(
+        analyzer::LSAnalyzer, @nospecialize(func), arginfo::CC.ArgInfo,
+        si::CC.StmtInfo, @nospecialize(atype), sv::CC.InferenceState, max_methods::Int
+    )
+    ret = @invoke CC.abstract_call_gf_by_type(
+        analyzer::ToplevelAbstractAnalyzer, func::Any, arginfo::CC.ArgInfo,
+        si::CC.StmtInfo, atype::Any, sv::CC.InferenceState, max_methods::Int)
+    report_method_error_after_call!(analyzer, ret, arginfo, atype, sv)
+    return ret
+end
 end
 
 # TODO Better to factor out and share it with `JET.JETAnalyzer`

--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -374,8 +374,16 @@ function CC.abstract_eval_new_opaque_closure(
     pushfirst!(oc_argtypes, po.env)
     interp.oc_body_annotation_states[po.source] = OCBodyAnnotationState()
     arginfo, stmtinfo = CC.ArgInfo(nothing, oc_argtypes), CC.StmtInfo(true, false)
-    callinfo = CC.abstract_call_opaque_closure(
-        interp, po, arginfo, stmtinfo, sv, #=check=#false)::CC.Future
+    @static if hasmethod(CC.abstract_call_opaque_closure,
+        Tuple{CC.AbstractInterpreter, CC.PartialOpaque, CC.ArgInfo,
+              CC.StmtInfo, Union{Vector{CC.VarState}, Nothing}, CC.AbsIntState,
+              Bool})
+        callinfo = CC.abstract_call_opaque_closure(
+            interp, po, arginfo, stmtinfo, nothing, sv, #=check=#false)::CC.Future
+    else
+        callinfo = CC.abstract_call_opaque_closure(
+            interp, po, arginfo, stmtinfo, sv, #=check=#false)::CC.Future
+    end
     return CC.Future{CC.RTEffects}(callinfo, interp, sv) do callinfo, _, sv
         consume_oc_body_annotation_state!(interp, po.source)
         sv.stmt_info[sv.currpc] = CC.OpaqueClosureCreateInfo(callinfo)
@@ -497,6 +505,22 @@ end
 # signature-view inference from `abstract_eval_new_opaque_closure` passes `check=false`
 # and must not be recorded: it would join `most_general_argtypes` (the declared `Any`s)
 # into every observation and erase the refinement.
+@static if hasmethod(CC.abstract_call_opaque_closure,
+    Tuple{CC.AbstractInterpreter, CC.PartialOpaque, CC.ArgInfo,
+          CC.StmtInfo, Union{Vector{CC.VarState}, Nothing}, CC.AbsIntState,
+          Bool})
+function CC.abstract_call_opaque_closure(
+        interp::ASTTypeAnnotator, closure::CC.PartialOpaque, arginfo::CC.ArgInfo,
+        si::CC.StmtInfo, vtypes::Union{Vector{CC.VarState},Nothing}, sv::CC.AbsIntState,
+        check::Bool
+    )
+    check && record_oc_argtype_observation!(interp, closure, arginfo)
+    return @invoke CC.abstract_call_opaque_closure(
+        interp::CC.AbstractInterpreter, closure::CC.PartialOpaque, arginfo::CC.ArgInfo,
+        si::CC.StmtInfo, vtypes::Union{Vector{CC.VarState},Nothing}, sv::CC.AbsIntState,
+        check::Bool)
+end
+else
 function CC.abstract_call_opaque_closure(
         interp::ASTTypeAnnotator, closure::CC.PartialOpaque, arginfo::CC.ArgInfo,
         si::CC.StmtInfo, sv::CC.AbsIntState, check::Bool
@@ -506,11 +530,29 @@ function CC.abstract_call_opaque_closure(
         interp::CC.AbstractInterpreter, closure::CC.PartialOpaque, arginfo::CC.ArgInfo,
         si::CC.StmtInfo, sv::CC.AbsIntState, check::Bool)
 end
+end
 
 # `Generator(f, iter)` and `Filter(f, iter)` invoke `f` as iteration advances. In
 # nested iterator pipelines, that invocation is mediated by iterator machinery, so
 # the `PartialOpaque` call hook may not observe it. Treat construction as observing
 # `f` at the iterator element type.
+@static if hasmethod(CC.abstract_call_gf_by_type,
+        Tuple{CC.AbstractInterpreter, Any, CC.ArgInfo, CC.StmtInfo, Any,
+              Union{Vector{CC.VarState}, Nothing}, CC.AbsIntState, Int})
+function CC.abstract_call_gf_by_type(
+        interp::ASTTypeAnnotator, @nospecialize(func), arginfo::CC.ArgInfo,
+        si::CC.StmtInfo, @nospecialize(atype), vtypes::Union{Vector{CC.VarState},Nothing},
+        sv::CC.AbsIntState, max_methods::Int
+    )
+    if func === Base.Generator || func === Base.Iterators.Filter
+        record_iterator_argtype_observation!(interp, arginfo)
+    end
+    return @invoke CC.abstract_call_gf_by_type(
+        interp::CC.AbstractInterpreter, func::Any, arginfo::CC.ArgInfo,
+        si::CC.StmtInfo, atype::Any, vtypes::Union{Vector{CC.VarState},Nothing},
+        sv::CC.AbsIntState, max_methods::Int)
+end
+else
 function CC.abstract_call_gf_by_type(
         interp::ASTTypeAnnotator, @nospecialize(func), arginfo::CC.ArgInfo,
         si::CC.StmtInfo, @nospecialize(atype), sv::CC.AbsIntState, max_methods::Int
@@ -521,6 +563,7 @@ function CC.abstract_call_gf_by_type(
     return @invoke CC.abstract_call_gf_by_type(
         interp::CC.AbstractInterpreter, func::Any, arginfo::CC.ArgInfo,
         si::CC.StmtInfo, atype::Any, sv::CC.AbsIntState, max_methods::Int)
+end
 end
 
 function record_iterator_argtype_observation!(


### PR DESCRIPTION
Add `hasmethod`-based compatibility branches to abstract interpretation hooks such as `abstract_call_gf_by_type` and
`abstract_call_opaque_closure` so JETLS defines overloads for both API shapes for pre-1.12.6 API and the incoming 1.12.7 API. The old paths keep supporting the 1.12.6-era Compiler.jl implementation, while the new paths forward the additional reaching-def state for newer Compiler.jl checkouts.

This keeps the current analysis behavior unchanged aside from restoring compatibility across the v1.12 Compiler.jl series.

The changelog notes the compatibility fix.