### PR TITLE
deps: Update JS/JL for lambda-aware closure bindings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,8 +27,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [sources]
 Compiler = {rev = "avi/JETLS-Compiler-head", subdir = "Compiler", url = "https://github.com/JuliaLang/julia"}
 JET = {rev = "ab8d6dc4", url = "https://github.com/aviatesk/JET.jl"}
-JuliaLowering = {rev = "8399119aa7", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
-JuliaSyntax = {rev = "8399119aa7", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
+JuliaLowering = {rev = "f66055cc4d", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
+JuliaSyntax = {rev = "f66055cc4d", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
 LSP = {path = "LSP"}
 
 [compat]

--- a/src/analysis/Closure2Opaque.jl
+++ b/src/analysis/Closure2Opaque.jl
@@ -20,35 +20,48 @@ into inference context module (which the regular conversion would require).
 
 # Limitations
 
-- Multi-method bindings (a single name with multiple `K"method_defs"` anywhere in `st3`)
-  can't be represented as a single OC, so they fall through to the regular synthetic-struct
-  path. A whole-tree pre-pass (`collect_multi_method_bindings`) identifies these so the
-  per-block rewrite can skip every method definition for such bindings.
+- Local closures with multiple `K"method"` nodes for one `ClosureKey` can't be
+  represented as a single OC, so they fall through to the regular synthetic-struct
+  path. A whole-tree pre-pass (`collect_multi_method_bindings`) counts methods per
+  key so the per-block rewrite can skip every definition of that closure.
 - Bodies whose `K"method_defs"` shape doesn't contain exactly one method, or whose
   method declares its own static parameters (e.g. generated or generic local methods),
   are likewise left untouched.
 
 # Usage
 
-Designed to be called by `TypeAnnotation.infer_toplevel_tree` against a `K"toplevel"` /
-`K"block"` `SyntaxTreeC` produced by `JL.resolve_scopes`, before `JL.convert_closures` runs.
+Designed to be called by `TypeAnnotation.infer_toplevel_tree` against the `K"lambda"`
+root produced by `JL.resolve_scopes` (its `lambda_bindings` seeds the enclosing-lambda
+tracking), before `JL.convert_closures` runs.
 The rewrite is non-destructive: nodes that don't match are returned unchanged, so the
 pipeline downstream sees an equivalent tree with only the eligible closures swapped.
 """
 function rewrite_local_closures_to_opaque(ctx::JL.VariableAnalysisContext, st3::SyntaxTreeC)
-    multis = collect_multi_method_bindings(ctx, st3)
-    return _rewrite_local_closures_to_opaque(ctx, st3, multis)
+    lambda_scope_id = (st3.lambda_bindings::JL.LambdaBindings).scope_id
+    multis = collect_multi_method_bindings(ctx, st3, lambda_scope_id)
+    return _rewrite_local_closures_to_opaque(ctx, st3, multis, lambda_scope_id)
 end
 
-function _rewrite_local_closures_to_opaque(ctx::JL.VariableAnalysisContext, st3::SyntaxTreeC, multis::Set{Int})
-    if JS.kind(st3) === JS.K"block"
-        return rewrite_closure_block(ctx, st3, multis)
+function _rewrite_local_closures_to_opaque(
+        ctx::JL.VariableAnalysisContext, st3::SyntaxTreeC,
+        multis::Set{JL.ClosureKey}, lambda_scope_id::Int
+    )
+    k = JS.kind(st3)
+    if k === JS.K"block"
+        return rewrite_closure_block(ctx, st3, multis, lambda_scope_id)
+    elseif k === JS.K"lambda"
+        lambda_scope_id = (st3.lambda_bindings::JL.LambdaBindings).scope_id
     end
-    return JS.mapchildren(c::SyntaxTreeC -> _rewrite_local_closures_to_opaque(ctx, c, multis), ctx, st3)
+    let lambda_scope_id=lambda_scope_id
+        return JS.mapchildren(ctx, st3) do c::SyntaxTreeC
+            _rewrite_local_closures_to_opaque(ctx, c, multis, lambda_scope_id)
+        end
+    end
 end
 
 function rewrite_closure_block(
-        ctx::JL.VariableAnalysisContext, blk3::SyntaxTreeC, multis::Set{Int}
+        ctx::JL.VariableAnalysisContext, blk3::SyntaxTreeC,
+        multis::Set{JL.ClosureKey}, lambda_scope_id::Int
     )
     children_old = JS.children(blk3)
     n = length(children_old)
@@ -57,35 +70,38 @@ function rewrite_closure_block(
     for i = 1:n
         consumed[i] && continue
         child = children_old[i]
-        if JS.kind(child) === JS.K"function_decl" && is_local_closure_decl(ctx, child)
-            func_name = child[1]
-            md_idx = find_matching_method_defs(children_old, i, var_id(func_name), consumed)
-            if md_idx !== nothing && !(var_id(func_name) in multis)
+        func_key = JS.kind(child) === JS.K"function_decl" ?
+            local_closure_key(ctx, child, lambda_scope_id) : nothing
+        if func_key !== nothing
+            md_idx = find_matching_method_defs(
+                children_old, i, func_key.binding, consumed)
+            if md_idx !== nothing && func_key ∉ multis
                 method_defs = children_old[md_idx]
                 oc = try_build_oc_assignment(ctx, child, method_defs)
                 if oc !== nothing
-                    push!(new_children, _rewrite_local_closures_to_opaque(ctx, oc, multis))
+                    push!(new_children,
+                        _rewrite_local_closures_to_opaque(ctx, oc, multis, lambda_scope_id))
                     consumed[md_idx] = true
                     continue
                 end
             end
         end
-        push!(new_children, _rewrite_local_closures_to_opaque(ctx, child, multis))
+        push!(new_children,
+            _rewrite_local_closures_to_opaque(ctx, child, multis, lambda_scope_id))
     end
     return JL.@ast ctx blk3 [JS.K"block" new_children...]
 end
 
-# Collect `var_id`s that resolve to more than one method, plus any helper closure
-# bindings reachable from multi-method *closure* wrappers.
+# Collect closure keys that resolve to more than one method, plus any helper
+# closures reachable from multi-method *closure* wrappers.
 #
-# Multi-method detection counts `K"method"` nodes per `var_id` across the whole
-# tree. JL has two ways to express multi-method bindings — multiple sibling
+# Multi-method detection counts `K"method"` nodes per `ClosureKey` across the
+# whole tree. JL has two ways to express multi-method bindings — multiple sibling
 # `K"method_defs"` (e.g. kwarg wrappers, `f(::T1)` + `f(::T2)`) or a single
 # `K"method_defs"` packing multiple methods (e.g. default-positional-arg) — and
-# both reduce to the same `K"method"` count once flattened. `K"method"` is JL-
-# specific to method-definition bodies, so a whole-tree count is unambiguous;
-# nested closures' methods are tagged under their own (inner) `var_id` and don't
-# bleed into outer counts.
+# both reduce to the same `K"method"` count once flattened. The enclosing lambda
+# in `ClosureKey` prevents definitions of the same binding in nested lambdas from
+# bleeding into each other's counts.
 #
 # The reachability propagation handles kwarg closures: JL splits `f = (x; kw=1) -> ...`
 # into a multi-method wrapper `f` (positional dispatch + kwsorter) plus a single-method
@@ -98,68 +114,98 @@ end
 # top-level function with default positional args or kwargs) never goes through
 # synthetic-struct closure conversion, so single-method closures inside its bodies are
 # still safely rewritable to OCs and must not be tagged.
-function collect_multi_method_bindings(ctx::JL.VariableAnalysisContext, st3::SyntaxTreeC)
-    method_defs_by_vid = Dict{Int,Vector{SyntaxTreeC}}()
-    methods_per_vid = Dict{Int,Int}()
-    multis = Set{Int}()
-    stack = SyntaxTreeC[st3]
+function collect_multi_method_bindings(
+        ctx::JL.VariableAnalysisContext, st3::SyntaxTreeC, root_scope_id::Int
+    )
+    method_defs_by_key = Dict{JL.ClosureKey,Vector{SyntaxTreeC}}()
+    methods_per_key = Dict{JL.ClosureKey,Int}()
+    multis = Set{JL.ClosureKey}()
+    stack = Tuple{SyntaxTreeC,Int}[(st3, root_scope_id)]
     while !isempty(stack)
-        node = pop!(stack)
+        node, lambda_scope_id = pop!(stack)
         k = JS.kind(node)
-        if ((k === JS.K"method" || k === JS.K"method_defs") &&
-            JS.numchildren(node) >= 1 && JS.kind(node[1]) === JS.K"BindingId")
-            vid = var_id(node[1])
+        if k === JS.K"lambda"
+            lambda_scope_id = (node.lambda_bindings::JL.LambdaBindings).scope_id
+        elseif ((k === JS.K"method" || k === JS.K"method_defs") &&
+                JS.numchildren(node) >= 1 && JS.kind(node[1]) === JS.K"BindingId")
+            key = JL.ClosureKey(var_id(node[1]), lambda_scope_id)
             if k === JS.K"method"
-                n = (methods_per_vid[vid] = get(methods_per_vid, vid, 0) + 1)
-                n == 2 && push!(multis, vid) # fires exactly once per binding
+                n = (methods_per_key[key] = get(methods_per_key, key, 0) + 1)
+                n == 2 && push!(multis, key)
             else
-                push!(get!(() -> SyntaxTreeC[], method_defs_by_vid, vid), node)
+                push!(get!(() -> SyntaxTreeC[], method_defs_by_key, key), node)
             end
         end
         if !JS.is_leaf(node)
             for c in JS.children(node)
-                push!(stack, c)
+                push!(stack, (c, lambda_scope_id))
             end
         end
     end
-    worklist = Int[vid for vid in multis if haskey(ctx.closure_bindings, vid)]
+    worklist = JL.ClosureKey[key for key in multis if haskey(ctx.closure_bindings, key)]
+    candidate_bids = Set{Int}(key.binding for key in keys(method_defs_by_key))
     while !isempty(worklist)
-        vid = pop!(worklist)
-        for md in method_defs_by_vid[vid]
-            collect_referenced_closures!(md, multis, worklist, method_defs_by_vid)
+        key = pop!(worklist)
+        for md in method_defs_by_key[key]
+            collect_referenced_closures!(
+                ctx, md, key.lam, multis, worklist, method_defs_by_key, candidate_bids)
         end
     end
     return multis
 end
 
 function collect_referenced_closures!(
-        root::SyntaxTreeC, multis::Set{Int}, worklist::Vector{Int},
-        method_defs_by_vid::Dict{Int,Vector{SyntaxTreeC}}
+        ctx::JL.VariableAnalysisContext, root::SyntaxTreeC, lambda_scope_id::Int,
+        multis::Set{JL.ClosureKey}, worklist::Vector{JL.ClosureKey},
+        method_defs_by_key::Dict{JL.ClosureKey,Vector{SyntaxTreeC}},
+        candidate_bids::Set{Int}
     )
-    stack = SyntaxTreeC[root]
+    stack = Tuple{SyntaxTreeC,Int}[(c, lambda_scope_id) for c in JS.children(root)]
     while !isempty(stack)
-        node = pop!(stack)
-        if JS.kind(node) === JS.K"BindingId"
-            id = var_id(node)
-            if id ∉ multis && haskey(method_defs_by_vid, id)
-                push!(multis, id)
-                push!(worklist, id)
+        node, lambda_scope_id = pop!(stack)
+        k = JS.kind(node)
+        if k === JS.K"function_decl" || k === JS.K"method_defs"
+            # Nested definitions need no descent: their sibling `[local]`/`[removable]`
+            # BindingId occurrences tag them, and tagged ones are walked via the worklist.
+            continue
+        elseif k === JS.K"lambda"
+            lambda_scope_id = (node.lambda_bindings::JL.LambdaBindings).scope_id
+        elseif k === JS.K"BindingId" && var_id(node) in candidate_bids
+            key = find_enclosing_closure_key(ctx, var_id(node), lambda_scope_id)
+            if key !== nothing && key ∉ multis && haskey(method_defs_by_key, key)
+                push!(multis, key)
+                push!(worklist, key)
             end
         end
         if !JS.is_leaf(node)
             for c in JS.children(node)
-                push!(stack, c)
+                push!(stack, (c, lambda_scope_id))
             end
         end
     end
     return nothing
 end
 
-function is_local_closure_decl(ctx::JL.VariableAnalysisContext, fd::SyntaxTreeC)
-    JS.numchildren(fd) >= 1 || return false
+function find_enclosing_closure_key(
+        ctx::JL.VariableAnalysisContext, binding_id::Int, lambda_scope_id::Int
+    )
+    while true
+        key = JL.ClosureKey(binding_id, lambda_scope_id)
+        haskey(ctx.closure_bindings, key) && return key
+        parent = @something JL.parent(ctx, ctx.scopes[lambda_scope_id]) return nothing
+        lambda_scope_id = JL.enclosing_lambda(ctx, parent).id
+    end
+end
+
+# Returns the `ClosureKey` for a `function_decl` of a local closure, `nothing` otherwise.
+function local_closure_key(
+        ctx::JL.VariableAnalysisContext, fd::SyntaxTreeC, lambda_scope_id::Int
+    )
+    JS.numchildren(fd) >= 1 || return nothing
     func_name = fd[1]
-    return JS.kind(func_name) === JS.K"BindingId" &&
-        haskey(ctx.closure_bindings, var_id(func_name))
+    JS.kind(func_name) === JS.K"BindingId" || return nothing
+    key = JL.ClosureKey(var_id(func_name), lambda_scope_id)
+    return haskey(ctx.closure_bindings, key) ? key : nothing
 end
 
 function find_matching_method_defs(

--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -126,9 +126,9 @@ types to `Any`.
 - **Closures**: Single-method local closures are rewritten to `K"_opaque_closure"`
   by [`Closure2Opaque.rewrite_local_closures_to_opaque`](@ref) before
   `JL.convert_closures`, so CC's native `OpaqueClosure` path handles them
-  precisely (body, captures, and call sites all infer). Multi-method local
-  closures (same name with multiple method definitions) aren't representable as
-  a single OC, so the rewrite skips them and JL's synthetic struct path takes
+  precisely (body, captures, and call sites all infer). Local closures with
+  multiple method definitions for one `ClosureKey` aren't representable as a
+  single OC, so the rewrite skips them and JL's synthetic struct path takes
   over. JL's standard runtime materializes the synthetic struct type before
   dispatch, but `infer_toplevel_tree` deliberately avoids `Core.eval` to keep
   analysis side-effect-free, so the synthetic type never appears in

--- a/src/document-symbol.jl
+++ b/src/document-symbol.jl
@@ -836,33 +836,58 @@ function build_node_maps!(
     return parent_map, node_map
 end
 
+function binding_provenance_range(ctx3::JL.VariableAnalysisContext, bid::Int)
+    provs = JS.flattened_provenance(JL.binding_ex(ctx3, bid))
+    isempty(provs) && return nothing
+    prov = last(provs)
+    return (JS.first_byte(prov), JS.last_byte(prov))
+end
+
 function build_func_to_scopes(ctx3::JL.VariableAnalysisContext)
+    # Keyed by binding id: scopes of every definition of a binding (JL keys
+    # `closure_bindings` per definition-site lambda) merge under the one
+    # symbol rendered for it.
     func_to_scopes = Dict{Int,Vector{Int}}()
-    kwsorter_to_func = Dict{Int,Int}()  # kwsorter bid → main func bid
-    for (func_bid, cb) in ctx3.closure_bindings
-        if !isempty(cb.lambdas)
-            func_to_scopes[func_bid] = Int[lb.scope_id for lb in cb.lambdas]
+    main_by_range = Dict{Tuple{Int,Int},Int}()
+    main_by_lambda_name = Dict{Tuple{Int,String},Set{Int}}()
+    helper_scopes = Pair{JL.ClosureKey,Vector{Int}}[]
+    for (func_key, cb) in ctx3.closure_bindings
+        bid = func_key.binding
+        scope_ids = Int[lb.scope_id for lb in cb.lambdas]
+        if !isempty(scope_ids)
+            append!(get!(Vector{Int}, func_to_scopes, bid), scope_ids)
         end
-        binfo = JL.get_binding(ctx3, func_bid)
+        binfo = JL.get_binding(ctx3, bid)
         # Detect kw body/sorter pattern: #funcname#N or #kw_body#funcname#N
-        m = match(r"^#(?:kw_body#)?(.+)#\d+$", binfo.name)
-        if m !== nothing
-            main_func_name = m.captures[1]
-            # Find the main function binding with this name
-            for (other_bid, _) in ctx3.closure_bindings
-                other_binfo = JL.get_binding(ctx3, other_bid)
-                if other_binfo.name == main_func_name
-                    kwsorter_to_func[func_bid] = other_bid
-                    break
-                end
-            end
+        if occursin(r"^#(?:kw_body#)?.+#\d+$", binfo.name)
+            push!(helper_scopes, func_key => scope_ids)
+        else
+            key = (func_key.lam, binfo.name)
+            push!(get!(Set{Int}, main_by_lambda_name, key), bid)
+            range = @something binding_provenance_range(ctx3, bid) continue
+            main_by_range[range] = bid
         end
     end
-    # Merge kwsorter scopes into main function scopes
-    for (kwsorter_bid, main_func_bid) in kwsorter_to_func
-        if haskey(func_to_scopes, kwsorter_bid) && haskey(func_to_scopes, main_func_bid)
-            append!(func_to_scopes[main_func_bid], func_to_scopes[kwsorter_bid])
+    # Prefer provenance ranges, which distinguish same-named definitions in a
+    # lambda. A binding shared by nested redefinitions retains only its first
+    # provenance, so fall back to an unambiguous definition-site lambda match.
+    for (helper_key, scope_ids) in helper_scopes
+        isempty(scope_ids) && continue
+        helper_bid = helper_key.binding
+        provs = JS.flattened_provenance(JL.binding_ex(ctx3, helper_bid))
+        isempty(provs) && continue
+        prov = last(provs)
+        range = (JS.first_byte(prov), JS.last_byte(prov))
+        main_bid = get(main_by_range, range, nothing)
+        if main_bid === nothing
+            name = @something get_name_val(prov) continue
+            candidates = get(main_by_lambda_name, (helper_key.lam, name), nothing)
+            candidates === nothing && continue
+            length(candidates) == 1 || continue
+            main_bid = only(candidates)
         end
+        haskey(func_to_scopes, main_bid) || continue
+        append!(func_to_scopes[main_bid], scope_ids)
     end
     return func_to_scopes
 end

--- a/test/analysis/test_Closure2Opaque.jl
+++ b/test/analysis/test_Closure2Opaque.jl
@@ -291,6 +291,22 @@ end
         @test val === true
         @test count_opaque_closures(tree) == 2
     end
+
+    let (val, tree) = rewrite_lower_eval("""
+            let a = 1, b = 10
+                inner() = a
+                v1 = inner
+                function mid()
+                    inner() = a + b
+                end
+                mid()
+                v2 = inner
+                (v1(), v2())
+            end
+            """)
+        @test val == (1, 11)
+        @test count_opaque_closures(tree) == 3
+    end
 end
 
 @testset "do-block as map argument" begin
@@ -307,11 +323,10 @@ end
 end
 
 # Multi-method local closures aren't representable as a single OC, so the rewrite
-# must skip them and let `JL.convert_closures` produce a synthetic struct. JL wraps
-# each method definition in its own inner block, so a sibling-only count would see
-# only one `K"method_defs"` per block. The pre-pass in
-# `_collect_multi_method_bindings` walks the whole tree to count `K"method_defs"`
-# per `var_id`, which is what lets the rewrite skip both methods here.
+# must skip them and let `JL.convert_closures` produce a synthetic struct. JL can
+# place methods in separate inner blocks, so scanning sibling `K"method_defs"`
+# nodes is insufficient. `collect_multi_method_bindings` counts `K"method"` nodes
+# per `ClosureKey` across the tree, allowing both definitions to bypass the rewrite.
 @testset "multi-method local closure should fall through" begin
     let tree = rewrite_only("""
             let

--- a/test/test_document_symbol.jl
+++ b/test/test_document_symbol.jl
@@ -775,6 +775,49 @@ end
             y_sym = only(filter(c -> c.name == "y", inner_sym.children))
             @test y_sym.kind == SymbolKind.Object
         end
+
+        # A nested-lambda redefinition is a separate `ClosureKey` entry in JL;
+        # its scopes must still merge under the one symbol rendered for the
+        # binding so its parameters don't vanish from the outline
+        let code = """
+            function outer(a, b)
+                inner(x) = a + x
+                function mid()
+                    inner(y, z) = a + b + y + z
+                end
+                mid()
+                return inner
+            end
+            """
+            symbols = get_document_symbols(code)
+            children = only(symbols).children
+            @test children !== nothing
+            inner_sym = only(filter(c -> c.name == "inner", children))
+            @test inner_sym.children !== nothing
+            @test Set(c.name for c in inner_sym.children) == Set(["x", "y", "z"])
+        end
+
+        # A local function declared in an outer lambda but defined only inside
+        # a nested lambda must still render as a Function with its parameters
+        let code = """
+            function outer()
+                local f
+                function mid()
+                    f(x) = x + 1
+                end
+                mid()
+                return f
+            end
+            """
+            symbols = get_document_symbols(code)
+            children = only(symbols).children
+            @test children !== nothing
+            f_sym = only(filter(c -> c.name == "f", children))
+            @test f_sym.kind == SymbolKind.Function
+            @test f_sym.children !== nothing
+            x_sym = only(filter(c -> c.name == "x", f_sym.children))
+            @test x_sym.kind == SymbolKind.Object
+        end
     end
 
     @testset "descendant scopes within nested function" begin
@@ -1242,7 +1285,8 @@ end
         @test kw_sym.detail == "; kw"
     end
 
-    # Varargs keyword argument should show only its own detail, not the entire parameters block
+    # Varargs keyword argument should show only its own detail, not the entire
+    # parameters block
     let code = """
         function outer()
             function inner(_; kw=nothing, kws...)
@@ -1261,6 +1305,68 @@ end
         @test kw_sym.detail == "kw=nothing"
         kws_sym = only(filter(c -> c.name == "kws", inner_sym.children))
         @test kws_sym.detail == "kws..."
+    end
+
+    # kw helper scopes must merge into their exact definition, not another
+    # same-named binding in a sibling scope of the same lambda
+    let code = """
+        function outer()
+            let
+                f(x) = 2x
+            end
+            let
+                function f(; k = 1)
+                    b = k + 1
+                    return b
+                end
+                f()
+            end
+        end
+        """
+        symbols = get_document_symbols(code)
+        @test length(symbols) == 1
+        children = symbols[1].children
+        @test children !== nothing
+        let_syms = filter(c -> c.detail == "let", children)
+        @test length(let_syms) == 2
+        f_syms = DocumentSymbol[]
+        for let_sym in let_syms
+            @test let_sym.children !== nothing
+            append!(f_syms, filter(c -> c.name == "f", let_sym.children))
+        end
+        @test length(f_syms) == 2
+        kw_f_sym = only(filter(s -> s.detail == "function f(; k = 1)", f_syms))
+        @test kw_f_sym.children !== nothing
+        @test Set(c.name for c in kw_f_sym.children) == Set(["k", "b"])
+        plain_f_sym = only(filter(s -> s.detail == "f(x) =", f_syms))
+        @test plain_f_sym.children !== nothing
+        @test Set(c.name for c in plain_f_sym.children) == Set(["x"])
+    end
+
+    let code = """
+        function outer(a, b)
+            f(x; k = 1) = begin
+                first_body = a + x + k
+                first_body
+            end
+            function mid()
+                f(y, z; q = 2) = begin
+                    second_body = a + b + y + z + q
+                    second_body
+                end
+            end
+            mid()
+            return f
+        end
+        """
+        symbols = get_document_symbols(code)
+        children = only(symbols).children
+        @test children !== nothing
+        f_sym = only(filter(c -> c.name == "f", children))
+        @test f_sym.children !== nothing
+        child_names = Set(c.name for c in f_sym.children)
+        @test Set(["x", "y", "z", "k", "first_body"]) ⊆ child_names
+        @test Set(["q", "second_body"]) ⊆ child_names
     end
 end
 

--- a/test/test_lowering_diagnostic.jl
+++ b/test/test_lowering_diagnostic.jl
@@ -467,6 +467,31 @@ end
                 diagnostic.range.start.line == 0
             end
         end
+        # JuliaLowering marks local `#kw_body#f#N` bindings as internal, so
+        # they must not be reported as unused
+        @test isempty(get_lowering_diagnostics("""
+            function outer()
+                g(; kw = 1) = kw
+                return g()
+            end
+            """))
+    end
+
+    @testset "var-string binding with '#' prefix" begin
+        # User-authored `var"#..."` bindings must keep unused reports
+        let diagnostics = get_lowering_diagnostics("""
+            function fx()
+                var"#x" = 1
+                return 2
+            end
+            """)
+            @test length(diagnostics) == 1
+            @test only(diagnostics).message == "Unused local binding `#x`"
+        end
+        let diagnostics = get_lowering_diagnostics("fz(var\"#z\") = 1")
+            @test length(diagnostics) == 1
+            @test only(diagnostics).message == "Unused argument `#z`"
+        end
     end
 
     @testset "macro definition" begin


### PR DESCRIPTION
JuliaLang/julia#62412 keys JuliaLowering closure bindings by both the binding ID and definition-site lambda. Updating JS/JL without adapting JETLS caused local closure conversion to conflate nested definitions, and document symbols could lose parameters, keyword arguments, and local variables from nested function redefinitions.

Track `JL.ClosureKey` throughout `Closure2Opaque` method counting and reachability while carrying the enclosing lambda scope through tree traversal. Build document-symbol scope mappings by binding ID, then associate keyword helper scopes with their exact source definitions or an unambiguous definition-site lambda match.

The updated revision also preserves internal metadata for generated keyword-body helpers (JuliaLang/julia#62428). This keeps them out of unused-binding diagnostics without suppressing reports for user-authored `var"#..."` bindings.