### PR TITLE
full-analysis: Remove configurable analysis worker count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Breaking
 
+- Removed the experimental `n_analysis_workers` initialization option. Full-analysis requests are now processed serially, while signature analysis within each request remains parallel based on the available Julia threads. Existing client or `.JETLSConfig.toml` configurations must remove this option.
+
 - `inference/non-boolean-cond` is now reported as [`inference/type-error/non-bool-cond`](https://aviatesk.github.io/JETLS.jl/release/diagnostic/#diagnostic/reference/inference/type-error/non-bool-cond). Existing diagnostic pattern configurations that match the old code continue to apply for now, but this compatibility support may be removed in a future release.
 
 ### Added

--- a/docs/src/launching.md
+++ b/docs/src/launching.md
@@ -139,40 +139,9 @@ these options configure fundamental server behavior.
 
 ### [Schema](@id init-options/schema)
 
-A [JSON Schema](https://json-schema.org/) for initialization options is available.
-See the [JSON Schema](@ref config/schema-cli) section for download links.
-
-```json
-{
-  "n_analysis_workers": 1
-}
-```
-
-### [Reference](@id init-options/reference)
-
-#### [`n_analysis_workers` (experimental)](@id init-options/n_analysis_workers)
-
-- **Type**: integer
-- **Default**: `1`
-- **Minimum**: `1`
-
-Number of concurrent analysis worker tasks for running full analysis.
-
-The code loading phase must execute sequentially due to package environment and
-world age constraints. However, when multiple analysis units are open (e.g.,
-package source code and test code), increasing `n_analysis_workers` may reduce
-overall analysis time: while one unit is in the signature analysis phase,
-another can begin code loading concurrently.
-
-!!! warning "Experimental"
-    This option is experimental and may be removed or its semantics may be changed
-    substantially in future versions as the full analysis architecture evolves.
-
-!!! note "Signature analysis parallelization"
-    The signature analysis phase is parallelized automatically using
-    `Threads.@spawn` when Julia is started with multiple threads. This
-    parallelization is independent of `n_analysis_workers` and provides
-    significant speedups (e.g., ~4x faster with 4 threads for large packages).
+A [JSON Schema](https://json-schema.org/) for initialization options is
+available. See the [JSON Schema](@ref config/schema-cli) section for download
+links.
 
 ### [How to configure initialization options](@id init-options/configure)
 
@@ -189,8 +158,9 @@ Configure initialization options in [`.JETLSConfig.toml`](@ref config/file-based
 at your project root:
 
 ```toml
-[initialization_options]
-n_analysis_workers = 2
+[[initialization_options.analysis_overrides]]
+path = "test/fixtures/**"
+full_analysis = false
 ```
 
 This method is client-agnostic and can be easily committed to version control.
@@ -211,7 +181,12 @@ Configure initialization options in VSCode's `settings.json`:
 ```json
 {
   "jetls-client.initializationOptions": {
-    "n_analysis_workers": 2
+    "analysis_overrides": [
+      {
+        "path": "test/fixtures/**",
+        "full_analysis": false
+      }
+    ]
   }
 }
 ```
@@ -225,7 +200,12 @@ Configure initialization options in Zed's `settings.json`:
   "lsp": {
     "JETLS": {
       "initialization_options": {
-        "n_analysis_workers": 2
+        "analysis_overrides": [
+          {
+            "path": "test/fixtures/**",
+            "full_analysis": false
+          }
+        ]
       }
     }
   }

--- a/jetls-client/CHANGELOG.md
+++ b/jetls-client/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
 - Diff: [`d4f7fe9b...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/d4f7fe9b...HEAD)
 
+### Removed
+
+- Removed the experimental `n_analysis_workers` property from `jetls-client.initializationOptions`. Existing VSCode settings must remove this property.
+
 ## v0.5.0
 
 - Commit: [`d4f7fe9b`](https://github.com/aviatesk/JETLS.jl/commit/d4f7fe9b)

--- a/jetls-client/README.md
+++ b/jetls-client/README.md
@@ -130,7 +130,12 @@ For detailed initialization options and examples, see the
 ```jsonc
 {
   "jetls-client.initializationOptions": {
-    "n_analysis_workers": 2
+    "analysis_overrides": [
+      {
+        "path": "test/fixtures/**",
+        "full_analysis": false
+      }
+    ]
   }
 }
 ```

--- a/jetls-client/package.json
+++ b/jetls-client/package.json
@@ -139,13 +139,6 @@
                 },
                 "markdownDescription": "Override full analysis behavior for specific file patterns. Primarily used as a temporary workaround to disable analysis for files affected by memory leak issues. Each override specifies a glob pattern, optionally a module name, and can opt back into full analysis. Note: This is an experimental feature that may be removed or changed in future versions.",
                 "type": "array"
-              },
-              "n_analysis_workers": {
-                "default": 1,
-                "markdownDescription": "Number of concurrent analysis worker tasks for running full analysis (experimental). Default is 1. See [documentation](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options/n_analysis_workers) for details and current limitations.",
-                "maximum": 9223372036854775807,
-                "minimum": -9223372036854775808,
-                "type": "integer"
               }
             },
             "required": [],

--- a/schemas/config-toml.schema.json
+++ b/schemas/config-toml.schema.json
@@ -221,13 +221,6 @@
             "type": "object"
           },
           "type": "array"
-        },
-        "n_analysis_workers": {
-          "default": 1,
-          "description": "Number of concurrent analysis worker tasks for running full analysis (experimental). Default is 1. See [documentation](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options/n_analysis_workers) for details and current limitations.",
-          "maximum": 9223372036854775807,
-          "minimum": -9223372036854775808,
-          "type": "integer"
         }
       },
       "required": [],

--- a/schemas/description.toml
+++ b/schemas/description.toml
@@ -33,7 +33,6 @@ executable = "Path to custom formatter executable for document formatting. The f
 executable_range = "Path to custom formatter executable for range formatting. Should accept a `--lines=START:END` argument to format only the specified line range."
 
 [InitOptions]
-n_analysis_workers = "Number of concurrent analysis worker tasks for running full analysis (experimental). Default is 1. See [documentation](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options/n_analysis_workers) for details and current limitations."
 analysis_overrides = "Override full analysis behavior for specific file patterns. Primarily used as a temporary workaround to disable analysis for files affected by memory leak issues. Each override specifies a glob pattern, optionally a module name, and can opt back into full analysis. Note: This is an experimental feature that may be removed or changed in future versions."
 
 [AnalysisOverride]

--- a/schemas/init-options.schema.json
+++ b/schemas/init-options.schema.json
@@ -35,13 +35,6 @@
             "type": "object"
           },
           "type": "array"
-        },
-        "n_analysis_workers": {
-          "default": 1,
-          "description": "Number of concurrent analysis worker tasks for running full analysis (experimental). Default is 1. See [documentation](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options/n_analysis_workers) for details and current limitations.",
-          "maximum": 9223372036854775807,
-          "minimum": -9223372036854775808,
-          "type": "integer"
         }
       },
       "type": "object"

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -288,7 +288,7 @@ function runserver(
         @error "Message handling loop failed"
         Base.display_error(stderr, err, catch_backtrace())
     finally
-        stop_analysis_workers(server)
+        stop_analysis_worker(server)
         put!(seq_queue, nothing); put!(con_queue, nothing);
         close(seq_queue); close(con_queue);
         waitall((seq_task, con_task))

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -179,27 +179,22 @@ end
 # Analysis worker
 # ===============
 
-function start_analysis_workers!(server::Server)
-    n_workers = get_init_option(server.state.init_options, :n_analysis_workers)
-    @static JETLS_DEV_MODE && @info "Starting $n_workers analysis workers"
-    worker_tasks = server.state.analysis_manager.worker_tasks
-    isempty(worker_tasks) || error("The server has already started analysis workers")
-    resize!(worker_tasks, n_workers)
-    for i = 1:n_workers
-        worker_tasks[i] = Threads.@spawn :default try
-            analysis_worker(server)
-        catch err
-            @error "Critical error happened in analysis worker"
-            Base.display_error(stderr, err, catch_backtrace())
-        end
+function start_analysis_worker!(server::Server)
+    @static JETLS_DEV_MODE && @info "Starting analysis worker"
+    worker_task = server.state.analysis_manager.worker_task
+    isassigned(worker_task) && error("The server has already started an analysis worker")
+    task = Threads.@spawn :default try
+        analysis_worker(server)
+    catch err
+        @error "Critical error happened in analysis worker"
+        Base.display_error(stderr, err, catch_backtrace())
     end
-    return worker_tasks
+    worker_task[] = task
+    return task
 end
 
 # Analysis queue processing implementation (analysis serialized per AnalysisEntry)
 function analysis_worker(server::Server)
-    # Note: Currently single worker, but designed for future multi-worker scaling.
-    # When multiple workers exist, the per-entry serialization ensures correctness.
     while true
         request = take!(server.state.analysis_manager.queue)
         request === nothing && break
@@ -208,11 +203,14 @@ function analysis_worker(server::Server)
     end
 end
 
-function stop_analysis_workers(server::Server)
-    for _ = 1:length(server.state.analysis_manager.worker_tasks)
-        put!(server.state.analysis_manager.queue, nothing)
-    end
-    waitall(server.state.analysis_manager.worker_tasks)
+function stop_analysis_worker(server::Server)
+    manager = server.state.analysis_manager
+    worker_task = manager.worker_task
+    isassigned(worker_task) || return nothing
+    task = worker_task[]
+    istaskdone(task) || put!(manager.queue, nothing)
+    wait(task)
+    return nothing
 end
 
 # Analysis worker pipeline

--- a/src/app/cli-check.jl
+++ b/src/app/cli-check.jl
@@ -315,7 +315,7 @@ function run_check(args::Vector{String})
     paths = String[isabspath(p) ? p : joinpath(root_path, p) for p in paths]
 
     server = start_cli_server(root_path)
-    skip_analysis || start_analysis_workers!(server)
+    skip_analysis || start_analysis_worker!(server)
     progress_ctx = ProgressContext(progress_mode, stderr)
 
     start_time = time()
@@ -586,6 +586,6 @@ function print_diagnostics(
 end
 
 function cleanup_cli_tasks(server::Server)
-    stop_analysis_workers(server)
+    stop_analysis_worker(server)
     close(server.endpoint)
 end

--- a/src/init-options.jl
+++ b/src/init-options.jl
@@ -2,21 +2,11 @@ function merge_init_options(base::InitOptions, overlay::InitOptions)
     merge_and_track(Returns(nothing), base, overlay, ())
 end
 
-function validate_init_options(server::Server, opts::InitOptions)
-    n = opts.n_analysis_workers
-    if n !== nothing && n < 1
-        show_warning_message(server,
-            "`n_analysis_workers` must be at least 1 (got $n), using default")
-        return InitOptions(; n_analysis_workers=DEFAULT_INIT_OPTIONS.n_analysis_workers)
-    end
-    return opts
-end
-
 function parse_init_options(server::Server, @nospecialize init_options)
     init_options === nothing && return DEFAULT_INIT_OPTIONS
     init_options isa AbstractDict || return DEFAULT_INIT_OPTIONS
     parsed = try
-        validate_init_options(server, parse_config_from_dict(InitOptions, init_options))
+        parse_config_from_dict(InitOptions, init_options)
     catch err
         show_warning_message(server,
             "Failed to parse initializationOptions, using defaults: $err")
@@ -47,7 +37,7 @@ function load_file_init_options(server::Server, filepath::AbstractString)
         return nothing
     end
     try
-        return validate_init_options(server, parse_config_from_dict(InitOptions, init_options_dict))
+        return parse_config_from_dict(InitOptions, init_options_dict)
     catch err
         show_error_message(server,
             "Failed to parse `[initialization_options]` in $filepath: $err")

--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -76,7 +76,7 @@ function handle_InitializeRequest(
         load_file_init_options!(server, config_path)
     end
 
-    start_analysis_workers!(server)
+    start_analysis_worker!(server)
 
     if supports(server, :textDocument, :completion, :dynamicRegistration)
         completionProvider = nothing # will be registered dynamically

--- a/src/types.jl
+++ b/src/types.jl
@@ -337,7 +337,7 @@ struct AnalysisManager
     analyzed_generations::AnalyzedGenerations
     debounced::DebouncedRequests
     instantiated_envs::InstantiatedEnvs
-    worker_tasks::Vector{Task}
+    worker_task::Base.RefValue{Task}
     function AnalysisManager()
         return new(
             AnalysisCache(),
@@ -347,7 +347,7 @@ struct AnalysisManager
             AnalyzedGenerations(),
             DebouncedRequests(),
             InstantiatedEnvs(),
-            Task[], # initialized by start_analysis_workers!
+            Ref{Task}(), # initialized by start_analysis_worker!
         )
     end
 end
@@ -604,19 +604,16 @@ merge_key_value(analysis_override::AnalysisOverride) = analysis_override.path
 # Static initialization options from `InitializeParams.initializationOptions`.
 # These are set once during the initialize request and remain constant.
 @kwdef struct InitOptions <: ConfigSection
-    n_analysis_workers::Maybe{Int} = nothing
     analysis_overrides::Maybe{Vector{AnalysisOverride}} = nothing
 end
 @define_eq_overloads InitOptions
 function Base.show(io::IO, init_options::InitOptions)
     print(io, "InitOptions(;")
-    n_analysis_workers = init_options.n_analysis_workers
-    n_analysis_workers === nothing || print(io, " n_analysis_workers=", n_analysis_workers)
     analysis_overrides = init_options.analysis_overrides
     analysis_overrides === nothing || print(io, " analysis_overrides=", analysis_overrides)
     print(io, ")")
 end
-const DEFAULT_INIT_OPTIONS = InitOptions(; n_analysis_workers=1, analysis_overrides=AnalysisOverride[])
+const DEFAULT_INIT_OPTIONS = InitOptions(; analysis_overrides=AnalysisOverride[])
 
 @kwdef struct LaTeXEmojiConfig <: ConfigSection
     strip_prefix::Maybe{Union{Missing,Bool}} = nothing # missing is used as sentinel for default setting value


### PR DESCRIPTION
The experimental `n_analysis_workers` option allowed multiple full-analysis requests to run concurrently. Outside signature analysis, full analysis primarily performs environment-dependent code loading, where JETLS must serialize that work to keep the process-wide active project stable. JET virtual processing also mutates process-global state and is not safe to run concurrently.

On the other hand, the CPU-intensive signature-analysis phase is already parallelized across the available Julia threads. Multiple full-analysis workers (which can be configured by `n_analysis_workers`) therefore provide little additional useful parallelism while adding scheduling and lifecycle complexity.

If request-level parallelism is needed in the future, it should be implemented with isolated analysis processes rather than additional in-process workers. Process isolation would also let JETLS restart only the user-code process when Revise cannot restore a consistent state.

So this commit processes full-analysis requests through one worker, store its task in a single assigned `Ref{Task}`, and remove `n_analysis_workers` from initialization parsing, generated schemas, documentation, and the VSCode client.

This is a breaking configuration change. Existing users must remove `n_analysis_workers` from client or `.JETLSConfig.toml` settings.