### PR TITLE
binding/occurrence: Resolve names in quoted expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed false `lowering/macro-expansion-error` diagnostics when an old-style macro is nested inside a new-style macro. The failed expansion could also contaminate enclosing forms and produce repeated lowering diagnostics across a project, as reported for Makie. This incorporates [JuliaLang/julia#62221](https://github.com/JuliaLang/julia/pull/62221) and addresses [JuliaLang/JuliaLowering.jl#108](https://github.com/JuliaLang/JuliaLowering.jl/issues/108). (Closed https://github.com/aviatesk/JETLS.jl/issues/554)
 
+- Fixed many missing references, rename edits, document highlights, and `lowering/unused-import` diagnostic results for identifiers inside quoted expressions used by helper functions, macros, and generated functions.
+
 - Fixed a false `lowering/error` diagnostic for docstring signatures such as `someinterface(::Type{<:Integer})`.
 
 - Fixed a false `lowering/unused-import` report for a name used only inside a `@static` condition or a branch not selected by the JETLS analysis process:

--- a/src/analysis/occurrence-analysis.jl
+++ b/src/analysis/occurrence-analysis.jl
@@ -1,7 +1,8 @@
 """
     compute_binding_occurrences(
             ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC;
-            include_global_bindings::Bool = false
+            include_global_bindings::Bool = false,
+            generated_resolutions::Union{Nothing,Vector{InertResolution}} = nothing
         ) -> binding_occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}}
 
 Analyze a lowered syntax tree to find all occurrences of local and argument bindings.
@@ -19,6 +20,9 @@ information:
 # Arguments
 - `ctx3`: Variable analysis context from JuliaLowering containing binding information
 - `st3`: Lowered syntax tree (after scope resolution) to analyze
+- `include_global_bindings`: Whether to include global bindings in the result
+- `generated_resolutions`: Optional precomputed generated inert resolutions. When
+  provided, they are reused instead of lowering generated inert templates again.
 
 # Returns
 `binding_occurrences` is a dictionary mapping each non-internal local/argument binding to
@@ -33,7 +37,8 @@ a set of `BindingOccurrence` objects that record where and how the binding appea
 """
 function compute_binding_occurrences(
         ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC;
-        include_global_bindings::Bool = false
+        include_global_bindings::Bool = false,
+        generated_resolutions::Union{Nothing,Vector{InertResolution}} = nothing
     )
     occurrences = Dict{JL.BindingInfo,Set{BindingOccurrence}}()
 
@@ -64,7 +69,12 @@ function compute_binding_occurrences(
 
     compute_binding_occurrences!(occurrences, ctx3, st3; include_global_bindings)
 
-    record_generated_inert_argument_uses!(occurrences, ctx3, st3)
+    generated_resolutions = if generated_resolutions === nothing
+        collect_generated_inert_resolutions(ctx3, st3)
+    else
+        generated_resolutions
+    end
+    record_generated_inert_argument_uses!(occurrences, ctx3, generated_resolutions)
 
     # Aggregate occurrences for bindings that have the same name and location.
     # JL sometimes represents bindings that are considered "identical" at the source level
@@ -106,24 +116,30 @@ function compute_binding_occurrences(
     return occurrences
 end
 
-function enclosing_generated_range(node::SyntaxTreeC)
-    s = node
-    while true
-        ms = JS.macro_prov(s)
-        isnothing(ms) && return nothing
-        is_generated0(ms) && return JS.byte_range(ms)
-        s = ms
-    end
-end
-
 function record_generated_inert_argument_uses!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
-        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC
+        ctx3::JL.VariableAnalysisContext,
+        generated_resolutions::Vector{InertResolution}
     )
-    foreach_generated_inert_argument(ctx3, st3) do _, binfo, id_node
-        haskey(occurrences, binfo) || return true
-        push!(occurrences[binfo], BindingOccurrence(id_node, :use))
-        return true
+    for resolution in generated_resolutions
+        isempty(resolution.argument_remap) && continue
+        resolved_occurrences = compute_binding_occurrences(resolution.ctx3, resolution.st3)
+        for (resolved_binfo, source) in resolution.argument_remap
+            source_binfo = JL.get_binding(ctx3, source)
+            haskey(occurrences, source_binfo) || continue
+            resolved_boccs = get(resolved_occurrences, resolved_binfo, nothing)
+            resolved_boccs === nothing && continue
+            for occurrence in resolved_boccs
+                occurrence.kind === :use || continue
+                JS.byte_range(occurrence.tree) ⊆ resolution.source_range || continue
+                source_occurrences = occurrences[source_binfo]
+                any(source_occurrences) do existing
+                    existing.kind === occurrence.kind &&
+                        JS.byte_range(existing.tree) == JS.byte_range(occurrence.tree)
+                end && continue
+                push!(source_occurrences, occurrence)
+            end
+        end
     end
     return occurrences
 end
@@ -440,14 +456,14 @@ function compute_full_binding_occurrences(
         catch
             return nothing
         end
-        occs = compute_binding_occurrences(ctx3, st3; include_global_bindings=true)
+        generated_resolutions = collect_generated_inert_resolutions(ctx3, st3)
+        occs = compute_binding_occurrences(ctx3, st3;
+            include_global_bindings=true, generated_resolutions)
         collect_struct_inner_constructor_occurrences!(occs, ctx3, st0)
         collect_macrocall_occurrences!(occs, context_module, st0; soft_scope)
-        # Global bindings used inside inert nodes (quoted expressions) are not
-        # resolved by scope analysis. This applies to `@generated` functions,
-        # macro definitions, and any function that constructs quoted expressions.
-        # Run independent scope resolution on inert content to collect them.
-        collect_inert_global_occurrences!(occs, ctx3, st3, context_module; soft_scope)
+        # Add generated-body and policy-approved inert occurrences.
+        collect_inert_global_occurrences!(occs, st3, st0, context_module,
+            generated_resolutions; soft_scope)
         binding_occurrences = occs
     end
     collect_import_export_occurrences!(binding_occurrences, st0, context_module)
@@ -537,6 +553,7 @@ function collect_macrocall_occurrences!(
     traverse(st0) do st::SyntaxTreeC
         JS.kind(st) === JS.K"macrocall" || return nothing
         JS.numchildren(st) ≥ 1 || return nothing
+        should_resolve_macrocall(st0, JS.byte_range(st)) || return traversal_no_recurse
         macrocall_name = st[1]
         (; ctx3) = try
             jl_lower_for_scope_resolution(context_module, macrocall_name; soft_scope)
@@ -554,103 +571,59 @@ function collect_macrocall_occurrences!(
     return occurrences
 end
 
+function collect_resolved_inert_globals!(
+        occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
+        resolution::InertResolution
+    )
+    resolved_occurrences = compute_binding_occurrences(
+        resolution.ctx3, resolution.st3; include_global_bindings=true)
+    for (binfo, boccs) in resolved_occurrences
+        binfo.kind === :global || continue
+        binfo.is_internal && continue
+        binfo.name == resolution.placeholder_name && continue
+        target = get!(Set{BindingOccurrence}, occurrences, binfo)
+        for occurrence in boccs
+            JS.byte_range(occurrence.tree) ⊆ resolution.source_range || continue
+            push!(target, occurrence)
+        end
+    end
+    return occurrences
+end
+
 """
     collect_inert_global_occurrences!
 
-Collect global bindings used inside `K"inert"` and `K"syntaxinert"` nodes by
-running independent scope resolution on each inert subtree and recording any
-non-internal `:global` bindings it finds as `:use` occurrences. The inert subtree
-is lowered with `context_module` — the enclosing module at the inert's position —
-as the resolution module.
-
-# Approximation
-
-This is a pragmatic approximation, not a precise analysis. The enclosing
-module is correct for the cases where quoted code is eventually evaluated
-there:
-
-- `@eval body` — `body` is `eval`'d in the module where `@eval` appears.
-- User-defined macro bodies — free identifiers in a macro's returned AST
-  are hygienically resolved in the macro's defining module.
-- `@generated` function bodies — the returned AST becomes the generated
-  method's body, compiled in the function's module; global references
-  inside thus resolve in that module.
-
-The approximation breaks down whenever the inert content is ultimately
-evaluated somewhere other than `context_module`. Detecting these cases would
-require cross-function / whole-program analysis that we don't currently
-perform:
-
-- The inert content is spliced into another quote that introduces a new local scope —  e.g.
-  a builder that returns `quote function f(x); \$body; end end`, where identifiers inside
-  `body` are meant to resolve against `f`'s arguments, not globals in `context_module`.
-- The resulting `Expr`/`SyntaxTree` is handed off to `Core.eval` in a
-  different module — e.g. `g() = :(foo())` later called as
-  `Core.eval(SomeOtherModule, g())`, so `foo` resolves in
-  `SomeOtherModule` rather than `g`'s defining module.
-
-These cases may produce orphan entries (recorded in the wrong module) or
-miss real references. They are accepted as a known limitation.
-
-# Argument-name handling
-
-Free identifiers inside inert content that match an enclosing
-function/macro argument name are filtered out to avoid false
-`:global :use` occurrences. Two independent reasons motivate this:
-
-- `@generated` bodies — plain identifiers in the returned quote are
-  compile-time references to the function's parameters.
-  `compute_binding_occurrences` already records them as
-  `:argument :use` via `record_generated_inert_argument_uses!`; the
-  filter prevents duplicating those as `:global :use` here.
-- `quote ... \$arg ... end` inside any function or macro body —
-  scope resolution handles `\$arg` correctly (the argument `arg` is
-  used as an interpolation value, recorded as `:argument :use` in
-  the usual walk), and the inert template itself is not a reference
-  to `arg`. But `unwrap_interpolations` strips the `\$` node for
-  lowering, turning `\$arg` into a bare `arg` identifier which the
-  fresh resolution then classifies as `:global`. The filter
-  compensates for this unwrap artifact.
+Collect globals from generated bodies and inert ranges accepted by
+[`inert_resolution_policy`](@ref). This keeps the workspace occurrence index in
+sync with target selection for references and rename.
 """
 function collect_inert_global_occurrences!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
-        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, context_module::Module;
+        st3::SyntaxTreeC, st0::SyntaxTreeC, context_module::Module,
+        generated_resolutions::Vector{InertResolution};
         soft_scope::Bool = false
     )
-    arg_names = Set{String}()
-    for binfo in ctx3.bindings.info
-        if binfo.kind === :argument && !binfo.is_internal
-            push!(arg_names, binfo.name)
-        end
+    # Generated bodies need their function arguments remapped into runtime scope.
+    for resolution in generated_resolutions
+        collect_resolved_inert_globals!(occurrences, resolution)
     end
-    st3_range = JS.byte_range(st3)
-    traverse(st3) do st3′::SyntaxTreeC
-        # Skip `import`/`using` desugaring (see `is_import_eval_call`); re-lowering
-        # its inert module path would record spurious `:global :use` occurrences.
-        is_import_eval_call(st3′) && return traversal_no_recurse
-        JS.kind(st3′) in JS.KSet"inert syntaxinert" || return nothing
-        JS.numchildren(st3′) >= 1 || return nothing
-        # Skip the outer inert that wraps the entire generator template
-        JS.byte_range(st3′) == st3_range && return nothing
-        # Inert templates with interpolation fail to lower directly. Unwrap
-        # source `$` nodes and replace lowered `syntaxunquote` nodes with an
-        # internal placeholder so non-interpolated identifiers are resolved.
-        template, placeholder_name = prepare_inert_template(st3′[1])
-        ires = try
-            jl_lower_for_scope_resolution(context_module, template; soft_scope)
-        catch
-            return nothing
-        end
-        for binfo in ires.ctx3.bindings.info
-            if (binfo.kind === :global && !binfo.is_internal &&
-                    !(binfo.name in arg_names) && binfo.name != placeholder_name)
-                # Use the inert ctx's BindingInfo as key; when cached via
-                # BindingInfoKey(context_module, name, :global) it matches the import.
-                occ_set = get!(Set{BindingOccurrence}, occurrences, binfo)
-                push!(occ_set, BindingOccurrence(
-                    JL.binding_ex(ires.ctx3, binfo.id), :use))
-            end
-        end
+
+    seen = Set{Tuple{JS.Kind,UnitRange{Int}}}()
+    traverse(st3) do inert_tree::SyntaxTreeC
+        is_import_eval_call(inert_tree) && return traversal_no_recurse
+        JS.kind(inert_tree) in JS.KSet"inert syntaxinert" || return nothing
+        JS.numchildren(inert_tree) >= 1 || return nothing
+        range = JS.byte_range(inert_tree)
+        key = (JS.kind(inert_tree), range)
+        key in seen && return traversal_no_recurse
+        push!(seen, key)
+        # Generated ranges were handled above with their dedicated argument scope.
+        is_generated_inert_range(st0, range) && return traversal_no_recurse
+        policy = inert_resolution_policy(st0, range)
+        policy === :unresolved && return traversal_no_recurse
+        hard_scope = policy === :macro
+        resolution = resolve_inert_tree(context_module, inert_tree; hard_scope, soft_scope)
+        resolution === nothing || collect_resolved_inert_globals!(occurrences, resolution)
         return nothing
     end
     return occurrences

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -152,35 +152,26 @@ end
 
 _is_empty_non_leaf(st0::SyntaxTreeC) = !JS.is_leaf(st0) && JS.numchildren(st0) == 0
 
-function _rewrite_interpolations(
-        st::SyntaxTreeC, placeholder_name::Union{Nothing,String}
-    )
+function _unwrap_interpolations(st::SyntaxTreeC)
     k = JS.kind(st)
     if k === JS.K"$"
         if JS.numchildren(st) >= 1
-            new_child, _ = _rewrite_interpolations(st[1], placeholder_name)
+            new_child, _ = _unwrap_interpolations(st[1])
             return (new_child, true)
         end
         return (st, false)
-    elseif placeholder_name !== nothing && k === JS.K"syntaxunquote"
-        placeholder = JS.setattr!(
-            JS.newleaf(JS.syntax_graph(st), st, JS.K"Identifier"),
-            :name_val, placeholder_name)
-        return (placeholder, true)
     elseif JS.is_leaf(st)
         return (st, false)
     end
     new_children = JS.SyntaxList(JS.syntax_graph(st))
     changed = false
     for child in JS.children(st)
-        new_child, child_changed = _rewrite_interpolations(child, placeholder_name)
+        new_child, child_changed = _unwrap_interpolations(child)
         changed |= child_changed
         push!(new_children, new_child)
     end
     return (changed ? JS.mknode(st, new_children) : st, changed)
 end
-
-_unwrap_interpolations(st::SyntaxTreeC) = _rewrite_interpolations(st, nothing)
 
 """
 Return a tree where `JS.K"\$"` interpolation nodes are replaced by their content.
@@ -189,13 +180,7 @@ so that parent nodes (e.g. dot expressions like `x.\$name`) remain well-formed.
 """
 function unwrap_interpolations(st::SyntaxTreeC)
     ensure_jl_source_attr!(JS.syntax_graph(st))
-    return _unwrap_interpolations(st)[1]
-end
-
-function prepare_inert_template(st::SyntaxTreeC)
-    ensure_jl_source_attr!(JS.syntax_graph(st))
-    placeholder_name = String(gensym("JETLS_UNQUOTE_PLACEHOLDER"))
-    return _rewrite_interpolations(st, placeholder_name)[1], placeholder_name
+    return first(_unwrap_interpolations(st))
 end
 
 function is_macrocall_st0(st0::SyntaxTreeC, names::AbstractString...; from::Union{Nothing,Module}=nothing)
@@ -212,7 +197,25 @@ end
 
 is_mainfunc0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@main")
 
-is_generated0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@generated")
+function is_base_macrocall0(st0::SyntaxTreeC, name::AbstractString)
+    JS.kind(st0) === JS.K"macrocall" || return false
+    JS.numchildren(st0) >= 1 || return false
+    macro_name = st0[1]
+    JS.kind(macro_name) === JS.K"." || return false
+    JS.numchildren(macro_name) >= 2 || return false
+    get_name_val(macro_name[1]) == "Base" || return false
+    rhs = macro_name[2]
+    if JS.kind(rhs) in JS.KSet"quote inert" && JS.numchildren(rhs) >= 1
+        rhs = rhs[1]
+    end
+    return get_name_val(rhs) == name
+end
+
+is_base_generated0(st0::SyntaxTreeC) = is_base_macrocall0(st0, "@generated")
+is_generated0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@generated") || is_base_generated0(st0)
+
+is_base_ateval0(st0::SyntaxTreeC) = is_base_macrocall0(st0, "@eval")
+is_ateval0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@eval") || is_base_ateval0(st0)
 
 is_nospecialize_or_specialize_macrocall0(st0::SyntaxTreeC) =
     is_macrocall_st0(st0, "@nospecialize", "@specialize")
@@ -220,7 +223,8 @@ is_nospecialize_or_specialize_macrocall0(st0::SyntaxTreeC) =
 is_macro0(st0::SyntaxTreeC) = JS.kind(st0) === JS.K"macro"
 
 is_new_style_macrocall0(st0::SyntaxTreeC) =
-    is_macrocall_st0(st0, NEW_STYLE_MACROCALL_NAMES...)
+    is_macrocall_st0(st0, NEW_STYLE_MACROCALL_NAMES...) ||
+    is_base_generated0(st0) || is_base_ateval0(st0)
 
 is_doc0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@doc"; from=Core)
 is_doc0_any(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@doc") # Explicit `@doc` can have any module set.
@@ -375,59 +379,6 @@ function is_import_eval_call(st3::SyntaxTreeC)
     JS.kind(head) === JS.K"Value" || return false
     val = head.value
     return val === JL.eval_import || val === JL.eval_using
-end
-
-"""
-    foreach_inert_identifier(callback, st::SyntaxTreeC)
-
-Traverse `st` looking for `K"inert"` and `K"syntaxinert"` nodes, and call
-`f(id_node)` for each `K"Identifier"` found inside them. `callback` should
-return `true` to continue traversal or `false` to stop early.
-"""
-function foreach_inert_identifier(@specialize(callback), st::SyntaxTreeC)
-    res = traverse(st) do n::SyntaxTreeC
-        # Skip `import`/`using` desugaring (see `is_import_eval_call`).
-        is_import_eval_call(n) && return traversal_no_recurse
-        k = JS.kind(n)
-        if k === JS.K"inert"
-            inner = traverse(n) do m::SyntaxTreeC
-                JS.kind(m) === JS.K"Identifier" || return
-                callback(m) || return TraversalReturn(false; terminate=true)
-                return
-            end
-            inner === false && return TraversalReturn(false; terminate=true)
-            return traversal_no_recurse
-        elseif k === JS.K"syntaxinert"
-            inner = traverse(n) do m::SyntaxTreeC
-                m === n && return
-                mk = JS.kind(m)
-                mk in JS.KSet"inert syntaxinert syntaxunquote" && return traversal_no_recurse
-                mk === JS.K"Identifier" || return
-                callback(m) || return TraversalReturn(false; terminate=true)
-                return
-            end
-            inner === false && return TraversalReturn(false; terminate=true)
-        end
-        return
-    end
-    return res !== false
-end
-
-function find_inert_identifier(st::SyntaxTreeC, offset::Integer)
-    found = Ref{Union{Nothing,SyntaxTreeC}}(nothing)
-    foreach_inert_identifier(st) do id_node::SyntaxTreeC
-        if offset in JS.byte_range(id_node)
-            found[] = id_node
-            return false
-        end
-        return true
-    end
-    return found[]
-end
-
-function find_inert_identifier_name(st::SyntaxTreeC, offset::Integer)
-    id_node = @something find_inert_identifier(st, offset) return nothing
-    return get_name_val(id_node)
 end
 
 function is_nospecialize_or_specialize_macrocall3(st3::SyntaxTreeC)

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -260,8 +260,6 @@ function _select_target_binding(
     return @something(
         find_target_binding(ctx3, st3, offset),
         find_target_binding(ctx3, st3, offset-1), # Support cases like `var│`, `func│(5)`
-        find_inert_target_binding(ctx3, st3, offset),
-        find_inert_target_binding(ctx3, st3, offset-1),
         return nothing)
 end
 
@@ -305,6 +303,10 @@ function select_target_binding(
         binding = @something _find_internal_global_binding_at_source(ctx3, primary) primary
         return (; ctx3, st3, st0, binding)
     end
+    inert_result = select_inert_target_binding(
+        st0, ctx3, st3, offset, context_module; soft_scope)
+    inert_result !== nothing && return inert_result
+
     inner_constructor = select_struct_inner_constructor_binding(ctx3, st0, offset)
     if inner_constructor === nothing
         inner_constructor = select_struct_inner_constructor_binding(ctx3, st0, offset-1)
@@ -312,12 +314,7 @@ function select_target_binding(
     if inner_constructor !== nothing
         return (; ctx3, st3, st0, binding=inner_constructor)
     end
-    # Fall back to resolving an identifier inside a preserved macrocall's
-    # inert template (e.g. `LSAnalyzer` in `@eval ::LSAnalyzer = ...`).
-    # Inert contents aren't scope-resolved, so no `BindingId` exists for
-    # `find_target_binding` to pick up — we run a fresh resolution on just
-    # the inert subtree.
-    return find_inert_global_target_binding(st0, st3, offset, context_module; soft_scope)
+    return nothing
 end
 
 # The normal method's `meta :generated` payload carries the exact binding of its
@@ -376,85 +373,337 @@ function generated_lambda_argument_bindings(
     return args
 end
 
-function foreach_generated_inert_argument(
-        @specialize(callback), ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC
+struct InertResolution
+    ctx3::JL.VariableAnalysisContext
+    st3::SyntaxTreeC
+    argument_remap::Dict{JL.BindingInfo,SyntaxTreeC}
+    placeholder_name::String
+    source_range::UnitRange{Int}
+end
+
+function synthetic_parameter_remap(
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC,
+        parameters::Dict{String,SyntaxTreeC}
     )
-    method_ids = generated_method_ids(ctx3, st3)
-    isempty(method_ids) && return true
-    result = traverse(st3) do st3′::SyntaxTreeC
-        lambda = @something generated_method_lambda(st3′, method_ids) return nothing
-        args = generated_lambda_argument_bindings(ctx3, lambda)
-        isempty(args) && return traversal_no_recurse
-        completed = foreach_inert_identifier(lambda) do id_node::SyntaxTreeC
-            name = @something get_name_val(id_node) return true
-            binding = get(args, name, nothing)
-            binding === nothing && return true
-            return callback(binding, JL.get_binding(ctx3, binding), id_node)
+    remap = Dict{JL.BindingInfo,SyntaxTreeC}()
+    isempty(parameters) && return remap
+    # Synthetic parameters retain the source ranges of the generated arguments.
+    # Same-named arguments in nested lambdas have their own source ranges.
+    traverse(st3) do node::SyntaxTreeC
+        JS.kind(node) === JS.K"lambda" || return nothing
+        for (name, binding) in generated_lambda_argument_bindings(ctx3, node)
+            source = @something get(parameters, name, nothing) continue
+            JS.byte_range(binding) == JS.byte_range(source) || continue
+            remap[JL.get_binding(ctx3, binding)] = source
         end
-        completed || return TraversalReturn(false; terminate=true)
-        return traversal_no_recurse
+        return nothing
     end
-    return result !== false
+    return remap
 end
 
-function find_generated_inert_argument_binding(
-        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, offset::Int
+function _make_inert_placeholder(st3::SyntaxTreeC, placeholder_name::String)
+    placeholder = JS.newleaf(JS.syntax_graph(st3), st3, JS.K"Identifier")
+    placeholder = JS.setattr!(placeholder, :name_val, placeholder_name)
+    return placeholder
+end
+
+function _mask_inert_interpolations(
+        st3::SyntaxTreeC, placeholder_name::String, preserve_nested_interpolations::Bool,
+        quote_depth::Int = 0, syntax_quote_depth::Int = 0
     )
-    found = Ref{Union{Nothing,SyntaxTreeC}}(nothing)
-    foreach_generated_inert_argument(ctx3, st3) do binding, _, id_node
-        offset in JS.byte_range(id_node) || return true
-        found[] = binding
-        return false
+    kind = JS.kind(st3)
+    if kind === JS.K"$"
+        if preserve_nested_interpolations && quote_depth > 0
+            return (st3, false)
+        end
+        return (_make_inert_placeholder(st3, placeholder_name), true)
+    elseif kind === JS.K"syntaxunquote"
+        if preserve_nested_interpolations && syntax_quote_depth > 0
+            return (st3, false)
+        end
+        return (_make_inert_placeholder(st3, placeholder_name), true)
+    elseif JS.is_leaf(st3)
+        return (st3, false)
     end
-    return found[]
-end
 
-function find_inert_target_binding(
-        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, offset::Int)
-    binding = find_generated_inert_argument_binding(ctx3, st3, offset)
-    binding !== nothing && return binding
-    id_node = @something find_inert_identifier(st3, offset) return nothing
-    name = @something get_name_val(id_node) return nothing
-    generated_range = @something enclosing_generated_range(id_node) return nothing
-    for binfo in ctx3.bindings.info
-        binfo.kind === :argument || continue
-        binfo.name == name || continue
-        enclosing_generated_range(JL.binding_ex(ctx3, binfo.id)) == generated_range || continue
-        return JL.binding_ex(ctx3, binfo.id)
+    child_quote_depth = quote_depth + (kind === JS.K"quote")
+    child_syntax_quote_depth =
+        syntax_quote_depth + (kind in JS.KSet"syntaxquote syntaxinert")
+    new_children = JS.SyntaxList(JS.syntax_graph(st3))
+    changed = false
+    for child in JS.children(st3)
+        new_child, child_changed = _mask_inert_interpolations(
+            child, placeholder_name, preserve_nested_interpolations,
+            child_quote_depth, child_syntax_quote_depth)
+        changed |= child_changed
+        push!(new_children, new_child)
     end
-    return nothing
+    return (changed ? JS.mknode(st3, new_children) : st3, changed)
 end
+mask_inert_interpolations(
+    st3::SyntaxTreeC, placeholder_name::String; preserve_nested_interpolations::Bool = false
+) = first(_mask_inert_interpolations(st3, placeholder_name, preserve_nested_interpolations))
 
-find_inert_global_target_binding(
-    st0::SyntaxTreeC, st3::SyntaxTreeC, offset::Int, context_module::Module;
-    soft_scope::Bool = false
-) = @something(
-    _find_inert_global_target_binding(st0, st3, offset, context_module; soft_scope),
-    # Handle `var│` at end-of-token (same retry as `_select_target_binding`).
-    _find_inert_global_target_binding(st0, st3, offset-1, context_module; soft_scope),
-    return nothing)
-
-function _find_inert_global_target_binding(
-        st0::SyntaxTreeC, st3::SyntaxTreeC, offset::Int, context_module::Module;
-        soft_scope::Bool = false
+# Replace direct interpolation subtrees in a lowered inert template with a
+# synthetic identifier so scope resolution cannot reinterpret interpolation values
+# as free names. With `preserve_nested_interpolations`, regular and syntax
+# interpolations enclosed by their corresponding quote kind are kept for
+# JuliaLowering to resolve in the inert template's execution scope.
+function prepare_inert_template(
+        st3::SyntaxTreeC; preserve_nested_interpolations::Bool = false
     )
-    name = @something find_inert_identifier_name(st3, offset) return nothing
-    inert_tree = @something enclosing_inert_tree(st3, offset) return nothing
-    JS.numchildren(inert_tree) ≥ 1 || return nothing
-    template, _ = prepare_inert_template(inert_tree[1])
+    ensure_jl_source_attr!(JS.syntax_graph(st3))
+    placeholder_name = String(gensym("JETLS_UNQUOTE_PLACEHOLDER"))
+    template = mask_inert_interpolations(
+        st3, placeholder_name; preserve_nested_interpolations)
+    return template, placeholder_name
+end
+
+function resolve_inert_tree(
+        context_module::Module, inert_tree::SyntaxTreeC;
+        parameters::Dict{String,SyntaxTreeC} = Dict{String,SyntaxTreeC}(),
+        hard_scope::Bool = false,
+        soft_scope::Bool = false,
+        preserve_nested_interpolations::Bool = false
+    )
+    JS.numchildren(inert_tree) >= 1 || return nothing
+    template, placeholder_name = prepare_inert_template(
+        inert_tree[1]; preserve_nested_interpolations)
+    input = if hard_scope || !isempty(parameters)
+        graph = JS.syntax_graph(inert_tree)
+        parameter_nodes = JS.SyntaxList(graph)
+        for (name, source) in parameters
+            parameter = JS.newleaf(graph, source, JS.K"Identifier")
+            parameter = JS.setattr!(parameter, :name_val, name)
+            push!(parameter_nodes, parameter)
+        end
+        parameter_list = JL.@ast(graph, inert_tree, [JS.K"tuple" parameter_nodes...])
+        JL.@ast(graph, inert_tree, [JS.K"function" parameter_list template])
+    else
+        template
+    end
     ires = try
-        jl_lower_for_scope_resolution(context_module, template; soft_scope)
+        jl_lower_for_scope_resolution(context_module, input; soft_scope)
     catch
         return nothing
     end
-    for binfo in ires.ctx3.bindings.info
-        binfo.kind === :global || continue
-        binfo.is_internal && continue
-        binfo.name == name || continue
-        binding = JL.binding_ex(ires.ctx3, binfo.id)
-        return (; ctx3 = ires.ctx3, st3 = ires.st3, st0, binding)
+    argument_remap = synthetic_parameter_remap(ires.ctx3, ires.st3, parameters)
+    source_range = JS.byte_range(inert_tree)
+    return InertResolution(
+        ires.ctx3, ires.st3, argument_remap, placeholder_name, source_range)
+end
+
+function contains_syntaxunquote(st::SyntaxTreeC)
+    stack = JS.SyntaxList(st)
+    while !isempty(stack)
+        node = pop!(stack)
+        JS.kind(node) === JS.K"syntaxunquote" && return true
+        for child in JS.children(node)
+            push!(stack, child)
+        end
+    end
+    return false
+end
+
+function collect_generated_inert_resolutions(
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC
+    )
+    resolutions = InertResolution[]
+    seen = Set{Tuple{JS.Kind,UnitRange{Int}}}()
+    method_ids = generated_method_ids(ctx3, st3)
+    isempty(method_ids) && return resolutions
+    traverse(st3) do st3′::SyntaxTreeC
+        lambda = @something generated_method_lambda(st3′, method_ids) return nothing
+        args = generated_lambda_argument_bindings(ctx3, lambda)
+        method_binfo = JL.get_binding(ctx3, st3′[1])
+        context_module = method_binfo.mod
+        context_module isa Module || return traversal_no_recurse
+        traverse(lambda) do node::SyntaxTreeC
+            is_import_eval_call(node) && return traversal_no_recurse
+            JS.kind(node) in JS.KSet"inert syntaxinert" || return nothing
+            if JS.kind(node) === JS.K"syntaxinert" && contains_syntaxunquote(node)
+                return nothing
+            end
+            key = (JS.kind(node), JS.byte_range(node))
+            key in seen && return traversal_no_recurse
+            push!(seen, key)
+            resolution = resolve_inert_tree(context_module, node;
+                parameters=args, hard_scope=true,
+                preserve_nested_interpolations=true)
+            resolution === nothing || push!(resolutions, resolution)
+            return traversal_no_recurse
+        end
+        return traversal_no_recurse
+    end
+    return resolutions
+end
+
+function is_esc_call(st0::SyntaxTreeC)
+    JS.kind(st0) === JS.K"call" || return false
+    JS.numchildren(st0) >= 1 || return false
+    callee = st0[1]
+    get_name_val(callee) == "esc" && return true
+    JS.kind(callee) === JS.K"." || return false
+    JS.numchildren(callee) >= 2 || return false
+    get_name_val(callee[1]) == "Base" || return false
+    rhs = callee[2]
+    if JS.kind(rhs) in JS.KSet"quote inert" && JS.numchildren(rhs) >= 1
+        rhs = rhs[1]
+    end
+    return get_name_val(rhs) == "esc"
+end
+
+function is_esc_enclosed_range(st0::SyntaxTreeC, range::UnitRange{Int})
+    for ancestor in byte_ancestors(st0, range)
+        JS.byte_range(ancestor) == range && continue
+        is_esc_call(ancestor) && return true
+    end
+    return false
+end
+
+function is_quoted_range(st0::SyntaxTreeC, range::UnitRange{Int})
+    return any(a -> JS.kind(a) in JS.KSet"quote inert", byte_ancestors(st0, range))
+end
+
+function is_code_shaped_quote_range(st0::SyntaxTreeC, range::UnitRange{Int})
+    for ancestor in byte_ancestors(st0, range)
+        JS.kind(ancestor) in JS.KSet"quote inert" || continue
+        JS.numchildren(ancestor) == 1 || return true
+        return JS.kind(ancestor[1]) !== JS.K"Identifier"
+    end
+    return false
+end
+
+is_generated_inert_range(st0::SyntaxTreeC, range::UnitRange{Int}) =
+    any(is_generated0, byte_ancestors(st0, range))
+
+function eval_input_info(st0::SyntaxTreeC, range::UnitRange{Int})
+    for ancestor in byte_ancestors(st0, range)
+        is_ateval0(ancestor) || continue
+        nchildren = JS.numchildren(ancestor)
+        for i = 3:nchildren
+            range ⊆ JS.byte_range(ancestor[i]) || continue
+            nargs = nchildren - 2
+            is_direct = nargs == 1 && range == JS.byte_range(ancestor[i])
+            return (; nargs, is_direct)
+        end
     end
     return nothing
+end
+
+"""
+    inert_resolution_policy(st0::SyntaxTreeC, range::UnitRange{Int}) -> Symbol
+
+Choose how to resolve bindings in an inert source range. This deliberately uses
+construction-site resolution for free globals in code-shaped quotes: it is a
+pragmatic approximation that supports helper-based AST generation without
+interprocedural output-flow analysis.
+
+The policy is:
+- Bare identifiers inside code-shaped quotes do not capture outer locals.
+- Interpolation refers to outer lexical bindings.
+- Atomic quoted identifiers are not construction-site candidates because they
+  may be `Symbol` data.
+- Macro quotes use macro-definition scope unless syntactically enclosed by a
+  bare `esc(...)` or qualified `Base.esc(...)` call.
+- Free names in such directly escaped output are unresolved.
+- Unquoted one-argument `@eval` input uses its construction module.
+- Two-argument `@eval` input is unresolved.
+
+Escape detection is intentionally syntactic. Following a quoted value into a
+later `esc` call would require output-flow analysis, and module aliases such as
+`B.esc(...)` are not currently recognized.
+
+References and rename share this policy so they agree on binding identity and
+occurrences. Generated-function inert code is handled separately with its
+synthetic function scope and argument remapping.
+"""
+function inert_resolution_policy(st0::SyntaxTreeC, range::UnitRange{Int})
+    eval_input = eval_input_info(st0, range)
+    if eval_input !== nothing
+        eval_input.nargs == 1 || return :unresolved
+        if eval_input.is_direct && !is_quoted_range(st0, range)
+            return :construction
+        end
+    end
+    if is_code_shaped_quote_range(st0, range)
+        if any(is_macro0, byte_ancestors(st0, range)) && eval_input === nothing
+            is_esc_enclosed_range(st0, range) && return :unresolved
+            return :macro
+        end
+        return :construction
+    end
+    return :unresolved
+end
+
+function quote_stage_depth(st0::SyntaxTreeC, range::UnitRange{Int})
+    depth = 0
+    for ancestor in byte_ancestors(st0, range)
+        kind = JS.kind(ancestor)
+        if kind === JS.K"quote"
+            depth += 1
+        elseif kind === JS.K"$"
+            depth -= 1
+        end
+    end
+    return depth
+end
+
+# `@eval` contributes an implicit quote stage. Interpolation removes a stage, so
+# a macrocall at depth zero executes in the surrounding lexical context.
+function should_resolve_macrocall(st0::SyntaxTreeC, range::UnitRange{Int})
+    eval_input = eval_input_info(st0, range)
+    depth = quote_stage_depth(st0, range) + (eval_input === nothing ? 0 : 1)
+    depth <= 0 && return true
+    if eval_input !== nothing
+        return eval_input.nargs == 1 && depth == 1
+    end
+    return inert_resolution_policy(st0, range) !== :unresolved
+end
+
+function resolved_binding_at(resolution::InertResolution, offset::Int)
+    return @something(
+        find_target_binding(resolution.ctx3, resolution.st3, offset),
+        find_target_binding(resolution.ctx3, resolution.st3, offset-1),
+        return nothing)
+end
+
+function select_inert_target_binding(
+        st0::SyntaxTreeC, ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC,
+        offset::Int, context_module::Module;
+        soft_scope::Bool = false
+    )
+    inside_generated = false
+    for resolution in collect_generated_inert_resolutions(ctx3, st3)
+        (offset in resolution.source_range ||
+            (offset > 0 && offset-1 in resolution.source_range)) || continue
+        inside_generated = true
+        binding = @something resolved_binding_at(resolution, offset) continue
+        binfo = JL.get_binding(resolution.ctx3, binding)
+        source = get(resolution.argument_remap, binfo, nothing)
+        if source !== nothing
+            return (; ctx3, st3, st0, binding=source)
+        elseif !binfo.is_internal && binfo.name != resolution.placeholder_name
+            return (; ctx3=resolution.ctx3, st3=resolution.st3, st0, binding)
+        end
+    end
+    inside_generated && return nothing
+
+    inert_tree = @something(
+        enclosing_inert_tree(st3, offset),
+        offset > 0 ? enclosing_inert_tree(st3, offset-1) : nothing,
+        return nothing)
+    range = JS.byte_range(inert_tree)
+    policy = inert_resolution_policy(st0, range)
+    resolution = @something resolve_inert_tree(
+        context_module, inert_tree;
+        hard_scope=policy === :macro, soft_scope) return nothing
+    binding = @something resolved_binding_at(resolution, offset) return nothing
+    binfo = JL.get_binding(resolution.ctx3, binding)
+    binfo.is_internal && return nothing
+    binfo.name == resolution.placeholder_name && return nothing
+    binfo.kind === :global && policy === :unresolved && return nothing
+    return (; ctx3=resolution.ctx3, st3=resolution.st3, st0, binding)
 end
 
 # Find the innermost `K"inert"` or `K"syntaxinert"` node in `st3` whose byte
@@ -522,7 +771,9 @@ function select_macrocall_binding(
         bas = byte_ancestors(is_macrocall_name(offset), st0, offset)
     end
     isempty(bas) && return nothing
-    macrocall_name = bas[1][1]
+    macrocall = bas[1]
+    should_resolve_macrocall(st0, JS.byte_range(macrocall)) || return nothing
+    macrocall_name = macrocall[1]
     (; ctx3, st3) = try
         jl_lower_for_scope_resolution(context_module, macrocall_name; soft_scope)
     catch err

--- a/src/utils/jl-syntax-macros.jl
+++ b/src/utils/jl-syntax-macros.jl
@@ -140,7 +140,12 @@ push_inactive_code!(node::SyntaxTreeC, condval::Bool) =
 # expansion. Unlike old-style macros — whose expansion collapses source positions to
 # line granularity and is why `_remove_macrocalls` exists — these don't need to be
 # rewritten to a `block` to keep accurate locations for scope resolution.
-# This is used by `remove_macrocalls` in ast.jl
+#
+# TODO: Define these as `(module, name)` pairs and have `remove_macrocalls` accept the
+# caller's `context_module` so it can resolve each source macrocall to its macro object.
+# Source-name matching cannot recognize qualified calls or aliases, and can mistake an
+# unrelated same-named macro for one of these implementations. `Base.@generated` and
+# `Base.@eval` are special-cased in `ast.jl` until this resolution is available.
 const NEW_STYLE_MACROCALL_NAMES = (
     # JuliaLowering/src/syntax_macros.jl
     "@__FUNCTION__",

--- a/test/analysis/test_occurrence_analysis.jl
+++ b/test/analysis/test_occurrence_analysis.jl
@@ -428,6 +428,30 @@ end
         end
 
         with_binding_occurrences("""
+            Base.@generated function foo(x)
+                return :(x + 1)
+            end
+            """) do binding_occurrences
+            @test any(binding_occurrences) do (binding, occurrences)
+                binding.name == "x" && binding.kind === :argument &&
+                any(o -> o.kind === :use, occurrences)
+            end
+        end
+
+        # Interpolation in a nested quote executes in the generated output scope.
+        with_binding_occurrences("""
+            @generated function foo(x)
+                return :( :(\$x) )
+            end
+            """) do binding_occurrences
+            entries = collect(binding_occurrences)
+            i = @something findfirst(
+                ((b, _),) -> b.name == "x" && b.kind === :argument, entries)
+            _, occurrences = entries[i]
+            @test count(o -> o.kind === :use, occurrences) == 1
+        end
+
+        with_binding_occurrences("""
             @generated function foo(x, unused)
                 return :(x + 1)
             end
@@ -442,8 +466,7 @@ end
             end
         end
 
-        # Quote-local bindings should shadow generated-function arguments. Inert argument
-        # matching is currently name-based and links both local `x`s to the outer argument.
+        # Quote-local bindings shadow generated-function arguments.
         with_binding_occurrences("""
             @generated function foo(x)
                 return :(let x = 1
@@ -455,7 +478,51 @@ end
             i = @something findfirst(
                 ((b, _),) -> b.name == "x" && b.kind === :argument, entries)
             _, occurrences = entries[i]
-            @test_broken !any(o -> o.kind === :use, occurrences)
+            @test !any(o -> o.kind === :use, occurrences)
+        end
+
+        # Nested argument scopes must not be remapped to a same-named generated argument.
+        for code in (
+                """
+                @generated function foo(x)
+                    return :(function inner(x)
+                        x
+                    end)
+                end
+                """,
+                """
+                @generated function foo(x)
+                    return :(map(1:2) do x
+                        x
+                    end)
+                end
+                """,
+                """
+                @generated function foo(x)
+                    return :([x + 1 for x in 1:2])
+                end
+                """)
+            with_binding_occurrences(code) do binding_occurrences
+                entries = collect(binding_occurrences)
+                i = @something findfirst(
+                    ((b, _),) -> b.name == "x" && b.kind === :argument, entries)
+                _, occurrences = entries[i]
+                @test !any(o -> o.kind === :use, occurrences)
+            end
+        end
+
+        # The initializer RHS is evaluated before the new `let` binding exists.
+        with_binding_occurrences("""
+            @generated function foo(x)
+                return :(let x = x
+                    x
+                end)
+            end
+            """) do binding_occurrences
+            entries = collect(binding_occurrences)
+            i = @something findfirst(((b, _),) -> b.name == "x" && b.kind === :argument, entries)
+            _, occurrences = entries[i]
+            @test count(o -> o.kind === :use, occurrences) == 1
         end
 
         # aviatesk/JETLS.jl#722: a `@generated` function nested inside a
@@ -731,25 +798,217 @@ end
         end
     end
 
-    @testset "known inert occurrence limitations" begin
-        # A plain identifier inside a quote is generated-code syntax, not a use of
-        # the enclosing function argument. The statement-wide argument-name filter
-        # currently drops the generated code's global `x` occurrence.
+    @testset "inert occurrence policies" begin
+        # Code-shaped ordinary quotes use construction-site globals, not same-named
+        # outer locals.
         let boccs = get_full_binding_occurrences("""
                 function f(x)
                     return :(G(x))
                 end
                 """)
-            @test_broken any(boccs) do (binfo, occs)
+            @test all(("G", "x")) do name
+                any(boccs) do (binfo, occs)
+                    binfo.name == name && binfo.kind === :global && any(o -> o.kind === :use, occs)
+                end
+            end
+            @test !any(boccs) do (binfo, occs)
+                binfo.name == "x" && binfo.kind === :argument && any(o -> o.kind === :use, occs)
+            end
+        end
+
+        # A quote used as a complete top-level statement follows the same policy.
+        let boccs = get_full_binding_occurrences(":(G(x))")
+            @test all(("G", "x")) do name
+                any(boccs) do (binfo, occs)
+                    binfo.name == name && binfo.kind === :global && any(o -> o.kind === :use, occs)
+                end
+            end
+        end
+
+        # Atomic quoted identifiers are Symbol data without a syntax-use context.
+        let boccs = get_full_binding_occurrences("""
+                import Base: sin
+                names = (:sin, :cos)
+                """)
+            @test !any(boccs) do (binfo, occs)
+                binfo.name == "sin" && binfo.kind === :global && any(o -> o.kind === :use, occs)
+            end
+        end
+
+        # Quoted atomic input remains Symbol data when passed directly to `@eval`.
+        for eval_macro in ("@eval", "Base.@eval")
+            boccs = get_full_binding_occurrences("$eval_macro :sin")
+            @test !any(boccs) do (binfo, occs)
+                binfo.name == "sin" && binfo.kind === :global && any(o -> o.kind === :use, occs)
+            end
+        end
+
+        # Unquoted one-argument `@eval` input resolves in the construction module.
+        for eval_macro in ("@eval", "Base.@eval")
+            boccs = get_full_binding_occurrences("$eval_macro sin")
+            @test any(boccs) do (binfo, occs)
+                binfo.name == "sin" && binfo.kind === :global && any(o -> o.kind === :use, occs)
+            end
+        end
+
+        # Interpolation is an outer local use. Re-lowering the inert template must
+        # not manufacture a same-named global occurrence.
+        let boccs = get_full_binding_occurrences("""
+                function f()
+                    let x = 1
+                        return :(G(\$x))
+                    end
+                end
+                """)
+            @test any(boccs) do (binfo, occs)
+                binfo.name == "x" && binfo.kind === :local && any(o -> o.kind === :use, occs)
+            end
+            @test !any(boccs) do (binfo, occs)
                 binfo.name == "x" && binfo.kind === :global && any(o -> o.kind === :use, occs)
+            end
+        end
+
+        # One-argument `@eval` resolves inert globals in the construction module.
+        for eval_macro in ("@eval", "Base.@eval")
+            boccs = get_full_binding_occurrences("""
+                $eval_macro some_func(::EvalTarget) = nothing
+                """)
+            @test any(boccs) do (binfo, occs)
+                binfo.name == "EvalTarget" && binfo.kind === :global &&
+                    any(o -> o.kind === :use, occs)
+            end
+        end
+
+        # Two-argument `@eval` is unsupported even for a static-looking target.
+        for eval_macro in ("@eval", "Base.@eval")
+            boccs = get_full_binding_occurrences("""
+                $eval_macro SomeModule some_func(::EvalTarget) = nothing
+                """)
+            @test !any(boccs) do (binfo, occs)
+                binfo.name == "EvalTarget" && binfo.kind === :global &&
+                    any(o -> o.kind === :use, occs)
+            end
+        end
+
+        # A dynamic explicit module expression is likewise unsupported.
+        let boccs = get_full_binding_occurrences("""
+                @eval getcontext() some_func(::EvalTarget) = nothing
+                """)
+            @test !any(boccs) do (binfo, occs)
+                binfo.name == "EvalTarget" && binfo.kind === :global &&
+                    any(o -> o.kind === :use, occs)
+            end
+        end
+
+        # Generated method-body assignments introduce locals, not module globals.
+        let boccs = get_full_binding_occurrences("""
+                @generated function f(x)
+                    return quote
+                        y = x
+                        y
+                    end
+                end
+                """)
+            @test !any(boccs) do (binfo, occs)
+                binfo.name == "y" && binfo.kind === :global && any(o -> o.kind === :use, occs)
+            end
+        end
+
+        # Unescaped macro-output globals are hygienically resolved in the macro's
+        # definition module.
+        let boccs = get_full_binding_occurrences("""
+                macro m(ex)
+                    return :(helper(\$ex))
+                end
+                """)
+            @test any(boccs) do (binfo, occs)
+                binfo.name == "helper" && binfo.kind === :global && any(o -> o.kind === :use, occs)
+            end
+        end
+
+        # Macro hygiene renames names assigned in unescaped macro output, so the
+        # assignment must not be indexed as a use of a module-global `x`.
+        let boccs = get_full_binding_occurrences("""
+                macro m()
+                    quote
+                        x = 1
+                        helper()
+                    end
+                end
+                """)
+            @test any(boccs) do (binfo, occs)
+                binfo.name == "helper" && binfo.kind === :global && any(o -> o.kind === :use, occs)
+            end
+            @test !any(boccs) do (binfo, occs)
+                binfo.name == "x" && binfo.kind === :global && !isempty(occs)
+            end
+        end
+
+        # Escaped output is caller-owned and must not be indexed under the macro's
+        # definition module.
+        let boccs = get_full_binding_occurrences("""
+                macro m()
+                    return esc(:(helper(x)))
+                end
+                """)
+            @test !any(boccs) do (binfo, occs)
+                binfo.name in ("helper", "x") && binfo.kind === :global && any(o -> o.kind === :use, occs)
+            end
+        end
+
+        # The macro policy is determined by ancestry, so it also applies to macro
+        # definitions nested inside enclosing statements such as version-conditional `if` blocks.
+        let boccs = get_full_binding_occurrences("""
+                if VERSION >= v"1.11"
+                    macro m()
+                        return esc(:(helper(x)))
+                    end
+                end
+                """)
+            @test !any(boccs) do (binfo, occs)
+                binfo.name in ("helper", "x") && binfo.kind === :global && any(o -> o.kind === :use, occs)
+            end
+        end
+        let boccs = get_full_binding_occurrences("""
+                if VERSION >= v"1.11"
+                    macro m()
+                        quote
+                            x = 1
+                            helper()
+                        end
+                    end
+                end
+                """)
+            @test any(boccs) do (binfo, occs)
+                binfo.name == "helper" && binfo.kind === :global && any(o -> o.kind === :use, occs)
+            end
+            # Hygiene applies here as well: the assigned `x` must not leak
+            # as a module global.
+            @test !any(boccs) do (binfo, occs)
+                binfo.name == "x" && binfo.kind === :global && !isempty(occs)
+            end
+        end
+
+        # Unescaped code-shaped quotes in macro bodies use definition-module globals
+        # without requiring return-flow analysis.
+        let boccs = get_full_binding_occurrences("""
+                macro m()
+                    temporary = :(helper(x))
+                    return temporary
+                end
+                """)
+            @test all(("helper", "x")) do name
+                any(boccs) do (binfo, occs)
+                    binfo.name == name && binfo.kind === :global && any(o -> o.kind === :use, occs)
+                end
             end
         end
     end
 
-    # Inert (quoted) content inside `@generated` functions is processed via
-    # `_unwrap_interpolations`, which must preserve `name_val` on ancestors of
-    # interpolations (e.g. `K"unknown_head"` from compound assignments like `+=`)
-    # so that lowering succeeds and global bindings inside the quote are recorded.
+    # `prepare_inert_template` masks interpolations before re-lowering generated
+    # quoted code. Rebuilding ancestor nodes must preserve `name_val` metadata
+    # (e.g. `K"unknown_head"` for compound assignments such as `+=`), or lowering
+    # fails before globals in the quote can be recorded.
     @testset "inert content with compound assignment + interpolation" begin
         let boccs = get_full_binding_occurrences("""
                 @generated function f(x)
@@ -763,7 +1022,7 @@ end
                 """)
             @test boccs !== nothing
             # `sleep` is referenced only inside the inert block, so finding it
-            # requires `_unwrap_interpolations` to succeed through the `+=` node.
+            # requires interpolation masking to preserve the surrounding `+=` node.
             i = @something findfirst(((b, _),) -> b.name == "sleep", collect(boccs))
             binfo, occs = collect(boccs)[i]
             @test binfo.kind === :global

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -105,6 +105,47 @@ end
         @test diagnostic.range.var"end".line == 0
     end
 
+    @testset "generated quote-local shadowing" begin
+        for src in (
+                """
+                @generated function foo(x)
+                    return :(let x = 1
+                        x
+                    end)
+                end
+                """,
+                """
+                Base.@generated function foo(x)
+                    return :(let x = 1
+                        x
+                    end)
+                end
+                """,
+                """
+                @generated function foo(x)
+                    return :(function inner(x)
+                        x
+                    end)
+                end
+                """,
+                """
+                @generated function foo(x)
+                    return :(map(1:2) do x
+                        x
+                    end)
+                end
+                """,
+                """
+                @generated function foo(x)
+                    return :([x + 1 for x in 1:2])
+                end
+                """)
+            diagnostics = get_lowering_diagnostics(src; code = JETLS.LOWERING_UNUSED_ARGUMENT_CODE)
+            @test length(diagnostics) == 1
+            @test only(diagnostics).message == "Unused argument `x`"
+        end
+    end
+
     let diagnostics = get_lowering_diagnostics("""
         function foo(x)
             local y
@@ -933,6 +974,15 @@ end
             """)
             @test length(diagnostics) == 1
             @test only(diagnostics).message == "Unused argument `unused`"
+        end
+
+        # Nested interpolation uses the argument in the generated output scope.
+        let diagnostics = get_lowering_diagnostics("""
+            @generated function foo(x)
+                return :( :(\$x) )
+            end
+            """; code = JETLS.LOWERING_UNUSED_ARGUMENT_CODE)
+            @test isempty(diagnostics)
         end
     end
 
@@ -2103,13 +2153,34 @@ end
         @test isempty(diagnostics)
     end
 
-    # Imports used in quoted expressions inside helper functions for macros
+    # A code-shaped helper quote uses construction-site globals without requiring
+    # interprocedural proof that the expression reaches macro output.
     let diagnostics = get_unused_import_diagnostics("""
         using Base.Iterators: flatten
         genfunc(xs) = :(flatten(\$(esc(xs))))
         macro myflatten(xs) genfunc(xs) end
         """)
         @test isempty(diagnostics)
+    end
+
+    # Atomic quoted identifiers remain Symbol data without a syntax-use context.
+    let diagnostics = get_unused_import_diagnostics("""
+        import Base: sin
+        names = (:sin, :cos)
+        """)
+        @test length(diagnostics) == 1
+    end
+
+    # Following Symbol values into an interpolated `@eval` name requires constant
+    # propagation and syntax-provenance analysis.
+    let diagnostics = get_unused_import_diagnostics("""
+        import Base: sin
+        struct MyType end
+        for name in (:sin, :cos)
+            @eval \$name(x::MyType) = nothing
+        end
+        """)
+        @test_broken isempty(diagnostics)
     end
 
     # Imports used in @generated function with interpolation in dot expression

--- a/test/test_references.jl
+++ b/test/test_references.jl
@@ -172,6 +172,87 @@ end
         end
     end
 
+    @testset "ordinary inert references" begin
+        # Code-shaped ordinary quotes resolve free names in the construction module.
+        let code = """
+            global │x│ = nothing
+            f() = :(use(│x│))
+            g() = :(│x│ = 1)
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 6
+            for pos in positions
+                @test length(find_references(clean_code, pos)) == 3
+            end
+        end
+
+        # An atomic quoted identifier is Symbol data, not a reference target.
+        let code = "names = (:│sin│, :cos)"
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 2
+            for pos in positions
+                @test isempty(find_references(clean_code, pos))
+            end
+        end
+
+        # A bare quoted name does not capture a same-named function argument.
+        let code = """
+            global │x│ = nothing
+            function f(│x│)
+                return :(G(│x│))
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 6
+            expected = (2, 2, 1, 1, 2, 2)
+            @test all(zip(positions, expected)) do (pos, nrefs)
+                length(find_references(clean_code, pos)) == nrefs
+            end
+        end
+
+        let code = """
+            global │x│ = nothing
+            function f(│x│)
+                return :(G(\$│x│))
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 6
+            for pos in positions[1:2]
+                @test length(find_references(clean_code, pos)) == 1
+            end
+            for pos in positions[3:6]
+                @test length(find_references(clean_code, pos)) == 2
+            end
+        end
+
+        let code = """
+            f() = :(let │x│ = 1
+                │x│
+            end)
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 4
+            for pos in positions
+                @test length(find_references(clean_code, pos)) == 2
+            end
+        end
+
+        let code = """
+            function f()
+                let │x│ = 1
+                    return :(G(\$│x│))
+                end
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 4
+            for pos in positions
+                @test length(find_references(clean_code, pos)) == 2
+            end
+        end
+    end
+
     @testset "@generated function references" begin
         let code = """
             @generated function foo(│xx│x│)
@@ -186,8 +267,19 @@ end
             end
         end
 
-        # Quote-local bindings should shadow generated-function arguments. The current
-        # name-based inert lookup links all three `x` occurrences.
+        let code = """
+            Base.@generated function foo(│x│)
+                return :(│x│)
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 4
+            for pos in positions
+                @test length(find_references(clean_code, pos)) == 2
+            end
+        end
+
+        # Quote-local bindings shadow generated-function arguments.
         let code = """
             @generated function foo(│x│)
                 return :(let │x│ = 1
@@ -197,8 +289,186 @@ end
             """
             clean_code, positions = JETLS.get_text_and_positions(code)
             @test length(positions) == 6
-            @test_broken length(find_references(clean_code, positions[1])) == 1
-            @test_broken length(find_references(clean_code, positions[3])) == 2
+            @test length(find_references(clean_code, positions[1])) == 1
+            @test length(find_references(clean_code, positions[3])) == 2
+        end
+
+        # The `let` initializer sees the generated argument, while the new
+        # binding shadows it in the body.
+        let code = """
+            @generated function foo(│x│)
+                return :(let │x│ = │x│
+                    │x│
+                end)
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 8
+            argument_ranges = Set((
+                Range(; start=positions[1], var"end"=positions[2]),
+                Range(; start=positions[5], var"end"=positions[6])))
+            local_ranges = Set((
+                Range(; start=positions[3], var"end"=positions[4]),
+                Range(; start=positions[7], var"end"=positions[8])))
+            for pos in positions[[1, 2, 5, 6]]
+                refs = find_references(clean_code, pos)
+                @test Set(r.range for r in refs) == argument_ranges
+            end
+            for pos in positions[[3, 4, 7, 8]]
+                refs = find_references(clean_code, pos)
+                @test Set(r.range for r in refs) == local_ranges
+            end
+        end
+
+        # Assignments in the generated method body introduce function locals.
+        let code = """
+            @generated function foo(x)
+                return quote
+                    │y│ = x
+                    │y│
+                end
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 4
+            for pos in positions
+                @test length(find_references(clean_code, pos)) == 2
+            end
+        end
+
+        # Nested generated-body scopes also shadow the generated argument.
+        for code in (
+                """
+                @generated function foo(│x│)
+                    return :(function inner(│x│)
+                        │x│
+                    end)
+                end
+                """,
+                """
+                @generated function foo(│x│)
+                    return :(map(1:2) do │x│
+                        │x│
+                    end)
+                end
+                """,
+                """
+                @generated function foo(│x│)
+                    return :(for │x│ = 1:2
+                        println(│x│)
+                    end)
+                end
+                """,
+                """
+                @generated function foo(│x│)
+                    return :([│x│ + 1 for │x│ in 1:2])
+                end
+                """)
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 6
+            outer_range = Range(; start=positions[1], var"end"=positions[2])
+            local_ranges = Set((
+                Range(; start=positions[3], var"end"=positions[4]),
+                Range(; start=positions[5], var"end"=positions[6])))
+            for pos in positions[1:2]
+                refs = find_references(clean_code, pos)
+                @test Set(r.range for r in refs) == Set((outer_range,))
+            end
+            for pos in positions[3:6]
+                refs = find_references(clean_code, pos)
+                @test Set(r.range for r in refs) == local_ranges
+            end
+        end
+
+        # A quote-local static-parameter name shadows the outer static parameter.
+        let code = """
+            @generated function foo(x::│T│) where {│T│}
+                return :(let │T│ = 1
+                    │T│
+                end)
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 8
+            outer_ranges = Set((
+                Range(; start=positions[1], var"end"=positions[2]),
+                Range(; start=positions[3], var"end"=positions[4])))
+            local_ranges = Set((
+                Range(; start=positions[5], var"end"=positions[6]),
+                Range(; start=positions[7], var"end"=positions[8])))
+            for pos in positions[1:4]
+                refs = find_references(clean_code, pos)
+                @test Set(r.range for r in refs) == outer_ranges
+            end
+            for pos in positions[5:8]
+                refs = find_references(clean_code, pos)
+                @test Set(r.range for r in refs) == local_ranges
+            end
+        end
+
+        # The generated argument scope must not leak into a nested quote stage.
+        let code = """
+            @generated function foo(│x│)
+                return :(begin
+                    │x│
+                    :(│x│)
+                end)
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 6
+            outer_ranges = Set((
+                Range(; start=positions[1], var"end"=positions[2]),
+                Range(; start=positions[3], var"end"=positions[4])))
+            for pos in positions[1:4]
+                refs = find_references(clean_code, pos)
+                @test Set(r.range for r in refs) == outer_ranges
+            end
+            for pos in positions[5:6]
+                @test isempty(find_references(clean_code, pos))
+            end
+        end
+
+        # Interpolation removes the nested quote stage and refers to the generated
+        # argument in the surrounding output scope.
+        let code = """
+            @generated function foo(│x│)
+                return :( :(\$│x│) )
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 4
+            expected_ranges = Set((
+                Range(; start=positions[1], var"end"=positions[2]),
+                Range(; start=positions[3], var"end"=positions[4])))
+            for pos in positions
+                refs = find_references(clean_code, pos)
+                @test Set(r.range for r in refs) == expected_ranges
+            end
+        end
+
+        # Nested interpolation respects locals introduced in the generated output.
+        let code = """
+            @generated function foo(│x│)
+                return :(let │x│ = 1
+                    :(\$│x│)
+                end)
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 6
+            outer_range = Range(; start=positions[1], var"end"=positions[2])
+            local_ranges = Set((
+                Range(; start=positions[3], var"end"=positions[4]),
+                Range(; start=positions[5], var"end"=positions[6])))
+            for pos in positions[1:2]
+                refs = find_references(clean_code, pos)
+                @test Set(r.range for r in refs) == Set((outer_range,))
+            end
+            for pos in positions[3:6]
+                refs = find_references(clean_code, pos)
+                @test Set(r.range for r in refs) == local_ranges
+            end
         end
 
         # Static parameter merging
@@ -257,6 +527,28 @@ end
             @test length(refs_glob) == 1
             @test Set(r.range for r in refs_arg) == Set(r.range for r in refs_inert)
         end
+
+    end
+
+    # A future confidence model should exclude a generated temporary used only
+    # as compile-time AST data from both references and rename. Unused-import
+    # analysis may consume separate possible-use information.
+    @testset "speculative generated quote references" begin
+        let code = """
+            │helper│() = nothing
+            @generated function f(x)
+                pattern = :(│helper│())
+                inspect(pattern)
+                return :(nothing)
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 4
+            expected = (1, 1, 0, 0)
+            for (pos, nrefs) in zip(positions, expected)
+                @test_broken length(find_references(clean_code, pos)) == nrefs
+            end
+        end
     end
 
     @testset "macro references" begin
@@ -304,6 +596,130 @@ end
             for pos in positions
                 refs = find_references(clean_code, pos; include_declaration=false)
                 @test length(refs) == 1
+            end
+        end
+
+        # Unescaped macro-output globals resolve in the definition module, while
+        # interpolated macro arguments remain argument uses.
+        let code = """
+            │helper│(x) = x
+            macro m(│ex│)
+                return :(│helper│(\$│ex│))
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 8
+            for pos in positions[[1, 2, 5, 6]]
+                @test length(find_references(clean_code, pos)) == 2
+            end
+            for pos in positions[[3, 4, 7, 8]]
+                @test length(find_references(clean_code, pos)) == 2
+            end
+        end
+
+        # Hygienic locals in macro output have their own quote-local binding.
+        let code = """
+            macro m(ex)
+                return quote
+                    local │y│ = \$ex
+                    │y│
+                end
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 4
+            for pos in positions
+                @test length(find_references(clean_code, pos)) == 2
+            end
+        end
+
+        # Escaped output is caller-owned, not linked to definition-module globals.
+        for escape in ("esc", "Base.esc")
+            code = """
+                │helper│(x) = x
+                macro escaped()
+                    return $escape(:(│helper│(│x│)))
+                end
+                """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 6
+            for pos in positions[1:2]
+                @test length(find_references(clean_code, pos)) == 1
+            end
+            for pos in positions[3:6]
+                @test isempty(find_references(clean_code, pos))
+            end
+        end
+
+        # The macro policy also applies to macro definitions nested inside
+        # enclosing statements such as version-conditional `if` blocks.
+        let code = """
+            │helper│(x) = x
+            if VERSION >= v"1.11"
+                macro escaped()
+                    return esc(:(│helper│(│x│)))
+                end
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 6
+            for pos in positions[1:2]
+                @test length(find_references(clean_code, pos)) == 1
+            end
+            for pos in positions[3:6]
+                @test isempty(find_references(clean_code, pos))
+            end
+        end
+
+        # Escaped macro output does not expose nested macrocall bindings.
+        for escape in ("esc", "Base.esc")
+            code = """
+                macro │helper│()
+                    nothing
+                end
+                macro escaped()
+                    return $escape(:(│@helper│))
+                end
+                """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 4
+            for pos in positions[1:2]
+                @test length(find_references(clean_code, pos)) == 1
+            end
+            for pos in positions[3:4]
+                @test isempty(find_references(clean_code, pos))
+            end
+        end
+
+        # Interpolation inside escaped output still executes in definition scope.
+        let code = """
+            macro │helper│()
+                :(nothing)
+            end
+            macro escaped()
+                return esc(:(\$(│@helper│)))
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 4
+            for pos in positions
+                @test length(find_references(clean_code, pos)) == 2
+            end
+        end
+
+        # Macro-body code-shaped quotes use definition-module globals.
+        let code = """
+            │helper│(x) = x
+            macro m()
+                temporary = :(│helper│(│x│))
+                return temporary
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 6
+            expected = (2, 2, 2, 2, 1, 1)
+            @test all(zip(positions, expected)) do (pos, nrefs)
+                length(find_references(clean_code, pos)) == nrefs
             end
         end
     end
@@ -450,20 +866,120 @@ end
         end
     end
 
-    # Cursor on a non-`\$` identifier inside a preserved macrocall's inert
-    # template must resolve to the matching module-level global.
-    @testset "cursor on inert global inside preserved macrocall" begin
-        let code = """
-            struct │LSAnalyzer│ end
-            let x = 1
-                @eval some_func(::│LSAnalyzer│) = \$x
-            end
-            """
+    @testset "cursor on inert global inside @eval" begin
+        # One-argument `@eval` resolves inert globals in the construction module.
+        for eval_macro in ("@eval", "Base.@eval")
+            code = """
+                struct │LSAnalyzer│ end
+                let x = 1
+                    $eval_macro some_func(::│LSAnalyzer│) = \$x
+                end
+                """
             clean_code, positions = JETLS.get_text_and_positions(code)
             @test length(positions) == 4
             for pos in positions
                 refs = find_references(clean_code, pos)
                 @test length(refs) == 2
+            end
+        end
+
+        # Quoted atomic input remains Symbol data rather than a global reference.
+        for eval_macro in ("@eval", "Base.@eval")
+            code = """
+                global │gvar│ = nothing
+                $eval_macro :│gvar│
+                """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 4
+            for pos in positions[1:2]
+                @test length(find_references(clean_code, pos)) == 1
+            end
+            for pos in positions[3:4]
+                @test isempty(find_references(clean_code, pos))
+            end
+        end
+
+        # Nested quote stages inside `@eval` remain unresolved.
+        let code = """
+            global │x│ = nothing
+            @eval begin
+                q = :(use(│x│))
+            end
+            """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 4
+            for pos in positions
+                @test_broken length(find_references(clean_code, pos)) == 2
+            end
+        end
+
+        # Macrocalls in the evaluated stage resolve in the construction module.
+        for eval_macro in ("@eval", "Base.@eval")
+            code = """
+                macro │helper│()
+                    nothing
+                end
+                $eval_macro begin
+                    │@helper│
+                end
+                """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 4
+            for pos in positions
+                @test length(find_references(clean_code, pos)) == 2
+            end
+        end
+
+        # Nested quote stages inside `@eval` do not expose macrocall bindings.
+        for eval_macro in ("@eval", "Base.@eval")
+            code = """
+                macro │helper│()
+                    nothing
+                end
+                $eval_macro begin
+                    q = :(│@helper│)
+                end
+                """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 4
+            for pos in positions[1:2]
+                @test length(find_references(clean_code, pos)) == 1
+            end
+            for pos in positions[3:4]
+                @test isempty(find_references(clean_code, pos))
+            end
+        end
+
+        # Two-argument `@eval` is unsupported because its target module may be
+        # dynamic, so its inert global is left unresolved even for `Main`.
+        for eval_macro in ("@eval", "Base.@eval")
+            code = """
+                struct │LSAnalyzer│ end
+                $eval_macro SomeModule some_func(::│LSAnalyzer│) = nothing
+                """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 4
+            for (i, pos) in enumerate(positions)
+                refs = find_references(clean_code, pos)
+                @test length(refs) == (i <= 2 ? 1 : 0)
+            end
+        end
+
+        # Nested macrocalls in two-argument `@eval` input are unresolved too.
+        for eval_macro in ("@eval", "Base.@eval")
+            code = """
+                macro │helper│()
+                    nothing
+                end
+                $eval_macro SomeModule │@helper│
+                """
+            clean_code, positions = JETLS.get_text_and_positions(code)
+            @test length(positions) == 4
+            for pos in positions[1:2]
+                @test length(find_references(clean_code, pos)) == 1
+            end
+            for pos in positions[3:4]
+                @test isempty(find_references(clean_code, pos))
             end
         end
     end

--- a/test/test_rename.jl
+++ b/test/test_rename.jl
@@ -321,6 +321,33 @@ end
             end
         end
 
+        # Quote-local bindings shadow the generated argument.
+        let code = """
+            @generated function foo(│x│)
+                return :(let │x│ = 1
+                    │x│
+                end)
+            end
+            """
+            fi, positions, furi = rename_testcase(code, 6)
+            let rename_result = JETLS.local_binding_rename(
+                    server, furi, fi, positions[1], @__MODULE__, "arg")
+                @test rename_result !== nothing
+                (; result, error) = rename_result
+                @test result isa WorkspaceEdit && isnothing(error)
+                edits = only(result.changes).second
+                @test length(edits) == 1
+            end
+            let rename_result = JETLS.local_binding_rename(
+                    server, furi, fi, positions[3], @__MODULE__, "local_x")
+                @test rename_result !== nothing
+                (; result, error) = rename_result
+                @test result isa WorkspaceEdit && isnothing(error)
+                edits = only(result.changes).second
+                @test length(edits) == 2
+            end
+        end
+
         # Static parameter merging
         let code = """
             @generated function foo(x::│T│) where {│T│}
@@ -360,6 +387,23 @@ end
                     @test length(edits) == 2
                     @test all(edit -> edit.newText == "y", edits)
                 end
+            end
+        end
+    end
+
+    @testset "ordinary quote-local rename" begin
+        let code = """
+            f() = :(let │x│ = 1
+                │x│
+            end)
+            """
+            fi, positions, furi = rename_testcase(code, 4)
+            for pos in positions
+                rename_result = JETLS.local_binding_rename(
+                    server, furi, fi, pos, @__MODULE__, "y")
+                @test rename_result !== nothing &&
+                    rename_result.result isa WorkspaceEdit &&
+                    length(only(rename_result.result.changes).second) == 2
             end
         end
     end
@@ -411,6 +455,27 @@ end
         rename_prep = JETLS.global_binding_rename_preparation(
             state, furi, fi, only(positions), @__MODULE__)
         @test isnothing(rename_prep)
+    end
+
+    @testset "ordinary unanchored quote" begin
+        let code = "f() = :(use(│x│))"
+            fi, positions, furi = rename_testcase(code, 2)
+            for pos in positions
+                rename_prep = JETLS.global_binding_rename_preparation(
+                    state, furi, fi, pos, @__MODULE__)
+                @test !isnothing(rename_prep) && rename_prep.placeholder == "x"
+            end
+        end
+
+        # An atomic quoted identifier is Symbol data, not a global binding target.
+        let code = "names = (:│sin│, :cos)"
+            fi, positions, furi = rename_testcase(code, 2)
+            for pos in positions
+                rename_prep = JETLS.global_binding_rename_preparation(
+                    state, furi, fi, pos, @__MODULE__)
+                @test isnothing(rename_prep)
+            end
+        end
     end
 
     @testset "macro rename prepare" begin

--- a/test/utils/test_binding.jl
+++ b/test/utils/test_binding.jl
@@ -154,9 +154,7 @@ end
         return true
     end == 4
 
-    # User-written identifiers sitting in a macro's inert/quoted template
-    # (here the type name inside `@eval`) should resolve to the matching
-    # module-level global.
+    # One-argument `@eval` evaluates in the construction module.
     @test with_target_binding("""
         struct │LSAnalyzer│ end
         let x = 1
@@ -168,6 +166,22 @@ end
         @test binfo.kind === :global
         return true
     end == 4
+
+    # Two-argument `@eval` is left unresolved even when its target looks static.
+    @test with_target_binding("""
+        @eval SomeModule some_func(::│LSAnalyzer│) = nothing
+        """) do _, result
+        @test result === nothing
+        return true
+    end == 2
+
+    # A dynamic target module is likewise left unresolved.
+    @test with_target_binding("""
+        @eval getcontext() some_func(::│LSAnalyzer│) = nothing
+        """) do _, result
+        @test result === nothing
+        return true
+    end == 2
 
     @test with_target_binding("""
         struct │MyType│ end


### PR DESCRIPTION
References, rename, document highlights, and unused-import diagnostics could miss or misclassify identifiers inside quoted expressions. Generated arguments could also be confused with same-named inner bindings, producing incomplete references and unsafe rename edits.

Introduce a shared inert resolver for target selection and occurrence collection. Code-shaped ordinary quotes resolve in their construction module, macro quotes in definition scope, and generated bodies in a synthetic function scope with exact argument remapping. Direct interpolation remains in its enclosing lexical scope, while nested generated-output interpolation follows its corresponding quote stage.

Track quote and interpolation stages when classifying nested macrocalls. Support one-argument `@eval` in bare and `Base.@eval` forms, `@generated` and `Base.@generated`, and direct `esc(...)` or `Base.esc(...)` boundaries. Two-argument `@eval` and escaped free names remain unresolved.

This intentionally uses a pragmatic construction-site approximation. Atomic `Symbol` flow, indirect escape flow, nested quoted values inside `@eval`, general qualified or aliased new-style macro resolution, and confidence-aware filtering of generated temporary expressions remain future work.