### PR TITLE
diagnostic: Label inference related frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- `inference/*` diagnostic related information now labels inference frames as `origin`, `via`, or `entry`, making it clearer where the error originated and which analysis entry reported it.
+
 - `inference/type-error/*` now groups diagnostics for the subset of runtime `TypeError` cases that JETLS can infer, including non-`Bool` conditions and statically failing type assertions. Users can ignore or reconfigure this family together with a regex code match such as `inference/type-error/.*`.
 
 - Updated Compiler.jl API compatibility for the incoming Julia 1.12.7 release while retaining support for Julia pre-1.12.6 Compiler.jl APIs.

--- a/src/analysis/Analyzer.jl
+++ b/src/analysis/Analyzer.jl
@@ -1,11 +1,14 @@
 module Analyzer
 
-export LSAnalyzer, inference_error_report_related_stack, inference_error_report_severity,
-    inference_error_report_stack, reset_report_target_modules!
+export LSAnalyzer
+export inference_error_report_related_frames, inference_error_report_related_stack,
+    inference_error_report_severity, inference_error_report_stack,
+    reset_report_target_modules!
 export BoundsErrorReport, FieldErrorReport, KeywordTypeErrorReport, MethodErrorReport,
     NoMethodMatchReport, NonBooleanCondErrorReport, TypeAssertErrorReport,
     TypeErrorReport, UndefKeywordErrorReport, UndefVarErrorReport,
     UnsupportedKeywordArgReport
+export RelatedEntryFrame, RelatedFrame, RelatedFrameKind, RelatedOriginFrame, RelatedViaFrame
 
 using Core.IR
 using JET.JETInterface
@@ -37,22 +40,40 @@ function assert_valid_report_stack(
     n = length(report.vst)
     @assert valid lazy"invalid $kind stack for $report_type: stack=$stack, vst length=$n"
 end
-function inference_error_report_related_stack(@nospecialize report::JET.InferenceErrorReport)
+
+@enum RelatedFrameKind begin
+    RelatedOriginFrame
+    RelatedViaFrame
+    RelatedEntryFrame
+end
+
+struct RelatedFrame
+    idx::Int
+    kind::RelatedFrameKind
+end
+
+function inference_error_report_related_frames(@nospecialize report::JET.InferenceErrorReport)
     stk = inference_error_report_stack(report)
-    isempty(stk) && return Int[]
+    isempty(stk) && return RelatedFrame[]
     primary = first(stk)
-    related = Int[]
-    for idx in inference_error_report_origin_stack(report)
-        idx == primary && continue
-        idx ∈ related && continue
-        push!(related, idx)
+    entry = last(stk)
+    origin_stack = inference_error_report_origin_stack(report)
+    display_tail = Iterators.drop(stk, 1)
+    @static if JETLS_DEV_MODE
+        @assert isempty(intersect(origin_stack, display_tail)) lazy"related stack overlap found for $(report)"
     end
-    for idx in Iterators.drop(stk, 1)
+    related = RelatedFrame[]
+    for idx in origin_stack
         idx == primary && continue
-        idx ∈ related && continue
-        push!(related, idx)
+        push!(related, RelatedFrame(idx, RelatedOriginFrame))
     end
-    @static JETLS_DEV_MODE && assert_valid_report_stack(report, related, "related")
+    for idx in display_tail
+        idx == primary && continue
+        kind = idx == entry ? RelatedEntryFrame : RelatedViaFrame
+        push!(related, RelatedFrame(idx, kind))
+    end
+    @static JETLS_DEV_MODE &&
+        assert_valid_report_stack(report, map(frame -> frame.idx, related), "related")
     return related
 end
 function inference_error_report_origin_stack(@nospecialize report::JET.InferenceErrorReport)

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -418,11 +418,13 @@ function jet_inference_error_report_to_diagnostic(
         Base.invoke_in_world(world, JET.print_report_message, io, report)
     end |> postprocessor
     relatedInformation = DiagnosticRelatedInformation[]
-    for frameidx in inference_error_report_related_stack(report)
-        frame = report.vst[frameidx]
+    for related_frame in inference_error_report_related_frames(report)
+        frame = report.vst[related_frame.idx]
         location = @something jet_frame_to_location(frame) continue
-        local message = postprocessor(Base.invoke_in_world(world,
-            sprint, JET.print_frame_sig, frame, JET.PrintConfig())::String)
+        sig = Base.invoke_in_world(world,
+            sprint, JET.print_frame_sig, frame, JET.PrintConfig())::String
+        label = related_frame_label(related_frame.kind)
+        local message = postprocessor(label * ": " * sig)
         push!(relatedInformation, DiagnosticRelatedInformation(; location, message))
     end
     code = inference_error_report_code(report)
@@ -434,6 +436,13 @@ function jet_inference_error_report_to_diagnostic(
         code,
         codeDescription = diagnostic_code_description(code),
         relatedInformation)
+end
+
+function related_frame_label(kind::RelatedFrameKind)
+    kind === RelatedOriginFrame && return "origin"
+    kind === RelatedViaFrame && return "via"
+    kind === RelatedEntryFrame && return "entry"
+    error(lazy"unknown related frame kind: $kind")
 end
 
 function inference_error_report_code(@nospecialize report::JET.InferenceErrorReport)

--- a/test/analysis/test_Analyzer.jl
+++ b/test/analysis/test_Analyzer.jl
@@ -6,8 +6,17 @@ using JETLS
 include(normpath(pkgdir(JETLS), "test", "interactive-utils.jl"))
 include(normpath(pkgdir(JETLS), "test", "setup.jl"))
 
-using JETLS.JET: CC, get_reports
+using JETLS.JET: CC, JET, get_reports
 using JETLS.Analyzer
+
+related_frame_indices(report) =
+    map(frame -> frame.idx, inference_error_report_related_frames(report))
+related_frame_kinds(report) =
+    map(frame -> frame.kind, inference_error_report_related_frames(report))
+related_frame_signatures(report) =
+    map(inference_error_report_related_frames(report)) do frame
+        sprint(JET.print_frame_sig, report.vst[frame.idx], JET.PrintConfig())
+    end
 
 function analyze_signature(f; report_target_modules = nothing)
     analyzer = JETLS.LSAnalyzer(; report_target_modules)
@@ -114,6 +123,9 @@ end
 end
 
 only_int(x::Int) = 2x
+nested_only_int_inner(x) = only_int(x)
+nested_only_int_outer(x) = nested_only_int_inner(x)
+call_nested_only_int(x) = nested_only_int_outer(x)
 
 kwfunc(; code::String="code", message::String="message", data=nothing) = (code, message, data)
 kwslurp(; a=1, kwargs...) = (a, kwargs)
@@ -149,6 +161,21 @@ struct KwCallable end
             @test length(reports) == 1
             r = only(reports)
             @test r isa NoMethodMatchReport && r.union_split == 2 && length(r.t) == 1
+        end
+
+        let result = analyze_call(call_nested_only_int, (String,); report_target_modules=(@__MODULE__,))
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa NoMethodMatchReport && r.union_split == 0
+            @test related_frame_kinds(r) == [
+                RelatedViaFrame,
+                RelatedEntryFrame,
+            ]
+            @test related_frame_signatures(r) == [
+                "nested_only_int_outer(x::String)",
+                "call_nested_only_int(x::String)",
+            ]
         end
 
         # union split case: all branches fail

--- a/test/test_diagnostic.jl
+++ b/test/test_diagnostic.jl
@@ -88,8 +88,10 @@ end
     end
 
     f32(x::Float32) = sin(x) + cos(x)
-    let x = rand()
-        @show f32(x) # no matching method found `f32(::Float64)` (JETLS inference/method-error)
+    call_f32(x) = f32(x)
+    function main32()
+        x = rand()
+        @show call_f32(x) # no matching method found `f32(::Float64)` (JETLS inference/method-error)
     end
     """
 
@@ -108,7 +110,9 @@ end
                     if diag.code == JETLS.INFERENCE_FIELD_ERROR_CODE && occursin("type `MyStruct` has no field `propert`, available fields: `property`", diag.message)
                         found_diagnostic1 = true
                     elseif diag.code == JETLS.INFERENCE_METHOD_ERROR_CODE && occursin("no matching method found `f32(::Float64)`", diag.message)
-                        found_diagnostic2 = true
+                        related2 = something(diag.relatedInformation, DiagnosticRelatedInformation[])
+                        related_messages2 = map(info -> info.message, related2)
+                        found_diagnostic2 = only(related_messages2) == "entry: main32()"
                     end
                 end
             end


### PR DESCRIPTION
Inference diagnostics with related information previously showed only the related frame signature. For attributed reports, this made it hard to tell which frame was the error origin, which frames were intermediate calls, and which frame was the analysis entry that reported the diagnostic.

Carry a `RelatedFrameKind` alongside each related virtual-stack frame and prefix related-information messages with `origin:`, `via:`, or `entry:` when converting inference reports to LSP diagnostics. This keeps the existing frame signature while making the role of each related frame explicit.

The change is covered by analyzer and diagnostic integration tests, and the Unreleased changelog documents the updated related-information format with an example.