### PR TITLE
full-analysis: Pin signature inference to worker threads

### DIFF
--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -289,6 +289,7 @@ function runserver(
         Base.display_error(stderr, err, catch_backtrace())
     finally
         stop_analysis_worker(server)
+        stop_signature_analysis_workers(server)
         put!(seq_queue, nothing); put!(con_queue, nothing);
         close(seq_queue); close(con_queue);
         waitall((seq_task, con_task))

--- a/src/analysis/Interpreter.jl
+++ b/src/analysis/Interpreter.jl
@@ -98,6 +98,71 @@ mutable struct SignatureAnalysisProgress
     end
 end
 
+struct InterpreterSignatureAnalysisJob <: JETLS.AbstractSignatureAnalysisJob
+    interp::LSInterpreter
+    res::JET.VirtualProcessResult
+    progress::SignatureAnalysisProgress
+    index::Int
+    entrypoint::Union{Bool,Symbol}
+    cancellable_token::Union{Nothing,JETLS.CancellableToken}
+    n_sigs::Int
+    completion::Base.Event
+end
+
+function (job::InterpreterSignatureAnalysisJob)(server::Server)
+    (; interp, res, progress, index, entrypoint, cancellable_token, n_sigs) = job
+    try
+        if cancellable_token !== nothing && is_cancelled(cancellable_token.cancel_flag)
+            return
+        end
+        (; tt) = res.signature_infos[index]
+        # Create a new analyzer with fresh local caches (`inf_cache` and `analysis_results`)
+        # to avoid data races between concurrent signature analysis tasks
+        analyzer = JET.ToplevelAbstractAnalyzer(interp, JET.non_toplevel_concretized;
+            reset_report_target_modules = false,
+            refresh_local_cache = true)
+        inf_world = CC.get_inference_world(analyzer)
+        match = Base._which(tt;
+            # NOTE use the latest world counter with `method_table(analyzer)` unwrapped,
+            # otherwise it may use a world counter when this method isn't defined yet
+            method_table = CC.method_table(analyzer),
+            world = inf_world,
+            raise = false)
+        if (match !== nothing &&
+            (!(entrypoint isa Symbol) || # implies `analyze_from_definitions===true`
+             match.method.name === entrypoint))
+            # redirect keyword-slurping forwarders to the abstract keyword sorter,
+            # but only after the `entrypoint` check above sees the original method name
+            match = JETLS.redirect_keyword_slurp_match(analyzer, match, inf_world)
+            analyzer, result = JET.analyze_method_signature!(analyzer,
+                match.method, match.spec_types, match.sparams)
+            reports = JET.get_reports(analyzer, result)
+            isempty(reports) || @lock progress.reports_lock append!(
+                progress.reports, reports)
+        else
+            @static JETLS_DEV_MODE && @warn "Couldn't find a single method matching the signature" tt
+        end
+        done = (@atomic progress.done += 1)
+        if cancellable_token !== nothing
+            current_next = @atomic progress.next_interval
+            if done >= current_next
+                # Try to update next_interval (may race with other tasks)
+                @atomicreplace progress.next_interval current_next =>
+                    current_next + progress.interval
+                percentage = compute_percentage(done, n_sigs, 50) + 50
+                send_progress(server, cancellable_token.token,
+                    WorkDoneProgressReport(;
+                        cancellable = true,
+                        message = "$done / $n_sigs [signature analysis]",
+                        percentage))
+            end
+        end
+    catch err
+        @error "Error during signature analysis"
+        Base.showerror(stderr, err, catch_backtrace())
+    end
+end
+
 function compute_percentage(count, total, max=100)
     return min(round(Int, (count / total) * max), max)
 end
@@ -171,64 +236,14 @@ function JET.analyze_from_definitions!(interp::LSInterpreter, config::JET.Toplev
 
     progress = SignatureAnalysisProgress(n_sigs)
 
-    tasks = map(1:n_sigs) do i
-        Threads.@spawn :default try
-            if cancellable_token !== nothing && is_cancelled(cancellable_token.cancel_flag)
-                return
-            end
-            (; tt) = res.signature_infos[i]
-            # Create a new analyzer with fresh local caches (`inf_cache` and `analysis_results`)
-            # to avoid data races between concurrent signature analysis tasks
-            analyzer = JET.ToplevelAbstractAnalyzer(interp, JET.non_toplevel_concretized;
-                reset_report_target_modules = false,
-                refresh_local_cache = true)
-            inf_world = CC.get_inference_world(analyzer)
-            match = Base._which(tt;
-                # NOTE use the latest world counter with `method_table(analyzer)` unwrapped,
-                # otherwise it may use a world counter when this method isn't defined yet
-                method_table = CC.method_table(analyzer),
-                world = inf_world,
-                raise = false)
-            if (match !== nothing &&
-                (!(entrypoint isa Symbol) || # implies `analyze_from_definitions===true`
-                 match.method.name === entrypoint))
-                # redirect keyword-slurping forwarders to the abstract keyword sorter,
-                # but only after the `entrypoint` check above sees the original method name
-                match = JETLS.redirect_keyword_slurp_match(analyzer, match, inf_world)
-                analyzer, result = JET.analyze_method_signature!(analyzer,
-                    match.method, match.spec_types, match.sparams)
-                reports = JET.get_reports(analyzer, result)
-                isempty(reports) || @lock progress.reports_lock append!(progress.reports, reports)
-            else
-                @static JETLS_DEV_MODE && @warn "Couldn't find a single method matching the signature" tt
-            end
-            done = (@atomic progress.done += 1)
-            if cancellable_token !== nothing
-                current_next = @atomic progress.next_interval
-                if done >= current_next
-                    # Try to update next_interval (may race with other tasks)
-                    @atomicreplace progress.next_interval current_next => current_next + progress.interval
-                    percentage = compute_percentage(done, n_sigs, 50) + 50
-                    send_progress(interp.server, cancellable_token.token,
-                        WorkDoneProgressReport(;
-                            cancellable = true,
-                            message = "$done / $n_sigs [signature analysis]",
-                            percentage))
-                end
-            end
-            yield() # Give other tasks a chance to run
-        catch e
-            @error "Error during signature analysis"
-            Base.showerror(stderr, e, catch_backtrace())
-        end
+    jobs = InterpreterSignatureAnalysisJob[]
+    for i = 1:n_sigs
+        push!(jobs, InterpreterSignatureAnalysisJob(
+            interp, res, progress, i, entrypoint,
+            cancellable_token, n_sigs, Base.Event()))
     end
 
-    for task in tasks
-        wait(task)
-        if cancellable_token !== nothing && is_cancelled(cancellable_token.cancel_flag)
-            break
-        end
-    end
+    JETLS.run_signature_analysis_jobs!(interp.server, jobs)
 
     append!(res.inference_error_reports, progress.reports)
 end

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -176,8 +176,66 @@ function handle_analysis_progress_response(
         cancellable_token, notify_diagnostics)
 end
 
-# Analysis worker
-# ===============
+# Analysis workers
+# ================
+
+function start_signature_analysis_workers!(server::Server)
+    manager = server.state.analysis_manager
+    worker_tasks = manager.signature_worker_tasks
+    isempty(worker_tasks) || error("The server has already started signature analysis workers")
+    n_workers = max(1, Threads.threadpoolsize(:default) - 1)
+    @static JETLS_DEV_MODE && @info "Starting $n_workers signature analysis workers"
+    resize!(worker_tasks, n_workers)
+    for i = 1:n_workers
+        worker_tasks[i] = Threads.@spawn :default try
+            signature_analysis_worker(server)
+        catch err
+            @error "Critical error happened in signature analysis worker"
+            Base.display_error(stderr, err, catch_backtrace())
+        end
+    end
+    return worker_tasks
+end
+
+function signature_analysis_worker(server::Server)
+    # HACK: Compiler engine reservations are owned by OS thread ID.
+    # Prevent migration only while this job may run inference. This assumes jobs don't
+    # leave sticky child tasks running: stickiness isn't reference-counted, so restoring
+    # it could erase stickiness propagated by a child scheduled during the job.
+    queue = server.state.analysis_manager.signature_queue
+    while true
+        job = @something take!(queue) break
+        task = current_task()
+        was_sticky = task.sticky
+        task.sticky = true
+        try
+            @tryinvokelatest job(server)
+        finally
+            task.sticky = was_sticky
+            notify(signature_analysis_completion(job))
+        end
+        yield()
+    end
+end
+
+function run_signature_analysis_jobs!(
+        server::Server, jobs::Vector{<:AbstractSignatureAnalysisJob}
+    )
+    queue = server.state.analysis_manager.signature_queue
+    foreach(job -> put!(queue, job), jobs)
+    foreach(job -> wait(signature_analysis_completion(job)), jobs)
+    return nothing
+end
+
+function stop_signature_analysis_workers(server::Server)
+    manager = server.state.analysis_manager
+    worker_tasks = manager.signature_worker_tasks
+    for _ in worker_tasks
+        put!(manager.signature_queue, nothing)
+    end
+    foreach(wait, worker_tasks)
+    return nothing
+end
 
 function start_analysis_worker!(server::Server)
     @static JETLS_DEV_MODE && @info "Starting analysis worker"
@@ -874,6 +932,77 @@ mutable struct ReviseAnalysisProgress
     end
 end
 
+struct ReviseSignatureAnalysisJob <: AbstractSignatureAnalysisJob
+    workitem::SigWorkItem
+    analyzer::LSAnalyzer
+    progress::ReviseAnalysisProgress
+    inf_world::UInt
+    cancellable_token::Union{Nothing,CancellableToken}
+    n_sigs::Int
+    completion::Base.Event
+end
+
+function (job::ReviseSignatureAnalysisJob)(server::Server)
+    (; workitem, analyzer, progress, inf_world, cancellable_token, n_sigs) = job
+    siginfo = workitem.siginfo
+    try
+        if cancellable_token !== nothing && is_cancelled(cancellable_token.cancel_flag)
+            return
+        end
+        ext = Revise.get_extended_data(siginfo, :JETLS)
+        local reports::Vector{JET.InferenceErrorReport}
+        if ext !== nothing && ext.data isa SigAnalysisResult
+            prev_result = ext.data::SigAnalysisResult
+            if (CC.cache_owner(analyzer) === prev_result.codeinst.owner &&
+                prev_result.codeinst.max_world ≥ inf_world ≥ prev_result.codeinst.min_world)
+                @atomic progress.cached += 1
+                reports = prev_result.reports
+                @goto gotreports
+            end
+        end
+        # Create a new analyzer with fresh local caches (`inf_cache` and `analysis_results`)
+        # to avoid data races between concurrent signature analysis tasks
+        task_analyzer = JET.AbstractAnalyzer(analyzer,
+            JET.AnalyzerState(JET.AnalyzerState(analyzer), #=refresh_local_cache=#true))
+        match = signature_analysis_match(task_analyzer, siginfo.sig, inf_world)
+        if match !== nothing
+            task_analyzer, result = JET.analyze_method_signature!(task_analyzer,
+                match.method, match.spec_types, match.sparams)
+            @atomic progress.analyzed += 1
+            reports = JET.get_reports(task_analyzer, result)
+            # Cache the result if CodeInstance is available
+            if isdefined(result, :ci)
+                cache_sig_analysis!(workitem, SigAnalysisResult(reports, result.ci))
+            else
+                @static JETLS_DEV_MODE && @warn "Missing CodeInstance for method analysis instance for" siginfo.sig
+            end
+        else
+            @static JETLS_DEV_MODE && @warn "Couldn't find a single matching method for the signature" siginfo.sig
+            reports = JET.InferenceErrorReport[]
+        end
+        @label gotreports
+        isempty(reports) || @lock progress.reports_lock append!(progress.reports, reports)
+    catch err
+        @error "Error analyzing method signature" siginfo.sig
+        Base.showerror(stderr, err, catch_backtrace())
+    finally
+        done = (@atomic progress.done += 1)
+        if cancellable_token !== nothing
+            current_next = @atomic progress.next_interval
+            if done >= current_next
+                @atomicreplace progress.next_interval current_next =>
+                    current_next + progress.interval
+                percentage = min(round(Int, (done / n_sigs) * 100), 100)
+                send_progress(server, cancellable_token.token,
+                    WorkDoneProgressReport(;
+                        cancellable = true,
+                        message = "$done / $n_sigs [signature analysis]",
+                        percentage))
+            end
+        end
+    end
+end
+
 end # @static if JETLS_DEV_MODE
 
 const empty_lines_range = typemax(Int) => typemin(Int)
@@ -1039,65 +1168,12 @@ function analyze_package_with_revise(
         yield_to_endpoint()
     end
 
-    tasks = let analyzer=analyzer, progress=progress; map(workitems) do workitem
-        siginfo = workitem.siginfo
-        Threads.@spawn :default try
-            if cancellable_token !== nothing && is_cancelled(cancellable_token.cancel_flag)
-                return
-            end
-            ext = Revise.get_extended_data(siginfo, :JETLS)
-            local reports::Vector{JET.InferenceErrorReport}
-            if ext !== nothing && ext.data isa SigAnalysisResult
-                prev_result = ext.data::SigAnalysisResult
-                if (CC.cache_owner(analyzer) === prev_result.codeinst.owner &&
-                    prev_result.codeinst.max_world ≥ inf_world ≥ prev_result.codeinst.min_world)
-                    @atomic progress.cached += 1
-                    reports = prev_result.reports
-                    @goto gotreports
-                end
-            end
-            # Create a new analyzer with fresh local caches (`inf_cache` and `analysis_results`)
-            # to avoid data races between concurrent signature analysis tasks
-            task_analyzer = JET.AbstractAnalyzer(analyzer,
-                JET.AnalyzerState(JET.AnalyzerState(analyzer), #=refresh_local_cache=#true))
-            match = signature_analysis_match(task_analyzer, siginfo.sig, inf_world)
-            if match !== nothing
-                task_analyzer, result = JET.analyze_method_signature!(task_analyzer,
-                    match.method, match.spec_types, match.sparams)
-                @atomic progress.analyzed += 1
-                reports = JET.get_reports(task_analyzer, result)
-                # Cache the result if CodeInstance is available
-                if isdefined(result, :ci)
-                    cache_sig_analysis!(workitem, SigAnalysisResult(reports, result.ci))
-                else
-                    @static JETLS_DEV_MODE && @warn "Missing CodeInstance for method analysis instance for" siginfo.sig
-                end
-            else
-                @static JETLS_DEV_MODE && @warn "Couldn't find a single matching method for the signature" siginfo.sig
-                reports = JET.InferenceErrorReport[]
-            end
-            @label gotreports
-            isempty(reports) || @lock progress.reports_lock append!(progress.reports, reports)
-        catch err
-            @error "Error analyzing method signature" siginfo.sig
-            Base.showerror(stderr, err, catch_backtrace())
-        finally
-            done = (@atomic progress.done += 1)
-            if cancellable_token !== nothing
-                current_next = @atomic progress.next_interval
-                if done >= current_next
-                    @atomicreplace progress.next_interval current_next => current_next + progress.interval
-                    percentage = min(round(Int, (done / n_sigs) * 100), 100)
-                    send_progress(server, cancellable_token.token,
-                        WorkDoneProgressReport(;
-                            cancellable = true,
-                            message = "$done / $n_sigs [signature analysis]",
-                            percentage))
-                end
-            end
-        end
-    end; end
-    waitall(tasks)
+    jobs = ReviseSignatureAnalysisJob[]
+    for workitem in workitems
+        push!(jobs, ReviseSignatureAnalysisJob(
+            workitem, analyzer, progress, inf_world, cancellable_token, n_sigs, Base.Event()))
+    end
+    run_signature_analysis_jobs!(server, jobs)
 
     @label completed
 

--- a/src/app/cli-check.jl
+++ b/src/app/cli-check.jl
@@ -315,7 +315,10 @@ function run_check(args::Vector{String})
     paths = String[isabspath(p) ? p : joinpath(root_path, p) for p in paths]
 
     server = start_cli_server(root_path)
-    skip_analysis || start_analysis_worker!(server)
+    if !skip_analysis
+        start_signature_analysis_workers!(server)
+        start_analysis_worker!(server)
+    end
     progress_ctx = ProgressContext(progress_mode, stderr)
 
     start_time = time()
@@ -587,5 +590,6 @@ end
 
 function cleanup_cli_tasks(server::Server)
     stop_analysis_worker(server)
+    stop_signature_analysis_workers(server)
     close(server.endpoint)
 end

--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -76,6 +76,7 @@ function handle_InitializeRequest(
         load_file_init_options!(server, config_path)
     end
 
+    start_signature_analysis_workers!(server)
     start_analysis_worker!(server)
 
     if supports(server, :textDocument, :completion, :dynamicRegistration)

--- a/src/types.jl
+++ b/src/types.jl
@@ -322,6 +322,10 @@ struct AnalysisExecution
     prev_result::Union{Nothing,AnalysisResult}
 end
 
+abstract type AbstractSignatureAnalysisJob end
+signature_analysis_completion(job::AbstractSignatureAnalysisJob) =
+    getfield(job, :completion)::Base.Event
+
 const AnalysisCache = LWContainer{Dict{URI,AnalysisInfo}, LWStats}
 const PendingAnalyses = CASContainer{Dict{AnalysisEntry,Union{Nothing,AnalysisRequest}}, CASStats}
 const CurrentGenerations = CASContainer{Dict{AnalysisEntry,Int}, CASStats}
@@ -333,21 +337,25 @@ struct AnalysisManager
     cache::AnalysisCache
     pending_analyses::PendingAnalyses
     queue::Channel{Union{Nothing,AnalysisRequest}}
+    signature_queue::Channel{Union{Nothing,AbstractSignatureAnalysisJob}}
     current_generations::CurrentGenerations
     analyzed_generations::AnalyzedGenerations
     debounced::DebouncedRequests
     instantiated_envs::InstantiatedEnvs
     worker_task::Base.RefValue{Task}
+    signature_worker_tasks::Vector{Task}
     function AnalysisManager()
         return new(
             AnalysisCache(),
             PendingAnalyses(),
             Channel{Union{Nothing,AnalysisRequest}}(Inf),
+            Channel{Union{Nothing,AbstractSignatureAnalysisJob}}(Inf),
             CurrentGenerations(),
             AnalyzedGenerations(),
             DebouncedRequests(),
             InstantiatedEnvs(),
             Ref{Task}(), # initialized by start_analysis_worker!
+            Task[], # initialized by start_signature_analysis_workers!
         )
     end
 end


### PR DESCRIPTION
Parallel signature analysis ran each method in a migratable task. The JET abstract interpreter may wait on the shared `AbstractBindings` lock after `Compiler.engine_reserve`; resuming on another OS thread then violates the engine reservation owner, causing assertion failures or an indefinite hang near the end of full analysis.

Create a bounded signature-analysis worker pool when the server starts. Both Revise-based and virtualized analysis now enqueue explicit callable jobs and wait on per-job `Base.Event`s. Each worker becomes `sticky` only while a job may run inference, then restores its previous scheduling state so migration remains possible between jobs.

The regional `sticky` toggle assumes jobs do not leave sticky child tasks running, since Julia sticky state is not reference-counted.

Validated with the assertion-enabled Julia runtime using five signature workers and with `--threads=1`; both selfchecks completed without diagnostics.