### PR TITLE
config: Gate new analysis mode overrides

### DIFF
--- a/.JETLSConfig.toml
+++ b/.JETLSConfig.toml
@@ -69,9 +69,11 @@ path = "src/testrunner/testrunner-types.jl"
 [[initialization_options.analysis_overrides]]
 module_name = "JETLS"
 path = "src/**/*.jl"
+full_analysis = true
 [[initialization_options.analysis_overrides]]
 module_name = "LSP"
 path = "LSP/**/*.jl"
+full_analysis = true
 
 # Just disable analysis for test files for now
 [[initialization_options.analysis_overrides]]

--- a/jetls-client/package.json
+++ b/jetls-client/package.json
@@ -118,8 +118,13 @@
                 "items": {
                   "additionalProperties": false,
                   "properties": {
+                    "full_analysis": {
+                      "default": false,
+                      "markdownDescription": "Whether matched files should use the Revise-based full-analysis mode. This requires `JETLS_DEV_MODE` because the analysis relies on Revise-tracked loaded modules. Defaults to false, which keeps files out of full analysis and uses `module_name` only as a lowering context when provided. This option is highly experimental, and its behavior and semantics may change in future releases.",
+                      "type": "boolean"
+                    },
                     "module_name": {
-                      "markdownDescription": "Optional module name to associate with the matched files. When specified, analysis is performed within the context of this module.",
+                      "markdownDescription": "Optional module name to associate with the matched files. By default this is used as an out-of-scope lowering context. When `full_analysis` is true, it selects the loaded module to analyze.",
                       "type": "string"
                     },
                     "path": {
@@ -132,7 +137,7 @@
                   ],
                   "type": "object"
                 },
-                "markdownDescription": "Override full analysis behavior for specific file patterns. Primarily used as a temporary workaround to disable analysis for files affected by memory leak issues. Each override specifies a glob pattern and optionally a module name. Note: This is an experimental feature that may be removed or changed in future versions.",
+                "markdownDescription": "Override full analysis behavior for specific file patterns. Primarily used as a temporary workaround to disable analysis for files affected by memory leak issues. Each override specifies a glob pattern, optionally a module name, and can opt back into full analysis. Note: This is an experimental feature that may be removed or changed in future versions.",
                 "type": "array"
               },
               "n_analysis_workers": {

--- a/schemas/config-toml.schema.json
+++ b/schemas/config-toml.schema.json
@@ -197,12 +197,17 @@
       "properties": {
         "analysis_overrides": {
           "default": [],
-          "description": "Override full analysis behavior for specific file patterns. Primarily used as a temporary workaround to disable analysis for files affected by memory leak issues. Each override specifies a glob pattern and optionally a module name. Note: This is an experimental feature that may be removed or changed in future versions.",
+          "description": "Override full analysis behavior for specific file patterns. Primarily used as a temporary workaround to disable analysis for files affected by memory leak issues. Each override specifies a glob pattern, optionally a module name, and can opt back into full analysis. Note: This is an experimental feature that may be removed or changed in future versions.",
           "items": {
             "additionalProperties": false,
             "properties": {
+              "full_analysis": {
+                "default": false,
+                "description": "Whether matched files should use the Revise-based full-analysis mode. This requires `JETLS_DEV_MODE` because the analysis relies on Revise-tracked loaded modules. Defaults to false, which keeps files out of full analysis and uses `module_name` only as a lowering context when provided. This option is highly experimental, and its behavior and semantics may change in future releases.",
+                "type": "boolean"
+              },
               "module_name": {
-                "description": "Optional module name to associate with the matched files. When specified, analysis is performed within the context of this module.",
+                "description": "Optional module name to associate with the matched files. By default this is used as an out-of-scope lowering context. When `full_analysis` is true, it selects the loaded module to analyze.",
                 "type": "string"
               },
               "path": {

--- a/schemas/description.toml
+++ b/schemas/description.toml
@@ -34,11 +34,12 @@ executable_range = "Path to custom formatter executable for range formatting. Sh
 
 [InitOptions]
 n_analysis_workers = "Number of concurrent analysis worker tasks for running full analysis (experimental). Default is 1. See [documentation](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options/n_analysis_workers) for details and current limitations."
-analysis_overrides = "Override full analysis behavior for specific file patterns. Primarily used as a temporary workaround to disable analysis for files affected by memory leak issues. Each override specifies a glob pattern and optionally a module name. Note: This is an experimental feature that may be removed or changed in future versions."
+analysis_overrides = "Override full analysis behavior for specific file patterns. Primarily used as a temporary workaround to disable analysis for files affected by memory leak issues. Each override specifies a glob pattern, optionally a module name, and can opt back into full analysis. Note: This is an experimental feature that may be removed or changed in future versions."
 
 [AnalysisOverride]
 path = "Glob pattern to match files for which analysis should be overridden (e.g., `src/**/*.jl`, `test/**/*.jl`). Patterns are matched against file paths relative to the workspace root. Supports globstar (`**`) for matching directories recursively."
-module_name = "Optional module name to associate with the matched files. When specified, analysis is performed within the context of this module."
+module_name = "Optional module name to associate with the matched files. By default this is used as an out-of-scope lowering context. When `full_analysis` is true, it selects the loaded module to analyze."
+full_analysis = "Whether matched files should use the Revise-based full-analysis mode. This requires `JETLS_DEV_MODE` because the analysis relies on Revise-tracked loaded modules. Defaults to false, which keeps files out of full analysis and uses `module_name` only as a lowering context when provided. This option is highly experimental, and its behavior and semantics may change in future releases."
 
 [CompletionConfig]
 latex_emoji = "LaTeX and emoji completion configuration. See [documentation](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/completion/latex_emoji/strip_prefix)."

--- a/schemas/init-options.schema.json
+++ b/schemas/init-options.schema.json
@@ -11,13 +11,18 @@
       "properties": {
         "analysis_overrides": {
           "default": [],
-          "description": "Override full analysis behavior for specific file patterns. Primarily used as a temporary workaround to disable analysis for files affected by memory leak issues. Each override specifies a glob pattern and optionally a module name. Note: This is an experimental feature that may be removed or changed in future versions.",
+          "description": "Override full analysis behavior for specific file patterns. Primarily used as a temporary workaround to disable analysis for files affected by memory leak issues. Each override specifies a glob pattern, optionally a module name, and can opt back into full analysis. Note: This is an experimental feature that may be removed or changed in future versions.",
           "items": {
             "additionalProperties": false,
             "properties": {
+              "full_analysis": {
+                "default": false,
+                "description": "Whether matched files should use the Revise-based full-analysis mode. This requires `JETLS_DEV_MODE` because the analysis relies on Revise-tracked loaded modules. Defaults to false, which keeps files out of full analysis and uses `module_name` only as a lowering context when provided. This option is highly experimental, and its behavior and semantics may change in future releases.",
+                "type": "boolean"
+              },
               "module_name": {
                 "$ref": "#/$defs/Core.String",
-                "description": "Optional module name to associate with the matched files. When specified, analysis is performed within the context of this module."
+                "description": "Optional module name to associate with the matched files. By default this is used as an out-of-scope lowering context. When `full_analysis` is true, it selects the loaded module to analyze."
               },
               "path": {
                 "$ref": "#/$defs/Glob.FilenameMatch{Core.String}",

--- a/scripts/schema/setup-schema-context.jl
+++ b/scripts/schema/setup-schema-context.jl
@@ -69,6 +69,14 @@ function setup_ctx!(ctx::SchemaContext)
         Dict("type" => "string")
     end
 
+    optional!(ctx, JETLS.AnalysisOverride, :full_analysis)
+    override_field!(ctx, JETLS.AnalysisOverride, :full_analysis) do _
+        Dict(
+            "type" => "boolean",
+            "default" => false,
+            "description" => desc["AnalysisOverride"]["full_analysis"])
+    end
+
     optional!(ctx, JETLS.JETLSConfig, :formatter)
 
     # Unlike the struct definition, the actual config file requires a "custom" nesting

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -19,7 +19,12 @@ function parse_analysis_override(x::AbstractDict{String})
         error(lazy"Invalid `module_name` value found in analysis_override for `$path_value`. Must be a string, got `$(typeof(module_name))`")
     end
 
-    return AnalysisOverride(path_glob, module_name)
+    full_analysis = get(x, "full_analysis", false)
+    if !(full_analysis isa Bool)
+        error(lazy"Invalid `full_analysis` value found in analysis_override for `$path_value`. Must be a boolean, got `$(typeof(full_analysis))`")
+    end
+
+    return AnalysisOverride(path_glob, module_name, full_analysis)
 end
 
 # Cache lookup

--- a/src/types.jl
+++ b/src/types.jl
@@ -593,9 +593,10 @@ end
 @define_eq_overloads DiagnosticConfig
 
 # Internal, undocumented configuration for full-analysis module overrides.
-struct AnalysisOverride <: ConfigSection
+@kwdef struct AnalysisOverride <: ConfigSection
     path::Glob.FilenameMatch{String}
-    module_name::Maybe{String}
+    module_name::Maybe{String} = nothing
+    full_analysis::Bool = false
 end
 @define_eq_overloads AnalysisOverride
 merge_key_value(analysis_override::AnalysisOverride) = analysis_override.path

--- a/src/utils/pkg.jl
+++ b/src/utils/pkg.jl
@@ -21,6 +21,11 @@ function find_loaded_module(module_name::String)
     return topmod
 end
 
+function find_analysis_override_module(module_name::String)
+    module_name == "JETLSTestModule" && return JETLSTestModule
+    return find_loaded_module(module_name)
+end
+
 const JULIA_DIR = let
     p1 = normpath(Sys.BINDIR, "..", "..")
     p2 = normpath(Sys.BINDIR, Base.DATAROOTDIR, "julia")
@@ -40,31 +45,12 @@ function find_analysis_env_path(state::ServerState, uri::URI)
             for override in analysis_overrides
                 if occursin(override.path, path_for_glob)
                     module_name = override.module_name
-                    if module_name === nothing
-                        @static JETLS_DEV_MODE && @info "Analysis for this file is disabled" path=filepath
-                        return OutOfScope()
-                    elseif module_name == ""
-                        env_path = @something find_env_path(filepath) begin
-                            @warn "Analysis for this file is disabled, since Project.toml was not found" path=filepath
+                    if !override.full_analysis
+                        if module_name === nothing || module_name == ""
+                            @static JETLS_DEV_MODE && @info "Analysis for this file is disabled" path=filepath
                             return OutOfScope()
                         end
-                        pkg_name = @something find_pkg_name(env_path) begin
-                            @warn "New analysis is not supported for non-package code" path=filepath
-                            return OutOfScope()
-                        end
-                        pkg_uuid = @something find_pkg_uuid(env_path) begin
-                            @warn "New analysis is not supported for non-package code" path=filepath
-                            return OutOfScope()
-                        end
-                        return UserModule(env_path, pkg_name, pkg_uuid)
-                    elseif module_name == "JETLSTestModule"
-                        # Skip full analysis but provide a context module that has `Test`
-                        # available, so that lowering analysis can handle macros like
-                        # `@testset`/`@test` defined in test files.
-                        @static JETLS_DEV_MODE && @info "Using `JETLSTestModule` as out-of-scope lowering context" path=filepath
-                        return OutOfScope(JETLSTestModule)
-                    else
-                        mod = @something find_loaded_module(module_name) begin
+                        mod = @something find_analysis_override_module(module_name) begin
                             @warn "Analysis module override specified but module not found" module_name path=filepath
                             return OutOfScope()
                         end
@@ -73,6 +59,30 @@ function find_analysis_env_path(state::ServerState, uri::URI)
                             @info "Analysis module overridden" module_name=>nameof(mod) path _id=path maxlog=1
                         end
                         return OutOfScope(mod)
+                    elseif module_name === nothing || module_name == ""
+                        env_path = @something find_env_path(filepath) begin
+                            @warn "Analysis for this file is disabled, since Project.toml was not found" path=filepath
+                            return OutOfScope()
+                        end
+                        pkg_name = @something find_pkg_name(env_path) begin
+                            @warn "Full analysis is not supported for non-package code" path=filepath
+                            return OutOfScope()
+                        end
+                        pkg_uuid = @something find_pkg_uuid(env_path) begin
+                            @warn "Full analysis is not supported for non-package code" path=filepath
+                            return OutOfScope()
+                        end
+                        return UserModule(env_path, pkg_name, pkg_uuid)
+                    else
+                        mod = @something find_analysis_override_module(module_name) begin
+                            @warn "Analysis module override specified but module not found" module_name path=filepath
+                            return OutOfScope()
+                        end
+                        @static if JETLS_DEV_MODE
+                            path = filepath
+                            @info "Full analysis module overridden" module_name=>nameof(mod) path _id=path maxlog=1
+                        end
+                        return KnownModule(mod)
                     end
                 end
             end


### PR DESCRIPTION
Internal `analysis_overrides` entries with `module_name` used to imply full analysis for the named module. That made it difficult to reuse the same field as an out-of-scope lowering context, such as for Base development.

Add `full_analysis = false` to `AnalysisOverride` and parse it from initialization options. The default path now resolves `module_name` to an `OutOfScope` context; `full_analysis = true` opts into the Revise-based `KnownModule` or `UserModule` flow. Regenerate schemas and update `.JETLSConfig.toml` to opt this checkout back in.

The Revise-based full-analysis flag requires `JETLS_DEV_MODE` and remains highly experimental. The generated schema check passed; tests were not run because the focused tests were removed.