### PR TITLE
Make dev and test mode checks static

### DIFF
--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -41,13 +41,13 @@ call_in_server_world(@nospecialize(f), args...; kwargs...) =
 
 push_init_hook!(advance_server_world!)
 
-if JETLS_DEV_MODE
+@static if JETLS_DEV_MODE
     using Revise: Revise
 else
     const Revise = nothing
 end
 
-revise_now!() = JETLS_DEV_MODE && Revise.revise()
+revise_now!() = @static JETLS_DEV_MODE && Revise.revise()
 
 using LSP
 using LSP: LSP
@@ -71,9 +71,9 @@ abstract type AnalysisEntry end # used by `Analyzer.LSAnalyzer`
 
 include("AtomicContainers/AtomicContainers.jl")
 using .AtomicContainers
-# const SWStats  = JETLS_DEV_MODE ? AtomicContainers.SWStats  : Nothing
-# const LWStats  = JETLS_DEV_MODE ? AtomicContainers.LWStats  : Nothing
-# const CASStats = JETLS_DEV_MODE ? AtomicContainers.CASStats : Nothing
+# const SWStats  = @static JETLS_DEV_MODE ? AtomicContainers.SWStats  : Nothing
+# const LWStats  = @static JETLS_DEV_MODE ? AtomicContainers.LWStats  : Nothing
+# const CASStats = @static JETLS_DEV_MODE ? AtomicContainers.CASStats : Nothing
 const SWStats  = Nothing
 const LWStats  = Nothing
 const CASStats = Nothing
@@ -216,11 +216,11 @@ function runserver(
     )
     initialize_requested = shutdown_requested = false
     local exit_code::Int = 1
-    JETLS_DEV_MODE && @info "Running JETLS server loop"
+    @static JETLS_DEV_MODE && @info "Running JETLS server loop"
     seq_queue, seq_task = start_sequential_message_worker(server)
     con_queue, con_task = start_concurrent_message_worker(server)
     if !isnothing(client_process_id)
-        JETLS_DEV_MODE && @info "Monitoring client process ID" client_process_id
+        @static JETLS_DEV_MODE && @info "Monitoring client process ID" client_process_id
         Threads.@spawn while true
             # To handle cases where the client crashes and cannot execute the normal
             # server shutdown process, check every 60 seconds whether the `processId`
@@ -293,7 +293,7 @@ function runserver(
         waitall((seq_task, con_task))
         close(server.endpoint)
     end
-    JETLS_DEV_MODE && @info "Exited JETLS server loop"
+    @static JETLS_DEV_MODE && @info "Exited JETLS server loop"
     return exit_code
 end
 
@@ -349,7 +349,7 @@ function handle_sequential_message(server::Server, @nospecialize msg)
         handle_DidCloseNotebookDocumentNotification(server, msg)
     elseif msg isa DidSaveNotebookDocumentNotification
         handle_DidSaveNotebookDocumentNotification(server, msg)
-    elseif JETLS_DEV_MODE
+    elseif @static JETLS_DEV_MODE ? true : false
         if isdefined(msg, :method)
             _id = getfield(msg, :method)
         else
@@ -389,7 +389,7 @@ function handler_concurrent_message(server::Server, @nospecialize msg)
                     get!(()->CancelFlag(false), server.state.currently_handled, token)
                 Threads.@spawn :default @tryinvokelatest handle_response_message(server, msg, request_caller, cancel_flag)
             end
-        elseif JETLS_DEV_MODE
+        elseif @static JETLS_DEV_MODE ? true : false
             # Not a response to our request, or untyped message - log if in dev mode
             _id = get(()->get(msg, :id, nothing), msg, :method)
             @warn "[handler_concurrent_message] Unhandled message" msg _id=_id maxlog=1
@@ -518,7 +518,7 @@ function handle_request_message(server::Server, @nospecialize(msg), cancel_flag:
         handle_ExecuteCommandRequest(server, msg)
     elseif msg isa TextDocumentContentRequest
         handle_TextDocumentContentRequest(server, msg)
-    elseif JETLS_DEV_MODE
+    elseif @static JETLS_DEV_MODE ? true : false
         if isdefined(msg, :method)
             _id = getfield(msg, :method)
         else
@@ -534,7 +534,7 @@ function handle_notification_message(server::Server, @nospecialize msg)
         handle_DidChangeWatchedFilesNotification(server, msg)
     elseif msg isa DidChangeConfigurationNotification
         handle_DidChangeConfigurationNotification(server, msg)
-    elseif JETLS_DEV_MODE
+    elseif @static JETLS_DEV_MODE ? true : false
         if isdefined(msg, :method)
             _id = getfield(msg, :method)
         else

--- a/src/analysis/Interpreter.jl
+++ b/src/analysis/Interpreter.jl
@@ -200,7 +200,7 @@ function JET.analyze_from_definitions!(interp::LSInterpreter, config::JET.Toplev
                 reports = JET.get_reports(analyzer, result)
                 isempty(reports) || @lock progress.reports_lock append!(progress.reports, reports)
             else
-                JETLS_DEV_MODE && @warn "Couldn't find a single method matching the signature" tt
+                @static JETLS_DEV_MODE && @warn "Couldn't find a single method matching the signature" tt
             end
             done = (@atomic progress.done += 1)
             if cancellable_token !== nothing

--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -929,8 +929,8 @@ function get_inferrable_tree(
     (; ctx3, st3) = try
         jl_lower_for_scope_resolution(context_module, st0; world, trim_error_nodes=true, recover_from_macro_errors=false)
     catch err
-        JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
-        JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
+        @static JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
+        @static JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
         return nothing
     end
     return (; ctx3, st3)
@@ -1063,8 +1063,8 @@ function infer_lowered_tree(
         _, st5 = JL.linearize_ir(ctx4, st4)
         st5
     catch e
-        JETLS_DEV_MODE && @error "infer_toplevel_tree: Lowering failed" e
-        JETLS_DEV_MODE && Base.showerror(stderr, e, catch_backtrace())
+        @static JETLS_DEV_MODE && @error "infer_toplevel_tree: Lowering failed" e
+        @static JETLS_DEV_MODE && Base.showerror(stderr, e, catch_backtrace())
         return nothing
     end |> prepare_type_attr
     lwr = JL.to_lowered_expr(inferrable_tree)

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -173,7 +173,7 @@ end
 
 function start_analysis_workers!(server::Server)
     n_workers = get_init_option(server.state.init_options, :n_analysis_workers)
-    JETLS_DEV_MODE && @info "Starting $n_workers analysis workers"
+    @static JETLS_DEV_MODE && @info "Starting $n_workers analysis workers"
     worker_tasks = server.state.analysis_manager.worker_tasks
     isempty(worker_tasks) || error("The server has already started analysis workers")
     resize!(worker_tasks, n_workers)
@@ -317,7 +317,7 @@ function schedule_analysis!(
                 # Cancel existing timer if any
                 debounce_timer, debounce_completion = debounced[request.entry]
                 close(debounce_timer)
-                JETLS_DEV_MODE && @info "Cancelled analysis debounce timer:" entry=progress_title(request.entry) uri generation
+                @static JETLS_DEV_MODE && @info "Cancelled analysis debounce timer:" entry=progress_title(request.entry) uri generation
                 notify(debounce_completion)
             end
             local new_debounced = copy(debounced)
@@ -350,7 +350,7 @@ function queue_request!(server::Server, request::AnalysisRequest)
             local new_analyses = copy(analyses)
             new_analyses[request.entry] = request
             if old_request !== nothing # replaced by the new request i.e. cancelled
-                JETLS_DEV_MODE && @info "Cancelled duplicated pending analysis request:" entry=progress_title(request.entry) uri=request.uri generation=get_generation(manager,request.entry)
+                @static JETLS_DEV_MODE && @info "Cancelled duplicated pending analysis request:" entry=progress_title(request.entry) uri=request.uri generation=get_generation(manager,request.entry)
                 notify(old_request.completion)
             end
             return new_analyses, false
@@ -371,12 +371,12 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
 
     if is_generation_analyzed(manager, request)
         # Skip if this generation was already analyzed (no new changes since last analysis)
-        JETLS_DEV_MODE && @info "Skipped analysis for unchanged analysis unit" entry=progress_title(request.entry) uri=request.uri generation=get_generation(manager,request.entry)
+        @static JETLS_DEV_MODE && @info "Skipped analysis for unchanged analysis unit" entry=progress_title(request.entry) uri=request.uri generation=get_generation(manager,request.entry)
         @goto next_request
     end
 
     if is_abandoned_request(server, request)
-        JETLS_DEV_MODE && @info "Skipped analysis for closed editor-managed document" entry=progress_title(request.entry) uri=request.uri
+        @static JETLS_DEV_MODE && @info "Skipped analysis for closed editor-managed document" entry=progress_title(request.entry) uri=request.uri
         @goto next_request
     end
 
@@ -384,7 +384,7 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
     prev_result = execution.prev_result
 
     if has_any_parse_errors(server, execution)
-        JETLS_DEV_MODE && @info "Requested analysis unit has parse errors" entry=progress_title(request.entry) uri=request.uri generation=get_generation(manager,request.entry)
+        @static JETLS_DEV_MODE && @info "Requested analysis unit has parse errors" entry=progress_title(request.entry) uri=request.uri generation=get_generation(manager,request.entry)
         @goto next_request
     end
 
@@ -394,7 +394,7 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
     end
 
     s = time()
-    JETLS_DEV_MODE && @info "Executing analysis for:" entry=progress_title(request.entry) uri=request.uri generation=get_generation(manager,request.entry)
+    @static JETLS_DEV_MODE && @info "Executing analysis for:" entry=progress_title(request.entry) uri=request.uri generation=get_generation(manager,request.entry)
     local cleanup::Bool = local failed::Bool = false
     analysis_result = try
         result, cleanup = execute_analysis(server, execution)
@@ -419,7 +419,7 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
     @assert !(analysis_result isa Bool)
 
     tm = round(time() - s, digits=2)
-    JETLS_DEV_MODE && @info "Analysis completed in $tm seconds:" entry=progress_title(request.entry) uri=request.uri generation=get_generation(manager,request.entry)
+    @static JETLS_DEV_MODE && @info "Analysis completed in $tm seconds:" entry=progress_title(request.entry) uri=request.uri generation=get_generation(manager,request.entry)
 
     if is_abandoned_request(server, request)
         # Document was closed mid-analysis. `file_cache`/`notebook_cache`
@@ -427,7 +427,7 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
         # `cleanup_analysis_state!` is taking care of
         # `manager.cache`/generations/debounced + the OLD prev_result's methods.
         # We just need to drop the methods this analysis just defined and skip the cache write.
-        JETLS_DEV_MODE && @info "Discarding analysis result for closed editor-managed document" entry=progress_title(request.entry) uri=request.uri
+        @static JETLS_DEV_MODE && @info "Discarding analysis result for closed editor-managed document" entry=progress_title(request.entry) uri=request.uri
         cleanup_prev_methods(analysis_result)
         @goto next_request
     end
@@ -527,8 +527,8 @@ function cleanup_prev_methods(prev_result::AnalysisResult)
         try
             Base.delete_method(m)
         catch e
-            JETLS_DEV_MODE && @warn "Failed to delete method $m" disabled=is_method_disabled(m)
-            JETLS_DEV_MODE && Base.showerror(stderr, e, catch_backtrace())
+            @static JETLS_DEV_MODE && @warn "Failed to delete method $m" disabled=is_method_disabled(m)
+            @static JETLS_DEV_MODE && Base.showerror(stderr, e, catch_backtrace())
         end
     end
 end
@@ -820,7 +820,7 @@ struct SigAnalysisResult
     codeinst::CC.CodeInstance
 end
 
-if JETLS_DEV_MODE
+@static if JETLS_DEV_MODE
 # Revise is currently only loaded in JETLS_DEV_MODE
 struct SigWorkItem
     file::String
@@ -850,7 +850,7 @@ mutable struct ReviseAnalysisProgress
     end
 end
 
-end # if JETLS_DEV_MODE
+end # @static if JETLS_DEV_MODE
 
 const empty_lines_range = typemax(Int) => typemin(Int)
 
@@ -1066,10 +1066,10 @@ function analyze_package_with_revise(
                 if isdefined(result, :ci)
                     siginfos[index] = Revise.replace_extended_data(siginfo, :JETLS, SigAnalysisResult(reports, result.ci))
                 else
-                    JETLS_DEV_MODE && @warn "Missing CodeInstance for method analysis instance for" siginfo.sig
+                    @static JETLS_DEV_MODE && @warn "Missing CodeInstance for method analysis instance for" siginfo.sig
                 end
             else
-                JETLS_DEV_MODE && @warn "Couldn't find a single matching method for the signature" siginfo.sig
+                @static JETLS_DEV_MODE && @warn "Couldn't find a single matching method for the signature" siginfo.sig
                 reports = JET.InferenceErrorReport[]
             end
             @label gotreports
@@ -1381,9 +1381,9 @@ function ensure_instantiated!(server::Server, env_path::String)
     if get_config(server, :full_analysis, :auto_instantiate)
         io = IOBuffer()
         try
-            JETLS_DEV_MODE && @info "Resolving package environment" env_path
+            @static JETLS_DEV_MODE && @info "Resolving package environment" env_path
             Pkg.resolve(; io)
-            JETLS_DEV_MODE && @info "Instantiating package environment" env_path
+            @static JETLS_DEV_MODE && @info "Instantiating package environment" env_path
             Pkg.instantiate(; io)
         catch e
             @error """Failed to instantiate package environment;

--- a/src/app/cli-serve.jl
+++ b/src/app/cli-serve.jl
@@ -147,7 +147,7 @@ function run_serve(args::Vector{String})
     show_setup_info("Running JETLS with the following setup:")
 
     @with_cli_LOAD_PATH begin
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             global currently_running
             currently_running = server = Server(endpoint)
             runserver_task = let client_process_id=client_process_id, transport=transport

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -183,14 +183,14 @@ function _apply_diagnostic_config(
     )
     code = diagnostic.code
     if !(code isa String)
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @warn "Diagnostic code must be a string" code code_type = typeof(code)
         elseif JETLS_TEST_MODE
             error(lazy"Diagnostic code must be a string, got $(typeof(code)): $code")
         end
         return diagnostic
     elseif code ∉ ALL_DIAGNOSTIC_CODES
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @warn "Diagnostic code is not registered" code
         elseif JETLS_TEST_MODE
             error(lazy"Diagnostic code is not registered: $code")
@@ -1632,9 +1632,9 @@ function per_stmt_diagnostics!(
                     relatedInformation))
             end
         else
-            JETLS_DEBUG_LOWERING && @warn "Error in lowering (with macrocall nodes)"
-            JETLS_DEBUG_LOWERING && showerror(stderr, err)
-            JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
+            @static JETLS_DEBUG_LOWERING && @warn "Error in lowering (with macrocall nodes)"
+            @static JETLS_DEBUG_LOWERING && showerror(stderr, err)
+            @static JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
         end
         nothing # signal primary-attempt failure to the fallback path
     end

--- a/src/did-change-watched-files.jl
+++ b/src/did-change-watched-files.jl
@@ -26,7 +26,7 @@ function did_change_watched_files_registration(server::Server)
                 pattern = "**/*.jl"),
             kind = WatchKind.Create | WatchKind.Change | WatchKind.Delete),
     ]
-    if JETLS_DEV_MODE
+    @static if JETLS_DEV_MODE
         push!(watchers, FileSystemWatcher(;
             globPattern = RelativePattern(;
                 baseUri = root_uri,
@@ -130,7 +130,7 @@ is_server_revise_trigger_file(path::AbstractString) = endswith(path, SERVER_REVI
 is_jl_file(path::AbstractString) = endswith(path, ".jl")
 
 function handle_server_revise_trigger!(server::Server, trigger_path::AbstractString)
-    JETLS_DEV_MODE || return show_warning_message(server,  ".JETLS_REVISE requires dev mode")
+    @static JETLS_DEV_MODE || return show_warning_message(server,  ".JETLS_REVISE requires dev mode")
     revise_now!()
     advance_server_world!()
     show_info_message(server, "JETLS server world advanced: $trigger_path")

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -111,7 +111,7 @@ function handle_DidSaveTextDocumentNotification(server::Server, msg::DidSaveText
         # Some language client implementations (in this case Zed) appear to be
         # sending `textDocument/didSave` notifications for arbitrary text documents,
         # so we add a save guard for such cases.
-        JETLS_DEV_MODE && @warn "Received textDocument/didSave for unopened or unsupported document" uri
+        @static JETLS_DEV_MODE && @warn "Received textDocument/didSave for unopened or unsupported document" uri
         return nothing
     end
     text = msg.params.text

--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -51,7 +51,7 @@ function handle_InitializeRequest(
         # leave Refs undefined
     end
 
-    if !JETLS_TEST_MODE
+    @static if !JETLS_TEST_MODE
         client_pid = something(init_params.processId, client_process_id, Some(nothing))
         version = JETLS_VERSION
         if version == "dev"
@@ -82,7 +82,7 @@ function handle_InitializeRequest(
         completionProvider = nothing # will be registered dynamically
     else
         completionProvider = completion_options()
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Registering 'textDocument/completion' with `InitializeResponse`"
         end
     end
@@ -91,7 +91,7 @@ function handle_InitializeRequest(
         signatureHelpProvider = nothing # will be registered dynamically
     else
         signatureHelpProvider = signature_help_options()
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Registering 'textDocument/signatureHelp' with `InitializeResponse`"
         end
     end
@@ -100,7 +100,7 @@ function handle_InitializeRequest(
         declarationProvider = nothing # will be registered dynamically
     else
         declarationProvider = declaration_options()
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Registering 'textDocument/declaration' with `InitializeResponse`"
         end
     end
@@ -109,7 +109,7 @@ function handle_InitializeRequest(
         definitionProvider = nothing # will be registered dynamically
     else
         definitionProvider = definition_options()
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Registering 'textDocument/definition' with `InitializeResponse`"
         end
     end
@@ -118,7 +118,7 @@ function handle_InitializeRequest(
         typeDefinitionProvider = nothing # will be registered dynamically
     else
         typeDefinitionProvider = type_definition_options()
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Registering 'textDocument/typeDefinition' with `InitializeResponse`"
         end
     end
@@ -127,7 +127,7 @@ function handle_InitializeRequest(
         documentHighlightProvider = nothing # will be registered dynamically
     else
         documentHighlightProvider = document_highlight_options()
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Registering 'textDocument/documentHighlight' with `InitializeResponse`"
         end
     end
@@ -136,7 +136,7 @@ function handle_InitializeRequest(
         documentSymbolProvider = nothing # will be registered dynamically
     else
         documentSymbolProvider = document_symbol_options()
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Registering 'textDocument/documentSymbol' with `InitializeResponse`"
         end
     end
@@ -145,7 +145,7 @@ function handle_InitializeRequest(
         referencesProvider = nothing # will be registered dynamically
     else
         referencesProvider = references_options(server)
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Registering 'textDocument/references' with `InitializeResponse`"
         end
     end
@@ -154,7 +154,7 @@ function handle_InitializeRequest(
         hoverProvider = nothing # will be registered dynamically
     else
         hoverProvider = hover_options()
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Registering 'textDocument/hover' with `InitializeResponse`"
         end
     end
@@ -163,7 +163,7 @@ function handle_InitializeRequest(
         diagnosticProvider = nothing # will be registered dynamically
     else
         diagnosticProvider = diagnostic_options()
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Registering 'textDocument/diagnostic' with `InitializeResponse`"
         end
     end
@@ -172,7 +172,7 @@ function handle_InitializeRequest(
         codeLensProvider = nothing # will be registered dynamically
     else
         codeLensProvider = code_lens_options()
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Registering 'textDocument/codeLens' with `InitializeResponse`"
         end
     end
@@ -181,7 +181,7 @@ function handle_InitializeRequest(
         documentLinkProvider = nothing # will be registered dynamically
     else
         documentLinkProvider = document_link_options()
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Registering 'textDocument/documentLink' with `InitializeResponse`"
         end
     end
@@ -190,14 +190,14 @@ function handle_InitializeRequest(
         codeActionProvider = nothing # will be registered dynamically
     else
         codeActionProvider = code_action_options()
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Registering 'textDocument/codeAction' with `InitializeResponse`"
         end
     end
 
     # No support for dynamic registration
     executeCommandProvider = execute_command_options()
-    if JETLS_DEV_MODE
+    @static if JETLS_DEV_MODE
         @info "Registering 'workspace/executeCommand' with `InitializeResponse`"
     end
 
@@ -205,7 +205,7 @@ function handle_InitializeRequest(
         documentFormattingProvider = nothing # will be registered dynamically
     else
         documentFormattingProvider = formatting_options(server)
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Registering 'textDocument/formatting' with `InitializeResponse`"
         end
     end
@@ -214,7 +214,7 @@ function handle_InitializeRequest(
         documentRangeFormattingProvider = nothing # will be registered dynamically
     else
         documentRangeFormattingProvider = range_formatting_options(server)
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Registering 'textDocument/rangeFormatting' with `InitializeResponse`"
         end
     end
@@ -230,7 +230,7 @@ function handle_InitializeRequest(
         inlayHintProvider = nothing # will be registered dynamically
     else
         inlayHintProvider = inlay_hint_options()
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Registering 'textDocument/inlayHint' with `InitializeResponse`"
         end
     end
@@ -247,7 +247,7 @@ function handle_InitializeRequest(
         semanticTokensProvider = nothing # will be registered dynamically
     else
         semanticTokensProvider = semantic_tokens_options()
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Registering 'textDocument/semanticTokens' with `InitializeResponse`"
         end
     end
@@ -256,7 +256,7 @@ function handle_InitializeRequest(
         renameProvider = nothing # will be registered dynamically
     else
         renameProvider = rename_options(server)
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Registering 'textDocument/rename' with `InitializeResponse`"
         end
     end
@@ -265,7 +265,7 @@ function handle_InitializeRequest(
         workspaceSymbolProvider = nothing # will be registered dynamically
     else
         workspaceSymbolProvider = workspace_symbol_options(server)
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Registering 'workspace/symbol' with `InitializeResponse`"
         end
     end
@@ -276,7 +276,7 @@ function handle_InitializeRequest(
         textDocumentContent = nothing # will be registered dynamically
     else
         textDocumentContent = text_document_content_options()
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Registering 'workspace/textDocumentContent' with `InitializeResponse`"
         end
     end
@@ -344,7 +344,7 @@ function handle_InitializeRequest(
                 @goto skip_monitoring
             end
         end
-        JETLS_DEV_MODE && @info "Monitoring parent process ID" process_id
+        @static JETLS_DEV_MODE && @info "Monitoring parent process ID" process_id
         Threads.@spawn while true
             # To handle cases where the client crashes and cannot execute the normal
             # server shutdown process, check every 60 seconds whether the `processId`
@@ -380,7 +380,7 @@ function handle_InitializedNotification(server::Server)
     # Load configurations: This needs to be done after the `InitializedNotification` is sent from the client
     # - Load .JETLSConfig.toml configuration
     if !isdefined(state, :root_path)
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "`server.state.root_path` is not defined, skip config registration at startup."
         end
     else
@@ -397,7 +397,7 @@ function handle_InitializedNotification(server::Server)
 
     if supports(server, :textDocument, :completion, :dynamicRegistration)
         push!(registrations, completion_registration())
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'textDocument/completion' upon `InitializedNotification`"
         end
     else
@@ -408,7 +408,7 @@ function handle_InitializedNotification(server::Server)
 
     if supports(server, :textDocument, :signatureHelp, :dynamicRegistration)
         push!(registrations, signature_help_registration())
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'textDocument/signatureHelp' upon `InitializedNotification`"
         end
     else
@@ -419,14 +419,14 @@ function handle_InitializedNotification(server::Server)
 
     if supports(server, :textDocument, :declaration, :dynamicRegistration)
         push!(registrations, declaration_registration())
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'textDocument/declaration' upon `InitializedNotification`"
         end
     end
 
     if supports(server, :textDocument, :definition, :dynamicRegistration)
         push!(registrations, definition_registration())
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'textDocument/definition' upon `InitializedNotification`"
         end
     else
@@ -437,14 +437,14 @@ function handle_InitializedNotification(server::Server)
 
     if supports(server, :textDocument, :typeDefinition, :dynamicRegistration)
         push!(registrations, type_definition_registration())
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'textDocument/typeDefinition' upon `InitializedNotification`"
         end
     end
 
     if supports(server, :textDocument, :documentHighlight, :dynamicRegistration)
         push!(registrations, document_highlight_registration())
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'textDocument/documentHighlight' upon `InitializedNotification`"
         end
     else
@@ -454,7 +454,7 @@ function handle_InitializedNotification(server::Server)
 
     if supports(server, :textDocument, :documentSymbol, :dynamicRegistration)
         push!(registrations, document_symbol_registration())
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'textDocument/documentSymbol' upon `InitializedNotification`"
         end
     else
@@ -464,7 +464,7 @@ function handle_InitializedNotification(server::Server)
 
     if supports(server, :textDocument, :references, :dynamicRegistration)
         push!(registrations, references_registration(server))
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'textDocument/references' upon `InitializedNotification`"
         end
     else
@@ -474,7 +474,7 @@ function handle_InitializedNotification(server::Server)
 
     if supports(server, :textDocument, :hover, :dynamicRegistration)
         push!(registrations, hover_registration())
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'textDocument/hover' upon `InitializedNotification`"
         end
     else
@@ -485,14 +485,14 @@ function handle_InitializedNotification(server::Server)
 
     if supports(server, :textDocument, :diagnostic, :dynamicRegistration)
         push!(registrations, diagnostic_registration())
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'textDocument/diagnostic' upon `InitializedNotification`"
         end
     end
 
     if supports(server, :textDocument, :codeLens, :dynamicRegistration)
         push!(registrations, code_lens_registration())
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'textDocument/codeLens' upon `InitializedNotification`"
         end
     else
@@ -503,7 +503,7 @@ function handle_InitializedNotification(server::Server)
 
     if supports(server, :textDocument, :documentLink, :dynamicRegistration)
         push!(registrations, document_link_registration())
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'textDocument/documentLink' upon `InitializedNotification`"
         end
     else
@@ -514,7 +514,7 @@ function handle_InitializedNotification(server::Server)
 
     if supports(server, :textDocument, :codeAction, :dynamicRegistration)
         push!(registrations, code_action_registration())
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'textDocument/codeAction' upon `InitializedNotification`"
         end
     else
@@ -525,7 +525,7 @@ function handle_InitializedNotification(server::Server)
 
     if supports(server, :textDocument, :formatting, :dynamicRegistration)
         push!(registrations, formatting_registration(server))
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'textDocument/formatting' upon `InitializedNotification`"
         end
     else
@@ -536,7 +536,7 @@ function handle_InitializedNotification(server::Server)
 
     if supports(server, :textDocument, :rangeFormatting, :dynamicRegistration)
         push!(registrations, range_formatting_registration(server))
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'textDocument/rangeFormatting' upon `InitializedNotification`"
         end
     else
@@ -547,7 +547,7 @@ function handle_InitializedNotification(server::Server)
 
     if supports(server, :textDocument, :rename, :dynamicRegistration)
         push!(registrations, rename_registration(server))
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'textDocument/rename' upon `InitializedNotification`"
         end
     else
@@ -560,7 +560,7 @@ function handle_InitializedNotification(server::Server)
     if (supports(state, :textDocument, :semanticTokens, :augmentsSyntaxTokens) &&
         supports(server, :textDocument, :semanticTokens, :dynamicRegistration))
         push!(registrations, semantic_tokens_registration())
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'textDocument/semanticTokens' upon `InitializedNotification`"
         end
     else
@@ -570,7 +570,7 @@ function handle_InitializedNotification(server::Server)
 
     if supports(server, :textDocument, :inlayHint, :dynamicRegistration)
         push!(registrations, inlay_hint_registration(#=static=#false))
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'textDocument/inlayHint' upon `InitializedNotification`"
         end
     # elseif getcapability(server,
@@ -578,21 +578,21 @@ function handle_InitializedNotification(server::Server)
     #     # `InlayHintRegistrationOptions` extends `StaticRegistrationOptions`,
     #     # prefer it over the registration with `InitializeResponse` if the client supports it
     #     push!(registrations, inlay_hint_registration(#=static=#true))
-    #     if JETLS_DEV_MODE
+    #     @static if JETLS_DEV_MODE
     #         @info "Statically registering 'textDocument/inlayHint' upon `InitializedNotification`"
     #     end
     end
 
     if supports(server, :workspace, :symbol, :dynamicRegistration)
         push!(registrations, workspace_symbol_registration(server))
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'workspace/symbol' upon `InitializedNotification`"
         end
     end
 
     if supports(server, :workspace, :textDocumentContent, :dynamicRegistration)
         push!(registrations, text_document_content_registration())
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'workspace/textDocumentContent' upon `InitializedNotification`"
         end
     end
@@ -601,7 +601,7 @@ function handle_InitializedNotification(server::Server)
         registration = did_change_watched_files_registration(server)
         if registration !== nothing
             push!(registrations, registration)
-            if JETLS_DEV_MODE
+            @static if JETLS_DEV_MODE
                 @info "Dynamically registering 'workspace/didChangeWatchedFiles' upon `InitializedNotification`"
             end
         end
@@ -612,13 +612,13 @@ function handle_InitializedNotification(server::Server)
 
     if supports(server, :workspace, :didChangeConfiguration, :dynamicRegistration)
         push!(registrations, did_change_configuration_registration())
-        if JETLS_DEV_MODE
+        @static if JETLS_DEV_MODE
             @info "Dynamically registering 'workspace/didChangeConfiguration' upon `InitializedNotification`"
         end
     end
 
     register(server, registrations)
 
-    JETLS_DEV_MODE && show_setup_info("Initialized JETLS with the following setup:")
-    JETLS_DEV_MODE && @info "JETLS initialization options" init_options=state.init_options
+    @static JETLS_DEV_MODE && show_setup_info("Initialized JETLS with the following setup:")
+    @static JETLS_DEV_MODE && @info "JETLS initialization options" init_options=state.init_options
 end

--- a/src/notebook.jl
+++ b/src/notebook.jl
@@ -183,7 +183,7 @@ function handle_DidChangeNotebookDocumentNotification(
     next_notebook_info = store!(state.notebook_cache) do cache::Base.PersistentDict{URI,NotebookInfo}
         notebook_info = get(cache, notebook_uri, nothing)
         if notebook_info === nothing
-            JETLS_DEV_MODE && @warn "Received notebookDocument/didChange for unknown notebook" notebook_uri
+            @static JETLS_DEV_MODE && @warn "Received notebookDocument/didChange for unknown notebook" notebook_uri
             return cache, nothing
         end
         cells = copy(notebook_info.cells)

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -100,7 +100,7 @@ function extract_kwarg_name(arg::SyntaxTreeC; sig::Bool=false)
     elseif JS.kind(arg) === JS.K"..."
         return nothing
     end
-    JETLS_DEBUG_LOWERING && @info "Unknown kwarg form" arg
+    @static JETLS_DEBUG_LOWERING && @info "Unknown kwarg form" arg
     return nothing
 end
 
@@ -390,7 +390,7 @@ function make_siginfo(
                 end
             end
         else
-            JETLS_DEBUG_LOWERING && @info "No active arg" active_arg ca.args[active_arg]
+            @static JETLS_DEBUG_LOWERING && @info "No active arg" active_arg ca.args[active_arg]
             nothing
         end
 

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -70,9 +70,9 @@ function jl_lower_for_scope_resolution(
         JL.expand_forms_1(context_module, st0, true, world)
     catch err
         recover_from_macro_errors || rethrow(err)
-        JETLS_DEBUG_LOWERING && @warn "Error in macro expansion; trimming and retrying"
-        JETLS_DEBUG_LOWERING && showerror(stderr, err)
-        JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
+        @static JETLS_DEBUG_LOWERING && @warn "Error in macro expansion; trimming and retrying"
+        @static JETLS_DEBUG_LOWERING && showerror(stderr, err)
+        @static JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
         st0 = remove_macrocalls(st0)
         JL.expand_forms_1(context_module, st0, true, world)
     end
@@ -108,8 +108,8 @@ function cursor_bindings(
     (; ctx3, st2) = try
         jl_lower_for_scope_resolution(context_module, st0; soft_scope)
     catch err
-        JETLS_DEBUG_LOWERING && @warn "Error in lowering" err
-        JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
+        @static JETLS_DEBUG_LOWERING && @warn "Error in lowering" err
+        @static JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
         return nothing # lowering failed, e.g. because of incomplete input
     end
 
@@ -156,7 +156,7 @@ function cursor_bindings(
             || bdistances[i] < bdistances[prev]
             || binfo.kind === :static_parameter)
             seen[binfo.name] = i
-        elseif JETLS_DEBUG_LOWERING
+        elseif @static JETLS_DEBUG_LOWERING ? true : false
             @info "Found two bindings with the same name:" binfo bscopeinfos[prev][1]
         end
     end
@@ -260,8 +260,8 @@ function select_target_binding(
         # Remove macros to preserve precise source locations
         jl_lower_for_scope_resolution(context_module, remove_macrocalls(st0; strip_static=true); soft_scope)
     catch err
-        JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
-        JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
+        @static JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
+        @static JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
         return nothing
     end
     primary = _select_target_binding(ctx3, st3, offset)
@@ -377,8 +377,8 @@ function select_macrocall_binding(
     (; ctx3, st3) = try
         jl_lower_for_scope_resolution(context_module, macrocall_name; soft_scope)
     catch err
-        JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
-        JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
+        @static JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
+        @static JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
         return nothing
     end
     for binfo in ctx3.bindings.info
@@ -422,8 +422,8 @@ function select_export_public_binding(
     (; ctx3, st3) = try
         jl_lower_for_scope_resolution(context_module, name_node; soft_scope)
     catch err
-        JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
-        JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
+        @static JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
+        @static JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
         return nothing
     end
     for binfo in ctx3.bindings.info
@@ -466,8 +466,8 @@ function select_import_using_binding(
     (; ctx3, st3) = try
         jl_lower_for_scope_resolution(context_module, name_node; soft_scope)
     catch err
-        JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
-        JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
+        @static JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
+        @static JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
         return nothing
     end
     for binfo in ctx3.bindings.info

--- a/src/utils/general.jl
+++ b/src/utils/general.jl
@@ -34,7 +34,7 @@ Internal `@elapsed` definition for JETLS that is only active in `JETLS_DEV_MODE`
 When `JETLS_DEV_MODE` is `false`, this macro simply evaluates the expression without timing.
 """
 macro elapsed(ex)
-    if JETLS_DEV_MODE
+    @static if JETLS_DEV_MODE
         :(Base.@elapsed $(esc(ex)))
     else
         :(begin $(esc(ex)); 0.0; end)
@@ -183,7 +183,7 @@ macro tryinvokelatest(ex)
     callex = Expr(:call, f)
     isempty(kwargs) || push!(callex.args, Expr(:parameters, kwargs...))
     push!(callex.args, args...)
-    callex = if JETLS_DEV_MODE
+    callex = @static if JETLS_DEV_MODE
         worldex = Expr(:call, :call_in_server_world, f)
         isempty(kwargs) || push!(worldex.args, Expr(:parameters, kwargs...))
         push!(worldex.args, args...)
@@ -192,7 +192,7 @@ macro tryinvokelatest(ex)
         callex
     end
 
-    JETLS_TEST_MODE && return callex
+    @static JETLS_TEST_MODE && return callex
 
     arglist = Any[f, args..., kwargs...]
     callargs = map(1:length(arglist)) do i::Int

--- a/src/utils/pkg.jl
+++ b/src/utils/pkg.jl
@@ -27,7 +27,7 @@ function find_analysis_env_path(state::ServerState, uri::URI)
                 if occursin(override.path, path_for_glob)
                     module_name = override.module_name
                     if module_name === nothing
-                        JETLS_DEV_MODE && @info "Analysis for this file is disabled" path=filepath
+                        @static JETLS_DEV_MODE && @info "Analysis for this file is disabled" path=filepath
                         return OutOfScope()
                     elseif module_name == ""
                         env_path = @something find_env_path(filepath) begin
@@ -47,14 +47,14 @@ function find_analysis_env_path(state::ServerState, uri::URI)
                         # Skip full analysis but provide a context module that has `Test`
                         # available, so that lowering analysis can handle macros like
                         # `@testset`/`@test` defined in test files.
-                        JETLS_DEV_MODE && @info "Using `JETLSTestModule` as out-of-scope lowering context" path=filepath
+                        @static JETLS_DEV_MODE && @info "Using `JETLSTestModule` as out-of-scope lowering context" path=filepath
                         return OutOfScope(JETLSTestModule)
                     else
                         mod = @something find_loaded_module(module_name) begin
                             @warn "Analysis module override specified but module not found" module_name path=filepath
                             return OutOfScope()
                         end
-                        if JETLS_DEV_MODE
+                        @static if JETLS_DEV_MODE
                             path = filepath
                             @info "Analysis module overridden" module_name path _id=path maxlog=1
                         end

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -210,10 +210,10 @@ function get_file_info(
             cache !== nothing && return cache
         end
         if time() - start > timeout
-            JETLS_TEST_MODE || @warn "File cache not found" uri _id=uri maxlog=1 # Some tests intentionally call this path, so this log is probably not necessary.
+            @static JETLS_TEST_MODE || @warn "File cache not found" uri _id=uri maxlog=1 # Some tests intentionally call this path, so this log is probably not necessary.
             return nothing
         end
-        JETLS_DEV_MODE && @info "Waiting for file cache" uri _id=request_id maxlog=1
+        @static JETLS_DEV_MODE && @info "Waiting for file cache" uri _id=request_id maxlog=1
         # Shorten the polling interval under `JETLS_TEST_MODE` (paired with the
         # shortened `timeout` above) so the timeout-exercising tests finish fast.
         sleep(@static JETLS_TEST_MODE ? 0.05 : 0.5)
@@ -289,8 +289,8 @@ function _store_unsynced_file_info!(state::ServerState, uri::URI; force::Bool=fa
         parsed_stream = try
             ParseStream!(read(filename))
         catch e
-            JETLS_DEV_MODE && @error "Error parsing file $(filename)"
-            JETLS_DEV_MODE && Base.showerror(stderr, e, catch_backtrace())
+            @static JETLS_DEV_MODE && @error "Error parsing file $(filename)"
+            @static JETLS_DEV_MODE && Base.showerror(stderr, e, catch_backtrace())
             return cache, nothing
         end
         fi = FileInfo(version, parsed_stream, filename, state.encoding)

--- a/src/workspace-configuration.jl
+++ b/src/workspace-configuration.jl
@@ -42,7 +42,7 @@ function handle_workspace_configuration_response(
         if result isa Vector && !isempty(result)
             config_value = first(result)
             caller.handler(server, config_value)
-        elseif JETLS_DEV_MODE
+        elseif @static JETLS_DEV_MODE ? true : false
             @info "workspace/configuration returned empty result"
         end
     else


### PR DESCRIPTION
Replace runtime `JETLS_DEV_MODE`, `JETLS_TEST_MODE`, and `JETLS_DEBUG_LOWERING` branches with `@static` guards across the server.

This removes dead runtime paths for mode-specific logging, Revise integration, and test behavior so those branches are resolved at compile tim, hopefully improving codegen latency in the release environment.