### PR TITLE
binding/occurrence: Resolve new-style macros by object identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed false `lowering/macro-expansion-error` diagnostics when an old-style macro is nested inside a new-style macro. The failed expansion could also contaminate enclosing forms and produce repeated lowering diagnostics across a project, as reported for Makie. This incorporates [JuliaLang/julia#62221](https://github.com/JuliaLang/julia/pull/62221) and addresses [JuliaLang/JuliaLowering.jl#108](https://github.com/JuliaLang/JuliaLowering.jl/issues/108). (Closed https://github.com/aviatesk/JETLS.jl/issues/554)
 
+- Fixed missing or incorrect references, rename edits, document highlights, and diagnostics around qualified or aliased macros such as `Test.@test`; unrelated user-defined macros with the same name are no longer mistaken for built-in macros.
+
 - Fixed many missing references, rename edits, document highlights, and `lowering/unused-import` diagnostic results for identifiers inside quoted expressions used by helper functions, macros, and generated functions.
 
 - Fixed a false `lowering/error` diagnostic for docstring signatures such as `someinterface(::Type{<:Integer})`.

--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -33,7 +33,7 @@ in "Prerequisite" and "Limitations".
 The pipeline has four steps. Each step's output feeds the next:
 
 1. **Lower for scope resolution**:
-   [`get_inferrable_tree(st0::SyntaxTreeC, context_module::Module) -> (; ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC) | nothing`](@ref get_inferrable_tree)
+   [`get_inferrable_tree(st0::SyntaxTreeC, context_module::Module, world::UInt) -> (; ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC) | nothing`](@ref get_inferrable_tree)
    walks a top-level `st0` through JuliaLowering's early scope passes against
    `context_module`, returning an `(ctx3, st3)` pair. Surface `K"error"` nodes are stripped
    first so incomplete user input still produces a usable lowered tree.
@@ -920,12 +920,12 @@ JuliaLowering happily lowers what's left. For example, in
 See the [`TypeAnnotation`](@ref) module docstring for the full pipeline.
 """
 function get_inferrable_tree(
-        st0::SyntaxTreeC, context_module::Module;
-        world::UInt = Base.get_world_counter(),
+        st0::SyntaxTreeC, context_module::Module, world::UInt;
         caller::AbstractString = "get_inferrable_tree"
     )
     (; ctx3, st3) = try
-        jl_lower_for_scope_resolution(context_module, st0; world, trim_error_nodes=true, recover_from_macro_errors=false)
+        jl_lower_for_scope_resolution(context_module, world, st0;
+            trim_error_nodes=true, recover_from_macro_errors=false)
     catch err
         @static JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
         @static JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
@@ -1686,7 +1686,7 @@ function build_inferred_context(
         world::UInt = Base.get_world_counter(),
         caller::AbstractString = "build_inferred_context"
     )
-    (; ctx3, st3) = @something get_inferrable_tree(st0, context_module; world, caller) return nothing
+    (; ctx3, st3) = @something get_inferrable_tree(st0, context_module, world; caller) return nothing
     inferred = @something infer_toplevel_tree(ctx3, st3, st0, context_module; world) return nothing
     # `JS.prune` minimizes provenance, so collect query-dispatch indexes first.
     surface_kind_index, macrocall_types = collect_provenance_indexes(inferred)

--- a/src/analysis/occurrence-analysis.jl
+++ b/src/analysis/occurrence-analysis.jl
@@ -1,6 +1,6 @@
 """
     compute_binding_occurrences(
-            ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC;
+            ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, world::UInt;
             include_global_bindings::Bool = false,
             generated_resolutions::Union{Nothing,Vector{InertResolution}} = nothing
         ) -> binding_occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}}
@@ -23,6 +23,7 @@ information:
 - `include_global_bindings`: Whether to include global bindings in the result
 - `generated_resolutions`: Optional precomputed generated inert resolutions. When
   provided, they are reused instead of lowering generated inert templates again.
+- `world`: World age used when lowering generated inert templates
 
 # Returns
 `binding_occurrences` is a dictionary mapping each non-internal local/argument binding to
@@ -36,7 +37,7 @@ a set of `BindingOccurrence` objects that record where and how the binding appea
     variable diagnostics or comprehensive binding analysis.
 """
 function compute_binding_occurrences(
-        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC;
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, world::UInt;
         include_global_bindings::Bool = false,
         generated_resolutions::Union{Nothing,Vector{InertResolution}} = nothing
     )
@@ -70,11 +71,12 @@ function compute_binding_occurrences(
     compute_binding_occurrences!(occurrences, ctx3, st3; include_global_bindings)
 
     generated_resolutions = if generated_resolutions === nothing
-        collect_generated_inert_resolutions(ctx3, st3)
+        collect_generated_inert_resolutions(ctx3, st3, world)
     else
         generated_resolutions
     end
-    record_generated_inert_argument_uses!(occurrences, ctx3, generated_resolutions)
+    record_generated_inert_argument_uses!(
+        occurrences, ctx3, generated_resolutions, world)
 
     # Aggregate occurrences for bindings that have the same name and location.
     # JL sometimes represents bindings that are considered "identical" at the source level
@@ -119,11 +121,12 @@ end
 function record_generated_inert_argument_uses!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
         ctx3::JL.VariableAnalysisContext,
-        generated_resolutions::Vector{InertResolution}
+        generated_resolutions::Vector{InertResolution}, world::UInt
     )
     for resolution in generated_resolutions
         isempty(resolution.argument_remap) && continue
-        resolved_occurrences = compute_binding_occurrences(resolution.ctx3, resolution.st3)
+        resolved_occurrences = compute_binding_occurrences(
+            resolution.ctx3, resolution.st3, world)
         for (resolved_binfo, source) in resolution.argument_remap
             source_binfo = JL.get_binding(ctx3, source)
             haskey(occurrences, source_binfo) || continue
@@ -436,7 +439,8 @@ function compute_full_binding_occurrences(
         # unit using `collect_search_uris`, the notebook URI is used instead, and its
         # lowering requires `soft_scope`.
         is_notebook_uri(state, uri)
-    (; context_module) = get_context_info(state, uri, offset_to_xy(fi, JS.first_byte(st0)); lookup_func)
+    pos = offset_to_xy(fi, JS.first_byte(st0))
+    (; context_module, world) = get_context_info(state, uri, pos; lookup_func)
 
     if JS.kind(st0) in JS.KSet"export public import using"
         # `import`/`using`/`export`/`public` declarations are collected from the source tree
@@ -450,19 +454,20 @@ function compute_full_binding_occurrences(
         # scope-aware, since each branch is resolved within its enclosing scope.
         # TODO: This won't be necessary once JuliaLowering can preserve precise
         # source locations for old macro-expanded code.
+        st0′ = remove_macrocalls(context_module, world, st0; strip_static=true)
         (; ctx3, st3) = try
-            jl_lower_for_scope_resolution(context_module,
-                remove_macrocalls(st0; strip_static=true); soft_scope)
+            jl_lower_for_scope_resolution(context_module, world, st0′; soft_scope)
         catch
             return nothing
         end
-        generated_resolutions = collect_generated_inert_resolutions(ctx3, st3)
-        occs = compute_binding_occurrences(ctx3, st3;
+        generated_resolutions = collect_generated_inert_resolutions(ctx3, st3, world)
+        occs = compute_binding_occurrences(ctx3, st3, world;
             include_global_bindings=true, generated_resolutions)
         collect_struct_inner_constructor_occurrences!(occs, ctx3, st0)
-        collect_macrocall_occurrences!(occs, context_module, st0; soft_scope)
+        collect_macrocall_occurrences!(
+            occs, context_module, world, st0; soft_scope)
         # Add generated-body and policy-approved inert occurrences.
-        collect_inert_global_occurrences!(occs, st3, st0, context_module,
+        collect_inert_global_occurrences!(occs, st3, st0, context_module, world,
             generated_resolutions; soft_scope)
         binding_occurrences = occs
     end
@@ -547,16 +552,18 @@ end
 
 function collect_macrocall_occurrences!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
-        context_module::Module, st0::SyntaxTreeC;
-        soft_scope::Bool = false
+        context_module::Module, world::UInt, st0::SyntaxTreeC;
+        soft_scope::Bool = false,
     )
     traverse(st0) do st::SyntaxTreeC
         JS.kind(st) === JS.K"macrocall" || return nothing
         JS.numchildren(st) ≥ 1 || return nothing
-        should_resolve_macrocall(st0, JS.byte_range(st)) || return traversal_no_recurse
+        should_resolve_macrocall(
+            context_module, world, st0, JS.byte_range(st)) || return traversal_no_recurse
         macrocall_name = st[1]
         (; ctx3) = try
-            jl_lower_for_scope_resolution(context_module, macrocall_name; soft_scope)
+            jl_lower_for_scope_resolution(
+                context_module, world, macrocall_name; soft_scope)
         catch
             return traversal_no_recurse
         end
@@ -573,10 +580,10 @@ end
 
 function collect_resolved_inert_globals!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
-        resolution::InertResolution
+        resolution::InertResolution, world::UInt
     )
     resolved_occurrences = compute_binding_occurrences(
-        resolution.ctx3, resolution.st3; include_global_bindings=true)
+        resolution.ctx3, resolution.st3, world; include_global_bindings=true)
     for (binfo, boccs) in resolved_occurrences
         binfo.kind === :global || continue
         binfo.is_internal && continue
@@ -599,13 +606,13 @@ sync with target selection for references and rename.
 """
 function collect_inert_global_occurrences!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
-        st3::SyntaxTreeC, st0::SyntaxTreeC, context_module::Module,
+        st3::SyntaxTreeC, st0::SyntaxTreeC, context_module::Module, world::UInt,
         generated_resolutions::Vector{InertResolution};
-        soft_scope::Bool = false
+        soft_scope::Bool = false,
     )
     # Generated bodies need their function arguments remapped into runtime scope.
     for resolution in generated_resolutions
-        collect_resolved_inert_globals!(occurrences, resolution)
+        collect_resolved_inert_globals!(occurrences, resolution, world)
     end
 
     seen = Set{Tuple{JS.Kind,UnitRange{Int}}}()
@@ -618,12 +625,12 @@ function collect_inert_global_occurrences!(
         key in seen && return traversal_no_recurse
         push!(seen, key)
         # Generated ranges were handled above with their dedicated argument scope.
-        is_generated_inert_range(st0, range) && return traversal_no_recurse
-        policy = inert_resolution_policy(st0, range)
+        is_generated_inert_range(context_module, world, st0, range) && return traversal_no_recurse
+        policy = inert_resolution_policy(context_module, world, st0, range)
         policy === :unresolved && return traversal_no_recurse
         hard_scope = policy === :macro
-        resolution = resolve_inert_tree(context_module, inert_tree; hard_scope, soft_scope)
-        resolution === nothing || collect_resolved_inert_globals!(occurrences, resolution)
+        resolution = resolve_inert_tree(context_module, world, inert_tree; hard_scope, soft_scope)
+        resolution === nothing || collect_resolved_inert_globals!(occurrences, resolution, world)
         return nothing
     end
     return occurrences

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -176,8 +176,8 @@ end
 function get_cursor_bindings_cached!(comp_ctx::CompletionCtx)
     isdefined(comp_ctx, :cursor_bindings) && return comp_ctx.cursor_bindings
     return comp_ctx.cursor_bindings = cursor_bindings(
-        comp_ctx.st0_top, comp_ctx.offset, comp_ctx.context_module;
-            soft_scope=comp_ctx.soft_scope)
+        comp_ctx.st0_top, comp_ctx.offset, comp_ctx.context_module, comp_ctx.world;
+        soft_scope=comp_ctx.soft_scope)
 end
 
 # Typical completion UI
@@ -341,7 +341,7 @@ function global_completions!(
         # A `Union{}` prefix type is uninformative (the prefix throws or is dead code);
         # treat it like `nothing` so module/const prefixes such as `Base.` still complete.
         if prefixtyp === nothing || prefixtyp === Union{}
-            prefixtyp = resolve_global_const(context_module, dotprefix, world)
+            prefixtyp = resolve_global_const(context_module, world, dotprefix)
         end
         # Module prefix → enumerate that module's globals below.
         # Otherwise → property completion (abstract-call
@@ -798,7 +798,7 @@ function call_completions!(
     ctx = get_inferred_ctx!(comp_ctx; caller="call_completions!")
     fntyp = ctx === nothing ? nothing : get_type_for_range(ctx, JS.byte_range(call[1]))
     if fntyp === nothing
-        fntyp = resolve_global_const(context_module, call[1], world)
+        fntyp = resolve_global_const(context_module, world, call[1])
     end
     fntyp isa Core.Const || return nothing
 

--- a/src/declaration.jl
+++ b/src/declaration.jl
@@ -73,9 +73,10 @@ function find_declaration(
     state = server.state
     st0 = build_syntax_tree(fi)
     offset = xy_to_offset(fi, pos)
-    (; context_module) = get_context_info(state, uri, pos)
+    (; context_module, world) = get_context_info(state, uri, pos)
 
-    binding_result = select_target_binding(st0, offset, context_module; caller="find_declaration", soft_scope)
+    binding_result = select_target_binding(
+        st0, offset, context_module, world; caller="find_declaration", soft_scope)
     if !isnothing(binding_result)
         (; ctx3, st3, binding) = binding_result
         binfo = JL.get_binding(ctx3, binding)
@@ -83,7 +84,7 @@ function find_declaration(
             locations = find_global_binding_declarations(server, uri, binfo)
         else
             locations = find_local_binding_declarations(
-                state, uri, fi, ctx3, st3, binfo)
+                state, uri, fi, ctx3, st3, binfo, world)
         end
         isempty(locations) || return locations, binding
     end
@@ -119,10 +120,10 @@ end
 
 function find_local_binding_declarations(
         state::ServerState, uri::URI, fi::FileInfo,
-        ctx3, st3, binfo::JL.BindingInfo,
+        ctx3, st3, binfo::JL.BindingInfo, world::UInt,
     )
     locations = Location[]
-    binding_occurrences = compute_binding_occurrences(ctx3, st3)
+    binding_occurrences = compute_binding_occurrences(ctx3, st3, world)
     haskey(binding_occurrences, binfo) || return locations
     seen_locations = Set{Tuple{URI,Range}}()
     for occurrence in binding_occurrences[binfo]

--- a/src/definition.jl
+++ b/src/definition.jl
@@ -164,7 +164,8 @@ function find_definition(
     end
 
     # Phase 2: source-level binding pass.
-    binding_jump = find_binding_definitions(server, uri, fi, st0, offset, context_module, soft_scope)
+    binding_jump = find_binding_definitions(
+        server, uri, fi, st0, offset, context_module, world; soft_scope)
     binding_jump === nothing || return binding_jump
 
     node === nothing && return nothing
@@ -213,10 +214,12 @@ end
 # the binding info.
 function find_binding_definitions(
         server::Server, uri::URI, fi::FileInfo, st0::SyntaxTreeC,
-        offset::Int, context_module::Module, soft_scope::Bool,
+        offset::Int, context_module::Module, world::UInt;
+        soft_scope::Bool = false
     )
     binding_result = @something select_target_binding(
-        st0, offset, context_module; caller="find_definition", soft_scope) return nothing
+        st0, offset, context_module, world;
+        caller="find_definition", soft_scope) return nothing
     (; ctx3, st3, binding) = binding_result
     binfo = JL.get_binding(ctx3, binding)
     if binfo.kind === :global
@@ -272,7 +275,7 @@ function find_value_definitions(
         ctx::Union{Nothing,InferredTreeContext}, world::UInt,
     )
     if ctx === nothing
-        objtyp = resolve_global_const(context_module, node, world)
+        objtyp = resolve_global_const(context_module, world, node)
     else
         objtyp = get_type_for_range(ctx, rng)
     end

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -1530,7 +1530,7 @@ function analyze_lowered_code!(
         inactive_branch_names::Set{String} = Set{String}()
     )
     (; ctx3, ctx4, st0, st3) = res
-    binding_occurrences = compute_binding_occurrences(ctx3, st3;
+    binding_occurrences = compute_binding_occurrences(ctx3, st3, world;
         include_global_bindings=true)
 
     reported = Set{LoweringDiagnosticKey}() # to prevent duplicate reports for unused default or keyword arguments
@@ -1538,7 +1538,7 @@ function analyze_lowered_code!(
 
     analyze_unconstrained_static_parameters!(diagnostics, fi, ctx3, st3, reported)
 
-    has_implicit_args = is_macro0(st0) || is_generated0(st0)
+    has_implicit_args = is_macro0(st0) || !isempty(generated_method_ids(ctx3, st3))
     analyze_unused_bindings!(
         diagnostics, fi, st0, ctx3, binding_occurrences, has_implicit_args, reported,
         kwarg_type_names, kwarg_locations;
@@ -1578,7 +1578,7 @@ function per_stmt_diagnostics!(
     (st0, _) = desugar_main_macrocall(st0)
     macro_diags = MacroDiagnostic[]
     res = Base.ScopedValues.@with MACRO_DIAGNOSTIC_SINK => macro_diags try
-        jl_lower_for_scope_resolution(context_module, st0; world,
+        jl_lower_for_scope_resolution(context_module, world, st0;
             recover_from_macro_errors=false, convert_closures=true, soft_scope)
     catch err
         if err isa JL.LoweringError
@@ -1636,9 +1636,9 @@ function per_stmt_diagnostics!(
         # the sink during the primary attempt would push the same entry again here
         # — emitting twice. With the sink unbound, those `push_macro_*!` calls
         # become no-ops, and stubs that genuinely throw simply re-throw and we bail.
-        st0 = remove_macrocalls(st0)
+        st0 = remove_macrocalls(context_module, world, st0)
         res = try
-            jl_lower_for_scope_resolution(context_module, st0; world,
+            jl_lower_for_scope_resolution(context_module, world, st0;
                 recover_from_macro_errors=false, convert_closures=true, soft_scope)
         catch
             return diagnostics

--- a/src/document-highlight.jl
+++ b/src/document-highlight.jl
@@ -50,11 +50,12 @@ function document_highlights!(
     )
     st0_top = build_syntax_tree(fi)
     offset = xy_to_offset(fi, pos)
-    (; context_module) = get_context_info(state, uri, pos)
+    (; context_module, world) = get_context_info(state, uri, pos)
     soft_scope = is_notebook_cell_uri(state, uri)
 
     (; ctx3, st3, binding) = @something begin
-        select_target_binding(st0_top, offset, context_module; caller="document_highlights!", soft_scope)
+        select_target_binding(st0_top, offset, context_module, world;
+            caller="document_highlights!", soft_scope)
     end return highlights
 
     binfo = JL.get_binding(ctx3, binding)
@@ -63,7 +64,7 @@ function document_highlights!(
     if binfo.kind === :global
         global_document_highlights!(highlights′, state, uri, fi, st0_top, binfo)
     else
-        local_document_highlights!(highlights′, state, uri, fi, ctx3, st3, binfo)
+        local_document_highlights!(highlights′, state, uri, fi, ctx3, st3, binfo, world)
     end
 
     for (range, kind) in highlights′
@@ -100,9 +101,11 @@ end
 
 function local_document_highlights!(
         highlights′::Dict{Range,DocumentHighlightKind.Ty},
-        state::ServerState, uri::URI, fi::FileInfo, ctx3, st3, binfo::JL.BindingInfo,
+        state::ServerState, uri::URI, fi::FileInfo,
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC,
+        binfo::JL.BindingInfo, world::UInt,
     )
-    binding_occurrences = compute_binding_occurrences(ctx3, st3)
+    binding_occurrences = compute_binding_occurrences(ctx3, st3, world)
     if haskey(binding_occurrences, binfo)
         for occurrence in binding_occurrences[binfo]
             add_highlight_for_occurrence!(highlights′, state, uri, fi, occurrence)

--- a/src/document-symbol.jl
+++ b/src/document-symbol.jl
@@ -74,8 +74,8 @@ function get_document_symbols!(state::ServerState, uri::URI, fi::FileInfo)
         end
         st0 = build_syntax_tree(fi)
         pos = Position(; line=0, character=0)
-        (; context_module) = get_context_info(state, uri, pos)
-        symbols = extract_document_symbols(st0, fi, context_module)
+        (; context_module, world) = get_context_info(state, uri, pos)
+        symbols = extract_document_symbols(st0, fi, context_module, world)
         return DocumentSymbolCacheData(cache, cache_uri => symbols), symbols
     end
 end
@@ -91,65 +91,67 @@ function invalidate_document_symbol_cache!(state::ServerState, uri::URI)
     end
 end
 
-function extract_document_symbols(st0_top::SyntaxTreeC, fi::FileInfo, context_module::Module)
+function extract_document_symbols(
+        st0_top::SyntaxTreeC, fi::FileInfo, context_module::Module, world::UInt
+    )
     @assert JS.kind(st0_top) === JS.K"toplevel"
     symbols = DocumentSymbol[]
-    extract_toplevel_symbols!(symbols, st0_top, fi, context_module)
+    extract_toplevel_symbols!(symbols, st0_top, fi, context_module, world)
     sort!(symbols; by = s::DocumentSymbol -> (s.range.start.line, s.range.start.character))
     return symbols
 end
 
 function extract_toplevel_symbols!(
         symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
-        context_module::Module
+        context_module::Module, world::UInt
     )
     for i = 1:JS.numchildren(st0)
-        extract_toplevel_symbol!(symbols, st0[i], fi, context_module)
+        extract_toplevel_symbol!(symbols, st0[i], fi, context_module, world)
     end
 end
 
 function extract_toplevel_symbol!(
         symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
-        context_module::Module
+        context_module::Module, world::UInt
     )
     k = JS.kind(st0)
     if k === JS.K"module"
-        extract_module_symbol!(symbols, st0, fi, context_module)
+        extract_module_symbol!(symbols, st0, fi, context_module, world)
     elseif k === JS.K"function"
-        extract_function_symbol!(symbols, st0, fi, context_module)
+        extract_function_symbol!(symbols, st0, fi, context_module, world)
     elseif k === JS.K"macro"
-        extract_macro_symbol!(symbols, st0, fi, context_module)
+        extract_macro_symbol!(symbols, st0, fi, context_module, world)
     elseif k === JS.K"struct"
-        extract_struct_symbol!(symbols, st0, fi, context_module)
+        extract_struct_symbol!(symbols, st0, fi, context_module, world)
     elseif k === JS.K"abstract"
         extract_abstract_type_symbol!(symbols, st0, fi)
     elseif k === JS.K"primitive"
         extract_primitive_type_symbol!(symbols, st0, fi)
     elseif k === JS.K"const"
-        extract_const_symbols!(symbols, st0, fi, context_module)
+        extract_const_symbols!(symbols, st0, fi, context_module, world)
     elseif k === JS.K"global"
-        extract_global_symbols!(symbols, st0, fi, context_module)
+        extract_global_symbols!(symbols, st0, fi, context_module, world)
     elseif k === JS.K"="
-        extract_toplevel_assignment_symbols!(symbols, st0, fi, context_module)
+        extract_toplevel_assignment_symbols!(symbols, st0, fi, context_module, world)
     elseif k === JS.K"let"
-        extract_let_symbol!(symbols, st0, fi, context_module)
+        extract_let_symbol!(symbols, st0, fi, context_module, world)
     elseif k === JS.K"while"
-        extract_while_symbol!(symbols, st0, fi, context_module)
+        extract_while_symbol!(symbols, st0, fi, context_module, world)
     elseif k === JS.K"for"
-        extract_for_symbol!(symbols, st0, fi, context_module)
+        extract_for_symbol!(symbols, st0, fi, context_module, world)
     elseif k === JS.K"if"
-        extract_if_symbol!(symbols, st0, fi, context_module)
+        extract_if_symbol!(symbols, st0, fi, context_module, world)
     elseif k === JS.K"toplevel" || k === JS.K"block"
-        extract_toplevel_symbols!(symbols, st0, fi, context_module)
+        extract_toplevel_symbols!(symbols, st0, fi, context_module, world)
     elseif k === JS.K"macrocall"
-        extract_macrocall_symbol!(symbols, st0, fi, context_module)
+        extract_macrocall_symbol!(symbols, st0, fi, context_module, world)
     end
     return nothing
 end
 
 function extract_module_symbol!(
         symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
-        parent_context_module::Module
+        parent_context_module::Module, world::UInt
     )
     JS.numchildren(st0) ≥ 3 || return nothing
     name_node = st0[2]
@@ -164,7 +166,7 @@ function extract_module_symbol!(
     children = DocumentSymbol[]
     body = st0[end]
     if JS.kind(body) === JS.K"block"
-        extract_toplevel_symbols!(children, body, fi, context_module)
+        extract_toplevel_symbols!(children, body, fi, context_module, world)
     end
     is_baremodule = JS.has_flags(st0, JS.BARE_MODULE_FLAG)
     detail = (is_baremodule ? "baremodule " : "module ") * name
@@ -180,12 +182,13 @@ end
 
 function extract_function_symbol!(
         symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
-        context_module::Module
+        context_module::Module, world::UInt
     )
     JS.numchildren(st0) ≥ 1 || return nothing
     sig = st0[1]
     name, name_node = @something extract_function_name(sig) return nothing
-    children = @something extract_scoped_children(st0, fi, context_module) Some(nothing)
+    children = @something extract_scoped_children(
+        st0, fi, context_module, world) Some(nothing)
     is_short_form = JS.has_flags(st0, JS.SHORT_FORM_FUNCTION_FLAG)
     detail = is_short_form ? JS.sourcetext(sig) * " =" : "function " * JS.sourcetext(sig)
     push!(symbols, DocumentSymbol(;
@@ -251,7 +254,7 @@ end
 
 function extract_macro_symbol!(
         symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
-        context_module::Module
+        context_module::Module, world::UInt
     )
     JS.numchildren(st0) ≥ 1 || return nothing
     sig_orig = st0[1]
@@ -269,7 +272,7 @@ function extract_macro_symbol!(
     end
     name = "@" * name
     detail = "macro " * JS.sourcetext(sig_orig)
-    children = @something extract_scoped_children(st0, fi, context_module) Some(nothing)
+    children = @something extract_scoped_children(st0, fi, context_module, world) Some(nothing)
     push!(symbols, DocumentSymbol(;
         name,
         detail,
@@ -282,7 +285,7 @@ end
 
 function extract_struct_symbol!(
         symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
-        context_module::Module
+        context_module::Module, world::UInt
     )
     JS.numchildren(st0) ≥ 2 || return nothing
     sig_node = st0[2]
@@ -305,9 +308,10 @@ function extract_struct_symbol!(
             child = body[i]
             child_k = JS.kind(child)
             if child_k === JS.K"function"
-                extract_function_symbol!(children, child, fi, context_module)
+                extract_function_symbol!(children, child, fi, context_module, world)
             elseif child_k === JS.K"="
-                extract_toplevel_assignment_symbols!(children, child, fi, context_module)
+                extract_toplevel_assignment_symbols!(
+                    children, child, fi, context_module, world)
             else
                 extract_struct_field!(children, child, fi)
             end
@@ -395,7 +399,7 @@ end
 
 function extract_const_symbols!(
         symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
-        context_module::Module
+        context_module::Module, world::UInt
     )
     JS.numchildren(st0) ≥ 1 || return nothing
     assign = st0[1]
@@ -405,13 +409,14 @@ function extract_const_symbols!(
     rhs = assign[2]
     range = jsobj_to_range(st0, fi)
     detail = lstrip(JS.sourcetext(st0))
-    extract_assignment_symbols!(symbols, lhs, rhs, range, SymbolKind.Constant, detail, fi, context_module)
+    extract_assignment_symbols!(
+        symbols, lhs, rhs, range, SymbolKind.Constant, detail, fi, context_module, world)
     return nothing
 end
 
 function extract_global_symbols!(
         symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
-        context_module::Module
+        context_module::Module, world::UInt
     )
     JS.numchildren(st0) ≥ 1 || return nothing
     inner = st0[1]
@@ -421,21 +426,25 @@ function extract_global_symbols!(
         JS.numchildren(inner) ≥ 2 || return nothing
         lhs = inner[1]
         rhs = inner[2]
-        extract_assignment_symbols!(symbols, lhs, rhs, range, SymbolKind.Variable, detail, fi, context_module)
+        extract_assignment_symbols!(
+            symbols, lhs, rhs, range, SymbolKind.Variable, detail, fi,
+            context_module, world)
     else
-        extract_assignment_symbols!(symbols, inner, nothing, range, SymbolKind.Variable, detail, fi, context_module)
+        extract_assignment_symbols!(
+            symbols, inner, nothing, range, SymbolKind.Variable, detail, fi,
+            context_module, world)
     end
     return nothing
 end
 
 function extract_assignment_symbols!(
-        symbols::Vector{DocumentSymbol}, lhs::SyntaxTreeC, rhs::Union{SyntaxTreeC,Nothing},
-        range::Range, kind::SymbolKind.Ty, detail::AbstractString, fi::FileInfo,
-        context_module::Module
+        symbols::Vector{DocumentSymbol}, lhs::SyntaxTreeC,
+        rhs::Union{SyntaxTreeC,Nothing}, range::Range, kind::SymbolKind.Ty,
+        detail::AbstractString, fi::FileInfo, context_module::Module, world::UInt
     )
     children = if rhs !== nothing && JS.kind(rhs) === JS.K"let"
         let_children = DocumentSymbol[]
-        extract_let_symbol!(let_children, rhs, fi, context_module)
+        extract_let_symbol!(let_children, rhs, fi, context_module, world)
         @somereal let_children Some(nothing)
     else
         nothing
@@ -490,40 +499,41 @@ function extract_assignment_symbols!(
             children))
     end
     if rhs !== nothing && JS.kind(rhs) === JS.K"block"
-        extract_toplevel_symbols!(symbols, rhs, fi, context_module)
+        extract_toplevel_symbols!(symbols, rhs, fi, context_module, world)
     end
     return nothing
 end
 
 function extract_toplevel_assignment_symbols!(
         symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
-        context_module::Module
+        context_module::Module, world::UInt
     )
     JS.numchildren(st0) ≥ 2 || return nothing
     lhs = st0[1]
     JS.kind(lhs) in JS.KSet". ref" && return nothing # Skip property assignment like obj.field = value
     lhs_unwrapped = unwrap_funcdef_sig(lhs)
     if JS.kind(lhs_unwrapped) === JS.K"call" || is_mainfunc0(lhs_unwrapped)
-        extract_short_function_symbol!(symbols, st0, fi, context_module)
+        extract_short_function_symbol!(symbols, st0, fi, context_module, world)
         return nothing
     end
     rhs = st0[2]
     range = jsobj_to_range(st0, fi)
     detail = lstrip(JS.sourcetext(st0))
     kind = is_anonymous_function_rhs(rhs) ? SymbolKind.Function : SymbolKind.Variable
-    extract_assignment_symbols!(symbols, lhs, rhs, range, kind, detail, fi, context_module)
+    extract_assignment_symbols!(
+        symbols, lhs, rhs, range, kind, detail, fi, context_module, world)
     return nothing
 end
 
 # Short-form function definition: `f(x) = x` or `f(x) where T = x`
 function extract_short_function_symbol!(
         symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
-        context_module::Module
+        context_module::Module, world::UInt
     )
     JS.numchildren(st0) ≥ 2 || return nothing
     sig = st0[1]
     name, name_node = @something extract_function_name(sig) return nothing
-    children = @something extract_scoped_children(st0, fi, context_module) Some(nothing)
+    children = @something extract_scoped_children(st0, fi, context_module, world) Some(nothing)
     detail = JS.sourcetext(sig) * " ="
     push!(symbols, DocumentSymbol(;
         name,
@@ -543,13 +553,13 @@ extract_for_symbol!(args...) = extract_namespace_symbol!(args..., "for ")
 
 function extract_namespace_symbol!(
         symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
-        context_module::Module, prefix::AbstractString
+        context_module::Module, world::UInt, prefix::AbstractString
     )
     JS.numchildren(st0) ≥ 2 || return nothing
-    children = @something extract_scoped_children(st0, fi, context_module) return nothing
+    children = @something extract_scoped_children(st0, fi, context_module, world) return nothing
     body = st0[end]
     if JS.kind(body) === JS.K"block"
-        extract_macrocalls_from_block!(children, body, fi, context_module)
+        extract_macrocalls_from_block!(children, body, fi, context_module, world)
     end
     push!(symbols, DocumentSymbol(;
         name = " ",
@@ -563,13 +573,13 @@ end
 
 function extract_if_symbol!(
         symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
-        context_module::Module;
+        context_module::Module, world::UInt;
         prefix::AbstractString = "if ",
         range_node::SyntaxTreeC = st0
     )
     JS.numchildren(st0) ≥ 2 || return nothing
     children = DocumentSymbol[]
-    extract_if_children!(children, st0, fi, context_module)
+    extract_if_children!(children, st0, fi, context_module, world)
     isempty(children) && return nothing
     push!(symbols, DocumentSymbol(;
         name = " ",
@@ -583,58 +593,61 @@ end
 
 function extract_if_children!(
         children::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
-        context_module::Module
+        context_module::Module, world::UInt
     )
     for i in 2:JS.numchildren(st0)
         child = st0[i]
         k = JS.kind(child)
         if k === JS.K"block"
-            extract_toplevel_symbols!(children, child, fi, context_module)
+            extract_toplevel_symbols!(children, child, fi, context_module, world)
         elseif k === JS.K"elseif" || k === JS.K"if"
-            extract_if_children!(children, child, fi, context_module)
+            extract_if_children!(children, child, fi, context_module, world)
         end
     end
     return nothing
 end
 
 function extract_macrocalls_from_block!(
-        symbols::Vector{DocumentSymbol}, st::SyntaxTreeC, fi::FileInfo, context_module::Module
+        symbols::Vector{DocumentSymbol}, st::SyntaxTreeC, fi::FileInfo,
+        context_module::Module, world::UInt
     )
     for i = 1:JS.numchildren(st)
         child = st[i]
         if JS.kind(child) === JS.K"macrocall"
-            extract_macrocall_symbol!(symbols, child, fi, context_module)
+            extract_macrocall_symbol!(symbols, child, fi, context_module, world)
         end
     end
     return nothing
 end
 
 function extract_macrocall_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo, context_module::Module
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        context_module::Module, world::UInt
     )
     macro_name = get_macrocall_name(st0)
     if macro_name == "@enum"
         extract_enum_symbol!(symbols, st0, fi)
     elseif macro_name == "@static"
-        extract_static_if_symbol!(symbols, st0, fi, context_module)
+        extract_static_if_symbol!(symbols, st0, fi, context_module, world)
     elseif macro_name == "@testset"
-        extract_testset_symbol!(symbols, st0, fi, context_module)
+        extract_testset_symbol!(symbols, st0, fi, context_module, world)
     elseif macro_name == "@test"
         extract_test_symbol!(symbols, st0, fi)
     else
-        extract_toplevel_symbols!(symbols, st0, fi, context_module)
+        extract_toplevel_symbols!(symbols, st0, fi, context_module, world)
     end
     return nothing
 end
 
 function extract_static_if_symbol!(
         symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
-        context_module::Module
+        context_module::Module, world::UInt
     )
     JS.numchildren(st0) ≥ 3 || return nothing
     if_node = st0[3]
     JS.kind(if_node) === JS.K"if" || return nothing
-    extract_if_symbol!(symbols, if_node, fi, context_module; prefix="@static if ", range_node=st0)
+    extract_if_symbol!(symbols, if_node, fi, context_module, world;
+        prefix = "@static if ", range_node = st0)
     return nothing
 end
 
@@ -656,7 +669,7 @@ end
 
 function extract_testset_symbol!(
         symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
-        context_module::Module
+        context_module::Module, world::UInt
     )
     JS.numchildren(st0) ≥ 3 || return nothing
 
@@ -682,18 +695,18 @@ function extract_testset_symbol!(
     body_kind = JS.kind(body)
     children = DocumentSymbol[]
     if body_kind === JS.K"block"
-        extract_toplevel_symbols!(children, body, fi, context_module)
+        extract_toplevel_symbols!(children, body, fi, context_module, world)
     elseif body_kind === JS.K"for" || body_kind === JS.K"let"
         JS.numchildren(body) ≥ 2 || return nothing
         body_block = body[end]
         if JS.kind(body_block) === JS.K"block"
-            extract_toplevel_symbols!(children, body_block, fi, context_module)
+            extract_toplevel_symbols!(children, body_block, fi, context_module, world)
         end
     elseif body_kind === JS.K"call"
         # Function call: @testset "desc" test_func()
         # No children to extract, the test function itself is the body
     else
-        extract_toplevel_symbol!(children, body, fi, context_module)
+        extract_toplevel_symbol!(children, body, fi, context_module, world)
     end
 
     # For @testset let, use bindings node as selection range since there's no description
@@ -786,11 +799,11 @@ end
 
 # Binding-based extraction for scoped children (function body, let block, etc.)
 function extract_scoped_children(
-        st0::SyntaxTreeC, fi::FileInfo, context_module::Module;
+        st0::SyntaxTreeC, fi::FileInfo, context_module::Module, world::UInt;
         soft_scope::Bool = false
     )
     (; ctx3) = try
-        jl_lower_for_scope_resolution(context_module, st0; soft_scope)
+        jl_lower_for_scope_resolution(context_module, world, st0; soft_scope)
     catch
         return nothing
     end

--- a/src/hover.jl
+++ b/src/hover.jl
@@ -93,7 +93,8 @@ function _get_hover(
     # without running full-analysis on the test source.
     context_module = something(context_module, ctx_info.context_module)
     soft_scope = is_notebook_cell_uri(state, uri)
-    binding_result = select_target_binding(st0_top, offset, context_module; soft_scope)
+    binding_result = select_target_binding(
+        st0_top, offset, context_module, world; soft_scope)
     is_cancelled(cancel_flag) && return nothing
 
     if binding_result !== nothing
@@ -140,7 +141,7 @@ function _get_hover(
     end
     # Fallback when the TypeAnnotation pipeline can't supply a type
     if typ === nothing
-        typ = resolve_global_const(context_module, node, world)
+        typ = resolve_global_const(context_module, world, node)
         if typ !== nothing && type_str === nothing && display_node === node
             type_str = hover_type_string(typ, JS.sourcetext(display_node))
         end

--- a/src/references.jl
+++ b/src/references.jl
@@ -84,12 +84,13 @@ function find_references(
     )
     st0_top = build_syntax_tree(fi)
     offset = xy_to_offset(fi, pos)
-    (; context_module) = get_context_info(server.state, uri, pos)
+    (; context_module, world) = get_context_info(server.state, uri, pos)
     soft_scope = is_notebook_cell_uri(server.state, uri)
     locations = Location[]
 
     (; ctx3, st3, binding) = @something begin
-        select_target_binding(st0_top, offset, context_module; caller="find_references", soft_scope)
+        select_target_binding(st0_top, offset, context_module, world;
+            caller="find_references", soft_scope)
     end return locations
 
     binfo = JL.get_binding(ctx3, binding)
@@ -97,7 +98,7 @@ function find_references(
         error = find_global_references!(locations, server, uri, binfo; include_declaration, kwargs...)
         error !== nothing && return error
     else
-        find_local_references!(locations, server, uri, fi, ctx3, st3, binfo;
+        find_local_references!(locations, server, uri, fi, ctx3, st3, binfo, world;
             include_declaration)
     end
 
@@ -192,11 +193,11 @@ end
 
 function find_local_references!(
         locations::Vector{Location}, server::Server, uri::URI, fi::FileInfo,
-        ctx3, st3, binfo::JL.BindingInfo;
+        ctx3, st3, binfo::JL.BindingInfo, world::UInt;
         include_declaration::Bool = true,
     )
     seen_locations = Set{Tuple{URI,Range}}()
-    binding_occurrences = compute_binding_occurrences(ctx3, st3)
+    binding_occurrences = compute_binding_occurrences(ctx3, st3, world)
     if haskey(binding_occurrences, binfo)
         for occurrence in binding_occurrences[binfo]
             if include_declaration || occurrence.kind === :use

--- a/src/rename.jl
+++ b/src/rename.jl
@@ -63,27 +63,29 @@ function handle_PrepareRenameRequest(
     end
     fi = result
 
-    (; context_module) = get_context_info(state, uri, pos)
+    (; context_module, world) = get_context_info(state, uri, pos)
     soft_scope = is_notebook_cell_uri(state, uri)
     return send(server,
         PrepareRenameResponse(;
             id = msg.id,
             result = @something(
-                local_binding_rename_preparation(state, uri, fi, pos, context_module; soft_scope),
-                global_binding_rename_preparation(state, uri, fi, pos, context_module; soft_scope),
+                local_binding_rename_preparation(state, uri, fi, pos, context_module, world; soft_scope),
+                global_binding_rename_preparation(state, uri, fi, pos, context_module, world; soft_scope),
                 file_rename_preparation(state, uri, fi, pos),
                 null)))
 end
 
 function local_binding_rename_preparation(
-        state::ServerState, uri::URI, fi::FileInfo, pos::Position, context_module::Module;
-        soft_scope::Bool = false
+        state::ServerState, uri::URI, fi::FileInfo, pos::Position,
+        context_module::Module, world::UInt;
+        soft_scope::Bool = false,
     )
     st0_top = build_syntax_tree(fi)
     offset = xy_to_offset(fi, pos)
 
     (; ctx3, binding) = @something begin
-        select_target_binding(st0_top, offset, context_module; caller="local_binding_rename_preparation", soft_scope)
+        select_target_binding(st0_top, offset, context_module, world;
+            caller="local_binding_rename_preparation", soft_scope)
     end return nothing
 
     binfo = JL.get_binding(ctx3, binding)
@@ -96,14 +98,16 @@ function local_binding_rename_preparation(
 end
 
 function global_binding_rename_preparation(
-        state::ServerState, uri::URI, fi::FileInfo, pos::Position, context_module::Module;
+        state::ServerState, uri::URI, fi::FileInfo, pos::Position,
+        context_module::Module, world::UInt;
         soft_scope::Bool = false
     )
     st0_top = build_syntax_tree(fi)
     offset = xy_to_offset(fi, pos)
 
     (; ctx3, binding) = @something begin
-        select_target_binding(st0_top, offset, context_module; caller="global_binding_rename_preparation", soft_scope)
+        select_target_binding(st0_top, offset, context_module, world;
+            caller="global_binding_rename_preparation", soft_scope)
     end return nothing
 
     binfo = JL.get_binding(ctx3, binding)
@@ -188,17 +192,18 @@ function rename(
         server::Server, uri::URI, fi::FileInfo, pos::Position, newName::String;
         token::Union{Nothing,ProgressToken} = nothing,
         cancel_flag::AbstractCancelFlag = DUMMY_CANCEL_FLAG)
-    (; context_module) = get_context_info(server.state, uri, pos)
+    (; context_module, world) = get_context_info(server.state, uri, pos)
     soft_scope = is_notebook_cell_uri(server.state, uri)
     return @something(
-        local_binding_rename(server, uri, fi, pos, context_module, newName; soft_scope),
-        global_binding_rename(server, uri, fi, pos, context_module, newName; token, cancel_flag, soft_scope),
+        local_binding_rename(server, uri, fi, pos, context_module, world, newName; soft_scope),
+        global_binding_rename(server, uri, fi, pos, context_module, world, newName; token, cancel_flag, soft_scope),
         file_rename(server, uri, fi, pos, newName),
         (; result = null, error = nothing))
 end
 
 function local_binding_rename(
-        server::Server, uri::URI, fi::FileInfo, pos::Position, context_module::Module, newName::String;
+        server::Server, uri::URI, fi::FileInfo, pos::Position,
+        context_module::Module, world::UInt, newName::String;
         soft_scope::Bool = false
     )
     state = server.state
@@ -206,7 +211,8 @@ function local_binding_rename(
     offset = xy_to_offset(fi, pos)
 
     (; ctx3, st3, binding) = @something begin
-        select_target_binding(st0_top, offset, context_module; caller="local_binding_rename", soft_scope)
+        select_target_binding(st0_top, offset, context_module, world;
+            caller="local_binding_rename", soft_scope)
     end return nothing
 
     binfo = JL.get_binding(ctx3, binding)
@@ -224,7 +230,7 @@ function local_binding_rename(
         end
     end
 
-    binding_occurrences = compute_binding_occurrences(ctx3, st3)
+    binding_occurrences = compute_binding_occurrences(ctx3, st3, world)
     haskey(binding_occurrences, binfo) ||
         return (; result = nothing,
             error = ResponseError(;
@@ -257,7 +263,8 @@ function local_binding_rename(
 end
 
 function global_binding_rename(
-        server::Server, uri::URI, fi::FileInfo, pos::Position, context_module::Module, newName::String;
+        server::Server, uri::URI, fi::FileInfo, pos::Position,
+        context_module::Module, world::UInt, newName::String;
         token::Union{Nothing,ProgressToken} = nothing,
         cancel_flag::AbstractCancelFlag = DUMMY_CANCEL_FLAG,
         soft_scope::Bool = false
@@ -266,7 +273,8 @@ function global_binding_rename(
     offset = xy_to_offset(fi, pos)
 
     (; ctx3, binding) = @something begin
-        select_target_binding(st0_top, offset, context_module; caller="global_binding_rename", soft_scope)
+        select_target_binding(st0_top, offset, context_module, world;
+            caller="global_binding_rename", soft_scope)
     end return nothing
 
     binfo = JL.get_binding(ctx3, binding)

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -608,7 +608,7 @@ function cursor_siginfos(
         world, caller="cursor_siginfos", cache=fi.inferred_context_cache)
     fntyp = ctx === nothing ? nothing : get_type_for_range(ctx, JS.byte_range(call[1]))
     if fntyp === nothing
-        fntyp = resolve_global_const(context_module, call[1], world)
+        fntyp = resolve_global_const(context_module, world, call[1])
     end
     fntyp isa Core.Const || return empty_siginfos
 

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -197,41 +197,57 @@ end
 
 is_mainfunc0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@main")
 
-function is_base_macrocall0(st0::SyntaxTreeC, name::AbstractString)
-    JS.kind(st0) === JS.K"macrocall" || return false
-    JS.numchildren(st0) >= 1 || return false
-    macro_name = st0[1]
-    JS.kind(macro_name) === JS.K"." || return false
-    JS.numchildren(macro_name) >= 2 || return false
-    get_name_val(macro_name[1]) == "Base" || return false
-    rhs = macro_name[2]
-    if JS.kind(rhs) in JS.KSet"quote inert" && JS.numchildren(rhs) >= 1
-        rhs = rhs[1]
-    end
-    return get_name_val(rhs) == name
+function resolve_macrocall_object(context_module::Module, world::UInt, st0::SyntaxTreeC)
+    JS.kind(st0) === JS.K"macrocall" || return nothing
+    JS.numchildren(st0) >= 1 || return nothing
+    macro_const = resolve_global_const(context_module, world, st0[1])
+    macro_const isa Core.Const || return nothing
+    return macro_const.val
 end
 
-is_base_generated0(st0::SyntaxTreeC) = is_base_macrocall0(st0, "@generated")
-is_generated0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@generated") || is_base_generated0(st0)
+function is_macro_object_binding(
+        macro_object, world::UInt, defining_module::Module, name::Symbol
+    )
+    Base.invoke_in_world(world, isdefinedglobal, defining_module, name) || return false
+    target = Base.invoke_in_world(world, getglobal, defining_module, name)
+    return macro_object === target
+end
 
-is_base_ateval0(st0::SyntaxTreeC) = is_base_macrocall0(st0, "@eval")
-is_ateval0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@eval") || is_base_ateval0(st0)
+function is_macrocall_binding0(
+        context_module::Module, world::UInt, st0::SyntaxTreeC,
+        defining_module::Module, name::Symbol
+    )
+    macro_object = @something resolve_macrocall_object(context_module, world, st0) return false
+    return is_macro_object_binding(macro_object, world, defining_module, name)
+end
+
+is_generated0(context_module::Module, world::UInt, st0::SyntaxTreeC) =
+    is_macrocall_binding0(context_module, world, st0, Base, Symbol("@generated"))
+
+is_ateval0(context_module::Module, world::UInt, st0::SyntaxTreeC) =
+    is_macrocall_binding0(context_module, world, st0, Base, Symbol("@eval"))
 
 is_nospecialize_or_specialize_macrocall0(st0::SyntaxTreeC) =
     is_macrocall_st0(st0, "@nospecialize", "@specialize")
 
 is_macro0(st0::SyntaxTreeC) = JS.kind(st0) === JS.K"macro"
 
-is_new_style_macrocall0(st0::SyntaxTreeC) =
-    is_macrocall_st0(st0, NEW_STYLE_MACROCALL_NAMES...) ||
-    is_base_generated0(st0) || is_base_ateval0(st0)
+function is_new_style_macrocall0(
+        context_module::Module, world::UInt, st0::SyntaxTreeC
+    )
+    macro_object = @something resolve_macrocall_object(context_module, world, st0) return false
+    return any(NEW_STYLE_MACRO_BINDINGS) do (defining_module, name)
+        is_macro_object_binding(macro_object, world, defining_module, name)
+    end
+end
 
 is_doc0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@doc"; from=Core)
 is_doc0_any(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@doc") # Explicit `@doc` can have any module set.
 
 is_cmd0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@cmd"; from=Core)
 
-is_static0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@static")
+is_static0(context_module::Module, world::UInt, st0::SyntaxTreeC) =
+    is_macrocall_binding0(context_module, world, st0, Base, Symbol("@static"))
 
 """
     collect_import_names(st0::SyntaxTreeC) -> Vector{Pair{SyntaxTreeC, String}}
@@ -392,19 +408,28 @@ function is_nospecialize_or_specialize_macrocall3(st3::SyntaxTreeC)
     return get_name_val(macro_name) in ("nospecialize", "specialize")
 end
 
-function _remove_macrocalls(st0::SyntaxTreeC; strip_static::Bool=false)
+function _remove_macrocalls(
+        context_module::Union{Nothing,Module}, world::UInt, st0::SyntaxTreeC;
+        strip_static::Bool = false
+    )
     if JS.kind(st0) === JS.K"macrocall"
-        if is_new_style_macrocall0(st0) && !(strip_static && is_static0(st0))
-            # Macros with new-style JuliaLowering implementations preserve
-            # fine-grained provenance during expansion, so we don't need to
-            # rewrite them to a `block` to keep source locations accurate.
-            # See `NEW_STYLE_MACROCALL_NAMES` for the list.
-            # With `strip_static`, `@static` is exempted from this exemption: it is
-            # rewritten to a `block` keeping *all* branches (a plain runtime
-            # conditional) instead of expanding to the single platform-selected
-            # branch, so occurrence analysis sees every branch — scope-aware — rather
-            # than dropping the branches not taken on the current platform.
-            return st0, false
+        is_new_style = context_module !== nothing &&
+            is_new_style_macrocall0(context_module, world, st0)
+        strip_current_static = strip_static && context_module !== nothing &&
+            is_static0(context_module, world, st0)
+        if is_new_style && !strip_current_static
+            # Preserve this macrocall, but still remove old-style macros and `@static`
+            # calls nested in its arguments.
+            new_children = JS.SyntaxList(JS.syntax_graph(st0))
+            push!(new_children, st0[1])
+            changed = false
+            for i = 2:JS.numchildren(st0)
+                child, child_changed = _remove_macrocalls(
+                    context_module, world, st0[i]; strip_static)
+                changed |= child_changed
+                push!(new_children, child)
+            end
+            return (changed ? JS.mknode(st0, new_children) : st0, changed)
         elseif is_mainfunc0(st0)
             # `@main` functions are desugared by `desugar_main_macrocall` below,
             # so there's no need to remove them here
@@ -428,7 +453,8 @@ function _remove_macrocalls(st0::SyntaxTreeC; strip_static::Bool=false)
             # arguments out of the macrocall into a bare `block`, any surviving
             # `$` would be out of context and fail lowering, so unwrap
             # interpolations on the lifted child.
-            stripped, _ = _remove_macrocalls(st0[i]; strip_static)
+            stripped, _ = _remove_macrocalls(
+                context_module, world, st0[i]; strip_static)
             push!(new_children, _unwrap_interpolations(stripped)[1])
         end
         return JL.@ast(JS.syntax_graph(st0), st0, [JS.K"block" new_children...]), true
@@ -437,8 +463,18 @@ function _remove_macrocalls(st0::SyntaxTreeC; strip_static::Bool=false)
     end
     (st0, changed) = desugar_main_macrocall(st0)
     new_children = JS.SyntaxList(JS.syntax_graph(st0))
+    inner_context = if JS.kind(st0) === JS.K"module" && JS.numchildren(st0) >= 2
+        module_const = context_module === nothing ? nothing :
+            resolve_global_const(context_module, world, st0[2])
+        module_const isa Core.Const && module_const.val isa Module ?
+            module_const.val : nothing
+    else
+        context_module
+    end
     for c in JS.children(st0)
-        nc, cc = _remove_macrocalls(c; strip_static)
+        child_context = JS.kind(st0) === JS.K"module" && JS.kind(c) === JS.K"block" ?
+            inner_context : context_module
+        nc, cc = _remove_macrocalls(child_context, world, c; strip_static)
         changed |= cc
         push!(new_children, nc)
     end
@@ -504,12 +540,17 @@ function desugar_main_macrocall(st0::SyntaxTreeC)
 end
 
 """
-    remove_macrocalls(st0::SyntaxTreeC; strip_static::Bool=false) -> SyntaxTreeC
+    remove_macrocalls(
+        context_module::Module, world::UInt, st0::SyntaxTreeC;
+        strip_static::Bool=false
+    ) -> SyntaxTreeC
 
-Convert each `macrocall` node to a `block` node, keeping the arguments intact so that
-identifiers passed to macros retain their original source locations. The transformed
-tree can then be fed into scope/binding resolution to drive LSP features such as
-find-references, document-highlight, rename, and go-to-definition.
+Convert each old-style `macrocall` node to a `block` node, keeping the arguments intact
+so that identifiers passed to macros retain their original source locations. Macro names
+are resolved from `context_module`; calls whose macro object matches a binding in
+`NEW_STYLE_MACRO_BINDINGS` are preserved. The transformed tree can then be fed into
+scope/binding resolution to drive LSP features such as find-references,
+document-highlight, rename, and go-to-definition.
 
 With `strip_static=true`, `@static` conditionals are also rewritten to plain runtime
 conditionals (keeping every branch) rather than expanded to the single branch selected
@@ -546,14 +587,17 @@ any bindings or control flow the macros themselves would have introduced.
 !!! note "Future direction"
     This transform is a workaround for old-style macros that lose provenance
     during expansion. Macros with new-style JuliaLowering implementations (listed
-    in `NEW_STYLE_MACROCALL_NAMES`) already preserve provenance and are therefore
+    in `NEW_STYLE_MACRO_BINDINGS`) already preserve provenance and are therefore
     exempt from removal, and `@main` is handled separately by
     `desugar_main_macrocall`. As more macros migrate to the new style, the scope
     of this transformation is expected to shrink.
 """
-function remove_macrocalls(st0::SyntaxTreeC; strip_static::Bool=false)
+function remove_macrocalls(
+        context_module::Module, world::UInt, st0::SyntaxTreeC;
+        strip_static::Bool = false
+    )
     ensure_jl_source_attr!(JS.syntax_graph(st0))
-    return first(_remove_macrocalls(st0; strip_static))
+    return first(_remove_macrocalls(context_module, world, st0; strip_static))
 end
 
 # Iteratively peel a function-definition signature's `where {…}` clauses and outer `::T`

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -52,8 +52,7 @@ end
 
 """
     jl_lower_for_scope_resolution(
-            context_module::Module, st0::SyntaxTreeC;
-            world::UInt = Base.get_world_counter(),
+            context_module::Module, world::UInt, st0::SyntaxTreeC;
             trim_error_nodes::Bool = true,
             recover_from_macro_errors::Bool = true,
             convert_closures::Bool = false,
@@ -77,8 +76,7 @@ Throw if lowering fails otherwise.
 Note that ctx objects share mutable information, so we only return `ctx3`
 """
 function jl_lower_for_scope_resolution(
-        context_module::Module, st0::SyntaxTreeC;
-        world::UInt = Base.get_world_counter(),
+        context_module::Module, world::UInt, st0::SyntaxTreeC;
         trim_error_nodes::Bool = true,
         recover_from_macro_errors::Bool = true,
         convert_closures::Bool = false,
@@ -95,7 +93,7 @@ function jl_lower_for_scope_resolution(
         @static JETLS_DEBUG_LOWERING && @warn "Error in macro expansion; trimming and retrying"
         @static JETLS_DEBUG_LOWERING && showerror(stderr, err)
         @static JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
-        st0 = remove_macrocalls(st0)
+        st0 = remove_macrocalls(context_module, world, st0)
         st0 = JL.rebase_layers(st0, context_module, JS.JL_OLD_SYNTAX_VERSION)
         JL.expand_forms_1(st0, world, true)
     end
@@ -123,13 +121,13 @@ as an ephemeral stack.)  We work around this by taking all available bindings
 and filtering out any that aren't declared in a scope containing the cursor.
 """
 function cursor_bindings(
-        st0_top::SyntaxTreeC, offset::Int, context_module::Module;
+        st0_top::SyntaxTreeC, offset::Int, context_module::Module, world::UInt;
         soft_scope::Bool = false
     )
     st0 = @something lowerable_toplevel_at(st0_top, offset) return nothing
     (st0, _) = desugar_main_macrocall(st0)
     (; ctx3, st2) = try
-        jl_lower_for_scope_resolution(context_module, st0; soft_scope)
+        jl_lower_for_scope_resolution(context_module, world, st0; soft_scope)
     catch err
         @static JETLS_DEBUG_LOWERING && @warn "Error in lowering" err
         @static JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
@@ -265,7 +263,7 @@ end
 
 """
     select_target_binding(
-            st0_top::SyntaxTreeC, offset::Int, context_module::Module;
+            st0_top::SyntaxTreeC, offset::Int, context_module::Module, world::UInt;
             soft_scope::Bool = false
         ) -> Union{Nothing, NamedTuple}
 
@@ -275,24 +273,28 @@ contains `(; ctx3, st3, st0, binding)` where `binding` satisfies
 `JS.kind(binding) === JS.K"BindingId"`.
 """
 function select_target_binding(
-        st0_top::SyntaxTreeC, offset::Int, context_module::Module;
+        st0_top::SyntaxTreeC, offset::Int, context_module::Module, world::UInt;
         caller::AbstractString = "select_target_binding",
         soft_scope::Bool = false
     )
     st0 = @something lowerable_toplevel_at(st0_top, offset) return nothing
 
-    macrocall_result = select_macrocall_binding(st0, offset, context_module, caller; soft_scope)
+    macrocall_result = select_macrocall_binding(
+        st0, offset, context_module, world; caller, soft_scope)
     macrocall_result !== nothing && return macrocall_result
 
-    export_public_result = select_export_public_binding(st0, offset, context_module, caller; soft_scope)
+    export_public_result = select_export_public_binding(
+        st0, offset, context_module, world; caller, soft_scope)
     export_public_result !== nothing && return export_public_result
 
-    import_using_result = select_import_using_binding(st0, offset, context_module, caller; soft_scope)
+    import_using_result = select_import_using_binding(
+        st0, offset, context_module, world; caller, soft_scope)
     import_using_result !== nothing && return import_using_result
 
+    st0′ = remove_macrocalls(context_module, world, st0; strip_static=true)
     (; ctx3, st3) = try
         # Remove macros to preserve precise source locations
-        jl_lower_for_scope_resolution(context_module, remove_macrocalls(st0; strip_static=true); soft_scope)
+        jl_lower_for_scope_resolution(context_module, world, st0′; soft_scope)
     catch err
         @static JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
         @static JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
@@ -304,7 +306,7 @@ function select_target_binding(
         return (; ctx3, st3, st0, binding)
     end
     inert_result = select_inert_target_binding(
-        st0, ctx3, st3, offset, context_module; soft_scope)
+        st0, ctx3, st3, offset, context_module, world; soft_scope)
     inert_result !== nothing && return inert_result
 
     inner_constructor = select_struct_inner_constructor_binding(ctx3, st0, offset)
@@ -460,7 +462,7 @@ function prepare_inert_template(
 end
 
 function resolve_inert_tree(
-        context_module::Module, inert_tree::SyntaxTreeC;
+        context_module::Module, world::UInt, inert_tree::SyntaxTreeC;
         parameters::Dict{String,SyntaxTreeC} = Dict{String,SyntaxTreeC}(),
         hard_scope::Bool = false,
         soft_scope::Bool = false,
@@ -483,7 +485,7 @@ function resolve_inert_tree(
         template
     end
     ires = try
-        jl_lower_for_scope_resolution(context_module, input; soft_scope)
+        jl_lower_for_scope_resolution(context_module, world, input; soft_scope)
     catch
         return nothing
     end
@@ -506,7 +508,7 @@ function contains_syntaxunquote(st::SyntaxTreeC)
 end
 
 function collect_generated_inert_resolutions(
-        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, world::UInt
     )
     resolutions = InertResolution[]
     seen = Set{Tuple{JS.Kind,UnitRange{Int}}}()
@@ -527,7 +529,7 @@ function collect_generated_inert_resolutions(
             key = (JS.kind(node), JS.byte_range(node))
             key in seen && return traversal_no_recurse
             push!(seen, key)
-            resolution = resolve_inert_tree(context_module, node;
+            resolution = resolve_inert_tree(context_module, world, node;
                 parameters=args, hard_scope=true,
                 preserve_nested_interpolations=true)
             resolution === nothing || push!(resolutions, resolution)
@@ -574,12 +576,19 @@ function is_code_shaped_quote_range(st0::SyntaxTreeC, range::UnitRange{Int})
     return false
 end
 
-is_generated_inert_range(st0::SyntaxTreeC, range::UnitRange{Int}) =
-    any(is_generated0, byte_ancestors(st0, range))
+function is_generated_inert_range(
+        context_module::Module, world::UInt, st0::SyntaxTreeC, range::UnitRange{Int}
+    )
+    return any(byte_ancestors(st0, range)) do ancestor
+        is_generated0(context_module, world, ancestor)
+    end
+end
 
-function eval_input_info(st0::SyntaxTreeC, range::UnitRange{Int})
+function eval_input_info(
+        context_module::Module, world::UInt, st0::SyntaxTreeC, range::UnitRange{Int}
+    )
     for ancestor in byte_ancestors(st0, range)
-        is_ateval0(ancestor) || continue
+        is_ateval0(context_module, world, ancestor) || continue
         nchildren = JS.numchildren(ancestor)
         for i = 3:nchildren
             range ⊆ JS.byte_range(ancestor[i]) || continue
@@ -592,7 +601,9 @@ function eval_input_info(st0::SyntaxTreeC, range::UnitRange{Int})
 end
 
 """
-    inert_resolution_policy(st0::SyntaxTreeC, range::UnitRange{Int}) -> Symbol
+    inert_resolution_policy(
+        context_module::Module, world::UInt, st0::SyntaxTreeC, range::UnitRange{Int}
+    ) -> Symbol
 
 Choose how to resolve bindings in an inert source range. This deliberately uses
 construction-site resolution for free globals in code-shaped quotes: it is a
@@ -618,8 +629,10 @@ References and rename share this policy so they agree on binding identity and
 occurrences. Generated-function inert code is handled separately with its
 synthetic function scope and argument remapping.
 """
-function inert_resolution_policy(st0::SyntaxTreeC, range::UnitRange{Int})
-    eval_input = eval_input_info(st0, range)
+function inert_resolution_policy(
+        context_module::Module, world::UInt, st0::SyntaxTreeC, range::UnitRange{Int}
+    )
+    eval_input = eval_input_info(context_module, world, st0, range)
     if eval_input !== nothing
         eval_input.nargs == 1 || return :unresolved
         if eval_input.is_direct && !is_quoted_range(st0, range)
@@ -651,14 +664,16 @@ end
 
 # `@eval` contributes an implicit quote stage. Interpolation removes a stage, so
 # a macrocall at depth zero executes in the surrounding lexical context.
-function should_resolve_macrocall(st0::SyntaxTreeC, range::UnitRange{Int})
-    eval_input = eval_input_info(st0, range)
+function should_resolve_macrocall(
+        context_module::Module, world::UInt, st0::SyntaxTreeC, range::UnitRange{Int}
+    )
+    eval_input = eval_input_info(context_module, world, st0, range)
     depth = quote_stage_depth(st0, range) + (eval_input === nothing ? 0 : 1)
     depth <= 0 && return true
     if eval_input !== nothing
         return eval_input.nargs == 1 && depth == 1
     end
-    return inert_resolution_policy(st0, range) !== :unresolved
+    return inert_resolution_policy(context_module, world, st0, range) !== :unresolved
 end
 
 function resolved_binding_at(resolution::InertResolution, offset::Int)
@@ -670,11 +685,11 @@ end
 
 function select_inert_target_binding(
         st0::SyntaxTreeC, ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC,
-        offset::Int, context_module::Module;
+        offset::Int, context_module::Module, world::UInt;
         soft_scope::Bool = false
     )
     inside_generated = false
-    for resolution in collect_generated_inert_resolutions(ctx3, st3)
+    for resolution in collect_generated_inert_resolutions(ctx3, st3, world)
         (offset in resolution.source_range ||
             (offset > 0 && offset-1 in resolution.source_range)) || continue
         inside_generated = true
@@ -694,9 +709,9 @@ function select_inert_target_binding(
         offset > 0 ? enclosing_inert_tree(st3, offset-1) : nothing,
         return nothing)
     range = JS.byte_range(inert_tree)
-    policy = inert_resolution_policy(st0, range)
+    policy = inert_resolution_policy(context_module, world, st0, range)
     resolution = @something resolve_inert_tree(
-        context_module, inert_tree;
+        context_module, world, inert_tree;
         hard_scope=policy === :macro, soft_scope) return nothing
     binding = @something resolved_binding_at(resolution, offset) return nothing
     binfo = JL.get_binding(resolution.ctx3, binding)
@@ -758,7 +773,8 @@ function select_struct_inner_constructor_binding(
 end
 
 function select_macrocall_binding(
-        st0::SyntaxTreeC, offset::Int, context_module::Module, caller::AbstractString;
+        st0::SyntaxTreeC, offset::Int, context_module::Module, world::UInt;
+        caller::AbstractString = "select_macrocall_binding",
         soft_scope::Bool = false
     )
     is_macrocall_name = (offset::Int) -> (st0′::SyntaxTreeC) ->
@@ -772,10 +788,11 @@ function select_macrocall_binding(
     end
     isempty(bas) && return nothing
     macrocall = bas[1]
-    should_resolve_macrocall(st0, JS.byte_range(macrocall)) || return nothing
+    should_resolve_macrocall(
+        context_module, world, st0, JS.byte_range(macrocall)) || return nothing
     macrocall_name = macrocall[1]
     (; ctx3, st3) = try
-        jl_lower_for_scope_resolution(context_module, macrocall_name; soft_scope)
+        jl_lower_for_scope_resolution(context_module, world, macrocall_name; soft_scope)
     catch err
         @static JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
         @static JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
@@ -795,7 +812,8 @@ end
 # Detect that case directly and lower just the single identifier under the
 # cursor so callers receive a normal `(ctx3, st3, st0, binding)` tuple.
 function select_export_public_binding(
-        st0::SyntaxTreeC, offset::Int, context_module::Module, caller::AbstractString;
+        st0::SyntaxTreeC, offset::Int, context_module::Module, world::UInt;
+        caller::AbstractString = "select_export_public_binding",
         soft_scope::Bool = false
     )
     find_name_node = (offset::Int) -> (st0′::SyntaxTreeC) -> begin
@@ -820,7 +838,7 @@ function select_export_public_binding(
             1:JS.numchildren(parent)) return nothing; end
     name_node = parent[i]
     (; ctx3, st3) = try
-        jl_lower_for_scope_resolution(context_module, name_node; soft_scope)
+        jl_lower_for_scope_resolution(context_module, world, name_node; soft_scope)
     catch err
         @static JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
         @static JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
@@ -840,7 +858,8 @@ end
 # detect the cursor against `foreach_local_import_identifier` and lower the
 # single matching identifier to synthesize a normal binding tuple.
 function select_import_using_binding(
-        st0::SyntaxTreeC, offset::Int, context_module::Module, caller::AbstractString;
+        st0::SyntaxTreeC, offset::Int, context_module::Module, world::UInt;
+        caller::AbstractString = "select_import_using_binding",
         soft_scope::Bool = false
     )
     find_name_node_at = function (offset::Int, st0′::SyntaxTreeC)
@@ -864,7 +883,7 @@ function select_import_using_binding(
     isempty(bas) && return nothing
     name_node = @something find_name_node_at(offset, bas[1]) return nothing
     (; ctx3, st3) = try
-        jl_lower_for_scope_resolution(context_module, name_node; soft_scope)
+        jl_lower_for_scope_resolution(context_module, world, name_node; soft_scope)
     catch err
         @static JETLS_DEBUG_LOWERING && @warn "Error in lowering ($caller)" err
         @static JETLS_DEBUG_LOWERING && Base.show_backtrace(stderr, catch_backtrace())
@@ -881,7 +900,7 @@ end
 
 """
     select_target_binding_definitions(
-            st0_top::SyntaxTreeC, offset::Int, context_module::Module
+            st0_top::SyntaxTreeC, offset::Int, context_module::Module, world::UInt
         ) -> nothing or (binding::SyntaxTreeC, definitions::SyntaxListC)
 
 Find the binding at the cursor position and return all of its definition sites.
@@ -892,11 +911,11 @@ has no definitions. Otherwise returns a tuple of `(binding, definitions)` where:
 - `definitions` is a `SyntaxListC` containing all definition sites for that binding
 """
 function select_target_binding_definitions(
-        st0_top::SyntaxTreeC, offset::Int, context_module::Module;
+        st0_top::SyntaxTreeC, offset::Int, context_module::Module, world::UInt;
         soft_scope::Bool = false, skip_global::Bool = false
     )
     (; ctx3, st3, binding) = @something select_target_binding(
-        st0_top, offset, context_module; soft_scope) return nothing
+        st0_top, offset, context_module, world; soft_scope) return nothing
     binfo = JL.get_binding(ctx3, binding)
     skip_global && binfo.kind === :global && return nothing
     definitions = @somereal lookup_binding_definitions(st3, binfo) return nothing

--- a/src/utils/jl-syntax-macros.jl
+++ b/src/utils/jl-syntax-macros.jl
@@ -135,61 +135,55 @@ push_inactive_code!(node::SyntaxTreeC, condval::Bool) =
         "Inactive `@static` branch (condition evaluated to `$condval`)",
         DiagnosticSeverity.Hint, LOWERING_INACTIVE_CODE)
 
-# Simple (non-qualified) macro names whose new-style implementations in this file and
+# Macro bindings whose new-style implementations in this file and
 # `JuliaLowering/src/syntax_macros.jl` preserve fine-grained source provenance during
 # expansion. Unlike old-style macros — whose expansion collapses source positions to
 # line granularity and is why `_remove_macrocalls` exists — these don't need to be
 # rewritten to a `block` to keep accurate locations for scope resolution.
-#
-# TODO: Define these as `(module, name)` pairs and have `remove_macrocalls` accept the
-# caller's `context_module` so it can resolve each source macrocall to its macro object.
-# Source-name matching cannot recognize qualified calls or aliases, and can mistake an
-# unrelated same-named macro for one of these implementations. `Base.@generated` and
-# `Base.@eval` are special-cased in `ast.jl` until this resolution is available.
-const NEW_STYLE_MACROCALL_NAMES = (
+const NEW_STYLE_MACRO_BINDINGS = (
     # JuliaLowering/src/syntax_macros.jl
-    "@__FUNCTION__",
-    "@ccall",
-    "@cfunction",
-    "@eval",
-    "@generated",
-    "@goto",
-    "@isdefined",
-    "@locals",
-    "@nospecialize",
+    Base => Symbol("@__FUNCTION__"),
+    Base => Symbol("@ccall"),
+    Base => Symbol("@cfunction"),
+    Base => Symbol("@eval"),
+    Base => Symbol("@generated"),
+    Base => Symbol("@goto"),
+    Base => Symbol("@isdefined"),
+    Base => Symbol("@locals"),
+    Base => Symbol("@nospecialize"),
     # src/utils/jl-syntax-macros.jl
-    "@assert",
-    "@assume_effects",
-    "@debug",
-    "@error",
-    "@inbounds",
-    "@inferred",
-    "@info",
-    "@inline",
-    "@invoke",
-    "@invokelatest",
-    "@kwdef",
-    "@label",
-    "@lazy_str",
-    "@lock",
-    "@logmsg",
-    "@noinline",
-    "@propagate_inbounds",
-    "@show",
-    "@something",
-    "@spawn",
-    "@specialize",
-    "@static",
-    "@test",
-    "@test_broken",
-    "@test_deprecated",
-    "@test_logs",
-    "@test_nowarn",
-    "@test_skip",
-    "@test_throws",
-    "@test_warn",
-    "@testset",
-    "@warn",
+    Base => Symbol("@assert"),
+    Base => Symbol("@assume_effects"),
+    Base => Symbol("@inbounds"),
+    Base => Symbol("@inline"),
+    Base => Symbol("@invoke"),
+    Base => Symbol("@invokelatest"),
+    Base => Symbol("@kwdef"),
+    Base => Symbol("@label"),
+    Base => Symbol("@lazy_str"),
+    Base => Symbol("@lock"),
+    Base => Symbol("@noinline"),
+    Base => Symbol("@propagate_inbounds"),
+    Base => Symbol("@show"),
+    Base => Symbol("@something"),
+    Base => Symbol("@specialize"),
+    Base => Symbol("@static"),
+    Base.Threads => Symbol("@spawn"),
+    Base.CoreLogging => Symbol("@debug"),
+    Base.CoreLogging => Symbol("@error"),
+    Base.CoreLogging => Symbol("@info"),
+    Base.CoreLogging => Symbol("@logmsg"),
+    Base.CoreLogging => Symbol("@warn"),
+    Test => Symbol("@inferred"),
+    Test => Symbol("@test"),
+    Test => Symbol("@test_broken"),
+    Test => Symbol("@test_deprecated"),
+    Test => Symbol("@test_logs"),
+    Test => Symbol("@test_nowarn"),
+    Test => Symbol("@test_skip"),
+    Test => Symbol("@test_throws"),
+    Test => Symbol("@test_warn"),
+    Test => Symbol("@testset"),
 )
 
 function Base.var"@specialize"(__context__::JL.MacroContext)

--- a/src/utils/type-annotation-utils.jl
+++ b/src/utils/type-annotation-utils.jl
@@ -74,7 +74,7 @@ function closure_argnames(po::Core.PartialOpaque, nargs::Int)
 end
 
 """
-    resolve_global_const(context_module::Module, node::SyntaxTreeC, world::UInt) ->
+    resolve_global_const(context_module::Module, world::UInt, node::SyntaxTreeC) ->
         Core.Const | nothing
 
 Best-effort static lookup of a `K"Identifier"` or `K"."` dotted-path node as a
@@ -93,7 +93,7 @@ inputs need real inference, which the caller already attempted.
 `world` pins the binding lookup so concurrent analysis updates can't make this
 fallback observe a newer world than the rest of the request.
 """
-function resolve_global_const(context_module::Module, node::SyntaxTreeC, world::UInt)
+function resolve_global_const(context_module::Module, world::UInt, node::SyntaxTreeC)
     if JS.kind(node) === JS.K"Identifier" && has_name_val(node)
         sym = Symbol(name_val(node))
         Base.invoke_in_world(world, isdefinedglobal, context_module, sym) || return nothing
@@ -105,11 +105,11 @@ function resolve_global_const(context_module::Module, node::SyntaxTreeC, world::
         if JS.kind(suffix) === JS.K"inert" && JS.numchildren(suffix) >= 1
             suffix = suffix[1]
         end
-        prefix_const = resolve_global_const(context_module, prefix, world)
+        prefix_const = resolve_global_const(context_module, world, prefix)
         prefix_const isa Core.Const || return nothing
         submod = prefix_const.val
         submod isa Module || return nothing
-        return resolve_global_const(submod, suffix, world)
+        return resolve_global_const(submod, world, suffix)
     end
     return nothing
 end

--- a/test/analysis/test_Closure2Opaque.jl
+++ b/test/analysis/test_Closure2Opaque.jl
@@ -16,8 +16,9 @@ function rewrite_lower_eval(code::AbstractString)
     st0_top = JETLS.build_syntax_tree(fi)
     last_value = Ref{Any}(nothing)
     last_st3_oc = Ref{Union{JETLS.SyntaxTreeC,Nothing}}(nothing)
+    world = Base.get_world_counter()
     JETLS.iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
-        result = JETLS.TypeAnnotation.get_inferrable_tree(st0, context_module)
+        result = JETLS.TypeAnnotation.get_inferrable_tree(st0, context_module, world)
         result === nothing && error("get_inferrable_tree failed for: $code")
         (; ctx3, st3) = result
         st3_oc = rewrite_local_closures_to_opaque(ctx3, st3)
@@ -41,8 +42,9 @@ function rewrite_only(code::AbstractString)
     fi = JETLS.FileInfo(1, code, @__FILE__)
     st0_top = JETLS.build_syntax_tree(fi)
     last_st3_oc = Ref{Union{JETLS.SyntaxTreeC,Nothing}}(nothing)
+    world = Base.get_world_counter()
     JETLS.iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
-        result = JETLS.TypeAnnotation.get_inferrable_tree(st0, context_module)
+        result = JETLS.TypeAnnotation.get_inferrable_tree(st0, context_module, world)
         result === nothing && error("get_inferrable_tree failed for: $code")
         (; ctx3, st3) = result
         last_st3_oc[] = rewrite_local_closures_to_opaque(ctx3, st3)

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -166,8 +166,9 @@ end
             fi = JETLS.FileInfo(1, code, @__FILE__)
             st0_top = JETLS.build_syntax_tree(fi)
             results = []
+            world = Base.get_world_counter()
             JETLS.iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
-                r = get_inferrable_tree(st0, Main)
+                r = get_inferrable_tree(st0, Main, world)
                 r === nothing || push!(results, (; r..., st0))
                 return nothing
             end
@@ -186,8 +187,9 @@ end
         let code = "@__undefined_macro_for_test__ xyz"
             fi = JETLS.FileInfo(1, code, @__FILE__)
             st0_top = JETLS.build_syntax_tree(fi)
+            world = Base.get_world_counter()
             JETLS.iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
-                @test isnothing(get_inferrable_tree(st0, @__MODULE__))
+                @test isnothing(get_inferrable_tree(st0, @__MODULE__, world))
                 return nothing
             end
         end

--- a/test/analysis/test_cfg_analysis.jl
+++ b/test/analysis/test_cfg_analysis.jl
@@ -14,10 +14,12 @@ module lowering_module end
 function get_undef_status(
         text::AbstractString;
         context_module::Module = lowering_module,
+        world::UInt = Base.get_world_counter(),
         allow_noreturn_optimization::Vector{Symbol} = Symbol[]
     )
     st0 = jlparse(text; rule=:statement, filename=@__FILE__)
-    (; ctx3, st3) = JETLS.jl_lower_for_scope_resolution(context_module, st0; trim_error_nodes=false, recover_from_macro_errors=false)
+    (; ctx3, st3) = JETLS.jl_lower_for_scope_resolution(context_module, world, st0;
+        trim_error_nodes=false, recover_from_macro_errors=false)
     (; undef_info) = JETLS.analyze_all_lambdas(ctx3, st3; allow_noreturn_optimization)
     result = Dict{String, Union{Nothing,Bool}}()
     for (binfo, info) in undef_info
@@ -1147,10 +1149,11 @@ end # @testset "undef analysis" begin
 function get_dead_stores(
         text::AbstractString;
         context_module::Module = lowering_module,
+        world::UInt = Base.get_world_counter(),
         allow_noreturn_optimization::Vector{Symbol} = Symbol[]
     )
     st0 = jlparse(text; rule=:statement, filename=@__FILE__)
-    (; ctx3, st3) = JETLS.jl_lower_for_scope_resolution(context_module, st0;
+    (; ctx3, st3) = JETLS.jl_lower_for_scope_resolution(context_module, world, st0;
         trim_error_nodes=false, recover_from_macro_errors=false)
     (; dead_store_info) = JETLS.analyze_all_lambdas(ctx3, st3;
         allow_noreturn_optimization)
@@ -1587,10 +1590,11 @@ end # @testset "dead store analysis" begin
 function get_unreachable_statements(
         text::AbstractString;
         context_module::Module = lowering_module,
+        world::UInt = Base.get_world_counter(),
         allow_noreturn_optimization::Vector{Symbol} = Symbol[]
     )
     st0 = jlparse(text; rule=:statement, filename=@__FILE__)
-    (; ctx3, st3) = JETLS.jl_lower_for_scope_resolution(context_module, st0;
+    (; ctx3, st3) = JETLS.jl_lower_for_scope_resolution(context_module, world, st0;
         trim_error_nodes=false, recover_from_macro_errors=false)
     (; unreachable_statements) = JETLS.analyze_all_lambdas(ctx3, st3;
         allow_noreturn_optimization)

--- a/test/analysis/test_occurrence_analysis.jl
+++ b/test/analysis/test_occurrence_analysis.jl
@@ -7,20 +7,29 @@ using JETLS.LSP.URIs2
 
 include(normpath(pkgdir(JETLS), "test", "jsjl-utils.jl"))
 
-module lowering_module end
+module lowering_module
+const B = Base
+end
+
+module same_named_eval_context
+macro eval(args...)
+    return esc(last(args))
+end
+end
 
 with_binding_occurrences(callback, code::AbstractString; kwargs...) =
     with_binding_occurrences(callback, lowering_module, code; kwargs...)
 function with_binding_occurrences(
         callback, context_module::Module, code::AbstractString;
+        world::UInt = Base.get_world_counter(),
         remove_macrocalls::Bool = false
     )
     st0 = jlparse(code; rule=:statement)
     if remove_macrocalls
-        st0 = JETLS.remove_macrocalls(st0)
+        st0 = JETLS.remove_macrocalls(context_module, world, st0)
     end
-    (; ctx3, st3) = JETLS.jl_lower_for_scope_resolution(context_module, st0)
-    binding_occurrences = JETLS.compute_binding_occurrences(ctx3, st3)
+    (; ctx3, st3) = JETLS.jl_lower_for_scope_resolution(context_module, world, st0)
+    binding_occurrences = JETLS.compute_binding_occurrences(ctx3, st3, world)
     callback(binding_occurrences)
 end
 
@@ -427,14 +436,15 @@ end
             end
         end
 
-        with_binding_occurrences("""
-            Base.@generated function foo(x)
-                return :(x + 1)
-            end
-            """) do binding_occurrences
-            @test any(binding_occurrences) do (binding, occurrences)
-                binding.name == "x" && binding.kind === :argument &&
-                any(o -> o.kind === :use, occurrences)
+        for generated_macro in ("Base.@generated", "B.@generated")
+            with_binding_occurrences("""
+                $generated_macro function foo(x)
+                    return :(x + 1)
+                end
+                """) do binding_occurrences
+                @test any(binding_occurrences) do (binding, occurrences)
+                    binding.name == "x" && binding.kind === :argument && any(o -> o.kind === :use, occurrences)
+                end
             end
         end
 
@@ -545,13 +555,14 @@ end
 
 function get_full_binding_occurrences(text::AbstractString;
         filename::String = joinpath(@__DIR__, "testfile.jl"),
+        context_module::Module = lowering_module,
         kwargs...)
     fi = JETLS.FileInfo(#=version=#0, text, filename)
     st0 = jlparse(text; rule=:statement)
     uri = filename2uri(filename)
     state = JETLS.ServerState()
     return JETLS.compute_full_binding_occurrences(state, uri, fi, st0;
-        lookup_func = Returns(JETLS.OutOfScope(lowering_module)),
+        lookup_func = Returns(JETLS.OutOfScope(context_module)),
         kwargs...)
 end
 
@@ -836,7 +847,7 @@ end
         end
 
         # Quoted atomic input remains Symbol data when passed directly to `@eval`.
-        for eval_macro in ("@eval", "Base.@eval")
+        for eval_macro in ("@eval", "Base.@eval", "B.@eval")
             boccs = get_full_binding_occurrences("$eval_macro :sin")
             @test !any(boccs) do (binfo, occs)
                 binfo.name == "sin" && binfo.kind === :global && any(o -> o.kind === :use, occs)
@@ -844,7 +855,7 @@ end
         end
 
         # Unquoted one-argument `@eval` input resolves in the construction module.
-        for eval_macro in ("@eval", "Base.@eval")
+        for eval_macro in ("@eval", "Base.@eval", "B.@eval")
             boccs = get_full_binding_occurrences("$eval_macro sin")
             @test any(boccs) do (binfo, occs)
                 binfo.name == "sin" && binfo.kind === :global && any(o -> o.kind === :use, occs)
@@ -869,24 +880,31 @@ end
         end
 
         # One-argument `@eval` resolves inert globals in the construction module.
-        for eval_macro in ("@eval", "Base.@eval")
+        for eval_macro in ("@eval", "Base.@eval", "B.@eval")
             boccs = get_full_binding_occurrences("""
                 $eval_macro some_func(::EvalTarget) = nothing
                 """)
             @test any(boccs) do (binfo, occs)
-                binfo.name == "EvalTarget" && binfo.kind === :global &&
-                    any(o -> o.kind === :use, occs)
+                binfo.name == "EvalTarget" && binfo.kind === :global && any(o -> o.kind === :use, occs)
             end
         end
 
         # Two-argument `@eval` is unsupported even for a static-looking target.
-        for eval_macro in ("@eval", "Base.@eval")
+        for eval_macro in ("@eval", "Base.@eval", "B.@eval")
             boccs = get_full_binding_occurrences("""
                 $eval_macro SomeModule some_func(::EvalTarget) = nothing
                 """)
             @test !any(boccs) do (binfo, occs)
-                binfo.name == "EvalTarget" && binfo.kind === :global &&
-                    any(o -> o.kind === :use, occs)
+                binfo.name == "EvalTarget" && binfo.kind === :global && any(o -> o.kind === :use, occs)
+            end
+        end
+
+        # An unrelated same-named macro is not classified as `Base.@eval`.
+        let boccs = get_full_binding_occurrences("""
+                @eval SomeModule some_func(::EvalTarget) = nothing
+                """; context_module=same_named_eval_context)
+            @test any(boccs) do (binfo, occs)
+                binfo.name == "EvalTarget" && binfo.kind === :global && any(o -> o.kind === :use, occs)
             end
         end
 
@@ -895,8 +913,7 @@ end
                 @eval getcontext() some_func(::EvalTarget) = nothing
                 """)
             @test !any(boccs) do (binfo, occs)
-                binfo.name == "EvalTarget" && binfo.kind === :global &&
-                    any(o -> o.kind === :use, occs)
+                binfo.name == "EvalTarget" && binfo.kind === :global && any(o -> o.kind === :use, occs)
             end
         end
 
@@ -1069,8 +1086,9 @@ function with_global_binding_occurrences(
 
     pos = first(positions)
     offset = JETLS.xy_to_offset(clean_code, pos, filename)
+    world = Base.get_world_counter()
     (; ctx3, binding) = @something(
-        JETLS.select_target_binding(st0_top, offset, lowering_module),
+        JETLS.select_target_binding(st0_top, offset, lowering_module, world),
         error("No binding found at cursor position"))
     target_binfo = JL.get_binding(ctx3, binding)
     @test target_binfo.kind === :global

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -14,10 +14,11 @@ module lowering_module end
 function get_cursor_bindings(
         fi::JETLS.FileInfo, b::Int;
         context_module::Module = lowering_module,
-        soft_scope::Bool = false
+        soft_scope::Bool = false,
+        world::UInt = Base.get_world_counter()
     )
     st0 = JETLS.build_syntax_tree(fi)
-    cb = JETLS.cursor_bindings(st0, b, context_module; soft_scope)
+    cb = JETLS.cursor_bindings(st0, b, context_module, world; soft_scope)
     return isnothing(cb) ? [] : cb
 end
 function get_cursor_bindings(marked_text::AbstractString; kwargs...)

--- a/test/test_document_symbol.jl
+++ b/test/test_document_symbol.jl
@@ -8,7 +8,8 @@ module lowering_module end
 function get_document_symbols(code::AbstractString, context_module::Module=lowering_module)
     fi = JETLS.FileInfo(1, code, @__FILE__, PositionEncodingKind.UTF16)
     st0 = JETLS.build_syntax_tree(fi)
-    return JETLS.extract_document_symbols(st0, fi, context_module)
+    world = Base.get_world_counter()
+    return JETLS.extract_document_symbols(st0, fi, context_module, world)
 end
 
 const DUMMY_RANGE = Range(Position(0, 0), Position(0, 0))

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -10,6 +10,7 @@ include(normpath(pkgdir(JETLS), "test", "setup.jl"))
 include(normpath(pkgdir(JETLS), "test", "jsjl-utils.jl"))
 
 module lowering_module
+const B = Base
 macro generated_label()
     return :(@label generated)
 end
@@ -967,11 +968,12 @@ end
             @test isempty(diagnostics)
         end
 
-        let diagnostics = get_lowering_diagnostics("""
-            @generated function foo(x, unused)
-                return :(x + 1)
-            end
-            """)
+        for generated_macro in ("@generated", "B.@generated")
+            diagnostics = get_lowering_diagnostics("""
+                $generated_macro function foo(x, unused)
+                    return :(x + 1)
+                end
+                """)
             @test length(diagnostics) == 1
             @test only(diagnostics).message == "Unused argument `unused`"
         end

--- a/test/test_references.jl
+++ b/test/test_references.jl
@@ -847,8 +847,8 @@ end
     # a Julia binding. `@ccall` has a new-style JuliaLowering implementation
     # that correctly encodes this by wrapping `foo` in `K"inert"`, so scope
     # resolution must leave it alone. That only holds while
-    # `_remove_macrocalls` preserves the `@ccall` macrocall (because the
-    # macrocall is in `NEW_STYLE_MACROCALL_NAMES`) — if it ever falls back to
+    # `_remove_macrocalls` preserves the `@ccall` macrocall (because its binding
+    # is in `NEW_STYLE_MACRO_BINDINGS`) — if it ever falls back to
     # the generic stripping path, `foo` gets lifted into a plain `block` and
     # is misresolved to the enclosing Julia binding of the same name.
     @testset "@ccall C symbol vs enclosing Julia binding" begin

--- a/test/test_rename.jl
+++ b/test/test_rename.jl
@@ -45,6 +45,57 @@ end
 
 module test_import_rename_context end
 
+function binding_rename_testcase(code::AbstractString, n::Int; kwargs...)
+    fi, positions, furi = rename_testcase(code, n; kwargs...)
+    world = Base.get_world_counter()
+    return (; fi, positions, furi, world)
+end
+
+function local_rename_preparation_testcase(
+        state::JETLS.ServerState, code::AbstractString, n::Int,
+        context_module::Module
+    )
+    (; fi, positions, furi, world) = binding_rename_testcase(code, n)
+    prepare(pos::Position) = JETLS.local_binding_rename_preparation(
+        state, furi, fi, pos, context_module, world)
+    return (; positions, prepare)
+end
+
+function global_rename_preparation_testcase(
+        state::JETLS.ServerState, code::AbstractString, n::Int,
+        context_module::Module
+    )
+    (; fi, positions, furi, world) = binding_rename_testcase(code, n)
+    prepare(pos::Position) = JETLS.global_binding_rename_preparation(
+        state, furi, fi, pos, context_module, world)
+    return (; positions, prepare)
+end
+
+function local_rename_testcase(
+        server::JETLS.Server, code::AbstractString, n::Int,
+        context_module::Module
+    )
+    (; fi, positions, furi, world) = binding_rename_testcase(code, n)
+    rename_binding(pos::Position, new_name::String) = JETLS.local_binding_rename(
+        server, furi, fi, pos, context_module, world, new_name)
+    return (; positions, furi, rename_binding)
+end
+
+function global_rename_testcase(
+        server::JETLS.Server, code::AbstractString, n::Int,
+        context_module::Module; register_file::Bool = false
+    )
+    testcase = if register_file
+        binding_rename_testcase(code, n; server, context_module)
+    else
+        binding_rename_testcase(code, n)
+    end
+    (; fi, positions, furi, world) = testcase
+    rename_binding(pos::Position, new_name::String) = JETLS.global_binding_rename(
+        server, furi, fi, pos, context_module, world, new_name)
+    return (; positions, furi, rename_binding)
+end
+
 @testset "local_binding_rename_preparation" begin
     state = JETLS.ServerState()
     let code = """
@@ -52,13 +103,13 @@ module test_import_rename_context end
             │pri│ntln│(│xx│x│, yyy)
         end
         """
-        fi, positions, furi = rename_testcase(code, 9)
+        (; positions, prepare) = local_rename_preparation_testcase(state, code, 9, @__MODULE__)
         for (i, pos) in enumerate(positions)
             if i in (4,5,6) # println
-                rename_prep = JETLS.local_binding_rename_preparation(state, furi, fi, pos, @__MODULE__)
+                rename_prep = prepare(pos)
                 @test isnothing(rename_prep)
             else
-                rename_prep = JETLS.local_binding_rename_preparation(state, furi, fi, pos, @__MODULE__)
+                rename_prep = prepare(pos)
                 @test !isnothing(rename_prep)
                 @test rename_prep.placeholder == "xxx"
             end
@@ -68,50 +119,47 @@ module test_import_rename_context end
     let code = """
         func(xxx) = println(xxx, 4│2)
         """
-        fi, positions, furi = rename_testcase(code, 1)
-        rename_prep = JETLS.local_binding_rename_preparation(state, furi, fi, only(positions), @__MODULE__)
+        (; positions, prepare) = local_rename_preparation_testcase(state, code, 1, @__MODULE__)
+        rename_prep = prepare(only(positions))
         @test isnothing(rename_prep)
     end
 
     @testset "static parameter rename prepare" begin
-        let code = """
-            func(::│TTT│) where │TTT│<:Integer = zero(│TTT│)
-            """
-            fi, positions, furi = rename_testcase(code, 6)
-            for pos in positions
-                rename_prep = JETLS.local_binding_rename_preparation(state, furi, fi, pos, @__MODULE__)
-                @test !isnothing(rename_prep)
-                @test rename_prep.placeholder == "TTT"
-            end
+        code = """
+        func(::│TTT│) where │TTT│<:Integer = zero(│TTT│)
+        """
+        (; positions, prepare) = local_rename_preparation_testcase(state, code, 6, @__MODULE__)
+        for pos in positions
+            rename_prep = prepare(pos)
+            @test !isnothing(rename_prep)
+            @test rename_prep.placeholder == "TTT"
         end
     end
 
     @testset "rename prepare with docstring" begin
-        let code = """
-            \"\"\"Docstring\"\"\"
-            function func(│xxx│, yyy)
-                println(│xxx│, yyy)
-            end
-            """
-            fi, positions, furi = rename_testcase(code, 4)
-            for pos in positions
-                rename_prep = JETLS.local_binding_rename_preparation(state, furi, fi, pos, @__MODULE__)
-                @test !isnothing(rename_prep)
-                @test rename_prep.placeholder == "xxx"
-            end
+        code = """
+        \"\"\"Docstring\"\"\"
+        function func(│xxx│, yyy)
+            println(│xxx│, yyy)
+        end
+        """
+        (; positions, prepare) = local_rename_preparation_testcase(state, code, 4, @__MODULE__)
+        for pos in positions
+            rename_prep = prepare(pos)
+            @test !isnothing(rename_prep)
+            @test rename_prep.placeholder == "xxx"
         end
     end
 
     @testset "rename prepare with macrocall" begin
-        let code = """
-            func(│xxx│) = @something rand((│xxx│, nothing)) return nothing
-            """
-            fi, positions, furi = rename_testcase(code, 4)
-            for pos in positions
-                rename_prep = JETLS.local_binding_rename_preparation(state, furi, fi, pos, @__MODULE__)
-                @test !isnothing(rename_prep)
-                @test rename_prep.placeholder == "xxx"
-            end
+        code = """
+        func(│xxx│) = @something rand((│xxx│, nothing)) return nothing
+        """
+        (; positions, prepare) = local_rename_preparation_testcase(state, code, 4, @__MODULE__)
+        for pos in positions
+            rename_prep = prepare(pos)
+            @test !isnothing(rename_prep)
+            @test rename_prep.placeholder == "xxx"
         end
     end
 end
@@ -123,13 +171,13 @@ end
             │pri│ntln│(│xx│x│, yyy)
         end
         """
-        fi, positions, furi = rename_testcase(code, 9)
+        (; positions, furi, rename_binding) = local_rename_testcase(server, code, 9, @__MODULE__)
         for (i, pos) in enumerate(positions)
             if i in (4,5,6) # println, should never be called if client supports rename prepare
-                rename = JETLS.local_binding_rename(server, furi, fi, pos, @__MODULE__, "zzz")
+                rename = rename_binding(pos, "zzz")
                 @test isnothing(rename)
             else
-                (; result, error) = JETLS.local_binding_rename(server, furi, fi, pos, @__MODULE__, "zzz")
+                (; result, error) = rename_binding(pos, "zzz")
                 @test result isa WorkspaceEdit && isnothing(error)
                 for (uri, edits) in result.changes
                     @test furi == uri
@@ -149,26 +197,26 @@ end
 
     # Guard against invalid variable names
     let code = "func(xx│x, yyy) = println(xxx, yyy)"
-        fi, positions, furi = rename_testcase(code, 1)
+        (; positions, rename_binding) = local_rename_testcase(server, code, 1, @__MODULE__)
         let
-            (; result, error) = JETLS.local_binding_rename(server, furi, fi, only(positions), @__MODULE__, "zzz zzz")
+            (; result, error) = rename_binding(only(positions), "zzz zzz")
             @test isnothing(result) && error isa ResponseError
         end
         let
-            (; result, error) = JETLS.local_binding_rename(server, furi, fi, only(positions), @__MODULE__, "42zzz")
+            (; result, error) = rename_binding(only(positions), "42zzz")
             @test isnothing(result) && error isa ResponseError
         end
         let
-            (; result, error) = JETLS.local_binding_rename(server, furi, fi, only(positions), @__MODULE__, "'zzz'")
+            (; result, error) = rename_binding(only(positions), "'zzz'")
             @test isnothing(result) && error isa ResponseError
         end
     end
 
     # Allow renaming on var"names"
     let code = """func(var"│xxx│") = println(var"│xxx│")"""
-        fi, positions, furi = rename_testcase(code, 4)
+        (; positions, furi, rename_binding) = local_rename_testcase(server, code, 4, @__MODULE__)
         for pos in positions
-            (; result, error) = JETLS.local_binding_rename(server, furi, fi, pos, @__MODULE__, "zzz zzz")
+            (; result, error) = rename_binding(pos, "zzz zzz")
             @test result isa WorkspaceEdit && isnothing(error)
             for (uri, edits) in result.changes
                 @test furi == uri
@@ -189,9 +237,9 @@ end
         let code = """
             func(::│TTT│) where │TTT│<:Integer = zero(│TTT│)
             """
-            fi, positions, furi = rename_testcase(code, 6)
+            (; positions, furi, rename_binding) = local_rename_testcase(server, code, 6, @__MODULE__)
             for pos in positions
-                (; result, error) = JETLS.local_binding_rename(server, furi, fi, pos, @__MODULE__, "SSS")
+                (; result, error) = rename_binding(pos, "SSS")
                 @test result isa WorkspaceEdit && isnothing(error)
                 for (uri, edits) in result.changes
                     @test furi == uri
@@ -214,52 +262,50 @@ end
     end
 
     @testset "rename with docstring" begin
-        let code = """
-            \"\"\"Docstring\"\"\"
-            function func(│xxx│, yyy)
-                println(│xxx│, yyy)
-            end
-            """
-            fi, positions, furi = rename_testcase(code, 4)
-            for pos in positions
-                (; result, error) = JETLS.local_binding_rename(server, furi, fi, pos, @__MODULE__, "zzz")
-                @test result isa WorkspaceEdit && isnothing(error)
-                for (uri, edits) in result.changes
-                    @test furi == uri
-                    @test length(edits) == 2
-                    @test count(edits) do edit
-                        edit.newText == "zzz" &&
-                        edit.range == Range(; start=positions[1], var"end"=positions[2])
-                    end == 1
-                    @test count(edits) do edit
-                        edit.newText == "zzz" &&
-                        edit.range == Range(; start=positions[3], var"end"=positions[4])
-                    end == 1
-                end
+        code = """
+        \"\"\"Docstring\"\"\"
+        function func(│xxx│, yyy)
+            println(│xxx│, yyy)
+        end
+        """
+        (; positions, furi, rename_binding) = local_rename_testcase(server, code, 4, @__MODULE__)
+        for pos in positions
+            (; result, error) = rename_binding(pos, "zzz")
+            @test result isa WorkspaceEdit && isnothing(error)
+            for (uri, edits) in result.changes
+                @test furi == uri
+                @test length(edits) == 2
+                @test count(edits) do edit
+                    edit.newText == "zzz" &&
+                    edit.range == Range(; start=positions[1], var"end"=positions[2])
+                end == 1
+                @test count(edits) do edit
+                    edit.newText == "zzz" &&
+                    edit.range == Range(; start=positions[3], var"end"=positions[4])
+                end == 1
             end
         end
     end
 
     @testset "rename with macrocall" begin
-        let code = """
-            func(│xxx│) = @something rand((│xxx│, nothing)) return nothing
-            """
-            fi, positions, furi = rename_testcase(code, 4)
-            for pos in positions
-                (; result, error) = JETLS.local_binding_rename(server, furi, fi, pos, @__MODULE__, "yyy")
-                @test result isa WorkspaceEdit && isnothing(error)
-                for (uri, edits) in result.changes
-                    @test furi == uri
-                    @test length(edits) == 2
-                    @test count(edits) do edit
-                        edit.newText == "yyy" &&
-                        edit.range == Range(; start=positions[1], var"end"=positions[2])
-                    end == 1
-                    @test count(edits) do edit
-                        edit.newText == "yyy" &&
-                        edit.range == Range(; start=positions[3], var"end"=positions[4])
-                    end == 1
-                end
+        code = """
+        func(│xxx│) = @something rand((│xxx│, nothing)) return nothing
+        """
+        (; positions, furi, rename_binding) = local_rename_testcase(server, code, 4, @__MODULE__)
+        for pos in positions
+            (; result, error) = rename_binding(pos, "yyy")
+            @test result isa WorkspaceEdit && isnothing(error)
+            for (uri, edits) in result.changes
+                @test furi == uri
+                @test length(edits) == 2
+                @test count(edits) do edit
+                    edit.newText == "yyy" &&
+                    edit.range == Range(; start=positions[1], var"end"=positions[2])
+                end == 1
+                @test count(edits) do edit
+                    edit.newText == "yyy" &&
+                    edit.range == Range(; start=positions[3], var"end"=positions[4])
+                end == 1
             end
         end
     end
@@ -268,36 +314,35 @@ end
         # A use in a `@static` branch not selected for the current platform must be
         # renamed too — otherwise the rename leaves that branch referring to the old name,
         # breaking the code on the platform where the branch is taken.
-        let code = """
-            function func()
-                │xx│x│ = 1
-                @static if Sys.iswindows()
-                    println(│xx│x│)
-                else
-                    println(│xx│x│)
-                end
+        code = """
+        function func()
+            │xx│x│ = 1
+            @static if Sys.iswindows()
+                println(│xx│x│)
+            else
+                println(│xx│x│)
             end
-            """
-            fi, positions, furi = rename_testcase(code, 9)
-            for pos in positions
-                (; result, error) = JETLS.local_binding_rename(server, furi, fi, pos, @__MODULE__, "yyy")
-                @test result isa WorkspaceEdit && isnothing(error)
-                for (uri, edits) in result.changes
-                    @test furi == uri
-                    @test length(edits) == 3
-                    @test count(edits) do edit
-                        edit.newText == "yyy" &&
-                        edit.range == Range(; start=positions[1], var"end"=positions[3])
-                    end == 1
-                    @test count(edits) do edit
-                        edit.newText == "yyy" &&
-                        edit.range == Range(; start=positions[4], var"end"=positions[6])
-                    end == 1
-                    @test count(edits) do edit
-                        edit.newText == "yyy" &&
-                        edit.range == Range(; start=positions[7], var"end"=positions[9])
-                    end == 1
-                end
+        end
+        """
+        (; positions, furi, rename_binding) = local_rename_testcase(server, code, 9, @__MODULE__)
+        for pos in positions
+            (; result, error) = rename_binding(pos, "yyy")
+            @test result isa WorkspaceEdit && isnothing(error)
+            for (uri, edits) in result.changes
+                @test furi == uri
+                @test length(edits) == 3
+                @test count(edits) do edit
+                    edit.newText == "yyy" &&
+                    edit.range == Range(; start=positions[1], var"end"=positions[3])
+                end == 1
+                @test count(edits) do edit
+                    edit.newText == "yyy" &&
+                    edit.range == Range(; start=positions[4], var"end"=positions[6])
+                end == 1
+                @test count(edits) do edit
+                    edit.newText == "yyy" &&
+                    edit.range == Range(; start=positions[7], var"end"=positions[9])
+                end == 1
             end
         end
     end
@@ -308,10 +353,9 @@ end
                 return :(copy(│x│) + │x│)
             end
             """
-            fi, positions, furi = rename_testcase(code, 6)
+            (; positions, furi, rename_binding) = local_rename_testcase(server, code, 6, @__MODULE__)
             for pos in positions
-                (; result, error) = JETLS.local_binding_rename(
-                    server, furi, fi, pos, @__MODULE__, "y")
+                (; result, error) = rename_binding(pos, "y")
                 @test result isa WorkspaceEdit && isnothing(error)
                 for (uri, edits) in result.changes
                     @test furi == uri
@@ -329,17 +373,15 @@ end
                 end)
             end
             """
-            fi, positions, furi = rename_testcase(code, 6)
-            let rename_result = JETLS.local_binding_rename(
-                    server, furi, fi, positions[1], @__MODULE__, "arg")
+            (; positions, rename_binding) = local_rename_testcase(server, code, 6, @__MODULE__)
+            let rename_result = rename_binding(positions[1], "arg")
                 @test rename_result !== nothing
                 (; result, error) = rename_result
                 @test result isa WorkspaceEdit && isnothing(error)
                 edits = only(result.changes).second
                 @test length(edits) == 1
             end
-            let rename_result = JETLS.local_binding_rename(
-                    server, furi, fi, positions[3], @__MODULE__, "local_x")
+            let rename_result = rename_binding(positions[3], "local_x")
                 @test rename_result !== nothing
                 (; result, error) = rename_result
                 @test result isa WorkspaceEdit && isnothing(error)
@@ -354,10 +396,9 @@ end
                 return :(zero(│T│))
             end
             """
-            fi, positions, furi = rename_testcase(code, 6)
+            (; positions, furi, rename_binding) = local_rename_testcase(server, code, 6, @__MODULE__)
             for pos in positions
-                (; result, error) = JETLS.local_binding_rename(
-                    server, furi, fi, pos, @__MODULE__, "S")
+                (; result, error) = rename_binding(pos, "S")
                 @test result isa WorkspaceEdit && isnothing(error)
                 for (uri, edits) in result.changes
                     @test furi == uri
@@ -377,10 +418,9 @@ end
                 end
             end
             """
-            fi, positions, furi = rename_testcase(code, 4)
+            (; positions, furi, rename_binding) = local_rename_testcase(server, code, 4, @__MODULE__)
             for pos in positions
-                (; result, error) = JETLS.local_binding_rename(
-                    server, furi, fi, pos, @__MODULE__, "y")
+                (; result, error) = rename_binding(pos, "y")
                 @test result isa WorkspaceEdit && isnothing(error)
                 for (uri, edits) in result.changes
                     @test furi == uri
@@ -392,19 +432,17 @@ end
     end
 
     @testset "ordinary quote-local rename" begin
-        let code = """
-            f() = :(let │x│ = 1
-                │x│
-            end)
-            """
-            fi, positions, furi = rename_testcase(code, 4)
-            for pos in positions
-                rename_result = JETLS.local_binding_rename(
-                    server, furi, fi, pos, @__MODULE__, "y")
-                @test rename_result !== nothing &&
-                    rename_result.result isa WorkspaceEdit &&
-                    length(only(rename_result.result.changes).second) == 2
-            end
+        code = """
+        f() = :(let │x│ = 1
+            │x│
+        end)
+        """
+        (; positions, rename_binding) = local_rename_testcase(server, code, 4, @__MODULE__)
+        for pos in positions
+            rename_result = rename_binding(pos, "y")
+            @test rename_result !== nothing &&
+                rename_result.result isa WorkspaceEdit &&
+                length(only(rename_result.result.changes).second) == 2
         end
     end
 end
@@ -416,34 +454,29 @@ end
         │bar│ = │foo│()
         │println│(│bar│)
         """
-        fi, positions, furi = rename_testcase(code, 10)
-
+        (; positions, prepare) = global_rename_preparation_testcase(state, code, 10, @__MODULE__)
         for pos in positions[1:2]
-            rename_prep = JETLS.global_binding_rename_preparation(state, furi, fi, pos, @__MODULE__)
+            rename_prep = prepare(pos)
             @test !isnothing(rename_prep)
             @test rename_prep.placeholder == "foo"
         end
-
         for pos in positions[3:4]
-            rename_prep = JETLS.global_binding_rename_preparation(state, furi, fi, pos, @__MODULE__)
+            rename_prep = prepare(pos)
             @test !isnothing(rename_prep)
             @test rename_prep.placeholder == "bar"
         end
-
         for pos in positions[5:6]
-            rename_prep = JETLS.global_binding_rename_preparation(state, furi, fi, pos, @__MODULE__)
+            rename_prep = prepare(pos)
             @test !isnothing(rename_prep)
             @test rename_prep.placeholder == "foo"
         end
-
         for pos in positions[7:8]
-            rename_prep = JETLS.global_binding_rename_preparation(state, furi, fi, pos, @__MODULE__)
+            rename_prep = prepare(pos)
             @test !isnothing(rename_prep)
             @test rename_prep.placeholder == "println"
         end
-
         for pos in positions[9:10]
-            rename_prep = JETLS.global_binding_rename_preparation(state, furi, fi, pos, @__MODULE__)
+            rename_prep = prepare(pos)
             @test !isnothing(rename_prep)
             @test rename_prep.placeholder == "bar"
         end
@@ -451,28 +484,25 @@ end
 
     # Non-binding position should be rejected
     let code = "func(xxx) = println(xxx, 4│2)"
-        fi, positions, furi = rename_testcase(code, 1)
-        rename_prep = JETLS.global_binding_rename_preparation(
-            state, furi, fi, only(positions), @__MODULE__)
+        (; positions, prepare) = global_rename_preparation_testcase(state, code, 1, @__MODULE__)
+        rename_prep = prepare(only(positions))
         @test isnothing(rename_prep)
     end
 
     @testset "ordinary unanchored quote" begin
         let code = "f() = :(use(│x│))"
-            fi, positions, furi = rename_testcase(code, 2)
+            (; positions, prepare) = global_rename_preparation_testcase(state, code, 2, @__MODULE__)
             for pos in positions
-                rename_prep = JETLS.global_binding_rename_preparation(
-                    state, furi, fi, pos, @__MODULE__)
+                rename_prep = prepare(pos)
                 @test !isnothing(rename_prep) && rename_prep.placeholder == "x"
             end
         end
 
         # An atomic quoted identifier is Symbol data, not a global binding target.
         let code = "names = (:│sin│, :cos)"
-            fi, positions, furi = rename_testcase(code, 2)
+            (; positions, prepare) = global_rename_preparation_testcase(state, code, 2, @__MODULE__)
             for pos in positions
-                rename_prep = JETLS.global_binding_rename_preparation(
-                    state, furi, fi, pos, @__MODULE__)
+                rename_prep = prepare(pos)
                 @test isnothing(rename_prep)
             end
         end
@@ -486,10 +516,9 @@ end
             end
             @mymacro println("hello")
             """
-            fi, positions, furi = rename_testcase(code, 2)
+            (; positions, prepare) = global_rename_preparation_testcase(state, code, 2, @__MODULE__)
             # Only test start position (end position selects implicit macro arg)
-            rename_prep = JETLS.global_binding_rename_preparation(
-                state, furi, fi, positions[1], @__MODULE__)
+            rename_prep = prepare(positions[1])
             @test !isnothing(rename_prep)
             @test rename_prep.placeholder == "mymacro"
         end
@@ -501,10 +530,9 @@ end
             end
             │@my│macro println("hello")
             """
-            fi, positions, furi = rename_testcase(code, 2)
+            (; positions, prepare) = global_rename_preparation_testcase(state, code, 2, @__MODULE__)
             for pos in positions
-                rename_prep = JETLS.global_binding_rename_preparation(
-                    state, furi, fi, pos, @__MODULE__)
+                rename_prep = prepare(pos)
                 @test !isnothing(rename_prep)
                 @test rename_prep.placeholder == "mymacro"
             end
@@ -519,9 +547,9 @@ end
         baz() = │foo│()
         │foo│(x) = x + 1
         """
-        fi, positions, furi = rename_testcase(code, 6)
+        (; positions, furi, rename_binding) = global_rename_testcase(server, code, 6, @__MODULE__)
         for pos in positions
-            (; result, error) = JETLS.global_binding_rename(server, furi, fi, pos, @__MODULE__, "qux")
+            (; result, error) = rename_binding(pos, "qux")
             @test result isa WorkspaceEdit && isnothing(error)
             for (uri, edits) in result.changes
                 @test furi == uri
@@ -541,11 +569,10 @@ end
             │@│mymacro println("hello")
             │@│mymacro println("world")
             """
-            fi, positions, furi = rename_testcase(code, 5)
+            (; positions, furi, rename_binding) = global_rename_testcase(server, code, 5, @__MODULE__)
             # Test from definition position
             let pos = positions[1]
-                (; result, error) = JETLS.global_binding_rename(
-                    server, furi, fi, pos, @__MODULE__, "newmacro")
+                (; result, error) = rename_binding(pos, "newmacro")
                 @test result isa WorkspaceEdit && isnothing(error)
                 for (uri, edits) in result.changes
                     @test furi == uri
@@ -561,10 +588,9 @@ end
             end
             # Test from macrocall positions
             for pos in positions[2:5]
-                (; result, error) = JETLS.global_binding_rename(
-                    server, furi, fi, pos, @__MODULE__, "newmacro")
+                (; result, error) = rename_binding(pos, "newmacro")
                 @test result isa WorkspaceEdit && isnothing(error)
-                for (uri, edits) in result.changes
+                for (_, edits) in result.changes
                     @test length(edits) == 3
                     @test all(edit -> edit.newText == "newmacro", edits)
                 end
@@ -578,10 +604,9 @@ end
             end
             │@│mymacro println("hello")
             """
-            fi, positions, furi = rename_testcase(code, 3)
+            (; positions, rename_binding) = global_rename_testcase(server, code, 3, @__MODULE__)
             for pos in positions
-                (; result, error) = JETLS.global_binding_rename(
-                    server, furi, fi, pos, @__MODULE__, "@newmacro")
+                (; result, error) = rename_binding(pos, "@newmacro")
                 @test result isa WorkspaceEdit && isnothing(error)
                 for (_, edits) in result.changes
                     @test all(edit -> edit.newText == "newmacro", edits)
@@ -598,10 +623,10 @@ end
             │foo│(1)
             bar() = │foo│()
             """
-            fi, positions, furi = rename_testcase(code, 6; server, context_module=test_import_rename_context)
+            (; positions, rename_binding) = global_rename_testcase(
+                server, code, 6, test_import_rename_context; register_file=true)
             for pos in positions
-                (; result, error) = JETLS.global_binding_rename(
-                    server, furi, fi, pos, test_import_rename_context, "qux")
+                (; result, error) = rename_binding(pos, "qux")
                 @test result isa WorkspaceEdit && isnothing(error)
                 edits = only(result.changes).second
                 @test length(edits) == 3
@@ -619,10 +644,10 @@ end
             using Base: foo as │myfoo│
             │myfoo│(1)
             """
-            fi, positions, furi = rename_testcase(code, 4; server, context_module=test_import_rename_context)
+            (; positions, rename_binding) = global_rename_testcase(
+                server, code, 4, test_import_rename_context; register_file=true)
             for pos in positions
-                (; result, error) = JETLS.global_binding_rename(
-                    server, furi, fi, pos, test_import_rename_context, "qux")
+                (; result, error) = rename_binding(pos, "qux")
                 @test result isa WorkspaceEdit && isnothing(error)
                 edits = only(result.changes).second
                 @test length(edits) == 2
@@ -635,10 +660,10 @@ end
             using Random: randcycle as │randcycle2│
             │randcycle2│(5)
             """
-            fi, positions, furi = rename_testcase(code, 4; server, context_module=test_import_rename_context)
+            (; positions, rename_binding) = global_rename_testcase(
+                server, code, 4, test_import_rename_context; register_file=true)
             for pos in positions
-                (; result, error) = JETLS.global_binding_rename(
-                    server, furi, fi, pos, test_import_rename_context, "randcycle")
+                (; result, error) = rename_binding(pos, "randcycle")
                 @test result isa WorkspaceEdit && isnothing(error)
                 edits = only(result.changes).second
                 @test length(edits) == 2
@@ -656,10 +681,10 @@ end
             import Base.│sin│
             │sin│(1.0)
             """
-            fi, positions, furi = rename_testcase(code, 4; server, context_module=test_import_rename_context)
+            (; positions, rename_binding) = global_rename_testcase(
+                server, code, 4, test_import_rename_context; register_file=true)
             for pos in positions
-                (; result, error) = JETLS.global_binding_rename(
-                    server, furi, fi, pos, test_import_rename_context, "mysin")
+                (; result, error) = rename_binding(pos, "mysin")
                 @test result isa WorkspaceEdit && isnothing(error)
                 edits = only(result.changes).second
                 @test length(edits) == 2
@@ -673,10 +698,10 @@ end
         let code = """
             using Base.│Iterators│
             """
-            fi, positions, furi = rename_testcase(code, 2; server, context_module=test_import_rename_context)
+            (; positions, rename_binding) = global_rename_testcase(
+                server, code, 2, test_import_rename_context; register_file=true)
             for pos in positions
-                (; result, error) = JETLS.global_binding_rename(
-                    server, furi, fi, pos, test_import_rename_context, "MyIter")
+                (; result, error) = rename_binding(pos, "MyIter")
                 @test result isa WorkspaceEdit && isnothing(error)
                 edits = only(result.changes).second
                 @test length(edits) == 1
@@ -688,20 +713,19 @@ end
     @testset "export/public rename" begin
         # Renaming from a cursor inside `export`/`public` should rewrite every
         # occurrence, including the export statement itself.
-        let code = """
-            │foo│() = 42
-            export │foo│
-            bar() = │foo│()
-            """
-            fi, positions, furi = rename_testcase(code, 6)
-            for pos in positions
-                (; result, error) = JETLS.global_binding_rename(
-                    server, furi, fi, pos, @__MODULE__, "qux")
-                @test result isa WorkspaceEdit && isnothing(error)
-                for (_, edits) in result.changes
-                    @test length(edits) == 3
-                    @test all(edit -> edit.newText == "qux", edits)
-                end
+        code = """
+        │foo│() = 42
+        export │foo│
+        bar() = │foo│()
+        """
+        (; positions, rename_binding) = global_rename_testcase(
+            server, code, 6, @__MODULE__)
+        for pos in positions
+            (; result, error) = rename_binding(pos, "qux")
+            @test result isa WorkspaceEdit && isnothing(error)
+            for (_, edits) in result.changes
+                @test length(edits) == 3
+                @test all(edit -> edit.newText == "qux", edits)
             end
         end
     end
@@ -716,14 +740,13 @@ end
         touch(joinpath(dir, "README.md"))
 
         for target_name = ("foo.jl", "subdir/foo.jl", "README.md")
-            let code = """include("│$(target_name)│")"""
-                fi, positions, furi = rename_testcase(code, 2;
-                    filename = joinpath(dir, "main.jl"))
-                for pos in positions
-                    rename_prep = JETLS.file_rename_preparation(state, furi, fi, pos)
-                    @test !isnothing(rename_prep)
-                    @test rename_prep.placeholder == target_name
-                end
+            code = """include("│$(target_name)│")"""
+            fi, positions, furi = rename_testcase(code, 2;
+                filename = joinpath(dir, "main.jl"))
+            for pos in positions
+                rename_prep = JETLS.file_rename_preparation(state, furi, fi, pos)
+                @test !isnothing(rename_prep)
+                @test rename_prep.placeholder == target_name
             end
         end
 
@@ -740,17 +763,16 @@ end
     server = JETLS.Server()
     mktempdir() do dir
         touch(joinpath(dir, "foo.jl"))
-        let code = """include("│foo.jl│")"""
-            fi, positions, furi = rename_testcase(code, 2;
-                filename = joinpath(dir, "main.jl"))
-            for pos in positions
-                (; result, error) = JETLS.file_rename(server, furi, fi, pos, "bar.jl")
-                @test result isa WorkspaceEdit && isnothing(error)
-                @test length(result.changes) == 1
-                edits = result.changes[furi]
-                @test length(edits) == 1
-                @test edits[1].newText == "bar.jl"
-            end
+        code = """include("│foo.jl│")"""
+        fi, positions, furi = rename_testcase(code, 2;
+            filename = joinpath(dir, "main.jl"))
+        for pos in positions
+            (; result, error) = JETLS.file_rename(server, furi, fi, pos, "bar.jl")
+            @test result isa WorkspaceEdit && isnothing(error)
+            @test length(result.changes) == 1
+            edits = result.changes[furi]
+            @test length(edits) == 1
+            @test edits[1].newText == "bar.jl"
         end
     end
 end

--- a/test/test_workspace_symbol.jl
+++ b/test/test_workspace_symbol.jl
@@ -10,7 +10,8 @@ function get_workspace_symbols(code::AbstractString)
     fi = JETLS.FileInfo(1, code, @__FILE__, PositionEncodingKind.UTF8)
     st0 = JETLS.build_syntax_tree(fi)
     workspace_symbols = WorkspaceSymbol[]
-    doc_symbols = JETLS.extract_document_symbols(st0, fi, lowering_module)
+    world = Base.get_world_counter()
+    doc_symbols = JETLS.extract_document_symbols(st0, fi, lowering_module, world)
     uri = URI("file:///$(@__FILE__)")
     JETLS.flatten_document_symbols!(workspace_symbols, doc_symbols, uri, nothing)
     return workspace_symbols

--- a/test/utils/test_ast.jl
+++ b/test/utils/test_ast.jl
@@ -6,6 +6,37 @@ using JETLS: JL, JS
 
 include(normpath(pkgdir(JETLS), "test", "jsjl-utils.jl"))
 
+module new_style_macro_context
+import Base: @inline as @base_inline
+using Test: Test
+const B = Base
+const ThreadsAlias = Base.Threads
+const T = Test
+end
+
+module same_named_macro_context
+macro inline(ex)
+    return esc(ex)
+end
+end
+
+module nested_same_named_macro_context
+module Inner
+macro inline(ex)
+    return esc(ex)
+end
+end
+end
+
+module nested_new_style_macro_context
+macro inline(ex)
+    return esc(ex)
+end
+module Inner
+using Base: @inline
+end
+end
+
 @testset "`byte_ancestors`" begin
     # Test with a simple function
     let code = """
@@ -452,6 +483,61 @@ end
     @test !JETLS.noparen_macrocall(jlparse("@test(true)"; rule=:statement))
     @test !JETLS.noparen_macrocall(jlparse("r\"xxx\""; rule=:statement))
     @test !JETLS.noparen_macrocall(jlparse("cmdmac`xxx`"; rule=:statement))
+end
+
+@testset "`remove_macrocalls` resolves macro objects" begin
+    world = Base.get_world_counter()
+    for code in (
+            "B.@inline x",
+            "@base_inline x",
+            "ThreadsAlias.@spawn x",
+            "T.@test true")
+        st0 = jlparse(code; rule=:statement)
+        transformed = JETLS.remove_macrocalls(new_style_macro_context, world, st0)
+        @test JS.kind(transformed) === JS.K"macrocall"
+    end
+
+    let st0 = jlparse("@inline x"; rule=:statement)
+        transformed = JETLS.remove_macrocalls(same_named_macro_context, world, st0)
+        @test JS.kind(transformed) === JS.K"block"
+    end
+
+    let st0 = jlparse("""
+            ThreadsAlias.@spawn begin
+                B.@static if true
+                    x
+                end
+            end
+            """; rule=:statement)
+        transformed = JETLS.remove_macrocalls(new_style_macro_context, world, st0; strip_static=true)
+        macrocalls = String[]
+        JETLS.traverse(transformed) do node::JS.SyntaxTree
+            JS.kind(node) === JS.K"macrocall" || return nothing
+            push!(macrocalls, JS.sourcetext(node[1]))
+            return nothing
+        end
+        @test macrocalls == ["ThreadsAlias.@spawn"]
+    end
+
+    for (context_module, expected_macrocalls) in (
+            (nested_same_named_macro_context, String[]),
+            (nested_new_style_macro_context, ["@inline"]))
+        st0 = jlparse("""
+            begin
+                module Inner
+                    @inline f() = 1
+                end
+            end
+            """; rule=:statement)
+        transformed = JETLS.remove_macrocalls(context_module, world, st0)
+        macrocalls = String[]
+        JETLS.traverse(transformed) do node::JS.SyntaxTree
+            JS.kind(node) === JS.K"macrocall" || return nothing
+            push!(macrocalls, JS.sourcetext(node[1]))
+            return nothing
+        end
+        @test macrocalls == expected_macrocalls
+    end
 end
 
 select_target_identifier(code::AbstractString, pos::Int) = JETLS.select_target_identifier(jlparse(code), pos)
@@ -924,7 +1010,7 @@ end
     # The repaired tree must be acceptable to scope-resolution lowering;
     # otherwise the repair didn't achieve its purpose.
     lowers_ok(st) = try
-        JETLS.jl_lower_for_scope_resolution(@__MODULE__, st;
+        JETLS.jl_lower_for_scope_resolution(@__MODULE__, Base.get_world_counter(), st;
             trim_error_nodes=false, recover_from_macro_errors=false)
         return true
     catch

--- a/test/utils/test_binding.jl
+++ b/test/utils/test_binding.jl
@@ -7,7 +7,9 @@ using JETLS.LSP.URIs2
 
 include(normpath(pkgdir(JETLS), "test", "jsjl-utils.jl"))
 
-module lowering_module end
+module lowering_module
+const B = Base
+end
 
 function with_target_binding(f, text::AbstractString; kwargs...)
     clean_code, positions = JETLS.get_text_and_positions(text; kwargs...)
@@ -15,7 +17,7 @@ function with_target_binding(f, text::AbstractString; kwargs...)
     cnt = 0
     for (i, pos) in enumerate(positions)
         offset = JETLS.xy_to_offset(clean_code, pos, @__FILE__)
-        cnt += f(i, JETLS.select_target_binding(st0_top, offset, lowering_module))
+        cnt += f(i, JETLS.select_target_binding(st0_top, offset, lowering_module, Base.get_world_counter()))
     end
     return cnt
 end
@@ -155,25 +157,29 @@ end
     end == 4
 
     # One-argument `@eval` evaluates in the construction module.
-    @test with_target_binding("""
-        struct │LSAnalyzer│ end
-        let x = 1
-            @eval some_func(::│LSAnalyzer│) = \$x
-        end
-        """) do _, (; ctx3, binding)
-        binfo = JL.get_binding(ctx3, binding)
-        @test binfo.name == "LSAnalyzer"
-        @test binfo.kind === :global
-        return true
-    end == 4
+    for eval_macro in ("@eval", "B.@eval")
+        @test with_target_binding("""
+            struct │LSAnalyzer│ end
+            let x = 1
+                $eval_macro some_func(::│LSAnalyzer│) = \$x
+            end
+            """) do _, (; ctx3, binding)
+            binfo = JL.get_binding(ctx3, binding)
+            @test binfo.name == "LSAnalyzer"
+            @test binfo.kind === :global
+            return true
+        end == 4
+    end
 
     # Two-argument `@eval` is left unresolved even when its target looks static.
-    @test with_target_binding("""
-        @eval SomeModule some_func(::│LSAnalyzer│) = nothing
-        """) do _, result
-        @test result === nothing
-        return true
-    end == 2
+    for eval_macro in ("@eval", "B.@eval")
+        @test with_target_binding("""
+            $eval_macro SomeModule some_func(::│LSAnalyzer│) = nothing
+            """) do _, result
+            @test result === nothing
+            return true
+        end == 2
+    end
 
     # A dynamic target module is likewise left unresolved.
     @test with_target_binding("""
@@ -230,7 +236,7 @@ end
         clean_code, positions = JETLS.get_text_and_positions(code)
         st0_top = jlparse(clean_code)
         offset = JETLS.xy_to_offset(clean_code, only(positions), @__FILE__)
-        @test isnothing(JETLS.select_target_binding(st0_top, offset, lowering_module))
+        @test isnothing(JETLS.select_target_binding(st0_top, offset, lowering_module, Base.get_world_counter()))
     end
 end
 
@@ -240,7 +246,7 @@ function with_target_binding_definitions(f, text::AbstractString; kwargs...)
     cnt = 0
     for (i, pos) in enumerate(positions)
         offset = JETLS.xy_to_offset(clean_code, pos, @__FILE__)
-        cnt += f(i, JETLS.select_target_binding_definitions(st0_top, offset, lowering_module))
+        cnt += f(i, JETLS.select_target_binding_definitions(st0_top, offset, lowering_module, Base.get_world_counter()))
     end
     return cnt
 end

--- a/test/utils/test_jl_syntax_macros.jl
+++ b/test/utils/test_jl_syntax_macros.jl
@@ -29,9 +29,9 @@ function jlexpand(
 end
 jlexpand(code::AbstractString; kwargs...) = jlexpand(lowering_module, code; kwargs...)
 
-function jlresolve(context_module::Module, code::AbstractString)
+function jlresolve(context_module::Module, code::AbstractString; world::UInt=Base.get_world_counter())
     st0 = jlparse(code; rule=:statement)
-    return JETLS.jl_lower_for_scope_resolution(context_module, st0;
+    return JETLS.jl_lower_for_scope_resolution(context_module, world, st0;
         recover_from_macro_errors=false, convert_closures=true)
 end
 jlresolve(code::AbstractString) = jlresolve(lowering_module, code)
@@ -62,9 +62,12 @@ end
 # downstream LSP analyses (`is_from_user_ast` etc.) can recognize it as
 # user code. Used by every macro stub's "binding resolution preserves
 # provenance" testset.
-function assert_binding_provenance(res, kind::Symbol, name::AbstractString)
+function assert_binding_provenance(
+        res, kind::Symbol, name::AbstractString;
+        world::UInt = Base.get_world_counter()
+    )
     binding_occurrences = JETLS.compute_binding_occurrences(
-        res.ctx3, res.st3; include_global_bindings=true)
+        res.ctx3, res.st3, world; include_global_bindings=true)
     binfo = nothing
     for (b, _) in binding_occurrences
         if b.kind === kind && b.name == name
@@ -100,9 +103,12 @@ end
 # binding of the given kind/name exists. Used for identifiers that the macro
 # stub intentionally drops (e.g. kwarg keys in logging macros, which are
 # metadata symbols and not user references).
-function assert_no_binding(res, kind::Symbol, name::AbstractString)
+function assert_no_binding(
+        res, kind::Symbol, name::AbstractString;
+        world::UInt = Base.get_world_counter()
+    )
     binding_occurrences = JETLS.compute_binding_occurrences(
-        res.ctx3, res.st3; include_global_bindings=true)
+        res.ctx3, res.st3, world; include_global_bindings=true)
     found = any(binding_occurrences) do (b, _)
         b.kind === kind && b.name == name
     end
@@ -230,6 +236,7 @@ end
     end
 
     @testset "binding resolution" begin
+        world = Base.get_world_counter()
         for code in [
             "@kwdef struct MyStruct{T <: Real}\n    a::T = 1.0\nend\n",
             "@kwdef struct MyStruct\n    a::Float64 = 1.0\nend\n",
@@ -240,7 +247,7 @@ end
         ]
             st0 = jlparse(code)
             offset = findfirst("MyStruct", code).start
-            result = JETLS.select_target_binding(st0, offset, lowering_module)
+            result = JETLS.select_target_binding(st0, offset, lowering_module, world)
             @test result !== nothing
             binfo = JL.get_binding(result.ctx3, result.binding)
             @test binfo.name == "MyStruct"


### PR DESCRIPTION
Qualified and aliased new-style macros such as `Test.@test` were classified by source spelling. This missed aliases and could preserve unrelated user-defined macros with the same name, producing incorrect binding results in references, rename, highlights, and diagnostics.

Resolve source macro names in the request module and world, then compare the resulting macro object with the registered defining-module binding. Thread the captured world through lowering and binding selection so all related analyses use a consistent snapshot. Nested module bodies switch to their resolved module context.

Preserved new-style calls still recurse into their arguments so nested old-style calls and `@static` are handled. Coverage includes qualified, aliased, same-named, nested-module, and generated/eval cases.