### PR TITLE
diagnostic: Fix unused import for method overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   end
   ```
 
+- Fixed a false `lowering/unused-import` report for names imported only to extend methods without qualification:
+  ```julia
+  import Base: show  # no longer reported as an unused import
+  struct A; x::Int; end
+  show(io::IO, a::A) = print(io, "A with ", a.x)
+  ```
+
 - Document-highlight and rename now also cover identifiers used in `@static` branches not selected by the JETLS analysis process.
 
 - Fixed false `lowering/unused-local`, `lowering/unused-argument`, and `lowering/unused-assignment` reports for a binding whose only use is in a `@static` branch not selected by the JETLS analysis process.

--- a/src/analysis/occurrence-analysis.jl
+++ b/src/analysis/occurrence-analysis.jl
@@ -13,6 +13,7 @@ information:
 - `occurrence.kind::Symbol`
   - `:decl` - explicit declarations like `local x`
   - `:def` - assignments or function arguments
+  - `:method_def` - method definition names
   - `:use` - references to the binding
 
 # Arguments
@@ -208,7 +209,8 @@ function compute_binding_occurrences!(
                 start_idx = 2 # skip recording use
             end
         elseif k in JS.KSet"method_defs constdecl"
-            if nc ≥ 1 && may_record_occurrence!(occurrences, :def, st[1], ctx3)
+            occurrence_kind = k === JS.K"method_defs" ? :method_def : :def
+            if nc ≥ 1 && may_record_occurrence!(occurrences, occurrence_kind, st[1], ctx3)
                 start_idx = 2
             end
         elseif k === JS.K"block" && nc ≥ 1 && JS.kind(st[1]) === JS.K"function_decl"

--- a/src/definition.jl
+++ b/src/definition.jl
@@ -249,7 +249,7 @@ function find_global_binding_definitions(
             get_unsynced_file_info!(state, search_uri)
         end continue
         for occurrence in find_global_binding_occurrences!(state, search_uri, fi, binfo)
-            if occurrence.kind === :def
+            if is_definition_occurrence(occurrence)
                 range, adjusted_uri = unadjust_range(state, search_uri, jsobj_to_range(occurrence.tree, fi))
                 push!(seen_locations, (adjusted_uri, range))
             end

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -1052,7 +1052,7 @@ function collect_undef_global_candidates!(
         bk === :global || continue
         binfo.is_internal && continue
         startswith(binfo.name, '#') && continue
-        any(o->o.kind===:def, occurrences) && continue
+        any(is_definition_occurrence, occurrences) && continue
         bmod = binfo.mod
         isnothing(bmod) && continue
         Base.invoke_in_world(world, isdefinedglobal, bmod, Symbol(binfo.name))::Bool && continue
@@ -1748,6 +1748,7 @@ function merge_def_used_names!(
         dst_names = get!(DefUsedNames, dst, context_module)
         union!(dst_names.def, names.def)
         union!(dst_names.used, names.used)
+        union!(dst_names.method_def, names.method_def)
     end
     return dst
 end
@@ -1758,12 +1759,15 @@ function update_def_used_names!(
     )
     for (binfo_key, occurrences) in binding_occurrences
         binfo_key.kind === :global || continue
+        has_method_def = any(o -> o.kind === :method_def, occurrences)
         if any(o -> o.kind === :use, occurrences)
             def_used_names = get!(DefUsedNames, mod_def_used_names, context_module)
             push!(def_used_names.used, binfo_key.name)
-        elseif any(o -> o.kind === :def, occurrences)
+            has_method_def && push!(def_used_names.method_def, binfo_key.name)
+        elseif any(is_definition_occurrence, occurrences)
             def_used_names = get!(DefUsedNames, mod_def_used_names, context_module)
             push!(def_used_names.def, binfo_key.name)
+            has_method_def && push!(def_used_names.method_def, binfo_key.name)
         end
     end
     return mod_def_used_names
@@ -1814,6 +1818,10 @@ function analyze_unused_imports!(
         for (name, infos) in imported_names
             def_used_names !== nothing && name in def_used_names.used && continue
             for info in infos
+                if (def_used_names !== nothing && info.import_kind === :import &&
+                    name in def_used_names.method_def)
+                    continue
+                end
                 push!(diagnostics, Diagnostic(;
                     range = info.name_range,
                     severity = DiagnosticSeverity.Information,
@@ -1852,7 +1860,8 @@ function collect_explicit_imports_by_module(
             imported_names =
                 get!(Dict{String,Vector{ImportInfo}}, mod_imported_names, context_module)
             push!(get!(Vector{ImportInfo}, imported_names, name),
-                ImportInfo(uri, name_range, delete_range))
+                ImportInfo(uri, name_range, delete_range,
+                    JS.kind(st0) === JS.K"import" ? :import : :using))
         end
         return TraversalNoRecurse()
     end

--- a/src/document-highlight.jl
+++ b/src/document-highlight.jl
@@ -83,7 +83,7 @@ function add_highlight_for_occurrence!(
 end
 
 document_highlight_kind(occurrence::AnyBindingOccurrence) =
-    occurrence.kind === :def ? DocumentHighlightKind.Write :
+    is_definition_occurrence(occurrence) ? DocumentHighlightKind.Write :
     occurrence.kind === :use ? DocumentHighlightKind.Read :
     DocumentHighlightKind.Text
 

--- a/src/semantic-tokens.jl
+++ b/src/semantic-tokens.jl
@@ -289,7 +289,7 @@ end
 function classify_token_modifier(occurrence_kind::Symbol)
     if occurrence_kind === :decl
         return SEMANTIC_TOKEN_MODIFIER_DECLARATION
-    elseif occurrence_kind === :def
+    elseif is_definition_occurrence_kind(occurrence_kind)
         return SEMANTIC_TOKEN_MODIFIER_DEFINITION
     end
     return UInt(0)

--- a/src/types.jl
+++ b/src/types.jl
@@ -794,6 +794,9 @@ end
 
 const AnyBindingOccurrence = Union{BindingOccurrence,CachedBindingOccurrence}
 
+is_definition_occurrence(occ::AnyBindingOccurrence) = is_definition_occurrence_kind(occ.kind)
+is_definition_occurrence_kind(kind::Symbol) = kind === :def || kind === :method_def
+
 abstract type AbstractCompletionResolverInfo end
 
 struct GlobalCompletionResolverInfo <: AbstractCompletionResolverInfo
@@ -845,12 +848,14 @@ end
 struct DefUsedNames
     def::Set{String}
     used::Set{String}
-    DefUsedNames() = new(Set{String}(), Set{String}())
+    method_def::Set{String}
+    DefUsedNames() = new(Set{String}(), Set{String}(), Set{String}())
 end
 struct ImportInfo
     uri::URI
     name_range::Range
     delete_range::Range
+    import_kind::Symbol
 end
 # Undef-global candidate emitted by the per-file phase (with fresh `ctx3`),
 # consumed by the cross-file phase (which only does a cheap def-name lookup).

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -1945,6 +1945,32 @@ end
         @test diagnostic.range.var"end".character == sizeof("using Base: sin, cos")
     end
 
+    # Unqualified method extension needs `import`, so it counts as using the import.
+    let diagnostics = get_unused_import_diagnostics("""
+        import Base: show
+
+        struct IssueUnusedImportShow
+            x::Int
+        end
+
+        show(io::IO, a::IssueUnusedImportShow) = print(io, "A with ", a.x)
+        """)
+        @test isempty(diagnostics)
+    end
+
+    let diagnostics = get_unused_import_diagnostics("""
+        using Base: show
+
+        struct IssueUnusedImportQShow
+            x::Int
+        end
+
+        Base.show(io::IO, a::IssueUnusedImportQShow) = print(io, "A with ", a.x)
+        """)
+        @test length(diagnostics) == 1
+        @test only(diagnostics).message == "Unused import `show`"
+    end
+
     # Macro imports should not be reported as unused when the macro is used
     # + Qualified macro calls (Module.@macro) should track module usage
     let diagnostics = get_unused_import_diagnostics("""


### PR DESCRIPTION
`lowering/unused-import` could flag `import Base: show` even when the import was required to define an unqualified method extension:

```julia
import Base: show
show(io::IO, x::T) = ...
```

Track method-definition occurrences separately from ordinary global definitions, while still treating them as definition sites for navigation, document-highlight, and semantic-token features. The unused-import diagnostic now suppresses these names only for explicit `import` statements, not `using` statements.

Validation covered the unused-import diagnostic tests, occurrence analysis, method definition lookup, semantic tokens, document highlights, and `./scripts/selfcheck.sh`.