### PR TITLE
diagnostic: Don't flag bindings used in dropped `@static` branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fixed a false `lowering/unused-import` report for a name used only inside a `@static` condition or a branch not taken on the current platform. Such names are now correctly recognized as used:
+- Fixed a false `lowering/unused-import` report for a name used only inside a `@static` condition or a branch not selected by the JETLS analysis process:
   ```julia
   using Base: VERSION
   @static if VERSION ≥ v"1.12"
@@ -95,7 +95,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   end
   ```
 
-- Document-highlight and rename now also cover identifiers used in `@static` branches not selected for the current platform.
+- Document-highlight and rename now also cover identifiers used in `@static` branches not selected by the JETLS analysis process.
+
+- Fixed false `lowering/unused-local`, `lowering/unused-argument`, and `lowering/unused-assignment` reports for a binding whose only use is in a `@static` branch not selected by the JETLS analysis process.
 
 ## 2026-06-26
 

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -910,7 +910,8 @@ function analyze_unused_bindings!(
         has_implicit_args::Bool, reported::Set{LoweringDiagnosticKey},
         kwarg_type_names::Dict{Tuple{Int,Int},Set{String}},
         kwarg_locations::Set{Tuple{Int,Int}};
-        allow_unused_underscore::Bool
+        allow_unused_underscore::Bool,
+        inactive_branch_names::Set{String} = Set{String}()
     )
     for (binfo, occurrences) in binding_occurrences
         bk = binfo.kind
@@ -919,6 +920,10 @@ function analyze_unused_bindings!(
             continue
         end
         bn = binfo.name
+        # A use in a `@static` branch dropped on this platform is absent from the lowered
+        # tree, so the binding looks unused here; don't report it (see
+        # `collect_inactive_branch_names`).
+        bn in inactive_branch_names && continue
         if has_implicit_args && bn in _IMPLICIT_BINDING_NAMES
             continue
         end
@@ -972,13 +977,17 @@ function analyze_unused_assignments!(
         diagnostics::Vector{Diagnostic}, fi::FileInfo, st0::SyntaxTreeC,
         dead_store_info::Dict{JL.BindingInfo, DeadStoreInfo},
         reported::Set{LoweringDiagnosticKey};
-        allow_unused_underscore::Bool
+        allow_unused_underscore::Bool,
+        inactive_branch_names::Set{String} = Set{String}()
     )
     for (binfo, dsinfo) in dead_store_info
         binfo.kind === :local || continue
         binfo.is_internal && continue
         startswith(binfo.name, '#') && continue
         bn = binfo.name
+        # See `analyze_unused_bindings!`: a value read only in a `@static` branch dropped
+        # on this platform looks dead here, but isn't on the platform taking that branch.
+        bn in inactive_branch_names && continue
         if allow_unused_underscore && startswith(bn, '_')
             continue
         end
@@ -1528,7 +1537,8 @@ function analyze_lowered_code!(
         analyzer::Union{Nothing,LSAnalyzer}, postprocessor::LSPostProcessor;
         skip_analysis_requiring_context::Bool = false,
         allow_unused_underscore::Bool = true,
-        allow_noreturn_optimization::Vector{Symbol} = Symbol[]
+        allow_noreturn_optimization::Vector{Symbol} = Symbol[],
+        inactive_branch_names::Set{String} = Set{String}()
     )
     (; ctx3, ctx4, st0, st3) = res
     binding_occurrences = compute_binding_occurrences(ctx3, st3;
@@ -1543,12 +1553,13 @@ function analyze_lowered_code!(
     analyze_unused_bindings!(
         diagnostics, fi, st0, ctx3, binding_occurrences, has_implicit_args, reported,
         kwarg_type_names, kwarg_locations;
-        allow_unused_underscore)
+        allow_unused_underscore, inactive_branch_names)
 
     (; undef_info, dead_store_info, unreachable_statements) =
         analyze_all_lambdas(ctx3, st3; allow_noreturn_optimization)
     analyze_undefined_local_bindings!(diagnostics, uri, fi, undef_info, reported)
-    analyze_unused_assignments!(diagnostics, fi, st0, dead_store_info, reported; allow_unused_underscore)
+    analyze_unused_assignments!(diagnostics, fi, st0, dead_store_info, reported;
+        allow_unused_underscore, inactive_branch_names)
 
     analyze_captured_boxes!(diagnostics, uri, fi, ctx4, st3, reported)
     analyze_unreachable_code!(diagnostics, fi, st3, unreachable_statements)
@@ -1628,6 +1639,7 @@ function per_stmt_diagnostics!(
         nothing # signal primary-attempt failure to the fallback path
     end
     emit_macro_diagnostics!(diagnostics, fi, macro_diags)
+    inactive_branch_names = collect_inactive_branch_names(macro_diags)
 
     if res === nothing
         # Fallback expansion runs *outside* the sink scope: `remove_macrocalls`
@@ -1660,7 +1672,36 @@ function per_stmt_diagnostics!(
 
     return analyze_lowered_code!(
         diagnostics, candidates, uri, fi, res, world, analyzer, postprocessor;
-        skip_analysis_requiring_context, allow_unused_underscore, allow_noreturn_optimization)
+        skip_analysis_requiring_context, allow_unused_underscore, allow_noreturn_optimization,
+        inactive_branch_names)
+end
+
+# Names of identifiers appearing in `@static` branches dropped at expansion time — the
+# regions reported as `lowering/inactive-code` via the macro-diagnostic sink. A local
+# binding or argument whose only use lives in such a dropped branch is absent from the
+# lowered tree and would otherwise be misreported as unused. The unused-binding /
+# unused-assignment analyses skip any binding whose name is in this set. Suppressing by
+# name is conservative: it can only hide a genuinely unused warning when the same name
+# happens to recur in a dropped branch, never introduce a false one.
+#
+# Only the dropped branches are walked — uses in the branch taken on this platform
+# survive into the lowered tree, so those bindings are never misreported and need no
+# suppression. `@static` reports *every* dropped branch via `push_inactive_code!`
+# (each arm of an `if`/`elseif`/`else` chain or short-circuit `&&`/`||`, including a
+# dropped `elseif`'s condition), so walking the inactive nodes misses no vanished use.
+function collect_inactive_branch_names(macro_diags::Vector{MacroDiagnostic})
+    names = Set{String}()
+    for d in macro_diags
+        d.code == LOWERING_INACTIVE_CODE || continue
+        traverse(d.node) do s
+            if JS.kind(s) === JS.K"Identifier"
+                nv = get_name_val(s)
+                nv === nothing || push!(names, nv)
+            end
+            return nothing
+        end
+    end
+    return names
 end
 
 function compute_unit_def_used_names(

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -64,6 +64,11 @@ length_utf16(s::AbstractString) = sum(c::Char -> codepoint(c) < 0x10000 ? 1 : 2,
 
 module EmptyModule end
 
+# A context module where `@static` conditions referencing `DEV_MODE` can be evaluated.
+module static_dev_mode_module
+    const DEV_MODE = false
+end
+
 @testset HierarchicalTestSet "unused binding detection" begin
     let diagnostics = get_lowering_diagnostics("""
         y = let x = 42
@@ -240,6 +245,68 @@ module EmptyModule end
                 diagnostic.range.start.line == 1 &&
                 diagnostic.range.var"end".line == 1
             end
+        end
+    end
+
+    @testset "use in dropped @static branch" begin
+        # `@static` expands to only the platform-selected branch, so a binding whose only
+        # use lives in a branch not taken here is absent from the lowered tree and would
+        # otherwise look unused. It must not be flagged — the use is real on the platform
+        # that takes the branch.
+        let diagnostics = get_lowering_diagnostics("""
+                function f(cond)
+                    x = compute()
+                    @static if Sys.iswindows()
+                        return g(x)
+                    end
+                    return h(cond)
+                end
+                """;
+                code = JETLS.LOWERING_UNUSED_LOCAL_CODE)
+            @test isempty(diagnostics)
+        end
+        # Same for an argument used only in a dropped branch.
+        let diagnostics = get_lowering_diagnostics("""
+                function f(x)
+                    @static if Sys.iswindows()
+                        return use(x)
+                    end
+                    return nothing
+                end
+                """;
+                code = JETLS.LOWERING_UNUSED_ARGUMENT_CODE)
+            @test isempty(diagnostics)
+        end
+        # A debug-only `@warn` guarded by `@static DEV_MODE` (short-circuit `&&` form):
+        # when `DEV_MODE` is `false` the `@warn` is dropped, so the caught `e` — used only
+        # there — must not be flagged unused.
+        let diagnostics = get_lowering_diagnostics("""
+                function f(x)
+                    try
+                        op(x)
+                    catch e
+                        @static DEV_MODE && @warn "error in op" e
+                    end
+                end
+                """;
+                code = JETLS.LOWERING_UNUSED_LOCAL_CODE,
+                context_module = static_dev_mode_module)
+            @test isempty(diagnostics)
+        end
+        # Guard against over-suppression: a genuinely unused binding is still reported even
+        # when the statement also contains a `@static` (its name isn't in any dropped branch).
+        let diagnostics = get_lowering_diagnostics("""
+                function f(cond)
+                    y = 1
+                    @static if Sys.iswindows()
+                        return g()
+                    end
+                    return h(cond)
+                end
+                """;
+                code = JETLS.LOWERING_UNUSED_LOCAL_CODE)
+            @test length(diagnostics) == 1
+            @test only(diagnostics).message == "Unused local binding `y`"
         end
     end
 
@@ -1413,6 +1480,20 @@ end
                 println(z)
             end
             """))
+    end
+
+    @testset "value read only in dropped @static branch" begin
+        # The assignment looks dead here because its only read is in a `@static` branch
+        # not taken on this platform, but it isn't dead on the platform taking the branch.
+        @test isempty(get_lowering_diagnostics("""
+            function f()
+                z = compute()
+                @static if Sys.iswindows()
+                    println(z)
+                end
+                return nothing
+            end
+            """; code = JETLS.LOWERING_UNUSED_ASSIGNMENT_CODE))
     end
 
     @testset "multiple dead stores" begin


### PR DESCRIPTION
A local binding, argument, or assignment whose only use is inside a `@static` branch not selected by the JETLS analysis process was falsely reported as `lowering/unused-local`,
`lowering/unused-argument`, or `lowering/unused-assignment`:

```julia
function f(x)
    try
        op(x)
    catch e
        @static DEV_MODE && @warn "error in op" e
    end
end
```

When `DEV_MODE` is `false`, `@static` drops the `@warn` at expansion time, so the only use of the caught `e` disappears from the lowered tree and `e` looks unused.

Unlike occurrence analysis, `per_stmt_diagnostics!` deliberately lowers with the real `@static` expansion (the selected branch only): the inactive-code graying, undef-global candidate scoping, and flow-sensitive analyses all need a faithful single-branch tree, so retaining every branch is not an option here. Instead collect the identifier names appearing in the dropped branches — already on hand as the `lowering/inactive-code` regions reported through the macro-diagnostic sink — and skip the unused-binding / unused-assignment reports for any binding whose name is in that set (`collect_inactive_branch_names`).

Suppressing by name is conservative: it can only hide a genuinely unused binding when the same name recurs in a dropped branch (a false negative), never introduce a false positive. A scope-aware variant would cross-match bindings against the all-branch occurrence lowering and is left as a follow-up. Adds tests for local, argument, and assignment suppression plus an over-suppression guard.