### PR TITLE
precompile: Warm up the `initialize` request round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Updated Compiler.jl API compatibility for the incoming Julia 1.12.7 release while retaining support for Julia pre-1.12.6 Compiler.jl APIs.
 
+- Improved startup latency by precompiling the `initialize` request round-trip, so the first request is less likely to hit strict client `initialize` timeouts (such as Helix's 20-second default). On slower machines, raising the client-side timeout may still be needed. (xref: https://github.com/aviatesk/JETLS.jl/issues/784)
+
 ## 2026-06-26
 
 - Commit: [`0d67c12`](https://github.com/aviatesk/JETLS.jl/commit/0d67c12)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -42,6 +42,14 @@ julia -e 'using Pkg; Pkg.Apps.add(; url="https://github.com/aviatesk/JETLS.jl", 
 This will install the `jetls` executable to `~/.julia/bin/`.
 Make sure `~/.julia/bin` is available on the `PATH` environment so the executable is accessible.
 
+!!! note
+    `Pkg.Apps.add` precompiles JETLS and its dependencies during installation,
+    which can take several minutes even on reasonably capable machines. This is
+    a one-time cost per installation; subsequent server startups are fast. Doing
+    it now also avoids precompilation being triggered on the first editor launch,
+    which could otherwise stall the server long enough to trip client
+    `initialize` timeouts.
+
 You can verify the installation by running:
 ```bash
 jetls --help
@@ -59,6 +67,11 @@ is properly added to your `PATH`.
     ```bash
     julia -e 'using Pkg; Pkg.Apps.add(; url="https://github.com/aviatesk/JETLS.jl", rev="2025-11-25")'
     ```
+
+!!! warning "Julia upgrades"
+    The `jetls` app is pinned to the Julia version used to install it, so after
+    upgrading Julia you must re-run the installation command above to make
+    `jetls` available again (this re-runs precompilation for the new Julia).
 
 ## [Editor setup](@id index/editor-setup)
 
@@ -224,8 +237,16 @@ name = "julia"
 language-servers = [ "jetls" ]
 
 [language-server]
-jetls = { command = "jetls", args = ["serve"] }
+jetls = { command = "jetls", args = ["serve"], timeout = 60 }
 ```
+
+!!! note
+    Helix aborts the `initialize` request if the server does not respond within
+    `timeout` seconds, which defaults to 20
+    (see [Language Server configuration](https://docs.helix-editor.com/languages.html#language-server-configuration)).
+    On the first startup JETLS must load and compile its Julia code, which can
+    exceed that default on slower machines and make Helix report
+    `request 0 timed out`. Setting a larger `timeout` (e.g. `60`) avoids this.
 
 ### [Advanced: using local JETLS checkout](@id index/editor-setup/advanced)
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -3,7 +3,6 @@ using PrecompileTools
 module __demo__ end
 
 @setup_workload let
-    server = Server()
     save_text = """
         struct Foo
             x::Int
@@ -22,8 +21,29 @@ module __demo__ end
     """)
     position = only(positions)
     mktemp() do filename, _
-        uri = filepath2uri(filename)
         @compile_workload let
+            # Warm up the `initialize` round-trip: JSON deserialize -> handler ->
+            # JSON serialize. Deserializing the deeply nested `InitializeParams`/
+            # `ClientCapabilities` dominates time-to-first-response and is otherwise
+            # compiled lazily on the first request, which on slow machines can exceed
+            # strict client initialize timeouts (e.g. Helix's 20s default). See #784.
+            init_json = """
+                {"jsonrpc":"2.0","id":0,"method":"initialize","params":{"processId":null,"rootUri":null,"capabilities":{"textDocument":{"completion":{"dynamicRegistration":true},"hover":{"dynamicRegistration":true}},"general":{"positionEncodings":["utf-8"]}}}}
+                """
+            init_msg = LSP.to_lsp_object(init_json)
+            # Capture the response via the recorder (populated synchronously by `send`)
+            # so we can compile `to_lsp_json` on this task; silence the handler's
+            # registration/process-id logs that would otherwise leak into precompile output.
+            Base.CoreLogging.with_logger(Base.CoreLogging.NullLogger()) do
+                recorder = ServerMessageRecorder()
+                init_server = Server(; callback=recorder)
+                handle_InitializeRequest(init_server, init_msg)
+                LSP.to_lsp_json(take!(recorder.sent_queue))
+                close(init_server.endpoint)
+            end
+
+            server = Server()
+            uri = filepath2uri(filename)
             entry = ScriptAnalysisEntry(uri)
             request = AnalysisRequest(entry, uri, #=generation=#1, #=token=#nothing, #=notify=#false)
             execution = AnalysisExecution(request, #=prev_result=#nothing)

--- a/src/types.jl
+++ b/src/types.jl
@@ -952,6 +952,8 @@ end
 struct ServerMessageRecorder
     received_queue::Channel{Any}
     sent_queue::Channel{Any}
+    ServerMessageRecorder() = new(Channel{Any}(Inf), Channel{Any}(Inf))
+    ServerMessageRecorder(received_queue::Channel{Any}, sent_queue::Channel{Any}) = new(received_queue, sent_queue)
 end
 function (callback::ServerMessageRecorder)(s::Symbol, @nospecialize(msg))
     if s === :received


### PR DESCRIPTION
On slower machines JETLS could fail to start with clients that enforce a strict `initialize` request timeout, such as Helix (which defaults to 20 seconds and reports `request 0 timed out`). The first `initialize` request lazily compiled the JSON deserialization of the deeply nested `InitializeParams`/`ClientCapabilities` (and the response serialization), costing several seconds of just-in-time compilation on top of package load -- enough to exceed the client timeout on modest hardware.

Add the `initialize` round-trip (deserialize -> handler -> serialize) to the `@compile_workload` so this work is baked into the pkgimage and the first request is served from precompiled native code. The response is captured through a `ServerMessageRecorder` rather than the endpoint output queue (which would race the write task and could hang the `take!`), and `handle_InitializeRequest`'s registration/process-id logs are silenced with a `NullLogger` so they do not leak into precompile output.

This does not fully eliminate the risk: package-load time remains, and installation (`Pkg.Apps.add`) itself runs precompilation that can take minutes. The docs now cover the Helix `timeout` setting and this reinstall requirement, and the CHANGELOG records the change.

xref: aviatesk/JETLS.jl#784