### PR TITLE
Ignore generated LocalPreferences.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ out
 Project.toml.bak
 Manifest.toml
 Manifest-*.toml
+LocalPreferences.toml
 .envrc
 **/.JETLSConfig.toml
 !.JETLSConfig.toml


### PR DESCRIPTION
`LocalPreferences.toml` is generated by Preferences.jl for local, machine-specific package configuration and should not be tracked. Split out of #782, where it rode along incidentally with the 1.14 work, as suggested in review so it can be merged on its own.