### PR TITLE
occurrence-analysis: Collect occurrences from all `@static` branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Reworked the [diagnostics documentation](https://aviatesk.github.io/JETLS.jl/release/diagnostic/): a new [Analysis stages](https://aviatesk.github.io/JETLS.jl/release/diagnostic/#diagnostic/stage) section explains what produces each diagnostic category, which tool powers it, when it runs, and how the stages depend on one another. It also adds a [security caveat](https://aviatesk.github.io/JETLS.jl/release/diagnostic/#diagnostic/stage/toplevel) that full analysis loads and runs your code (so JETLS should not be run on untrusted code), and documents how each [`inference/*` diagnostic](https://aviatesk.github.io/JETLS.jl/release/diagnostic/#diagnostic/reference/inference) corresponds to the Julia runtime error it predicts.
 
+### Fixed
+
+- Fixed a false `lowering/unused-import` report for a name used only inside a `@static` condition or a branch not taken on the current platform. Such names are now correctly recognized as used:
+  ```julia
+  using Base: VERSION
+  @static if VERSION ≥ v"1.12"
+      # `VERSION` is no longer misreported as an unused import
+  end
+  ```
+
+- Document-highlight and rename now also cover identifiers used in `@static` branches not selected for the current platform.
+
 ## 2026-06-26
 
 - Commit: [`0d67c12`](https://github.com/aviatesk/JETLS.jl/commit/0d67c12)

--- a/src/analysis/occurrence-analysis.jl
+++ b/src/analysis/occurrence-analysis.jl
@@ -456,11 +456,15 @@ function compute_full_binding_occurrences(
         # A statement that is *only* such a declaration has no other code, so skip lowering it.
         binding_occurrences = Dict{JL.BindingInfo,Set{BindingOccurrence}}()
     else
+        # Remove macros to preserve precise source locations. `strip_static=true` keeps
+        # every `@static` branch as a plain conditional, so identifiers used in the
+        # condition and in branches not taken on this platform are still collected —
+        # scope-aware, since each branch is resolved within its enclosing scope.
+        # TODO: This won't be necessary once JuliaLowering can preserve precise
+        # source locations for old macro-expanded code.
         (; ctx3, st3) = try
-            # Remove macros to preserve precise source locations.
-            # TODO: This won't be necessary once JuliaLowering can preserve precise
-            # source locations for old macro-expanded code.
-            jl_lower_for_scope_resolution(context_module, remove_macrocalls(st0); soft_scope)
+            jl_lower_for_scope_resolution(context_module,
+                remove_macrocalls(st0; strip_static=true); soft_scope)
         catch
             return nothing
         end

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -222,6 +222,8 @@ is_doc0_any(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@doc") # Explicit `@doc` 
 
 is_cmd0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@cmd"; from=Core)
 
+is_static0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@static")
+
 """
     collect_import_names(st0::SyntaxTreeC) -> Vector{Pair{SyntaxTreeC, String}}
 
@@ -421,13 +423,18 @@ function is_nospecialize_or_specialize_macrocall3(st3::SyntaxTreeC)
     return get_name_val(macro_name) in ("nospecialize", "specialize")
 end
 
-function _remove_macrocalls(st0::SyntaxTreeC)
+function _remove_macrocalls(st0::SyntaxTreeC; strip_static::Bool=false)
     if JS.kind(st0) === JS.K"macrocall"
-        if is_new_style_macrocall0(st0)
+        if is_new_style_macrocall0(st0) && !(strip_static && is_static0(st0))
             # Macros with new-style JuliaLowering implementations preserve
             # fine-grained provenance during expansion, so we don't need to
             # rewrite them to a `block` to keep source locations accurate.
             # See `NEW_STYLE_MACROCALL_NAMES` for the list.
+            # With `strip_static`, `@static` is exempted from this exemption: it is
+            # rewritten to a `block` keeping *all* branches (a plain runtime
+            # conditional) instead of expanding to the single platform-selected
+            # branch, so occurrence analysis sees every branch — scope-aware — rather
+            # than dropping the branches not taken on the current platform.
             return st0, false
         elseif is_mainfunc0(st0)
             # `@main` functions are desugared by `desugar_main_macrocall` below,
@@ -452,7 +459,7 @@ function _remove_macrocalls(st0::SyntaxTreeC)
             # arguments out of the macrocall into a bare `block`, any surviving
             # `$` would be out of context and fail lowering, so unwrap
             # interpolations on the lifted child.
-            stripped, _ = _remove_macrocalls(st0[i])
+            stripped, _ = _remove_macrocalls(st0[i]; strip_static)
             push!(new_children, _unwrap_interpolations(stripped)[1])
         end
         return JL.@ast(JS.syntax_graph(st0), st0, [JS.K"block" new_children...]), true
@@ -462,7 +469,7 @@ function _remove_macrocalls(st0::SyntaxTreeC)
     (st0, changed) = desugar_main_macrocall(st0)
     new_children = JS.SyntaxList(JS.syntax_graph(st0))
     for c in JS.children(st0)
-        nc, cc = _remove_macrocalls(c)
+        nc, cc = _remove_macrocalls(c; strip_static)
         changed |= cc
         push!(new_children, nc)
     end
@@ -539,12 +546,19 @@ function desugar_main_macrocall(st0::SyntaxTreeC)
 end
 
 """
-    remove_macrocalls(st0::SyntaxTreeC) -> SyntaxTreeC
+    remove_macrocalls(st0::SyntaxTreeC; strip_static::Bool=false) -> SyntaxTreeC
 
 Convert each `macrocall` node to a `block` node, keeping the arguments intact so that
 identifiers passed to macros retain their original source locations. The transformed
 tree can then be fed into scope/binding resolution to drive LSP features such as
 find-references, document-highlight, rename, and go-to-definition.
+
+With `strip_static=true`, `@static` conditionals are also rewritten to plain runtime
+conditionals (keeping every branch) rather than expanded to the single branch selected
+for the current platform. This lets occurrence analysis see identifiers used in the
+condition and in every branch — scope-aware, since each branch is resolved within its
+enclosing scope — instead of dropping the ones not taken here (which would otherwise be
+misreported as unused).
 
 This is useful because JuliaLowering's macro expansion (for old-style macros) loses
 fine-grained provenance information, reducing it to line-level granularity. For example,
@@ -579,9 +593,9 @@ any bindings or control flow the macros themselves would have introduced.
     `desugar_main_macrocall`. As more macros migrate to the new style, the scope
     of this transformation is expected to shrink.
 """
-function remove_macrocalls(st0::SyntaxTreeC)
+function remove_macrocalls(st0::SyntaxTreeC; strip_static::Bool=false)
     ensure_jl_source_attr!(JS.syntax_graph(st0))
-    return first(_remove_macrocalls(st0))
+    return first(_remove_macrocalls(st0; strip_static))
 end
 
 # Iteratively peel a function-definition signature's `where {…}` clauses and outer `::T`

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -258,7 +258,7 @@ function select_target_binding(
 
     (; ctx3, st3) = try
         # Remove macros to preserve precise source locations
-        jl_lower_for_scope_resolution(context_module, remove_macrocalls(st0); soft_scope)
+        jl_lower_for_scope_resolution(context_module, remove_macrocalls(st0; strip_static=true); soft_scope)
     catch err
         JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
         JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())

--- a/test/analysis/test_occurrence_analysis.jl
+++ b/test/analysis/test_occurrence_analysis.jl
@@ -483,6 +483,56 @@ end
         end
     end
 
+    @testset "@static condition/branch uses" begin
+        # `@static` expands to only the branch selected for the current platform, dropping
+        # its condition and the branches not taken. Occurrence analysis retains all
+        # branches (as a plain conditional) so identifiers used in the condition or in any
+        # branch are still recorded — otherwise they would be misreported as unused.
+        function global_use_names(boccs)
+            names = String[]
+            for (binfo, occs) in boccs
+                binfo.kind === :global || continue
+                any(o -> o.kind === :use, occs) || continue
+                push!(names, binfo.name)
+            end
+            return names
+        end
+        local_names(boccs) = [b.name for (b, _) in boccs if b.kind === :local]
+        # simple `if` condition
+        let names = global_use_names(get_full_binding_occurrences(
+                "@static if VERSION >= v\"1.11\"\n    nothing\nend"))
+            @test "VERSION" in names
+        end
+        # short-circuit `&&` left operand
+        let names = global_use_names(get_full_binding_occurrences(
+                "@static VERSION >= v\"1.11\" && nothing"))
+            @test "VERSION" in names
+        end
+        # every condition in an `elseif` chain is collected regardless of which branch
+        # the current platform takes
+        let names = global_use_names(get_full_binding_occurrences(
+                "@static if VERSION < v\"0\"\n    nothing\nelseif Sys.iswindows()\n    nothing\nend"))
+            @test "VERSION" in names
+            @test "Sys" in names
+        end
+        # uses in *both* branches are collected, including the one not taken here
+        let names = global_use_names(get_full_binding_occurrences(
+                "@static if Sys.iswindows()\n    winonly()\nelse\n    maconly()\nend"))
+            @test "winonly" in names
+            @test "maconly" in names
+        end
+        # branches are resolved within the enclosing scope: a name bound in a branch is a
+        # local (not a spurious global), and `return` inside a branch lowers cleanly
+        let boccs = get_full_binding_occurrences(
+                "function f()\n    @static if Sys.iswindows()\n        x = 1\n        use(x)\n    end\n    return g()\nend")
+            @test "x" in local_names(boccs)
+            @test "x" ∉ global_use_names(boccs)
+            for name in ("use", "g")
+                @test name in global_use_names(boccs)
+            end
+        end
+    end
+
     @testset "export/public" begin
         let boccs = get_full_binding_occurrences("export foo, @bar, baz")
             @test length(boccs) == 3

--- a/test/test_document_highlight.jl
+++ b/test/test_document_highlight.jl
@@ -115,6 +115,43 @@ end
             end
         end
 
+        @testset "highlight across @static branches" begin
+            # A binding used in a `@static` branch not selected for the current platform
+            # is still highlighted: occurrence analysis retains every branch (as a plain
+            # conditional), so the use isn't dropped with the unpicked branch.
+            let code = """
+                function func()
+                    │xx│x│ = 1
+                    @static if Sys.iswindows()
+                        println(│xx│x│)
+                    else
+                        println(│xx│x│)
+                    end
+                end
+                """
+                fi, positions = highlight_testcase(code, 9)
+                for pos in positions
+                    highlights = JETLS.document_highlights(fi, pos)
+                    @test length(highlights) == 3
+                    @test count(highlights) do highlight
+                        highlight.range.start == positions[1] &&
+                        highlight.range.var"end" == positions[3] &&
+                        highlight.kind == DocumentHighlightKind.Write
+                    end == 1
+                    @test count(highlights) do highlight
+                        highlight.range.start == positions[4] &&
+                        highlight.range.var"end" == positions[6] &&
+                        highlight.kind == DocumentHighlightKind.Read
+                    end == 1
+                    @test count(highlights) do highlight
+                        highlight.range.start == positions[7] &&
+                        highlight.range.var"end" == positions[9] &&
+                        highlight.kind == DocumentHighlightKind.Read
+                    end == 1
+                end
+            end
+        end
+
         @testset "do-block parameters in same lowering unit" begin
             # Two `do h` blocks share the same top-level statement but each
             # introduces its own fresh `h` binding; highlights must not cross.

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -1858,6 +1858,28 @@ end
         @test isempty(diagnostics)
     end
 
+    # Imports used only inside a `@static` condition should not be reported as unused:
+    # `@static` expands to only the platform-selected branch, dropping the condition.
+    let diagnostics = get_unused_import_diagnostics("""
+        using Base: VERSION
+        @static if VERSION >= v"1.11"
+            nothing
+        end
+        """)
+        @test isempty(diagnostics)
+    end
+
+    # Imports used only inside a `@static` branch not taken on this platform should not be
+    # reported as unused: removing the import would break the platform where it is taken.
+    let diagnostics = get_unused_import_diagnostics("""
+        using Base: VERSION
+        @static if Sys.iswindows()
+            println(VERSION)
+        end
+        """)
+        @test isempty(diagnostics)
+    end
+
     # Imports used inside macro body quoted expressions should not be reported as unused
     let diagnostics = get_unused_import_diagnostics("""
         using Base.Iterators: flatten

--- a/test/test_rename.jl
+++ b/test/test_rename.jl
@@ -264,6 +264,44 @@ end
         end
     end
 
+    @testset "rename across @static branches" begin
+        # A use in a `@static` branch not selected for the current platform must be
+        # renamed too — otherwise the rename leaves that branch referring to the old name,
+        # breaking the code on the platform where the branch is taken.
+        let code = """
+            function func()
+                │xx│x│ = 1
+                @static if Sys.iswindows()
+                    println(│xx│x│)
+                else
+                    println(│xx│x│)
+                end
+            end
+            """
+            fi, positions, furi = rename_testcase(code, 9)
+            for pos in positions
+                (; result, error) = JETLS.local_binding_rename(server, furi, fi, pos, @__MODULE__, "yyy")
+                @test result isa WorkspaceEdit && isnothing(error)
+                for (uri, edits) in result.changes
+                    @test furi == uri
+                    @test length(edits) == 3
+                    @test count(edits) do edit
+                        edit.newText == "yyy" &&
+                        edit.range == Range(; start=positions[1], var"end"=positions[3])
+                    end == 1
+                    @test count(edits) do edit
+                        edit.newText == "yyy" &&
+                        edit.range == Range(; start=positions[4], var"end"=positions[6])
+                    end == 1
+                    @test count(edits) do edit
+                        edit.newText == "yyy" &&
+                        edit.range == Range(; start=positions[7], var"end"=positions[9])
+                    end == 1
+                end
+            end
+        end
+    end
+
     @testset "@generated function rename" begin
         let code = """
             @generated function foo(│x│)


### PR DESCRIPTION
A name used only inside a `@static` condition or a branch not taken on the current platform was falsely reported as
`lowering/unused-import`, e.g. `ARCH` here:

```julia
using Sys: ARCH
@static if ARCH === :aarch64
    return "aarch64"
end
```

Document-highlight and rename had the same blind spot: uses in a branch not selected for this platform were silently missed, so a rename could leave that branch referring to the old name. The cause is that JETLS's new-style `@static` expands to only the platform-selected branch, dropping the condition and the other branches before occurrence analysis runs.

Add a `strip_static` option to `remove_macrocalls` that rewrites `@static` conditionals to plain runtime conditionals, keeping every branch instead of expanding to the selected one.
`compute_full_binding_occurrences` and `select_target_binding` now lower with `strip_static=true`. Each branch is resolved within its enclosing scope, so branch-local bindings stay local and `return`/`break`/`continue` lower correctly — no isolated per-branch lowering is needed. The diagnostic pipeline keeps the real `@static` expansion, so inactive branches are still grayed out and only the active branch is checked.