### PR TITLE
deps: Update JS/JL and adapt to static parameter capture

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,8 +27,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [sources]
 Compiler = {rev = "avi/JETLS-Compiler-head", subdir = "Compiler", url = "https://github.com/JuliaLang/julia"}
 JET = {rev = "ab8d6dc4", url = "https://github.com/aviatesk/JET.jl"}
-JuliaLowering = {rev = "00897fc3f3", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
-JuliaSyntax = {rev = "00897fc3f3", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
+JuliaLowering = {rev = "8399119aa7", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
+JuliaSyntax = {rev = "8399119aa7", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
 LSP = {path = "LSP"}
 
 [compat]

--- a/src/analysis/Closure2Opaque.jl
+++ b/src/analysis/Closure2Opaque.jl
@@ -1,7 +1,6 @@
 module Closure2Opaque
 
-using ..JETLS: JL, JS, SyntaxTreeC, TraversalReturn, get_name_val, is_core_svec_call,
-    traverse, var_id
+using ..JETLS: JL, JS, SyntaxTreeC, get_name_val, var_id
 
 export rewrite_local_closures_to_opaque
 
@@ -25,9 +24,9 @@ into inference context module (which the regular conversion would require).
   can't be represented as a single OC, so they fall through to the regular synthetic-struct
   path. A whole-tree pre-pass (`collect_multi_method_bindings`) identifies these so the
   per-block rewrite can skip every method definition for such bindings.
-- Bodies whose `K"method_defs"` shape doesn't match the expected
-  `(block (block (= sig_ssa svec_call) (method ...) (removable ...)))`
-  template (e.g. generated functions) are likewise left untouched.
+- Bodies whose `K"method_defs"` shape doesn't contain exactly one method, or whose
+  method declares its own static parameters (e.g. generated or generic local methods),
+  are likewise left untouched.
 
 # Usage
 
@@ -183,28 +182,32 @@ function find_matching_method_defs(
 end
 
 function is_method_defs_for(c::SyntaxTreeC, target_var_id::Int)
-    return JS.kind(c) === JS.K"method_defs" && JS.numchildren(c) >= 2 &&
+    return JS.kind(c) === JS.K"method_defs" && JS.numchildren(c) == 3 &&
         JS.kind(c[1]) === JS.K"BindingId" && var_id(c[1]) == target_var_id
 end
 
-# `method_defs[2]` is shaped like
-#   (block (block (= sig_ssa (call core.svec inner_argtypes_svec sparams_svec functionloc))
-#                 (method func_name sig_ssa lambda)
-#                 (removable sig_ssa)))
-# Returns `nothing` if the structure doesn't match (e.g. generated functions).
+# `method_defs` is shaped like
+#   (method_defs func_name (block typevar_setup...)
+#     (block (block (method func_name inner_argtypes_svec lambda))))
+# Returns `nothing` for non-single-method scaffolding and methods with their own
+# static parameters.
 function try_build_oc_assignment(
         ctx::JL.VariableAnalysisContext, fd::SyntaxTreeC, method_defs::SyntaxTreeC
     )
     func_name = fd[1]
-    method_node, sig_call = find_method_and_sig_call(method_defs[2], var_id(func_name))
-    method_node === nothing && return nothing
-    sig_call === nothing && return nothing
-    JS.numchildren(sig_call) >= 4 || return nothing
-    inner_argtypes = sig_call[2]
-    functionloc = sig_call[4]
+    typevars = method_defs[2]
+    JS.kind(typevars) === JS.K"block" || return nothing
+    JS.numchildren(typevars) == 0 || return nothing
+
+    method_node = @something find_single_method_node(
+        method_defs[3], var_id(func_name)) return nothing
+    inner_argtypes = method_node[2]
     JS.kind(inner_argtypes) === JS.K"call" || return nothing
     # `core.svec` callee + at least the function-type arg
     JS.numchildren(inner_argtypes) >= 2 || return nothing
+    callee = inner_argtypes[1]
+    JS.kind(callee) === JS.K"core" && get_name_val(callee) == "svec" || return nothing
+    functionloc = JL.@ast ctx method_node (::JS.K"SourceLocation")
 
     # The inner argtypes svec is `core.svec(function_type, user_arg_types...)`.
     # Skip the `core.svec` callee (idx 1) and the function-type marker (idx 2);
@@ -248,37 +251,16 @@ function try_build_oc_assignment(
     return JL.@ast ctx method_defs [JS.K"=" func_name oc]
 end
 
-# `sig_call` must be matched by `var_id` (not "first svec_call DFS finds"):
-# nested closures embed the inner OC's `method_defs` inside the outer OC's lambda body,
-# so an unconstrained DFS attributes the inner's user-argtypes to the outer OC.
-function find_method_and_sig_call(root::SyntaxTreeC, target_var_id::Int)
-    method_node = @something find_method_node(root, target_var_id) return (nothing, nothing)
-    JS.numchildren(method_node) >= 2 || return (method_node, nothing)
-    sig_ref = method_node[2]
-    JS.kind(sig_ref) === JS.K"BindingId" || return (method_node, nothing)
-    sig_call = find_sig_call_for(root, var_id(sig_ref))
-    return (method_node, sig_call)
-end
-
-function find_method_node(root::SyntaxTreeC, target_var_id::Int)
-    return traverse(root) do node::SyntaxTreeC
-        if (JS.kind(node) === JS.K"method" && JS.numchildren(node) == 3 &&
-            JS.kind(node[1]) === JS.K"BindingId" && var_id(node[1]) == target_var_id)
-            return TraversalReturn(node; terminate=true)
-        end
-        nothing
+function find_single_method_node(root::SyntaxTreeC, target_var_id::Int)
+    node = root
+    while JS.kind(node) === JS.K"block" && JS.numchildren(node) == 1
+        node = node[1]
     end
-end
-
-function find_sig_call_for(root::SyntaxTreeC, sig_var_id::Int)
-    return traverse(root) do node::SyntaxTreeC
-        if (JS.kind(node) === JS.K"=" && JS.numchildren(node) == 2 &&
-            JS.kind(node[1]) === JS.K"BindingId" && var_id(node[1]) == sig_var_id &&
-            JS.kind(node[2]) === JS.K"call" && is_core_svec_call(node[2]))
-            return TraversalReturn(node[2]; terminate=true)
-        end
-        nothing
+    if (JS.kind(node) === JS.K"method" && JS.numchildren(node) == 3 &&
+        JS.kind(node[1]) === JS.K"BindingId" && var_id(node[1]) == target_var_id)
+        return node
     end
+    return nothing
 end
 
 # Detect a vararg-typed entry in the user-argtypes svec. JL lowers both `(xs...)`

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -214,14 +214,17 @@ function to_completion(
     label_kind = CompletionItemKind.Variable
     label_detail = label_desc = nothing
 
+    # `:typevar` is defensive; current completion scopes expose `:static_parameter`.
     if binding.is_const
         label_kind = CompletionItemKind.Constant
-    elseif binding.kind === :static_parameter
+    elseif binding.kind in (:typevar, :static_parameter)
         label_kind = CompletionItemKind.TypeParameter
     end
 
-    if binding.kind in [:argument, :local, :global]
+    if binding.kind in (:argument, :local, :global)
         label_desc = String(binding.kind)
+    elseif binding.kind === :typevar
+        label_desc = "typevar"
     elseif binding.kind === :static_parameter
         label_desc = "sparam"
     end

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -815,21 +815,6 @@ function return_insert_data(
     return range.var"end", "\n$(indent)return $bn"
 end
 
-# `JL.method_def_expr` packages each lowered method's signature metadata as
-# `svec(svec(arg_types...), svec(static_parameters...), source_location)`, where the
-# static parameters are the locals `JL.assign_sparams` binds via `core.TypeVar` calls.
-# Matching that shape covers every method definition form — named, anonymous, callable
-# struct, macro-generated — while quoted code stays inert and never produces it.
-function method_signature_metadata(node::SyntaxTreeC)
-    JS.numchildren(node) == 4 && is_core_svec_call(node) || return nothing
-    arg_types = node[2]
-    sparams = node[3]
-    JS.kind(arg_types) === JS.K"call" && is_core_svec_call(arg_types) || return nothing
-    JS.kind(sparams) === JS.K"call" && is_core_svec_call(sparams) || return nothing
-    JS.kind(node[4]) === JS.K"SourceLocation" || return nothing
-    return arg_types, sparams
-end
-
 function collect_binding_ids!(ids::Set{JL.IdTag}, st::SyntaxTreeC)
     traverse(st) do node::SyntaxTreeC
         JS.kind(node) === JS.K"BindingId" && push!(ids, JL._binding_id(node))
@@ -838,39 +823,38 @@ function collect_binding_ids!(ids::Set{JL.IdTag}, st::SyntaxTreeC)
     return ids
 end
 
+function method_typevars(ctx3::JL.VariableAnalysisContext, method::SyntaxTreeC)
+    JS.kind(method) === JS.K"method" && JS.numchildren(method) == 3 || return nothing
+    arg_types = method[2]
+    is_core_svec_call(arg_types) || return nothing
+    lambda = method[3]
+    JS.kind(lambda) === JS.K"lambda" && JS.numchildren(lambda) >= 2 || return nothing
+    sparams = lambda[2]
+    JS.kind(sparams) === JS.K"block" || return nothing
+    typevar_ids = JL.IdTag[]
+    for sparam in JS.children(sparams)
+        JS.kind(sparam) === JS.K"BindingId" || continue
+        sp_id = JL._binding_id(sparam)
+        typevar_id = get(ctx3.sp_typevars, sp_id, nothing)
+        typevar_id === nothing || push!(typevar_ids, typevar_id)
+    end
+    isempty(typevar_ids) && return nothing
+    return arg_types, typevar_ids
+end
+
 function analyze_unconstrained_static_parameters!(
         diagnostics::Vector{Diagnostic}, fi::FileInfo, ctx3::JL.VariableAnalysisContext,
         st3::SyntaxTreeC, reported::Set{LoweringDiagnosticKey}
     )
-    typevar_assignments = Dict{JL.IdTag,SyntaxTreeC}()
-    signature_metadatas = Tuple{SyntaxTreeC,SyntaxTreeC}[]
+    methods = Tuple{SyntaxTreeC,Vector{JL.IdTag}}[]
     traverse(st3) do node::SyntaxTreeC
-        k = JS.kind(node)
-        if k === JS.K"=" && JS.numchildren(node) == 2 &&
-                JS.kind(node[1]) === JS.K"BindingId"
-            rhs = node[2]
-            if JS.kind(rhs) === JS.K"call" && JS.numchildren(rhs) >= 2 &&
-                    is_core_ref(rhs[1], "TypeVar")
-                typevar_assignments[JL._binding_id(node[1])] = rhs
-            end
-        elseif k === JS.K"call"
-            metadata = method_signature_metadata(node)
-            metadata === nothing || push!(signature_metadatas, metadata)
-        end
+        result = method_typevars(ctx3, node)
+        result === nothing || push!(methods, result)
         return nothing
     end
-    for (arg_types, sparams) in signature_metadatas
-        sparam_ids = JL.IdTag[]
-        for i = 2:JS.numchildren(sparams)
-            sparam = sparams[i]
-            # non-`BindingId` entries are e.g. the placeholder in `where {T,_}`
-            JS.kind(sparam) === JS.K"BindingId" || continue
-            id = JL._binding_id(sparam)
-            haskey(typevar_assignments, id) && push!(sparam_ids, id)
-        end
-        isempty(sparam_ids) && continue
+    for (arg_types, typevar_ids) in methods
         arg_type_ids = collect_binding_ids!(Set{JL.IdTag}(), arg_types)
-        constrained = Bool[id in arg_type_ids for id in sparam_ids]
+        constrained = Bool[id in arg_type_ids for id in typevar_ids]
         # A constrained type variable's bounds also constrain the type variables they
         # reference, but only those declared earlier: in `f(::T) where {T<:S, S}` the
         # `S` bound of `T` resolves to the later declaration without constraining it
@@ -878,23 +862,25 @@ function analyze_unconstrained_static_parameters!(
         todo = findall(constrained)
         while !isempty(todo)
             i = pop!(todo)
-            bound_ids = collect_binding_ids!(Set{JL.IdTag}(), typevar_assignments[sparam_ids[i]])
+            deps = @something get(ctx3.tv_deps, typevar_ids[i], nothing) continue
             for j = 1:i-1
                 constrained[j] && continue
-                sparam_ids[j] in bound_ids || continue
+                typevar_ids[j] in deps || continue
                 constrained[j] = true
                 push!(todo, j)
             end
         end
-        for i = eachindex(sparam_ids)
+        for i = eachindex(typevar_ids)
             constrained[i] && continue
-            binfo = JL.get_binding(ctx3, sparam_ids[i])
+            binfo = JL.get_binding(ctx3, typevar_ids[i])
             binfo.is_internal && continue
             bn = binfo.name
             startswith(bn, "#") && continue
             provs = JS.flattened_provenance(JL.binding_ex(ctx3, binfo.id))
             is_from_user_ast(provs) || continue
-            range = jsobj_to_range(last(provs), fi)
+            source = last(provs)
+            JS.sourcetext(source) == "_" && continue
+            range = jsobj_to_range(source, fi)
             key = LoweringDiagnosticKey(range, :static_parameter, bn)
             key in reported ? continue : push!(reported, key)
             push!(diagnostics, Diagnostic(;

--- a/src/hover.jl
+++ b/src/hover.jl
@@ -225,6 +225,7 @@ end
 
 binding_kind_label(kind::Symbol) =
     kind === :argument ? "(argument)" :
+    kind === :typevar ? "(type parameter)" :
     kind === :static_parameter ? "(static parameter)" :
     kind === :local ? "(local)" : "(global)"
 

--- a/src/semantic-tokens.jl
+++ b/src/semantic-tokens.jl
@@ -185,12 +185,12 @@ function collect_semantic_tokens_for_occurrences!(
         occs::BindingOccurrencesResult, st0::SyntaxTreeC,
     )
     # `:local` aliases for type parameters cover a superset of the corresponding
-    # `:static_parameter`'s occurrences — and for plain `struct A{T}; ...; end` are
-    # the only signal at all.
-    # Collect names from both and reclassify matching `:local`s as `typeParameter`.
+    # `:typevar` / `:static_parameter` occurrences — and for plain
+    # `struct A{T}; ...; end` are the only signal at all. Collect their names
+    # and reclassify matching `:local`s as `typeParameter`.
     type_param_names = Set{String}()
     for binfo_key in keys(occs)
-        if binfo_key.kind === :static_parameter
+        if binfo_key.kind in (:typevar, :static_parameter)
             push!(type_param_names, binfo_key.name)
         end
     end
@@ -277,12 +277,12 @@ end
 function classify_token_type(binfo_kind::Symbol)
     if binfo_kind === :argument
         return SEMANTIC_TOKEN_TYPE_PARAMETER
-    elseif binfo_kind === :static_parameter
-        return SEMANTIC_TOKEN_TYPE_TYPE_PARAMETER
     elseif binfo_kind === :local
         return SEMANTIC_TOKEN_TYPE_VARIABLE
     elseif binfo_kind === :global
         return SEMANTIC_TOKEN_TYPE_UNSPECIFIED
+    elseif binfo_kind in (:typevar, :static_parameter)
+        return SEMANTIC_TOKEN_TYPE_TYPE_PARAMETER
     else error("Unknown binding kind found") end
 end
 

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -175,9 +175,10 @@ function cursor_bindings(
         (binfo, _) = bscopeinfos[i]
 
         prev = get(seen, binfo.name, nothing)
+        # `:typevar` is defensive; current cursor scopes expose `:static_parameter`.
         if (isnothing(prev)
             || bdistances[i] < bdistances[prev]
-            || binfo.kind === :static_parameter)
+            || binfo.kind in (:typevar, :static_parameter))
             seen[binfo.name] = i
         elseif @static JETLS_DEBUG_LOWERING ? true : false
             @info "Found two bindings with the same name:" binfo bscopeinfos[prev][1]
@@ -219,6 +220,16 @@ function find_target_binding(ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC,
         # names whose context was inherited from the macrocall.
         binding_is_in_base_layer(ctx3, binfo) || return nothing
         binding_has_source_name(ctx3, binfo) || return nothing
+        if binfo.kind === :static_parameter
+            typevar_id = get(ctx3.sp_typevars, binfo.id, nothing)
+            if typevar_id !== nothing
+                typevar = JL.binding_ex(ctx3, typevar_id)
+                # Prefer `:typevar` at the shared `where` binder source.
+                if JS.byte_range(typevar) == JS.byte_range(st3′)
+                    return TraversalReturn(typevar)
+                end
+            end
+        end
         return TraversalReturn(st3′)
     end
 end
@@ -644,7 +655,7 @@ end
 is_same_binding(x::SyntaxTreeC, id::Int) = JS.kind(x) === JS.K"BindingId" && id == JL._binding_id(x)
 
 is_local_binding(binfo::JL.BindingInfo) =
-    binfo.kind === :argument || binfo.kind === :static_parameter || binfo.kind === :local
+    binfo.kind in (:argument, :typevar, :static_parameter, :local)
 
 """
     lookup_binding_definitions(st3::SyntaxTreeC, binfo::JL.BindingInfo) -> definitions::SyntaxListC
@@ -654,11 +665,11 @@ containing the syntax nodes where the binding may be defined.
 
 This function traverses the syntax tree to collect `definitions` that tracks all the
 assignment expressions (`=`) and function declarations where the binding may be defined.
-For `:argument` or `:static_parameter` bindings, `definitions` also includes the argument
-or static parameter declaration itself.
+For `:argument`, `:typevar`, or `:static_parameter` bindings, `definitions` also includes
+the argument or type parameter declaration itself.
 """
 function lookup_binding_definitions(st3::SyntaxTreeC, binfo::JL.BindingInfo)
-    if binfo.kind === :argument || binfo.kind === :static_parameter
+    if binfo.kind in (:argument, :typevar, :static_parameter)
         sl = JS.SyntaxList(JS.syntax_graph(st3), [binfo.node_id])
     else
         sl = JS.SyntaxList(JS.syntax_graph(st3))

--- a/test/analysis/test_Closure2Opaque.jl
+++ b/test/analysis/test_Closure2Opaque.jl
@@ -118,6 +118,50 @@ end
     end
 end
 
+@testset "static parameters" begin
+    let (val, _) = rewrite_lower_eval("""
+            function outer_static_capture(x::T) where T
+                f = (y::T) -> T(x + y)
+                f(x)
+            end
+            outer_static_capture(21)
+            """)
+        @test val == 42
+    end
+
+    let tree = rewrite_only("""
+            function outer_static_capture_tree(x::T) where T
+                f = (y::T) -> T(x + y)
+                f(x)
+            end
+            """)
+        @test count_opaque_closures(tree) == 1
+    end
+end
+
+@testset "limitations: unsupported local method shapes fall through" begin
+    @testset "method-owned static parameters" begin
+        let tree = rewrite_only("""
+                let f(y::S) where S = y
+                    f(42)
+                end
+                """)
+            @test count_opaque_closures(tree) == 0
+        end
+    end
+
+    @testset "generated local methods" begin
+        let tree = rewrite_only("""
+                let
+                    @generated f(x) = :(x)
+                    f(42)
+                end
+                """)
+            @test count_opaque_closures(tree) == 0
+        end
+    end
+end
+
 @testset "return type annotation" begin
     # Literal `::RT` on the closure: native `f(y)::T = body` lowers to
     # `convert(T, body)::T`, and the rewrite preserves that by passing the

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -331,6 +331,20 @@ end
             end
         end
 
+        @testset "outer static parameter captured by closure" begin
+            let code = """
+                function with_static_capture(x::T) where T<:Int
+                    inner(y::T) = x + y
+                    inner(x)
+                end
+                """
+                _, ctx = type_annotate(code)
+                # The signature-view body can't recover the outer static parameter bound.
+                @test_broken widenconst(get_type_for_range(ctx, range_of(code, "x + y"))) === Int
+                @test widenconst(get_type_for_range(ctx, range_of(code, "inner(x)"))) === Int
+            end
+        end
+
         # Multiple captures of different types — the OC's env tuple keeps each
         # capture's type independently; integer-positional access in the body
         # resolves each precisely.

--- a/test/analysis/test_occurrence_analysis.jl
+++ b/test/analysis/test_occurrence_analysis.jl
@@ -152,6 +152,11 @@ end
             @test binding_occurrences[binfos[idxs[1]]] === binding_occurrences[binfos[idxs[2]]]
             occurrences = binding_occurrences[binfos[idxs[1]]]
             @test any(occurrences) do occurrence
+                occurrence.kind === :def &&
+                JS.sourcetext(occurrence.tree) == "TTT1" &&
+                JS.source_line(occurrence.tree) == 1
+            end
+            @test any(occurrences) do occurrence
                 occurrence.kind === :use &&
                 JS.sourcetext(occurrence.tree) == "TTT1" &&
                 JS.source_line(occurrence.tree) == 2

--- a/test/test_hover.jl
+++ b/test/test_hover.jl
@@ -190,6 +190,12 @@ module M_field_hover
 end
 
 @testset HierarchicalTestSet "'hover' user-binding resolution" begin
+    @testset "method type parameters" begin
+        hover_test("func(x::│T) where T = T", "(type parameter) T")
+        hover_test("func(x::T) where │T = T", "(type parameter) T")
+        hover_test("func(x::T) where T = │T", "(static parameter) T")
+    end
+
     @testset "documented global binding" begin
         hover_test("documented_binding│", "Documented binding.";
             context_module = M_doc_binding)

--- a/test/test_semantic_tokens.jl
+++ b/test/test_semantic_tokens.jl
@@ -82,9 +82,9 @@ end
         @test length(type_params) == 3
         # `T` in `::T` (use)
         @test any(t -> t.line == 0 && t.char == 6  && t.len == 1 && t.mod == 0, type_params)
-        # `T` in `where T` carries both `:def` and `:decl`
+        # `T` in `where T` is a definition
         @test any(t -> t.line == 0 && t.char == 15 && t.len == 1 &&
-                       t.mod == (MOD_DEFINITION | MOD_DECLARATION), type_params)
+                       t.mod == MOD_DEFINITION, type_params)
         # `T` in `zero(T)` (use)
         @test any(t -> t.line == 0 && t.char == 32 && t.len == 1 && t.mod == 0, type_params)
     end
@@ -146,7 +146,7 @@ end
             @test any(t -> t.line == 1 && t.char == 7  && t.len == 1 && t.mod == 0, type_params) # x::T
             @test any(t -> t.line == 2 && t.char == 6  && t.len == 1 && t.mod == 0, type_params) # A{T}(x)
             @test any(t -> t.line == 2 && t.char == 18 && t.len == 1 &&
-                           t.mod == (MOD_DEFINITION | MOD_DECLARATION), type_params)             # where T
+                           t.mod == MOD_DEFINITION, type_params)                                 # where T
             @test any(t -> t.line == 2 && t.char == 26 && t.len == 1 && t.mod == 0, type_params) # new{T}
             @test any(t -> t.line == 2 && t.char == 37 && t.len == 1 && t.mod == 0, type_params) # convert(T, x)
         end

--- a/test/utils/test_binding.jl
+++ b/test/utils/test_binding.jl
@@ -125,6 +125,13 @@ end
         return true
     end == 4
 
+    let expected_kinds = (:typevar, :typevar, :static_parameter)
+        @test with_target_binding("func(x::│T) where │T = │T") do i, (; ctx3, binding)
+            @test JL.get_binding(ctx3, binding).kind === expected_kinds[i]
+            return true
+        end == 3
+    end
+
     # Qualified macrocall: cursor at end of macro name returns nothing
     @test with_target_binding("""
         Base.@info│ "hello"


### PR DESCRIPTION
JuliaLowering’s static-parameter capture changes (JuliaLang/julia#62374) method-definition lowering and introduces distinct `:typevar` bindings. Without matching updates, closure rewriting assumes the old method shape, diagnostics use obsolete context fields, and binding-based language features can miss or misclassify method type parameters.

Update JuliaSyntax and JuliaLowering to `8399119aa7`, adapt `Closure2Opaque` to the separated typevar setup and method body, and use `sp_typevars` and `tv_deps` for static-parameter diagnostics. Handle `:typevar` bindings across cursor selection, completion, hover, semantic tokens, and occurrence analysis, preferring the typevar binding at a shared `where` binder source.

Generic and generated local methods remain on the conservative synthetic-closure path. TypeAnnotation now covers outer static-parameter capture at closure call sites, while signature-view body inference still cannot recover static-parameter bounds from thunk method instances.