### PR TITLE
diagnostic/Analyzer: Report keyword-argument errors (unsupported, missing, type-mismatched)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added the `inference/undef-keyword` diagnostic: a call that omits a required keyword argument (one declared without a default), which raises `UndefKeywordError` at runtime, is now reported.
 
+- Added the `inference/type-error/keyword` diagnostic: a call that passes a keyword argument whose value type does not match the keyword's declared type (e.g. `f(; key=1.0)` for `f(; key::Int)`), which raises `TypeError` at runtime, is now reported.
+
 ### Changed
 
 - `inference/type-error/*` now groups diagnostics for the subset of runtime `TypeError` cases that JETLS can infer, including non-`Bool` conditions and statically failing type assertions. Users can ignore or reconfigure this family together with a regex code match such as `^inference/type-error/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added detection of unsupported keyword arguments: a call that passes a keyword argument the called method does not accept (e.g. `f(; unknown=...)`) is now reported under the `inference/method-error` diagnostic.
 
+- Added the `inference/undef-keyword` diagnostic: a call that omits a required keyword argument (one declared without a default), which raises `UndefKeywordError` at runtime, is now reported.
+
 ### Changed
 
 - `inference/type-error/*` now groups diagnostics for the subset of runtime `TypeError` cases that JETLS can infer, including non-`Bool` conditions and statically failing type assertions. Users can ignore or reconfigure this family together with a regex code match such as `^inference/type-error/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added the `inference/type-error/type-assert` diagnostic for type assertions that inference can prove will fail, such as `x::Int` when `x` is inferred as `Float64`.
 
+- Added detection of unsupported keyword arguments: a call that passes a keyword argument the called method does not accept (e.g. `f(; unknown=...)`) is now reported under the `inference/method-error` diagnostic.
+
 ### Changed
 
 - `inference/type-error/*` now groups diagnostics for the subset of runtime `TypeError` cases that JETLS can infer, including non-`Bool` conditions and statically failing type assertions. Users can ignore or reconfigure this family together with a regex code match such as `^inference/type-error/`.

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -126,6 +126,7 @@ Here is a summary table of the diagnostics explained in this section:
 | [`inference/bounds-error`](@ref diagnostic/reference/inference/bounds-error)                                   | `Warning`             | `JETLS/save`  | Out-of-bounds field access by index                    |
 | [`inference/method-error`](@ref diagnostic/reference/inference/method-error)                                   | `Warning`             | `JETLS/save`  | No matching method found for function calls            |
 | [`inference/undef-keyword`](@ref diagnostic/reference/inference/undef-keyword)                                 | `Warning`             | `JETLS/save`  | Missing required keyword argument                      |
+| [`inference/type-error/keyword`](@ref diagnostic/reference/inference/type-error/keyword)                       | `Warning`             | `JETLS/save`  | Keyword argument value type mismatch                   |
 | [`inference/type-error/type-assert`](@ref diagnostic/reference/inference/type-error/type-assert)               | `Warning`             | `JETLS/save`  | Type assertion failures                                |
 | [`inference/type-error/non-bool-cond`](@ref diagnostic/reference/inference/type-error/non-bool-cond)           | `Warning`             | `JETLS/save`  | Non-boolean value used in boolean context              |
 | [`testrunner/test-failure`](@ref diagnostic/reference/testrunner/test-failure)                                 | `Error`               | `JETLS/extra` | Test failures from TestRunner integration              |
@@ -1126,6 +1127,27 @@ required_keyword(42)  # missing keyword argument `key` (JETLS inference/undef-ke
 To avoid false positives, this is only reported when the keyword is
 statically known to be missing on every path; calls that forward keywords
 dynamically (e.g. `f(; kwargs...)`) are not flagged.
+
+#### [Keyword argument type error (`inference/type-error/keyword`)](@id diagnostic/reference/inference/type-error/keyword)
+
+**Default severity:** `Warning`
+
+Keyword arguments passed with a value whose type does not match the keyword's
+declared type. Julia inserts a type assertion in the keyword sorter and raises
+a `TypeError` at runtime in this case.
+
+Examples:
+
+```julia
+typed_keyword(; key::Int=0) = key
+
+typed_keyword(; key=1.0)  # TypeError: in keyword argument `key`, expected `Int64`, got a value of type `Float64`
+                          # (JETLS inference/type-error/keyword)
+```
+
+To avoid false positives, this is only reported when the value type can never
+match the declared type; calls where the value may match for some runtime
+values are not flagged.
 
 #### [Type assertion error (`inference/type-error/type-assert`)](@id diagnostic/reference/inference/type-error/type-assert)
 

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -1082,8 +1082,8 @@ runtime.
 Examples:
 
 ```julia
-function method_error_example()
-    return sin(1, 2)  # no matching method found `sin(::Int64, ::Int64)` (JETLS inference/method-error)
+let
+    sin(1, 2)  # no matching method found `sin(::Int64, ::Int64)` (JETLS inference/method-error)
 end
 ```
 
@@ -1097,6 +1097,16 @@ function union_split_method_error(x::Union{Int,String})
     return only_int(x)  # no matching method found `only_int(::String)` (1/2 union split)
                         # (JETLS inference/method-error)
 end
+```
+
+Passing a keyword argument that the called method does not accept, which
+raises a `MethodError` at runtime, is also reported under this code:
+
+```julia
+kwfunc(; kw1=nothing, kw2=nothing) = (kw1, kw2)
+
+kwfunc(; kw3=42)  # unsupported keyword argument `kw3` in `kwfunc(; kw3::Int64)`
+                  # (JETLS inference/method-error)
 ```
 
 #### [Type assertion error (`inference/type-error/type-assert`)](@id diagnostic/reference/inference/type-error/type-assert)

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -125,6 +125,7 @@ Here is a summary table of the diagnostics explained in this section:
 | [`inference/field-error`](@ref diagnostic/reference/inference/field-error)                                     | `Warning`             | `JETLS/save`  | Access to non-existent struct fields                   |
 | [`inference/bounds-error`](@ref diagnostic/reference/inference/bounds-error)                                   | `Warning`             | `JETLS/save`  | Out-of-bounds field access by index                    |
 | [`inference/method-error`](@ref diagnostic/reference/inference/method-error)                                   | `Warning`             | `JETLS/save`  | No matching method found for function calls            |
+| [`inference/undef-keyword`](@ref diagnostic/reference/inference/undef-keyword)                                 | `Warning`             | `JETLS/save`  | Missing required keyword argument                      |
 | [`inference/type-error/type-assert`](@ref diagnostic/reference/inference/type-error/type-assert)               | `Warning`             | `JETLS/save`  | Type assertion failures                                |
 | [`inference/type-error/non-bool-cond`](@ref diagnostic/reference/inference/type-error/non-bool-cond)           | `Warning`             | `JETLS/save`  | Non-boolean value used in boolean context              |
 | [`testrunner/test-failure`](@ref diagnostic/reference/testrunner/test-failure)                                 | `Error`               | `JETLS/extra` | Test failures from TestRunner integration              |
@@ -1082,9 +1083,7 @@ runtime.
 Examples:
 
 ```julia
-let
-    sin(1, 2)  # no matching method found `sin(::Int64, ::Int64)` (JETLS inference/method-error)
-end
+sin(1, 2)  # no matching method found `sin(::Int64, ::Int64)` (JETLS inference/method-error)
 ```
 
 When multiple union-split signatures fail to find matches, the diagnostic will
@@ -1108,6 +1107,25 @@ kwfunc(; kw1=nothing, kw2=nothing) = (kw1, kw2)
 kwfunc(; kw3=42)  # unsupported keyword argument `kw3` in `kwfunc(; kw3::Int64)`
                   # (JETLS inference/method-error)
 ```
+
+#### [Undefined keyword (`inference/undef-keyword`)](@id diagnostic/reference/inference/undef-keyword)
+
+**Default severity:** `Warning`
+
+Calls that omit a required keyword argument (a keyword declared without a
+default value). Julia raises an `UndefKeywordError` at runtime in this case.
+
+Examples:
+
+```julia
+required_keyword(pos; key) = (pos, key)
+
+required_keyword(42)  # missing keyword argument `key` (JETLS inference/undef-keyword)
+```
+
+To avoid false positives, this is only reported when the keyword is
+statically known to be missing on every path; calls that forward keywords
+dynamically (e.g. `f(; kwargs...)`) are not flagged.
 
 #### [Type assertion error (`inference/type-error/type-assert`)](@id diagnostic/reference/inference/type-error/type-assert)
 

--- a/src/analysis/Analyzer.jl
+++ b/src/analysis/Analyzer.jl
@@ -1,9 +1,9 @@
 module Analyzer
 
 export LSAnalyzer, inference_error_report_severity, inference_error_report_stack, reset_report_target_modules!
-export BoundsErrorReport, FieldErrorReport, MethodErrorReport, NonBooleanCondErrorReport,
-    TypeAssertErrorReport, TypeErrorReport, UndefKeywordErrorReport, UndefVarErrorReport,
-    UnsupportedKeywordArgReport
+export BoundsErrorReport, FieldErrorReport, KeywordTypeErrorReport, MethodErrorReport,
+    NonBooleanCondErrorReport, TypeAssertErrorReport, TypeErrorReport,
+    UndefKeywordErrorReport, UndefVarErrorReport, UnsupportedKeywordArgReport
 
 using Core.IR
 using JET.JETInterface
@@ -267,6 +267,7 @@ function after_abstract_call_gf_by_type(
         report_method_error!(analyzer′, sv′, ret′, arginfo, atype′[])
         report_unsupported_kwarg_error!(analyzer′, sv′, func, ret′, arginfo, max_methods)
         report_undef_keyword!(analyzer′, sv′, func, ret′, arginfo, max_methods)
+        report_keyword_typeerror!(analyzer′, sv′, func, ret′, arginfo, max_methods)
         return true
     end
     if isready(ret)
@@ -379,6 +380,8 @@ function CC.finish!(analyzer::LSAnalyzer, caller::CC.InferenceState, validation_
     # `finish!` runs after `finishinfer!`, and (for cycles) after every cycle member's
     # `finishinfer!`, so `caller.bestguess` is the converged return type here. Unwrap
     # `LimitedAccuracy` so a recursion-limited but diverging frame still keeps the report.
+    # `KeywordTypeErrorReport` is not filtered here: it has no empty-`nt` branch to fire
+    # on spuriously, so a type mismatch on a conditional path is a real error.
     if CC.ignorelimited(caller.bestguess) !== Union{}
         filter!(JET.get_reports(analyzer, caller.result)) do @nospecialize(report)
             return !(report isa UndefKeywordErrorReport)
@@ -854,6 +857,93 @@ function report_undef_keyword!(
             # such *required* one, which this matches under the usual required-before-optional
             # declaration order
             add_new_report!(analyzer, sv.result, UndefKeywordErrorReport(sv, name))
+            return true
+        end
+    end
+    return false
+end
+
+# KeywordTypeErrorReport
+# ----------------------
+
+# Passing a keyword argument whose value type does not match the keyword's declared type
+# (`func(2; kw=42.0)` for `func(a; kw::Int=42)`) raises a `TypeError` at runtime: the keyword
+# sorter asserts each typed keyword and throws `TypeError(Symbol("keyword argument"), :kw, Int,
+# got)`. As with `UndefKeywordErrorReport`, detect this at the call site rather than at that
+# `throw`, so the report does not depend on which call site first inferred the sorter. The
+# offending keyword, its declared type, and the provided type are recovered from the call's
+# keyword `NamedTuple` and the callee's declared keyword types (caller-independent and
+# cache-stable), since `call.exct` widens to the bare `TypeError` type once cached.
+@jetreport struct KeywordTypeErrorReport <: TypeErrorReport
+    var::Symbol
+    @nospecialize expected
+    @nospecialize got
+end
+function JETInterface.print_report_message(io::IO, r::KeywordTypeErrorReport)
+    print(io, "TypeError: in keyword argument `", r.var, "`, expected `", r.expected, "`, got ")
+    print_type_error_got(io, r.got)
+end
+inference_error_report_stack_impl(r::KeywordTypeErrorReport) = length(r.vst):-1:1
+inference_error_report_severity_impl(::KeywordTypeErrorReport) = DiagnosticSeverity.Warning
+
+# Recover the declared keyword types of `m` as `name => type` pairs (declaration order),
+# skipping the slurp (`kws...`). The keyword sorter forwards the sorted keywords to the body
+# function as leading positional arguments, so the body method's argument types are exactly the
+# declared keyword types in `Base.kwarg_decl` order.
+function keyword_arg_types(m::Method)
+    decls = Base.kwarg_decl(m)
+    isempty(decls) && return nothing
+    bf = Base.bodyfunction(m)
+    bf === nothing && return nothing
+    bms = methods(bf)
+    length(bms) == 1 || return nothing
+    bsig = Base.unwrap_unionall((first(bms)).sig)
+    bsig isa DataType || return nothing
+    params = bsig.parameters
+    length(params) ≥ 1 + length(decls) || return nothing
+    kwtypes = Pair{Symbol,Any}[]
+    for i = 1:length(decls)
+        name = decls[i]
+        endswith(String(name), "...") && continue # slurp accepts any keyword
+        ty = params[1+i]
+        ty isa Type || continue
+        push!(kwtypes, name => ty)
+    end
+    return kwtypes
+end
+
+function report_keyword_typeerror!(
+        analyzer::LSAnalyzer, sv::CC.InferenceState, @nospecialize(func),
+        call::CC.CallMeta, arginfo::CC.ArgInfo, max_methods::Int
+    )
+    func === Core.kwcall || return false
+    call.rt === Union{} || return false
+    CC.widenconst(call.exct) <: TypeError || return false
+    argtypes = arginfo.argtypes
+    # `Core.kwcall(kwnt, f, posargs...)`
+    length(argtypes) ≥ 3 || return false
+    kwt = CC.widenconst(argtypes[2])
+    names = @something kwcall_keyword_names(kwt) return false
+    isempty(names) && return false
+    ftype = CC.widenconst(argtypes[3])
+    posargtypes = Any[let argtype = argtypes[i]
+        CC.isvarargtype(argtype) ? argtype : CC.widenconst(argtype)
+    end for i = 4:length(argtypes)]
+    callsig = CC.argtypes_to_type(Any[ftype; posargtypes])
+    callsig === Union{} && return false
+    matches = @something CC.findall(callsig, CC.method_table(analyzer); limit=max_methods) return false
+    isempty(matches) && return false
+    for match in matches
+        kwtypes = @something keyword_arg_types(match.method) continue
+        for (name, expected) in kwtypes
+            idx = findfirst(==(name), names)
+            idx === nothing && continue # this typed keyword was not provided
+            got = fieldtype(kwt, idx)
+            # report only a definite mismatch: no value of `got` can satisfy the keyword's
+            # `isa expected` assertion (the `call.rt === Union{}` gate already ensures the call
+            # always throws, so this picks the offending keyword)
+            typeintersect(got, expected) === Union{} || continue
+            add_new_report!(analyzer, sv.result, KeywordTypeErrorReport(sv, name, expected, got))
             return true
         end
     end

--- a/src/analysis/Analyzer.jl
+++ b/src/analysis/Analyzer.jl
@@ -2,7 +2,8 @@ module Analyzer
 
 export LSAnalyzer, inference_error_report_severity, inference_error_report_stack, reset_report_target_modules!
 export BoundsErrorReport, FieldErrorReport, MethodErrorReport, NonBooleanCondErrorReport,
-    TypeAssertErrorReport, TypeErrorReport, UndefVarErrorReport, UnsupportedKeywordArgReport
+    TypeAssertErrorReport, TypeErrorReport, UndefKeywordErrorReport, UndefVarErrorReport,
+    UnsupportedKeywordArgReport
 
 using Core.IR
 using JET.JETInterface
@@ -265,6 +266,7 @@ function after_abstract_call_gf_by_type(
         ret′ = ret[]
         report_method_error!(analyzer′, sv′, ret′, arginfo, atype′[])
         report_unsupported_kwarg_error!(analyzer′, sv′, func, ret′, arginfo, max_methods)
+        report_undef_keyword!(analyzer′, sv′, func, ret′, arginfo, max_methods)
         return true
     end
     if isready(ret)
@@ -370,6 +372,22 @@ function CC.abstract_eval_value(analyzer::LSAnalyzer, @nospecialize(e), sstate::
     return ret
 end
 
+function CC.finish!(analyzer::LSAnalyzer, caller::CC.InferenceState, validation_world::UInt, time_before::UInt64)
+    # An `UndefKeywordError` thrown on a path that does not make the enclosing frame diverge
+    # was not actually taken (e.g. `f(; nt...)` lowers to a branch calling `f()` only when
+    # `nt` is empty), so drop such reports and keep only definitely-missing keyword calls.
+    # `finish!` runs after `finishinfer!`, and (for cycles) after every cycle member's
+    # `finishinfer!`, so `caller.bestguess` is the converged return type here. Unwrap
+    # `LimitedAccuracy` so a recursion-limited but diverging frame still keeps the report.
+    if CC.ignorelimited(caller.bestguess) !== Union{}
+        filter!(JET.get_reports(analyzer, caller.result)) do @nospecialize(report)
+            return !(report isa UndefKeywordErrorReport)
+        end
+    end
+    return @invoke CC.finish!(analyzer::ToplevelAbstractAnalyzer, caller::CC.InferenceState,
+        validation_world::UInt, time_before::UInt64)
+end
+
 # analysis
 # ========
 
@@ -383,6 +401,9 @@ Subtypes:
 - `FieldErrorReport`: Access to non-existent struct fields (corresponding to `FieldError`)
 - `BoundsErrorReport`: Out-of-bounds field access by index (corresponding to `BoundsError`)
 - `MethodErrorReport`: Method dispatch errors (corresponding to `MethodError`)
+- `UnsupportedKeywordArgReport`: Keyword arguments the method does not accept
+  (a `MethodError` raised via `Base.kwerr`)
+- `UndefKeywordErrorReport`: Missing required keyword arguments (corresponding to `UndefKeywordError`)
 - `TypeErrorReport`: Type errors (corresponding to `TypeError`)
 """
 abstract type LSErrorReport <: InferenceErrorReport end
@@ -772,6 +793,71 @@ function kwcall_keyword_names(@nospecialize kwt)
     names = kwt.parameters[1]
     isa(names, Tuple{Vararg{Symbol}}) || return nothing
     return names
+end
+
+# UndefKeywordErrorReport
+# -----------------------
+
+# Calling a function without one of its required keyword arguments (a keyword without a
+# default) raises `UndefKeywordError` at runtime. Detect this at the call site (not at the
+# `throw` inside the synthesized keyword sorter) so the report stays independent of analysis
+# order: the throw site only fires while the callee is freshly inferred, but its result —
+# including whether the call diverges — is cached and reused, which would make the report
+# appear or vanish depending on which signature got analyzed first.
+@jetreport struct UndefKeywordErrorReport <: LSErrorReport
+    var::Symbol
+end
+JETInterface.print_report_message(io::IO, r::UndefKeywordErrorReport) =
+    print(io, "missing keyword argument `", r.var, '`')
+inference_error_report_stack_impl(r::UndefKeywordErrorReport) = length(r.vst):-1:1
+inference_error_report_severity_impl(::UndefKeywordErrorReport) = DiagnosticSeverity.Warning
+
+function report_undef_keyword!(
+        analyzer::LSAnalyzer, sv::CC.InferenceState, @nospecialize(func),
+        call::CC.CallMeta, arginfo::CC.ArgInfo, max_methods::Int
+    )
+    # Decide *whether* to report from the return / exception types, which survive caching
+    # (`call.exct` carries the missing keyword as `Const(UndefKeywordError(name))` only while
+    # the callee is freshly inferred, and widens to the bare `UndefKeywordError` type once
+    # cached). Recover the *name* from the callee's declared keywords so both presence and
+    # message stay independent of analysis order.
+    call.rt === Union{} || return false
+    CC.widenconst(call.exct) <: UndefKeywordError || return false
+    argtypes = arginfo.argtypes
+    if func === Core.kwcall
+        # `Core.kwcall(kwnt, f, posargs...)`
+        length(argtypes) ≥ 3 || return false
+        provided = @something kwcall_keyword_names(CC.widenconst(argtypes[2])) return false
+        ftype = CC.widenconst(argtypes[3])
+        posbase = 4
+    else
+        # direct call with no keywords (the function's zero-keyword convenience method)
+        provided = ()
+        ftype = CC.widenconst(argtypes[1])
+        posbase = 2
+    end
+    # `arginfo.argtypes` may end in a `Vararg` (e.g. a splatted call like `f(xs...)`), and a
+    # positional argument may even be `Union{}` on a dead path. `argtypes_to_type` keeps a
+    # trailing vararg intact and collapses such dead paths to `Bottom`, where a plain
+    # `Tuple{...}` would instead error on a vararg or `Union{}` field.
+    callargtypes = Any[ftype]
+    append!(callargtypes, @view argtypes[posbase:end])
+    callsig = CC.argtypes_to_type(callargtypes)
+    callsig === Union{} && return false
+    matches = @something CC.findall(callsig, CC.method_table(analyzer); limit=max_methods) return false
+    isempty(matches) && return false
+    for match in matches
+        for name in Base.kwarg_decl(match.method)
+            endswith(String(name), "...") && continue # slurp absorbs any missing keyword
+            name ∈ provided && continue
+            # first declared keyword not supplied; the keyword sorter throws for the first
+            # such *required* one, which this matches under the usual required-before-optional
+            # declaration order
+            add_new_report!(analyzer, sv.result, UndefKeywordErrorReport(sv, name))
+            return true
+        end
+    end
+    return false
 end
 
 # NonBooleanCondErrorReport

--- a/src/analysis/Analyzer.jl
+++ b/src/analysis/Analyzer.jl
@@ -2,7 +2,7 @@ module Analyzer
 
 export LSAnalyzer, inference_error_report_severity, inference_error_report_stack, reset_report_target_modules!
 export BoundsErrorReport, FieldErrorReport, MethodErrorReport, NonBooleanCondErrorReport,
-    TypeAssertErrorReport, TypeErrorReport, UndefVarErrorReport
+    TypeAssertErrorReport, TypeErrorReport, UndefVarErrorReport, UnsupportedKeywordArgReport
 
 using Core.IR
 using JET.JETInterface
@@ -253,23 +253,24 @@ end # @static if VERSION ≥ v"1.12.2"
 # Analysis injections
 # ===================
 
-function report_method_error_after_call!(
-        analyzer::LSAnalyzer, ret::CC.Future, arginfo::CC.ArgInfo,
-        @nospecialize(atype), sv::CC.InferenceState
+function after_abstract_call_gf_by_type(
+        analyzer::LSAnalyzer, ret::CC.Future, @nospecialize(func), arginfo::CC.ArgInfo,
+        @nospecialize(atype), sv::CC.InferenceState, max_methods::Int
     )
     if !should_analyze(analyzer, sv)
         return nothing
     end
     atype′ = Ref{Any}(atype)
-    function after_abstract_call_gf_by_type(analyzer′::LSAnalyzer, sv′::CC.InferenceState)
+    function _after_abstract_call_gf_by_type(analyzer′::LSAnalyzer, sv′::CC.InferenceState)
         ret′ = ret[]
         report_method_error!(analyzer′, sv′, ret′, arginfo, atype′[])
+        report_unsupported_kwarg_error!(analyzer′, sv′, func, ret′, arginfo, max_methods)
         return true
     end
     if isready(ret)
-        after_abstract_call_gf_by_type(analyzer, sv)
+        _after_abstract_call_gf_by_type(analyzer, sv)
     else
-        push!(sv.tasks, after_abstract_call_gf_by_type)
+        push!(sv.tasks, _after_abstract_call_gf_by_type)
     end
     return nothing
 end
@@ -286,7 +287,7 @@ function CC.abstract_call_gf_by_type(
         analyzer::ToplevelAbstractAnalyzer, func::Any, arginfo::CC.ArgInfo,
         si::CC.StmtInfo, atype::Any, vtypes::Union{Vector{CC.VarState},Nothing},
         sv::CC.InferenceState, max_methods::Int)
-    report_method_error_after_call!(analyzer, ret, arginfo, atype, sv)
+    after_abstract_call_gf_by_type(analyzer, ret, func, arginfo, atype, sv, max_methods)
     return ret
 end
 else
@@ -297,7 +298,7 @@ function CC.abstract_call_gf_by_type(
     ret = @invoke CC.abstract_call_gf_by_type(
         analyzer::ToplevelAbstractAnalyzer, func::Any, arginfo::CC.ArgInfo,
         si::CC.StmtInfo, atype::Any, sv::CC.InferenceState, max_methods::Int)
-    report_method_error_after_call!(analyzer, ret, arginfo, atype, sv)
+    after_abstract_call_gf_by_type(analyzer, ret, func, arginfo, atype, sv, max_methods)
     return ret
 end
 end
@@ -680,6 +681,97 @@ function report_method_error_for_union_split!(
     if empty_matches !== nothing
         add_new_report!(analyzer, sv.result, MethodErrorReport(sv, empty_matches...))
     end
+end
+
+# UnsupportedKeywordArgReport
+# ---------------------------
+
+# A call like `f(; unknownkw=...)` is lowered to `Core.kwcall((unknownkw=...,), f)`.
+# This dispatches successfully to `f`'s generated keyword sorter, which then throws a
+# `MethodError` via `Base.kwerr` for the surplus keyword. Since this is an explicit
+# `throw` rather than a dispatch failure, `MethodErrorReport` does not fire; we detect
+# the statically-determined surplus keyword here instead.
+@jetreport struct UnsupportedKeywordArgReport <: LSErrorReport
+    @nospecialize ftype
+    posargtypes::Vector{Any}
+    @nospecialize kwt
+    unsupported::Vector{Symbol}
+end
+function JETInterface.print_report_message(io::IO, r::UnsupportedKeywordArgReport)
+    unsupported = r.unsupported
+    print(io, "unsupported keyword argument")
+    isone(length(unsupported)) || print(io, 's')
+    print(io, ' ')
+    for (i, name) in enumerate(unsupported)
+        i == 1 || print(io, ", ")
+        print(io, '`', name, '`')
+    end
+    kwt = Base.unwrap_unionall(r.kwt)::DataType
+    keys = kwt.parameters[1]::Tuple{Vararg{Symbol}}
+    kwargs = Pair{Symbol,Any}[Pair{Symbol,Any}(keys[i], fieldtype(kwt, i)) for i in eachindex(keys)]
+    print(io, " in `")
+    Base.show_signature_function(io, r.ftype)
+    Base.show_tuple_as_call(io, Symbol(""), Tuple{r.posargtypes...}; hasfirst=false, kwargs)
+    print(io, '`')
+end
+inference_error_report_stack_impl(r::UnsupportedKeywordArgReport) = length(r.vst):-1:1
+inference_error_report_severity_impl(::UnsupportedKeywordArgReport) = DiagnosticSeverity.Warning
+
+function report_unsupported_kwarg_error!(
+        analyzer::LSAnalyzer, sv::CC.InferenceState, @nospecialize(func),
+        call::CC.CallMeta, arginfo::CC.ArgInfo, max_methods::Int
+    )
+    func === Core.kwcall || return false
+    # only report when inference agrees that the call always throws
+    call.rt === Union{} || return false
+    argtypes = arginfo.argtypes
+    # `Core.kwcall(kwnt, f, posargs...)`: Any[typeof(kwcall), kwnt, f, posargs...]
+    length(argtypes) ≥ 3 || return false
+
+    kwt = CC.widenconst(argtypes[2])
+    kwnames = @something kwcall_keyword_names(kwt) return false
+    isempty(kwnames) && return false
+
+    ftype = CC.widenconst(argtypes[3])
+    # Keep a trailing `Vararg` intact (a splatted call like `f(xs...; kw=v)`) instead of
+    # widening it into a bogus element; this also renders as `f(::T...)` in the report message.
+    posargtypes = Any[let argtype = argtypes[i]
+        CC.isvarargtype(argtype) ? argtype : CC.widenconst(argtype)
+    end for i = 4:length(argtypes)]
+    # Bound the lookup by inference's own `max_methods` (as `find_method_matches` does), so a
+    # pathologically large match set (e.g. when `ftype` is abstract) bails cleanly rather than
+    # enumerating every applicable method. `findall` returns `nothing` past the limit.
+    # `argtypes_to_type` collapses dead paths (a `Union{}` argument) to `Bottom`, where a plain
+    # `Tuple{...}` would error on a `Union{}` field.
+    callsig = CC.argtypes_to_type(Any[ftype; posargtypes])
+    callsig === Union{} && return false
+    matches = @something CC.findall(callsig, CC.method_table(analyzer); limit=max_methods) return false
+    isempty(matches) && return false
+    supported = Set{Symbol}()
+    for match in matches
+        for name in Base.kwarg_decl(match.method)
+            # a slurping `kwargs...` shows up as a name ending with `...` and accepts anything
+            endswith(String(name), "...") && return false
+            push!(supported, name)
+        end
+    end
+
+    unsupported = Symbol[name for name in kwnames if name ∉ supported]
+    isempty(unsupported) && return false
+
+    report = UnsupportedKeywordArgReport(sv, ftype, posargtypes, kwt, unsupported)
+    add_new_report!(analyzer, sv.result, report)
+    return true
+end
+
+function kwcall_keyword_names(@nospecialize kwt)
+    kwt = Base.unwrap_unionall(kwt)
+    isa(kwt, DataType) || return nothing
+    kwt <: NamedTuple || return nothing
+    isempty(kwt.parameters) && return nothing
+    names = kwt.parameters[1]
+    isa(names, Tuple{Vararg{Symbol}}) || return nothing
+    return names
 end
 
 # NonBooleanCondErrorReport

--- a/src/analysis/Interpreter.jl
+++ b/src/analysis/Interpreter.jl
@@ -182,15 +182,19 @@ function JET.analyze_from_definitions!(interp::LSInterpreter, config::JET.Toplev
             analyzer = JET.ToplevelAbstractAnalyzer(interp, JET.non_toplevel_concretized;
                 reset_report_target_modules = false,
                 refresh_local_cache = true)
+            inf_world = CC.get_inference_world(analyzer)
             match = Base._which(tt;
                 # NOTE use the latest world counter with `method_table(analyzer)` unwrapped,
                 # otherwise it may use a world counter when this method isn't defined yet
                 method_table = CC.method_table(analyzer),
-                world = CC.get_inference_world(analyzer),
+                world = inf_world,
                 raise = false)
             if (match !== nothing &&
                 (!(entrypoint isa Symbol) || # implies `analyze_from_definitions===true`
                  match.method.name === entrypoint))
+                # redirect keyword-slurping forwarders to the abstract keyword sorter,
+                # but only after the `entrypoint` check above sees the original method name
+                match = JETLS.redirect_keyword_slurp_match(analyzer, match, inf_world)
                 analyzer, result = JET.analyze_method_signature!(analyzer,
                     match.method, match.spec_types, match.sparams)
                 reports = JET.get_reports(analyzer, result)

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -854,6 +854,42 @@ end # if JETLS_DEV_MODE
 
 const empty_lines_range = typemax(Int) => typemin(Int)
 
+function signature_method_slurps_keywords(m::Method)
+    for name in Base.kwarg_decl(m)
+        endswith(String(name), "...") && return true
+    end
+    return false
+end
+
+function abstract_kwsorter_signature(@nospecialize sig)
+    sig′ = Base.unwrap_unionall(sig)
+    sig′ isa DataType || return nothing
+    sig′ <: Tuple || return nothing
+    isempty(sig′.parameters) && return nothing
+    kwsig = Tuple{typeof(Core.kwcall), NamedTuple, sig′.parameters...}
+    return Base.rewrap_unionall(kwsig, sig)
+end
+
+# A keyword-forwarding method like `f(; kws...) = g(; kws...)` has the user-facing
+# signature `Tuple{typeof(f)}`, at which inference specializes `kws` to the *empty* set.
+# The forwarded call then looks like it omits `g`'s required keywords, producing spurious
+# `inference/undef-keyword` reports even though the keyword comes from `f`'s own caller.
+# Analyze the keyword sorter `Core.kwcall(::NamedTuple, ::typeof(f), ...)` instead, so `kws`
+# is an abstract `NamedTuple` ("any keywords") — the keyword analogue of how a positional
+# `args::T...` stays `Vararg{T}` rather than collapsing to zero arguments.
+function redirect_keyword_slurp_match(@nospecialize(analyzer), match::Core.MethodMatch, world::UInt)
+    signature_method_slurps_keywords(match.method) || return match
+    kwsig = @something abstract_kwsorter_signature(match.spec_types) return match
+    method_table = CC.method_table(analyzer)
+    return @something Base._which(kwsig; method_table, world, raise=false) match
+end
+
+function signature_analysis_match(@nospecialize(analyzer), @nospecialize(sig), world::UInt)
+    method_table = CC.method_table(analyzer)
+    match = @something Base._which(sig; method_table, world, raise=false) return nothing
+    return redirect_keyword_slurp_match(analyzer, match, world)
+end
+
 get_lines_in_ex(filepath::AbstractString, ex::Expr) = _get_lines_in_ex(empty_lines_range, filepath, ex)
 
 function _get_lines_in_ex(lines::Pair{Int,Int}, filepath::AbstractString, @nospecialize ex)
@@ -1020,10 +1056,7 @@ function analyze_package_with_revise(
             # to avoid data races between concurrent signature analysis tasks
             task_analyzer = JET.AbstractAnalyzer(analyzer,
                 JET.AnalyzerState(JET.AnalyzerState(analyzer), #=refresh_local_cache=#true))
-            match = Base._which(siginfo.sig;
-                method_table = CC.method_table(task_analyzer),
-                world = inf_world,
-                raise = false)
+            match = signature_analysis_match(task_analyzer, siginfo.sig, inf_world)
             if match !== nothing
                 task_analyzer, result = JET.analyze_method_signature!(task_analyzer,
                     match.method, match.spec_types, match.sparams)

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -450,6 +450,8 @@ function inference_error_report_code(@nospecialize report::JET.InferenceErrorRep
         return INFERENCE_METHOD_ERROR_CODE
     elseif report isa UnsupportedKeywordArgReport
         return INFERENCE_METHOD_ERROR_CODE
+    elseif report isa UndefKeywordErrorReport
+        return INFERENCE_UNDEF_KEYWORD_CODE
     elseif report isa TypeAssertErrorReport
         return INFERENCE_TYPE_ERROR_TYPE_ASSERT_CODE
     elseif report isa NonBooleanCondErrorReport

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -454,6 +454,8 @@ function inference_error_report_code(@nospecialize report::JET.InferenceErrorRep
         return INFERENCE_UNDEF_KEYWORD_CODE
     elseif report isa TypeAssertErrorReport
         return INFERENCE_TYPE_ERROR_TYPE_ASSERT_CODE
+    elseif report isa KeywordTypeErrorReport
+        return INFERENCE_TYPE_ERROR_KEYWORD_CODE
     elseif report isa NonBooleanCondErrorReport
         return INFERENCE_TYPE_ERROR_NON_BOOL_COND_CODE
     end

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -448,6 +448,8 @@ function inference_error_report_code(@nospecialize report::JET.InferenceErrorRep
         return INFERENCE_BOUNDS_ERROR_CODE
     elseif report isa MethodErrorReport
         return INFERENCE_METHOD_ERROR_CODE
+    elseif report isa UnsupportedKeywordArgReport
+        return INFERENCE_METHOD_ERROR_CODE
     elseif report isa TypeAssertErrorReport
         return INFERENCE_TYPE_ERROR_TYPE_ASSERT_CODE
     elseif report isa NonBooleanCondErrorReport

--- a/src/types.jl
+++ b/src/types.jl
@@ -530,6 +530,7 @@ const INFERENCE_METHOD_ERROR_CODE = "inference/method-error"
 const INFERENCE_UNDEF_KEYWORD_CODE = "inference/undef-keyword"
 const INFERENCE_TYPE_ERROR_NON_BOOL_COND_CODE = "inference/type-error/non-bool-cond"
 const INFERENCE_TYPE_ERROR_TYPE_ASSERT_CODE = "inference/type-error/type-assert"
+const INFERENCE_TYPE_ERROR_KEYWORD_CODE = "inference/type-error/keyword"
 const DEPRECATED_INFERENCE_NON_BOOLEAN_COND_CODE = "inference/non-boolean-cond"
 const TESTRUNNER_TEST_FAILURE_CODE = "testrunner/test-failure"
 
@@ -561,6 +562,7 @@ const ALL_DIAGNOSTIC_CODES = Set{String}(String[
     INFERENCE_UNDEF_KEYWORD_CODE,
     INFERENCE_TYPE_ERROR_NON_BOOL_COND_CODE,
     INFERENCE_TYPE_ERROR_TYPE_ASSERT_CODE,
+    INFERENCE_TYPE_ERROR_KEYWORD_CODE,
     TESTRUNNER_TEST_FAILURE_CODE,
 ])
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -527,6 +527,7 @@ const INFERENCE_UNDEF_STATIC_PARAM_CODE = "inference/undef-static-param" # curre
 const INFERENCE_FIELD_ERROR_CODE = "inference/field-error"
 const INFERENCE_BOUNDS_ERROR_CODE = "inference/bounds-error"
 const INFERENCE_METHOD_ERROR_CODE = "inference/method-error"
+const INFERENCE_UNDEF_KEYWORD_CODE = "inference/undef-keyword"
 const INFERENCE_TYPE_ERROR_NON_BOOL_COND_CODE = "inference/type-error/non-bool-cond"
 const INFERENCE_TYPE_ERROR_TYPE_ASSERT_CODE = "inference/type-error/type-assert"
 const DEPRECATED_INFERENCE_NON_BOOLEAN_COND_CODE = "inference/non-boolean-cond"
@@ -557,6 +558,7 @@ const ALL_DIAGNOSTIC_CODES = Set{String}(String[
     INFERENCE_FIELD_ERROR_CODE,
     INFERENCE_BOUNDS_ERROR_CODE,
     INFERENCE_METHOD_ERROR_CODE,
+    INFERENCE_UNDEF_KEYWORD_CODE,
     INFERENCE_TYPE_ERROR_NON_BOOL_COND_CODE,
     INFERENCE_TYPE_ERROR_TYPE_ASSERT_CODE,
     TESTRUNNER_TEST_FAILURE_CODE,

--- a/test/analysis/test_Analyzer.jl
+++ b/test/analysis/test_Analyzer.jl
@@ -366,6 +366,113 @@ end
     end
 end
 
+kwtyped(a::Int; kw::Int=42) = a * kw       # typed keyword with a default, plus a positional
+kwtyped2(; x::Int, y::String="s") = (x, y) # required typed x, optional typed y
+kwtypedfwd(; kws...) = kwtyped(1; kws...)   # forwards slurped keywords
+kwtypedbad(; kws...) = kwtyped(1; kw=2.0)   # slurps but hardcodes a mismatching call
+module KeywordTypeExternalModule
+    libkwtyped(; kw::Int=1) = kw
+end
+
+@testset "KeywordTypeErrorReport" begin
+    # keyword value whose type does not match the declared keyword type
+    let result = analyze_call() do
+            kwtyped(2; kw=42.0)
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa KeywordTypeErrorReport
+        @test r.var === :kw && r.expected === Int && r.got === Float64
+    end
+
+    # mismatch on a required typed keyword (routed through the keyword sorter)
+    let result = analyze_call() do
+            kwtyped2(; x=1.0)
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa KeywordTypeErrorReport && r.var === :x && r.expected === Int
+    end
+
+    # no report when the keyword value type matches
+    let result = analyze_call() do
+            kwtyped(2; kw=42)
+        end
+        @test isempty(get_reports(result))
+    end
+
+    # no report when the keyword is omitted (the default is used)
+    let result = analyze_call() do
+            kwtyped(2)
+        end
+        @test isempty(get_reports(result))
+    end
+
+    # no false positive when the value type only sometimes mismatches: the call does not
+    # definitely throw, so it is not flagged
+    let result = analyze_call((Union{Int,Float64},)) do x
+            kwtyped(1; kw=x)
+        end
+        @test !any(r -> r isa KeywordTypeErrorReport, get_reports(result))
+    end
+
+    # no false positive for a keyword-forwarding wrapper analyzed at its zero-keyword
+    # signature: a forwarded call carries no statically-known mismatching value
+    let result = analyze_call(kwtypedfwd)
+        @test isempty(get_reports(result))
+    end
+    # ... but a hardcoded mismatching call inside a slurping function is still reported
+    # (unlike missing keywords, slurping does not mask a value-type mismatch)
+    let result = analyze_call(kwtypedbad)
+        reports = get_reports(result)
+        @test length(reports) == 1
+        @test only(reports) isa KeywordTypeErrorReport
+    end
+
+    # each reached call site is reported independently (call-site, not throw-site, detection):
+    # both branches pass the same mismatching keyword, so throw-site detection — firing once on
+    # the shared sorter's fresh inference — would report only one of them
+    let result = analyze_call((Bool,)) do c
+            if c
+                kwtyped(1; kw=2.0)
+            else
+                kwtyped(1; kw=2.0)
+            end
+        end
+        reports = filter(r -> r isa KeywordTypeErrorReport, get_reports(result))
+        @test length(reports) == 2
+    end
+
+    # a definite type error on a conditional branch is still reported even when the frame
+    # returns normally on another path: unlike a missing keyword, a value-type mismatch is
+    # never spuriously synthesized on a non-taken branch, so it is not suppressed
+    let result = analyze_call((Bool,)) do c
+            c ? kwtyped(1; kw=2.0) : 0
+        end
+        reports = filter(r -> r isa KeywordTypeErrorReport, get_reports(result))
+        @test length(reports) == 1
+        @test only(reports).var === :kw
+    end
+
+    # the throw happens in the callee's module, but gating is on the caller: a call from a
+    # target module is reported even when the function is defined elsewhere
+    let result = analyze_call(; report_target_modules=(@__MODULE__,)) do
+            KeywordTypeExternalModule.libkwtyped(; kw=2.0)
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        @test only(reports) isa KeywordTypeErrorReport
+    end
+    # ... but not reported when the caller's module is outside the target set
+    let result = analyze_call(; report_target_modules=(KeywordTypeExternalModule,)) do
+            KeywordTypeExternalModule.libkwtyped(; kw=2.0)
+        end
+        @test isempty(get_reports(result))
+    end
+end
+
 @testset "BoundsError analysis" begin
     # `getindex(::Tuple, ::Int)`
     let result = analyze_call((Tuple{Int},)) do tpl1

--- a/test/analysis/test_Analyzer.jl
+++ b/test/analysis/test_Analyzer.jl
@@ -5,8 +5,21 @@ using JETLS
 
 include(normpath(pkgdir(JETLS), "test", "interactive-utils.jl"))
 
-using JETLS.JET: get_reports
+using JETLS.JET: CC, get_reports
 using JETLS.Analyzer
+
+function analyze_signature(f; report_target_modules = nothing)
+    analyzer = JETLS.LSAnalyzer(; report_target_modules)
+    analyzer = JET.AbstractAnalyzer(analyzer,
+        JET.AnalyzerState(JET.AnalyzerState(analyzer), #=refresh_local_cache=#true))
+    m = only(methods(f))
+    world = CC.get_inference_world(analyzer)
+    match = JETLS.signature_analysis_match(analyzer, m.sig, world)
+    match === nothing && error("No method match for signature analysis")
+    analyzer, result = JET.analyze_method_signature!(analyzer,
+        match.method, match.spec_types, match.sparams)
+    return get_reports(analyzer, result)
+end
 
 baremodule ExternalModule end
 
@@ -223,6 +236,133 @@ struct KwCallable end
         @test r isa UnsupportedKeywordArgReport
         @test r.ftype === typeof(kwvaropt) && r.unsupported == [:z]
         @test r.posargtypes == Any[Vararg{Int}]
+    end
+end
+
+kwreq(; x) = x            # required keyword x
+kwreq2(; x, y=2) = (x, y) # required x, optional y
+kwopt(; x=1) = x          # optional keyword x
+kwfwd(; kws...) = kwreq(; kws...) # forwards slurped keywords to a required-keyword function
+kwreqpos(pos; x) = (pos, x)
+kwfwdpos(; kws...) = kwreqpos(42; kws...)
+kwvarpos(pos...; x) = (pos, x) # required keyword + positional vararg
+kwcaller() = kwreq()      # never supplies the required keyword
+module UndefKeywordExternalModule
+    libkwreq(; x) = x
+end
+
+@testset "UndefKeywordErrorReport" begin
+    # required keyword missing on a direct call (no keyword sorter)
+    let result = analyze_call() do
+            kwreq()
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa UndefKeywordErrorReport && r.var === :x
+    end
+
+    # required keyword missing while another keyword is provided (via keyword sorter)
+    let result = analyze_call() do
+            kwreq2(; y=3)
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa UndefKeywordErrorReport && r.var === :x
+    end
+
+    # no report when the required keyword is provided
+    let result = analyze_call() do
+            kwreq(; x=1)
+        end
+        @test isempty(get_reports(result))
+    end
+
+    # no report for an optional keyword
+    let result = analyze_call() do
+            kwopt()
+        end
+        @test isempty(get_reports(result))
+    end
+
+    # no false positive when keywords are splatted dynamically: `nt` may supply `x`, so the
+    # call does not definitely throw
+    let result = analyze_call((NamedTuple,)) do nt
+            kwreq(; nt...)
+        end
+        @test isempty(get_reports(result))
+    end
+
+    # splatted positional arguments leave a trailing `Vararg` in the call's argtypes, which
+    # must be kept intact rather than widened into a bogus signature element
+    let result = analyze_call((Tuple{Vararg{Int}},)) do args
+            kwvarpos(args...)
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa UndefKeywordErrorReport && r.var === :x
+    end
+
+    # signature analysis uses an abstract keyword sorter for keyword-forwarding wrappers,
+    # so a required keyword may be supplied by the wrapper's own caller
+    let reports = analyze_signature(kwfwd)
+        @test isempty(reports)
+    end
+    let reports = analyze_signature(kwfwdpos)
+        @test isempty(reports)
+    end
+    # ... but a concrete zero-keyword call to the forwarder still reports the real error
+    let result = analyze_call(kwfwd, ())
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa UndefKeywordErrorReport && r.var === :x
+    end
+    let result = analyze_call(kwfwdpos, ())
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa UndefKeywordErrorReport && r.var === :x
+    end
+    # ... and a non-forwarding function that never supplies the keyword is still reported
+    let reports = analyze_signature(kwcaller)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa UndefKeywordErrorReport && r.var === :x
+    end
+
+    # each reached call site of the same missing-keyword callee must be reported
+    # independently. The throw lives in the callee's synthesized keyword sorter, which is
+    # inferred fresh only once; a throw-site detector would fire only for whichever call site
+    # triggered that inference and miss the rest, so detection must be per call site.
+    let result = analyze_call((Bool,)) do c
+            if c
+                kwreq()
+            else
+                kwreq()
+            end
+        end
+        reports = get_reports(result)
+        @test length(reports) == 2
+        @test all(r -> r isa UndefKeywordErrorReport && r.var === :x, reports)
+    end
+
+    # the throw happens in the callee's module, but gating is on the caller: a call from a
+    # target module is reported even when the function is defined elsewhere
+    let result = analyze_call(; report_target_modules=(@__MODULE__,)) do
+            UndefKeywordExternalModule.libkwreq()
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        @test only(reports) isa UndefKeywordErrorReport
+    end
+    # ... but not reported when the caller's module is outside the target set
+    let result = analyze_call(; report_target_modules=(UndefKeywordExternalModule,)) do
+            UndefKeywordExternalModule.libkwreq()
+        end
+        @test isempty(get_reports(result))
     end
 end
 

--- a/test/analysis/test_Analyzer.jl
+++ b/test/analysis/test_Analyzer.jl
@@ -140,6 +140,92 @@ only_int(x::Int) = 2x
     end
 end
 
+kwfunc(; code::String="code", message::String="message", data=nothing) = (code, message, data)
+kwslurp(; a=1, kwargs...) = (a, kwargs)
+kwpos(x::Int; y=1) = (x, y)
+kwvaropt(pos...; y=1) = (pos, y) # optional keyword + positional vararg
+struct KwCallable end
+(::KwCallable)(x::Int; y=1) = (x, y)
+
+@testset "UnsupportedKeywordArgReport" begin
+    # a single unsupported keyword argument
+    let result = analyze_call() do
+            kwfunc(; result="result")
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa UnsupportedKeywordArgReport
+        @test r.ftype === typeof(kwfunc)
+        @test r.unsupported == [:result]
+    end
+
+    # only the unsupported keywords are reported, supported ones are ignored
+    let result = analyze_call() do
+            kwfunc(; code="c", result="result", other=1)
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa UnsupportedKeywordArgReport && r.unsupported == [:result, :other]
+    end
+
+    # no report when all keywords are supported
+    let result = analyze_call() do
+            kwfunc(; code="c", data=42)
+        end
+        @test isempty(get_reports(result))
+    end
+
+    # no report when the method slurps `kwargs...` (accepts any keyword)
+    let result = analyze_call() do
+            kwslurp(; whatever=1)
+        end
+        @test isempty(get_reports(result))
+    end
+
+    # unsupported keyword combined with positional arguments
+    let result = analyze_call((Int,)) do x
+            kwpos(x; z=2)
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa UnsupportedKeywordArgReport && r.unsupported == [:z]
+    end
+
+    # supported keyword with positional arguments: no report
+    let result = analyze_call((Int,)) do x
+            kwpos(x; y=2)
+        end
+        @test isempty(get_reports(result))
+    end
+
+    # a non-constant callable object (resolved via its type, not a singleton instance)
+    let result = analyze_call((KwCallable, Int)) do c, x
+            c(x; z=2)
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa UnsupportedKeywordArgReport
+        @test r.ftype === KwCallable && r.unsupported == [:z]
+    end
+
+    # splatted positional arguments leave a trailing `Vararg` in the call's argtypes, which
+    # must be kept intact rather than widened into a bogus signature element
+    let result = analyze_call((Tuple{Vararg{Int}},)) do args
+            kwvaropt(args...; z=2)
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa UnsupportedKeywordArgReport
+        @test r.ftype === typeof(kwvaropt) && r.unsupported == [:z]
+        @test r.posargtypes == Any[Vararg{Int}]
+    end
+end
+
 @testset "BoundsError analysis" begin
     # `getindex(::Tuple, ::Int)`
     let result = analyze_call((Tuple{Int},)) do tpl1

--- a/test/analysis/test_Analyzer.jl
+++ b/test/analysis/test_Analyzer.jl
@@ -4,6 +4,7 @@ using Test
 using JETLS
 
 include(normpath(pkgdir(JETLS), "test", "interactive-utils.jl"))
+include(normpath(pkgdir(JETLS), "test", "setup.jl"))
 
 using JETLS.JET: CC, get_reports
 using JETLS.Analyzer
@@ -473,7 +474,7 @@ end
     end
 end
 
-@testset "BoundsError analysis" begin
+@testset "BoundsErrorReport" begin
     # `getindex(::Tuple, ::Int)`
     let result = analyze_call((Tuple{Int},)) do tpl1
             tpl1[1]
@@ -571,7 +572,7 @@ end
     end
 end
 
-@testset "TypeErrorReport" begin
+@testset HierarchicalTestSet "TypeErrorReport" begin
     @testset "TypeAssertErrorReport" begin
         let result = analyze_call((Int,)) do x
                 x::Int


### PR DESCRIPTION
## Summary

Julia raises several runtime errors for keyword-argument misuse that `LSAnalyzer` did not previously flag statically. This adds detection for three such cases, plus a supporting signature-analysis fix so that keyword forwarders are not misreported.

Each diagnostic fires only when inference proves the call always throws (return type `Union{}`), so calls that may succeed for some runtime values are not flagged.

## Diagnostics added

- **Unsupported keyword** → `inference/method-error`:
  A keyword the callee does not accept, e.g. `f(; unknown=1)`. Lowered to `Core.kwcall((unknown=1,), f)`, it dispatches to the generated keyword sorter and then throws a `MethodError` via `Base.kwerr`; since that is an explicit `throw` rather than a dispatch failure, it was previously unreported.

- **Missing required keyword** → `inference/undef-keyword` (new code):
  A required keyword (declared without a default) omitted at the call site, e.g. `f(42)` for `f(pos; key)`, which raises `UndefKeywordError`.

- **Keyword value type mismatch** → `inference/type-error/keyword` (new code): 
  A keyword passed with a value whose type can never match the declared type, e.g. `f(; key=1.0)` for `f(; key::Int)`, which raises `TypeError`.

## Notes on the approach

- **Call-site detection.** The missing-keyword and type-mismatch errors `throw`   inside the function's synthesized keyword sorter, which is inferred fresh only   once and then cached. Detecting at that `throw` makes the report depend on which call site happened to trigger the fresh inference — a race under concurrent signature analysis — so detection runs at each call site instead, from the cached, caller-independent return/exception types. Every reached call site reports independently.

- **Keyword forwarders.** `f(; kws...) = g(; kws...)` has the user-facing signature `Tuple{typeof(f)}`, at which signature analysis would specialize `kws` to the empty set and spuriously flag the forwarded call. Signature analysis now redirects such methods to the abstract keyword sorter (`Core.kwcall(::NamedTuple, ::typeof(f), …)`), keeping `kws` an abstract `NamedTuple`, applied uniformly on both the Revise and Interpreter paths.

## Known limitation

Keyword types that are method static parameters tied to another argument (e.g. `f(x::T; kw::T)`) are not resolved, so those mismatches are not reported. This is a safe-side miss, not a false positive.
