### PR TITLE
deps: Update JS/JL and adapt to standard-tree `SyntaxTree`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,15 +79,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Updated JuliaSyntax.jl and JuliaLowering.jl revisions, incorporating JuliaLowering's new standard-tree `SyntaxTree` representation ([JuliaLang/julia#62474](https://github.com/JuliaLang/julia/pull/62474)), which makes lowering — the backbone of most lowering-based LSP features — several times faster and reduces its memory footprint.
+
+- Improved startup latency by precompiling the `initialize` request round-trip, so the first request is less likely to hit strict client `initialize` timeouts (such as Helix's 20-second default). On slower machines, raising the client-side timeout may still be needed. (xref: https://github.com/aviatesk/JETLS.jl/issues/784)
+
+- Updated Compiler.jl API compatibility for the incoming Julia 1.12.7 release while retaining support for Julia pre-1.12.6 Compiler.jl APIs.
+
 - JETLS servers started without a workspace root (i.e., when an LSP `InitializeRequest` specifies neither `workspaceFolders` nor `rootUri`) now analyze opened Julia files as standalone scripts instead of discovering nearby project environments. This avoids automatic environment setup and package-wide analysis in rootless LSP sessions.
 
 - `inference/*` diagnostic related information now labels inference frames as `origin`, `via`, or `entry`, making it clearer where the error originated and which analysis entry reported it.
 
 - `inference/type-error/*` now groups diagnostics for the subset of runtime `TypeError` cases that JETLS can infer, including non-`Bool` conditions and statically failing type assertions. Users can ignore or reconfigure this family together with a regex code match such as `inference/type-error/.*`.
-
-- Updated Compiler.jl API compatibility for the incoming Julia 1.12.7 release while retaining support for Julia pre-1.12.6 Compiler.jl APIs.
-
-- Improved startup latency by precompiling the `initialize` request round-trip, so the first request is less likely to hit strict client `initialize` timeouts (such as Helix's 20-second default). On slower machines, raising the client-side timeout may still be needed. (xref: https://github.com/aviatesk/JETLS.jl/issues/784)
 
 - Reworked the [diagnostics documentation](https://aviatesk.github.io/JETLS.jl/release/diagnostic/): a new [Analysis stages](https://aviatesk.github.io/JETLS.jl/release/diagnostic/#diagnostic/stage) section explains what produces each diagnostic category, which tool powers it, when it runs, and how the stages depend on one another. It also adds a [security caveat](https://aviatesk.github.io/JETLS.jl/release/diagnostic/#diagnostic/stage/toplevel) that full analysis loads and runs your code (so JETLS should not be run on untrusted code), and documents how each [`inference/*` diagnostic](https://aviatesk.github.io/JETLS.jl/release/diagnostic/#diagnostic/reference/inference) corresponds to the Julia runtime error it predicts.
 

--- a/Project.toml
+++ b/Project.toml
@@ -31,8 +31,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [sources]
 Compiler = {rev = "4a5bbcb016", subdir = "Compiler", url = "https://github.com/JuliaLang/julia"}
 JET = {rev = "10eedc16", url = "https://github.com/aviatesk/JET.jl"}
-JuliaLowering = {rev = "8dc3ef6ac0", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
-JuliaSyntax = {rev = "8dc3ef6ac0", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
+JuliaLowering = {rev = "b531c73d15", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
+JuliaSyntax = {rev = "b531c73d15", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
 LSP = {path = "LSP"}
 
 [compat]

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -79,8 +79,8 @@ const SWStats  = Nothing
 const LWStats  = Nothing
 const CASStats = Nothing
 
-const SyntaxTreeC = JS.SyntaxTree
-const SyntaxListC = JS.SyntaxList
+const SyntaxTree = JS.SyntaxTree
+const SyntaxList = JS.SyntaxList
 
 include("analysis/Analyzer.jl")
 using .Analyzer

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -79,9 +79,8 @@ const SWStats  = Nothing
 const LWStats  = Nothing
 const CASStats = Nothing
 
-const AttrsC = Dict{Symbol, Dict{Int64, Any}}
-const SyntaxTreeC = JS.SyntaxTree{AttrsC}
-const SyntaxListC = JS.SyntaxList{AttrsC,Vector{Int}}
+const SyntaxTreeC = JS.SyntaxTree
+const SyntaxListC = JS.SyntaxList
 
 include("analysis/Analyzer.jl")
 using .Analyzer

--- a/src/analysis/Closure2Opaque.jl
+++ b/src/analysis/Closure2Opaque.jl
@@ -1,13 +1,13 @@
 module Closure2Opaque
 
-using ..JETLS: JL, JS, SyntaxTreeC, get_name_val, var_id
+using ..JETLS: JL, JS, SyntaxTree, get_name_val, var_id
 
 export rewrite_local_closures_to_opaque
 
 """
     rewrite_local_closures_to_opaque(
-            ctx::JL.VariableAnalysisContext, st3::SyntaxTreeC
-        ) -> SyntaxTreeC
+            ctx::JL.VariableAnalysisContext, st3::SyntaxTree
+        ) -> SyntaxTree
 
 Pre-lowering rewrite that turns single-method local closure definitions
 (`K"function_decl"` paired with a sibling `K"method_defs"`) into the equivalent
@@ -36,14 +36,14 @@ tracking), before `JL.convert_closures` runs.
 The rewrite is non-destructive: nodes that don't match are returned unchanged, so the
 pipeline downstream sees an equivalent tree with only the eligible closures swapped.
 """
-function rewrite_local_closures_to_opaque(ctx::JL.VariableAnalysisContext, st3::SyntaxTreeC)
+function rewrite_local_closures_to_opaque(ctx::JL.VariableAnalysisContext, st3::SyntaxTree)
     lambda_scope_id = JL.lambda_bindings(st3[1]).scope_id
     multis = collect_multi_method_bindings(ctx, st3, lambda_scope_id)
     return _rewrite_local_closures_to_opaque(ctx, st3, multis, lambda_scope_id)
 end
 
 function _rewrite_local_closures_to_opaque(
-        ctx::JL.VariableAnalysisContext, st3::SyntaxTreeC,
+        ctx::JL.VariableAnalysisContext, st3::SyntaxTree,
         multis::Set{JL.ClosureKey}, lambda_scope_id::Int
     )
     k = JS.kind(st3)
@@ -53,14 +53,14 @@ function _rewrite_local_closures_to_opaque(
         lambda_scope_id = JL.lambda_bindings(st3[1]).scope_id
     end
     let lambda_scope_id=lambda_scope_id
-        return JS.mapchildren(st3) do c::SyntaxTreeC
+        return JS.mapchildren(st3) do c::SyntaxTree
             _rewrite_local_closures_to_opaque(ctx, c, multis, lambda_scope_id)
         end
     end
 end
 
 function rewrite_closure_block(
-        ctx::JL.VariableAnalysisContext, blk3::SyntaxTreeC,
+        ctx::JL.VariableAnalysisContext, blk3::SyntaxTree,
         multis::Set{JL.ClosureKey}, lambda_scope_id::Int
     )
     children_old = JS.children(blk3)
@@ -115,12 +115,12 @@ end
 # synthetic-struct closure conversion, so single-method closures inside its bodies are
 # still safely rewritable to OCs and must not be tagged.
 function collect_multi_method_bindings(
-        ctx::JL.VariableAnalysisContext, st3::SyntaxTreeC, root_scope_id::Int
+        ctx::JL.VariableAnalysisContext, st3::SyntaxTree, root_scope_id::Int
     )
-    method_defs_by_key = Dict{JL.ClosureKey,Vector{SyntaxTreeC}}()
+    method_defs_by_key = Dict{JL.ClosureKey,Vector{SyntaxTree}}()
     methods_per_key = Dict{JL.ClosureKey,Int}()
     multis = Set{JL.ClosureKey}()
-    stack = Tuple{SyntaxTreeC,Int}[(st3, root_scope_id)]
+    stack = Tuple{SyntaxTree,Int}[(st3, root_scope_id)]
     while !isempty(stack)
         node, lambda_scope_id = pop!(stack)
         k = JS.kind(node)
@@ -133,7 +133,7 @@ function collect_multi_method_bindings(
                 n = (methods_per_key[key] = get(methods_per_key, key, 0) + 1)
                 n == 2 && push!(multis, key)
             else
-                push!(get!(() -> SyntaxTreeC[], method_defs_by_key, key), node)
+                push!(get!(() -> SyntaxTree[], method_defs_by_key, key), node)
             end
         end
         if !JS.is_leaf(node)
@@ -155,12 +155,12 @@ function collect_multi_method_bindings(
 end
 
 function collect_referenced_closures!(
-        ctx::JL.VariableAnalysisContext, root::SyntaxTreeC, lambda_scope_id::Int,
+        ctx::JL.VariableAnalysisContext, root::SyntaxTree, lambda_scope_id::Int,
         multis::Set{JL.ClosureKey}, worklist::Vector{JL.ClosureKey},
-        method_defs_by_key::Dict{JL.ClosureKey,Vector{SyntaxTreeC}},
+        method_defs_by_key::Dict{JL.ClosureKey,Vector{SyntaxTree}},
         candidate_bids::Set{Int}
     )
-    stack = Tuple{SyntaxTreeC,Int}[(c, lambda_scope_id) for c in JS.children(root)]
+    stack = Tuple{SyntaxTree,Int}[(c, lambda_scope_id) for c in JS.children(root)]
     while !isempty(stack)
         node, lambda_scope_id = pop!(stack)
         k = JS.kind(node)
@@ -199,7 +199,7 @@ end
 
 # Returns the `ClosureKey` for a `function_decl` of a local closure, `nothing` otherwise.
 function local_closure_key(
-        ctx::JL.VariableAnalysisContext, fd::SyntaxTreeC, lambda_scope_id::Int
+        ctx::JL.VariableAnalysisContext, fd::SyntaxTree, lambda_scope_id::Int
     )
     JS.numchildren(fd) >= 1 || return nothing
     func_name = fd[1]
@@ -227,7 +227,7 @@ function find_matching_method_defs(
     return nothing
 end
 
-function is_method_defs_for(c::SyntaxTreeC, target_var_id::Int)
+function is_method_defs_for(c::SyntaxTree, target_var_id::Int)
     return JS.kind(c) === JS.K"method_defs" && JS.numchildren(c) == 3 &&
         JS.kind(c[1]) === JS.K"BindingId" && var_id(c[1]) == target_var_id
 end
@@ -238,7 +238,7 @@ end
 # Returns `nothing` for non-single-method scaffolding and methods with their own
 # static parameters.
 function try_build_oc_assignment(
-        ctx::JL.VariableAnalysisContext, fd::SyntaxTreeC, method_defs::SyntaxTreeC
+        ctx::JL.VariableAnalysisContext, fd::SyntaxTree, method_defs::SyntaxTree
     )
     func_name = fd[1]
     typevars = method_defs[2]
@@ -297,7 +297,7 @@ function try_build_oc_assignment(
     return JL.@ast ctx method_defs [JS.K"=" func_name oc]
 end
 
-function find_single_method_node(root::SyntaxTreeC, target_var_id::Int)
+function find_single_method_node(root::SyntaxTree, target_var_id::Int)
     node = root
     while JS.kind(node) === JS.K"block" && JS.numchildren(node) == 1
         node = node[1]
@@ -311,7 +311,7 @@ end
 
 # Detect a vararg-typed entry in the user-argtypes svec. JL lowers both `(xs...)`
 # and `(xs::T...)` to `(call core.apply_type core.Vararg <type-arg>)`.
-function argtype_is_vararg(t::SyntaxTreeC)
+function argtype_is_vararg(t::SyntaxTree)
     JS.kind(t) === JS.K"call" && JS.numchildren(t) >= 2 || return false
     callee = t[1]
     JS.kind(callee) === JS.K"core" && get_name_val(callee) == "apply_type" || return false

--- a/src/analysis/Closure2Opaque.jl
+++ b/src/analysis/Closure2Opaque.jl
@@ -37,7 +37,7 @@ The rewrite is non-destructive: nodes that don't match are returned unchanged, s
 pipeline downstream sees an equivalent tree with only the eligible closures swapped.
 """
 function rewrite_local_closures_to_opaque(ctx::JL.VariableAnalysisContext, st3::SyntaxTreeC)
-    lambda_scope_id = (st3.lambda_bindings::JL.LambdaBindings).scope_id
+    lambda_scope_id = JL.lambda_bindings(st3[1]).scope_id
     multis = collect_multi_method_bindings(ctx, st3, lambda_scope_id)
     return _rewrite_local_closures_to_opaque(ctx, st3, multis, lambda_scope_id)
 end
@@ -50,10 +50,10 @@ function _rewrite_local_closures_to_opaque(
     if k === JS.K"block"
         return rewrite_closure_block(ctx, st3, multis, lambda_scope_id)
     elseif k === JS.K"lambda"
-        lambda_scope_id = (st3.lambda_bindings::JL.LambdaBindings).scope_id
+        lambda_scope_id = JL.lambda_bindings(st3[1]).scope_id
     end
     let lambda_scope_id=lambda_scope_id
-        return JS.mapchildren(ctx, st3) do c::SyntaxTreeC
+        return JS.mapchildren(st3) do c::SyntaxTreeC
             _rewrite_local_closures_to_opaque(ctx, c, multis, lambda_scope_id)
         end
     end
@@ -65,7 +65,7 @@ function rewrite_closure_block(
     )
     children_old = JS.children(blk3)
     n = length(children_old)
-    new_children = JS.SyntaxList(JS.syntax_graph(ctx))
+    new_children = JS.SyntaxList()
     consumed = falses(n)
     for i = 1:n
         consumed[i] && continue
@@ -125,7 +125,7 @@ function collect_multi_method_bindings(
         node, lambda_scope_id = pop!(stack)
         k = JS.kind(node)
         if k === JS.K"lambda"
-            lambda_scope_id = (node.lambda_bindings::JL.LambdaBindings).scope_id
+            lambda_scope_id = JL.lambda_bindings(node[1]).scope_id
         elseif ((k === JS.K"method" || k === JS.K"method_defs") &&
                 JS.numchildren(node) >= 1 && JS.kind(node[1]) === JS.K"BindingId")
             key = JL.ClosureKey(var_id(node[1]), lambda_scope_id)
@@ -169,7 +169,7 @@ function collect_referenced_closures!(
             # BindingId occurrences tag them, and tagged ones are walked via the worklist.
             continue
         elseif k === JS.K"lambda"
-            lambda_scope_id = (node.lambda_bindings::JL.LambdaBindings).scope_id
+            lambda_scope_id = JL.lambda_bindings(node[1]).scope_id
         elseif k === JS.K"BindingId" && var_id(node) in candidate_bids
             key = find_enclosing_closure_key(ctx, var_id(node), lambda_scope_id)
             if key !== nothing && key ∉ multis && haskey(method_defs_by_key, key)
@@ -258,7 +258,7 @@ function try_build_oc_assignment(
     # The inner argtypes svec is `core.svec(function_type, user_arg_types...)`.
     # Skip the `core.svec` callee (idx 1) and the function-type marker (idx 2);
     # the rest are the user-visible argtypes.
-    user_argtypes = JS.SyntaxList(JS.syntax_graph(ctx))
+    user_argtypes = JS.SyntaxList()
     for i = 3:JS.numchildren(inner_argtypes)
         push!(user_argtypes, inner_argtypes[i])
     end

--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -2,7 +2,7 @@
     TypeAnnotation
 
 Type-annotation pipeline for the LSP feature path: parse → lower → infer → query.
-Produces a `SyntaxTreeC` plus per-node `:type` annotations (side tables computed by
+Produces a `SyntaxTree` plus per-node `:type` annotations (side tables computed by
 a custom `CC.AbstractInterpreter`), wrapped in a query handle
 ([`InferredTreeContext`](@ref)) for byte-range type lookups.
 
@@ -33,13 +33,13 @@ in "Prerequisite" and "Limitations".
 The pipeline has four steps. Each step's output feeds the next:
 
 1. **Lower for scope resolution**:
-   [`get_inferrable_tree(st0::SyntaxTreeC, context_module::Module, world::UInt) -> (; ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC) | nothing`](@ref get_inferrable_tree)
+   [`get_inferrable_tree(st0::SyntaxTree, context_module::Module, world::UInt) -> (; ctx3::JL.VariableAnalysisContext, st3::SyntaxTree) | nothing`](@ref get_inferrable_tree)
    walks a top-level `st0` through JuliaLowering's early scope passes against
    `context_module`, returning an `(ctx3, st3)` pair. Surface `K"error"` nodes are stripped
    first so incomplete user input still produces a usable lowered tree.
 
 2. **Infer & annotate**:
-   [`infer_toplevel_tree(ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, st0::SyntaxTreeC, context_module::Module; world::UInt = Base.get_world_counter()) -> inferred_tree::SyntaxTreeC`](@ref infer_toplevel_tree)
+   [`infer_toplevel_tree(ctx3::JL.VariableAnalysisContext, st3::SyntaxTree, st0::SyntaxTree, context_module::Module; world::UInt = Base.get_world_counter()) -> inferred_tree::SyntaxTree`](@ref infer_toplevel_tree)
    takes `(ctx3, st3)` through the remaining JuliaLowering passes (`convert_closures` →
    `linearize_ir`), runs CC inference under the internal `ASTTypeAnnotator`, and
    records the inferred type of each lowered statement in node-keyed side tables
@@ -82,7 +82,7 @@ method bodies are inferred against `Any` argtypes.
 # Anonymous-thunk inference unit
 
 The basic inference unit is a thunk: a `Core.CodeInfo` paired with a
-`SyntaxTreeC` whose first statement is the block of statements to annotate, plus
+`SyntaxTree` whose first statement is the block of statements to annotate, plus
 a list of slot argtypes. The toplevel itself is one such thunk (`nargs=0`);
 method definitions are handled the same way — *not* via `Method` / `MethodInstance`
 dispatch, but by treating each method's body `CodeInfo` as another anonymous thunk
@@ -151,7 +151,7 @@ module TypeAnnotation
 
 using Core.IR
 using JET: CC, JET
-using ..JETLS: InferredContextCache, InferredContextCacheData, SyntaxTreeC,
+using ..JETLS: InferredContextCache, InferredContextCacheData, SyntaxTree,
     TraversalReturn, TreeAnnotations
 using ..JETLS: JETLS_DEBUG_LOWERING, JETLS_DEV_MODE, JL, JS
 using ..JETLS: get_name_val, iterate_toplevel_tree, jl_lower_for_scope_resolution, load,
@@ -182,16 +182,16 @@ struct SyntheticFilter
     user_assignment_ranges::Set{UnitRange{Int}}
 end
 
-function SyntheticFilter(st0::SyntaxTreeC, bindings::JL.Bindings)
+function SyntheticFilter(st0::SyntaxTree, bindings::JL.Bindings)
     destructure_ranges, user_assignment_ranges = collect_assignment_ranges(st0)
     return SyntheticFilter(bindings, destructure_ranges, user_assignment_ranges)
 end
 
 const MethodBodyRangeIndex = Dict{UnitRange{Int},UnitRange{Int}}
 
-function collect_method_body_ranges(st0::SyntaxTreeC)
+function collect_method_body_ranges(st0::SyntaxTree)
     ranges = MethodBodyRangeIndex()
-    traverse(st0) do node::SyntaxTreeC
+    traverse(st0) do node::SyntaxTree
         k = JS.kind(node)
         if k in JS.KSet"function macro"
             JS.numchildren(node) >= 2 || return nothing
@@ -227,7 +227,7 @@ struct ASTTypeAnnotator <: CC.AbstractInterpreter
     opt_params::CC.OptimizationParams
     inf_cache::Vector{CC.InferenceResult}
 
-    toptree::SyntaxTreeC
+    toptree::SyntaxTree
     topmi::MethodInstance
     # Consumer-side classifier for "user-written vs lowering-introduced" used by
     # `annotate_types!`. See `is_internal_binding_leaf` and `is_synthetic_destructure_stmt`.
@@ -236,7 +236,7 @@ struct ASTTypeAnnotator <: CC.AbstractInterpreter
     # interps of one inference pass.
     annotations::TreeAnnotations
     # OC `Method` → body's `K"code_info"` subtree; built by `register_oc_body_trees!`.
-    oc_body_trees::IdDict{Method,SyntaxTreeC}
+    oc_body_trees::IdDict{Method,SyntaxTree}
     # Pending eager OC body annotations. `abstract_eval_new_opaque_closure` opens an
     # entry, `finishinfer!` records the last body frame seen for that fresh OC method,
     # and the eager call's `Future` continuation consumes the entry.
@@ -256,7 +256,7 @@ struct ASTTypeAnnotator <: CC.AbstractInterpreter
     oc_key_memo::IdDict{Method,Union{Nothing,OCArgtypeKey}}
     function ASTTypeAnnotator(
             world::UInt,
-            toptree::SyntaxTreeC,
+            toptree::SyntaxTree,
             topmi::MethodInstance,
             filter::SyntheticFilter;
             inf_params::CC.InferenceParams = CC.InferenceParams(;
@@ -265,7 +265,7 @@ struct ASTTypeAnnotator <: CC.AbstractInterpreter
             opt_params::CC.OptimizationParams = CC.OptimizationParams(),
             inf_cache::Vector{CC.InferenceResult} = CC.InferenceResult[],
             annotations::TreeAnnotations = TreeAnnotations(),
-            oc_body_trees::IdDict{Method,SyntaxTreeC} = IdDict{Method,SyntaxTreeC}(),
+            oc_body_trees::IdDict{Method,SyntaxTree} = IdDict{Method,SyntaxTree}(),
             oc_body_annotation_states::IdDict{Method,OCBodyAnnotationState} = IdDict{Method,OCBodyAnnotationState}(),
             oc_argtype_observations::OCArgtypeTable = OCArgtypeTable(),
             oc_argtype_refinements::Union{Nothing,OCArgtypeTable} = nothing,
@@ -700,14 +700,14 @@ end
 # Walk to the *deepest* K"BindingId" in the source chain — argmap-renamed
 # user arguments have an intermediate `is_internal=true` local that would
 # misreport `true` if we stopped at the first hop.
-function is_internal_binding_leaf(filter::SyntheticFilter, leaf::SyntaxTreeC)
+function is_internal_binding_leaf(filter::SyntheticFilter, leaf::SyntaxTree)
     src = leaf.source
-    src isa SyntaxTreeC || return false
+    src isa SyntaxTree || return false
     JS.kind(src) === JS.K"BindingId" || return false
     last_binding = src
     while true
         nxt = last_binding.source
-        nxt isa SyntaxTreeC || break
+        nxt isa SyntaxTree || break
         JS.kind(nxt) === JS.K"BindingId" || break
         last_binding = nxt
     end
@@ -719,10 +719,10 @@ end
 #   `(; a, b) = rhs`, and the K"=" iter-spec of `for (a, b) in iter`)
 # - any other LHS → user-written simple assignment, recorded so it isn't
 #   misfiltered when it appears inside a destructure RHS.
-function collect_assignment_ranges(st0::SyntaxTreeC)
+function collect_assignment_ranges(st0::SyntaxTree)
     destructure = UnitRange{Int}[]
     user_simple = Set{UnitRange{Int}}()
-    traverse(st0) do st::SyntaxTreeC
+    traverse(st0) do st::SyntaxTree
         JS.kind(st) === JS.K"=" || return nothing
         rng = JS.byte_range(st)
         if JS.numchildren(st) >= 1 && JS.kind(st[1]) === JS.K"tuple"
@@ -738,7 +738,7 @@ end
 # Skip lowered `K"="`s that match a user-written simple `K"="` exactly —
 # `(a, b) = (x = 10; (x, x+1))` puts the inner `x = 10` inside the
 # destructure's byte range, where containment alone would misflag it.
-function is_synthetic_destructure_stmt(filter::SyntheticFilter, stmttree::SyntaxTreeC)
+function is_synthetic_destructure_stmt(filter::SyntheticFilter, stmttree::SyntaxTree)
     JS.kind(stmttree) === JS.K"=" || return false
     rng = JS.byte_range(stmttree)
     rng in filter.user_assignment_ranges && return false
@@ -755,11 +755,11 @@ end
 # form so they share the surrounding stmt's full byte range. Flagging by
 # that range equality skips annotating scaffolding leaves at ranges meant
 # for user-facing queries.
-is_synthetic_arg_leaf(stmttree::SyntaxTreeC, leaf::SyntaxTreeC) =
+is_synthetic_arg_leaf(stmttree::SyntaxTree, leaf::SyntaxTree) =
     JS.byte_range(leaf) == JS.byte_range(stmttree)
 
 function annotate_types!(
-        annotations::TreeAnnotations, citree::SyntaxTreeC, frame::CC.InferenceState,
+        annotations::TreeAnnotations, citree::SyntaxTree, frame::CC.InferenceState,
         filter::SyntheticFilter
     )
     if length(frame.src.code) != JS.numchildren(citree)
@@ -891,7 +891,7 @@ end
 # `JL.convert_closures`-hoisted regular closures), so an inner OC's Method
 # lives inside its outer OC's body, not in the thunk's top-level `src.code`.
 function register_oc_body_trees!(
-        oc_body_trees::IdDict{Method,SyntaxTreeC}, citree::SyntaxTreeC, src::CodeInfo
+        oc_body_trees::IdDict{Method,SyntaxTree}, citree::SyntaxTree, src::CodeInfo
     )
     block_citree = JS.kind(citree) in JS.KSet"thunk code_info" ? code_info_stmts(citree) : citree
     JS.numchildren(block_citree) == length(src.code) || return oc_body_trees
@@ -912,7 +912,7 @@ function register_oc_body_trees!(
     return oc_body_trees
 end
 
-function find_code_info_child(node::SyntaxTreeC)
+function find_code_info_child(node::SyntaxTree)
     for i = 1:JS.numchildren(node)
         c = node[i]
         JS.kind(c) === JS.K"code_info" && return c
@@ -922,7 +922,7 @@ end
 
 # Unwrap a (possibly `K"thunk"`-wrapped) `K"code_info"` node to its statements
 # block: `K"code_info"` children are `[K"Slots", stmts::K"block"]`.
-function code_info_stmts(citree::SyntaxTreeC)
+function code_info_stmts(citree::SyntaxTree)
     if JS.kind(citree) === JS.K"thunk"
         citree = citree[1]
     end
@@ -934,20 +934,20 @@ end
 # ======================
 
 """
-    is_type_annotation_skipped_toplevel(st0::SyntaxTreeC)
+    is_type_annotation_skipped_toplevel(st0::SyntaxTree)
 
 Return whether type-annotation features should skip a lowerable top-level form.
 Declaration-only forms have no useful inferred value annotations.
 """
-is_type_annotation_skipped_toplevel(st0::SyntaxTreeC) =
+is_type_annotation_skipped_toplevel(st0::SyntaxTree) =
     JS.kind(st0) in JS.KSet"using import export public abstract primitive String"
 
 """
     get_inferrable_tree(
-            st0::SyntaxTreeC, context_module::Module;
+            st0::SyntaxTree, context_module::Module;
             world::UInt = Base.get_world_counter(),
             caller::AbstractString = "get_inferrable_tree"
-        ) -> (; ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC) | nothing
+        ) -> (; ctx3::JL.VariableAnalysisContext, st3::SyntaxTree) | nothing
 
 [`TypeAnnotation`](@ref) pipeline step 1: lower `st0` for scope resolution against `mod`,
 returning the `(ctx3, st3)` pair that [`infer_toplevel_tree`](@ref) consumes.
@@ -963,7 +963,7 @@ JuliaLowering happily lowers what's left. For example, in
 See the [`TypeAnnotation`](@ref) module docstring for the full pipeline.
 """
 function get_inferrable_tree(
-        st0::SyntaxTreeC, context_module::Module, world::UInt;
+        st0::SyntaxTree, context_module::Module, world::UInt;
         caller::AbstractString = "get_inferrable_tree"
     )
     (; ctx3, st3) = try
@@ -979,14 +979,14 @@ end
 
 """
     infer_toplevel_tree(
-            ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC,
-            st0::SyntaxTreeC, context_module::Module;
+            ctx3::JL.VariableAnalysisContext, st3::SyntaxTree,
+            st0::SyntaxTree, context_module::Module;
             world::UInt = Base.get_world_counter()
-        ) -> inferred::SyntaxTreeC
+        ) -> inferred::SyntaxTree
 
 [`TypeAnnotation`](@ref) pipeline step 2: take `(ctx3, st3)` (typically from
 [`get_inferrable_tree`](@ref)) through the remaining JuliaLowering passes, run CC
-inference under the internal `ASTTypeAnnotator`, and return a `SyntaxTreeC`
+inference under the internal `ASTTypeAnnotator`, and return a `SyntaxTree`
 whose lowered statements carry `:type` annotations (recorded in the
 interpreter's `TreeAnnotations` side tables). The walk recurses
 into `Core.define_method` calls: each method body is inferred as its own anonymous
@@ -1013,8 +1013,8 @@ infer_toplevel_tree(args...; kwargs...) =
 const MAX_OC_REFINEMENT_PASSES = 3
 
 function _infer_toplevel_tree(
-        ctx3::JL.VariableAnalysisContext, inferrable_tree3::SyntaxTreeC,
-        st0::SyntaxTreeC, context_module::Module;
+        ctx3::JL.VariableAnalysisContext, inferrable_tree3::SyntaxTree,
+        st0::SyntaxTree, context_module::Module;
         world::UInt = Base.get_world_counter()
     )
     filter = SyntheticFilter(st0, ctx3.bindings)
@@ -1090,7 +1090,7 @@ end
 # Non-OC callees can still reuse pass-local inference results. Refinements are keyed
 # by body byte range, which is stable across re-lowering.
 function infer_lowered_tree(
-        ctx3::JL.VariableAnalysisContext, inferrable_tree3::SyntaxTreeC,
+        ctx3::JL.VariableAnalysisContext, inferrable_tree3::SyntaxTree,
         context_module::Module, world::UInt, filter::SyntheticFilter,
         method_body_ranges::MethodBodyRangeIndex,
         observations::OCArgtypeTable, refinements::Union{Nothing,OCArgtypeTable},
@@ -1127,7 +1127,7 @@ end
 # `argtypes === nothing` keeps the `InferenceResult`'s default argtypes (intended
 # for nargs=0 thunks); a `Vector{Any}` overrides them with one entry per slot.
 function infer_thunk!(
-        tree::SyntaxTreeC, src::CodeInfo, context_module::Module,
+        tree::SyntaxTree, src::CodeInfo, context_module::Module,
         argtypes::Union{Nothing,Vector{Any}}, world::UInt, filter::SyntheticFilter,
         annotations::TreeAnnotations,
         observations::OCArgtypeTable, refinements::Union{Nothing,OCArgtypeTable},
@@ -1191,7 +1191,7 @@ function resolve_toplevel_symbols!(src::CodeInfo, context_module::Module)
     return src
 end
 
-function is_core_define_method_call(st::SyntaxTreeC)
+function is_core_define_method_call(st::SyntaxTree)
     JS.kind(st) === JS.K"call" || return false
     JS.numchildren(st) >= 1 || return false
     callee = st[1]
@@ -1206,7 +1206,7 @@ function is_core_define_method_call(ex::Expr)
     return callee isa GlobalRef && callee.mod === Core && callee.name === :define_method
 end
 
-function method_definition_parts(node::SyntaxTreeC, stmt::Expr)
+function method_definition_parts(node::SyntaxTree, stmt::Expr)
     is_core_define_method_call(node) || return nothing
     JS.numchildren(node) == 5 || return nothing
     is_core_define_method_call(stmt) || return nothing
@@ -1220,7 +1220,7 @@ end
 
 function should_infer_method_body(
         method_body_ranges::MethodBodyRangeIndex,
-        method_node::SyntaxTreeC, body_tree::SyntaxTreeC
+        method_node::SyntaxTree, body_tree::SyntaxTree
     )
     method_range = JS.byte_range(method_node)
     body_range = JS.byte_range(body_tree)
@@ -1232,7 +1232,7 @@ function should_infer_method_body(
 end
 
 function infer_method_defs!(
-        inferred::SyntaxTreeC, src::CodeInfo, context_module::Module, world::UInt,
+        inferred::SyntaxTree, src::CodeInfo, context_module::Module, world::UInt,
         filter::SyntheticFilter, annotations::TreeAnnotations,
         method_body_ranges::MethodBodyRangeIndex,
         observations::OCArgtypeTable, refinements::Union{Nothing,OCArgtypeTable},
@@ -1449,8 +1449,8 @@ end
 
 """
     InferredTreeContext(
-            inferred_tree::SyntaxTreeC, annotations::TreeAnnotations,
-            ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC,
+            inferred_tree::SyntaxTree, annotations::TreeAnnotations,
+            ctx3::JL.VariableAnalysisContext, st3::SyntaxTree,
             surface_kind_index::Dict{UnitRange{Int},JS.Kind},
             macrocall_types::Dict{UnitRange{Int},Vector{Any}}
         ) -> ctx::InferredTreeContext
@@ -1478,18 +1478,18 @@ as new queries demand different indexes.
 See the [`TypeAnnotation`](@ref) module docstring for the full pipeline.
 """
 function InferredTreeContext(
-        inferred_tree::SyntaxTreeC, annotations::TreeAnnotations,
-        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC,
+        inferred_tree::SyntaxTree, annotations::TreeAnnotations,
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTree,
         surface_kind_index::Dict{UnitRange{Int},JS.Kind},
         macrocall_types::Dict{UnitRange{Int},Vector{Any}}
     )
-    by_byte_range = Dict{UnitRange{Int}, Vector{SyntaxTreeC}}()
+    by_byte_range = Dict{UnitRange{Int}, Vector{SyntaxTree}}()
     return_first_bytes = Int[]
-    return_nodes = SyntaxTreeC[]
+    return_nodes = SyntaxTree[]
 
-    traverse(inferred_tree) do st::SyntaxTreeC
+    traverse(inferred_tree) do st::SyntaxTree
         rng = JS.byte_range(st)
-        push!(get!(Vector{SyntaxTreeC}, by_byte_range, rng), st)
+        push!(get!(Vector{SyntaxTree}, by_byte_range, rng), st)
         if JS.kind(st) === JS.K"return"
             push!(return_first_bytes, JS.first_byte(st))
             push!(return_nodes, st)
@@ -1505,7 +1505,7 @@ function InferredTreeContext(
 
     user_return_form_ranges = collect_user_return_form_ranges(st3)
 
-    oc_body_scope = Dict{SyntaxTreeC,UnitRange{Int}}()
+    oc_body_scope = Dict{SyntaxTree,UnitRange{Int}}()
     populate_oc_body_scope!(oc_body_scope, inferred_tree, nothing)
     oc_argument_binding_types =
         collect_oc_argument_binding_types(ctx3, inferred_tree, annotations)
@@ -1524,10 +1524,10 @@ end
 # into the user-visible result.
 const DISPATCH_SURFACE_KINDS = JS.KSet"macrocall call dotcall tuple ' do juxtapose typed_comprehension for while function macro = comparison && || if ?"
 
-function collect_provenance_indexes(inferred_tree::SyntaxTreeC, annotations::TreeAnnotations)
+function collect_provenance_indexes(inferred_tree::SyntaxTree, annotations::TreeAnnotations)
     surface_kind_index = Dict{UnitRange{Int},JS.Kind}()
     macrocall_types = Dict{UnitRange{Int},Vector{Any}}()
-    traverse(inferred_tree) do st::SyntaxTreeC
+    traverse(inferred_tree) do st::SyntaxTree
         provs = JS.flattened_provenance(st)
         if !isempty(provs)
             prov = first(provs)
@@ -1555,8 +1555,8 @@ end
 # scope; entering its `K"code_info"` child overrides the inherited scope so an inner OC's
 # body is attributed to the inner method, not the outer.
 function populate_oc_body_scope!(
-        scope::Dict{SyntaxTreeC,UnitRange{Int}},
-        node::SyntaxTreeC,
+        scope::Dict{SyntaxTree,UnitRange{Int}},
+        node::SyntaxTree,
         current::Union{Nothing,UnitRange{Int}},
     )
     current === nothing || (scope[node] = current)
@@ -1576,7 +1576,7 @@ function populate_oc_body_scope!(
 end
 
 function collect_oc_argument_binding_types(
-        ctx3::JL.VariableAnalysisContext, inferred_tree::SyntaxTreeC,
+        ctx3::JL.VariableAnalysisContext, inferred_tree::SyntaxTree,
         annotations::TreeAnnotations
     )
     oc_argtypes = collect_oc_argtypes_by_binding(inferred_tree, annotations)
@@ -1609,11 +1609,11 @@ function collect_lambda_ranges(ctx3::JL.VariableAnalysisContext)
 end
 
 function collect_oc_argtypes_by_binding(
-        inferred_tree::SyntaxTreeC, annotations::TreeAnnotations
+        inferred_tree::SyntaxTree, annotations::TreeAnnotations
     )
     body_ranges_by_surface = collect_oc_body_ranges_by_surface(inferred_tree)
     oc_argtypes = Dict{Tuple{UnitRange{Int},Symbol},Any}()
-    traverse(inferred_tree) do st::SyntaxTreeC
+    traverse(inferred_tree) do st::SyntaxTree
         JS.kind(st) === JS.K"new_opaque_closure" || return nothing
         typ = @something get(annotations.types, st, nothing) return nothing
         entry = @something oc_argtypes_for_node(typ, JS.byte_range(st)) return nothing
@@ -1632,9 +1632,9 @@ function collect_oc_argtypes_by_binding(
     return oc_argtypes
 end
 
-function collect_oc_body_ranges_by_surface(inferred_tree::SyntaxTreeC)
+function collect_oc_body_ranges_by_surface(inferred_tree::SyntaxTree)
     body_ranges_by_surface = Dict{UnitRange{Int},Vector{UnitRange{Int}}}()
-    traverse(inferred_tree) do st::SyntaxTreeC
+    traverse(inferred_tree) do st::SyntaxTree
         JS.kind(st) === JS.K"opaque_closure_method" || return nothing
         surface_range = JS.byte_range(st)
         for child in JS.children(st)
@@ -1658,9 +1658,9 @@ function oc_argtypes_for_node(@nospecialize(typ), rng::UnitRange{Int})
 end
 
 # `st3` (not `st0`) so `K"return"`s introduced by macro expansion are picked up.
-function collect_user_return_form_ranges(st3::SyntaxTreeC)
+function collect_user_return_form_ranges(st3::SyntaxTree)
     ranges = UnitRange{Int}[]
-    traverse(st3) do st::SyntaxTreeC
+    traverse(st3) do st::SyntaxTree
         JS.kind(st) === JS.K"return" && push!(ranges, JS.byte_range(st))
         return nothing
     end
@@ -1684,7 +1684,7 @@ end
 
 """
     build_inferred_context_for_tree(
-            st0::SyntaxTreeC, context_module::Module;
+            st0::SyntaxTree, context_module::Module;
             world::UInt = Base.get_world_counter(),
             caller::AbstractString = "build_inferred_context_for_tree",
             cache::Union{Nothing,InferredContextCache} = nothing
@@ -1704,7 +1704,7 @@ Cache misses build outside the cache lock. Racing requests may duplicate inferen
 same key, but unrelated cache hits/misses are not blocked.
 """
 function build_inferred_context_for_tree(
-        st0::SyntaxTreeC, context_module::Module;
+        st0::SyntaxTree, context_module::Module;
         world::UInt = Base.get_world_counter(),
         caller::AbstractString = "build_inferred_context_for_tree",
         cache::Union{Nothing,InferredContextCache} = nothing
@@ -1730,7 +1730,7 @@ end
 
 """
     build_inferred_context_for_range(
-            st0_top::SyntaxTreeC, context_module::Module, rng::UnitRange{<:Integer};
+            st0_top::SyntaxTree, context_module::Module, rng::UnitRange{<:Integer};
             world::UInt = Base.get_world_counter(),
             caller::AbstractString = "build_inferred_context_for_range",
             cache::Union{Nothing,InferredContextCache} = nothing
@@ -1754,12 +1754,12 @@ Cache misses build outside the cache lock. Racing requests may duplicate inferen
 same key, but unrelated cache hits/misses are not blocked.
 """
 function build_inferred_context_for_range(
-        st0_top::SyntaxTreeC, context_module::Module, rng::UnitRange{<:Integer};
+        st0_top::SyntaxTree, context_module::Module, rng::UnitRange{<:Integer};
         world::UInt = Base.get_world_counter(),
         caller::AbstractString = "build_inferred_context_for_range",
         cache::Union{Nothing,InferredContextCache} = nothing
     )
-    return iterate_toplevel_tree(st0_top) do st0::SyntaxTreeC
+    return iterate_toplevel_tree(st0_top) do st0::SyntaxTree
         rng ⊆ JS.byte_range(st0) || return nothing
         ctx = build_inferred_context_for_tree(st0, context_module; world, caller, cache)
         return TraversalReturn(ctx; terminate=true)
@@ -1767,7 +1767,7 @@ function build_inferred_context_for_range(
 end
 
 function build_inferred_context(
-        st0::SyntaxTreeC, context_module::Module;
+        st0::SyntaxTree, context_module::Module;
         world::UInt = Base.get_world_counter(),
         caller::AbstractString = "build_inferred_context"
     )
@@ -1955,7 +1955,7 @@ end
 # the function's return type. The matching `Core.define_method` call or
 # `K"opaque_closure_method"` wraps a `K"code_info"` body whose `K"return"` stmts
 # carry the inferred return types; `tmerge` over them yields the function's value type.
-function method_body_tree(st::SyntaxTreeC)
+function method_body_tree(st::SyntaxTree)
     k = JS.kind(st)
     if is_core_define_method_call(st)
         JS.numchildren(st) == 5 || return nothing
@@ -2048,7 +2048,7 @@ end
 # `K"core"` callee can't appear in user source — user-written
 # `Core.Typeof(x)` lowers to `K"globalref"` — so a K"core" "Typeof"
 # call reliably marks JL's argtype-svec scaffolding.
-function is_synthetic_typeof_scaffolding(st::SyntaxTreeC)
+function is_synthetic_typeof_scaffolding(st::SyntaxTree)
     JS.kind(st) === JS.K"call" || return false
     JS.numchildren(st) >= 1 || return false
     c1 = st[1]

--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -2,9 +2,9 @@
     TypeAnnotation
 
 Type-annotation pipeline for the LSP feature path: parse → lower → infer → query.
-Produces a `SyntaxTreeC` whose nodes carry `:type` attributes computed by a custom
-`CC.AbstractInterpreter`, plus a query handle ([`InferredTreeContext`](@ref)) for
-byte-range type lookups.
+Produces a `SyntaxTreeC` plus per-node `:type` annotations (side tables computed by
+a custom `CC.AbstractInterpreter`), wrapped in a query handle
+([`InferredTreeContext`](@ref)) for byte-range type lookups.
 
 # Exported API
 
@@ -42,9 +42,9 @@ The pipeline has four steps. Each step's output feeds the next:
    [`infer_toplevel_tree(ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, st0::SyntaxTreeC, context_module::Module; world::UInt = Base.get_world_counter()) -> inferred_tree::SyntaxTreeC`](@ref infer_toplevel_tree)
    takes `(ctx3, st3)` through the remaining JuliaLowering passes (`convert_closures` →
    `linearize_ir`), runs CC inference under the internal `ASTTypeAnnotator`, and
-   writes the inferred type of each lowered statement back into the tree as a
-   `:type` attribute. The result is a `inferred_tree::SyntaxTreeC` whose nodes — both at
-   toplevel and inside method bodies — carry per-statement types.
+   records the inferred type of each lowered statement in node-keyed side tables
+   (`TreeAnnotations`). The result covers nodes both at toplevel and inside
+   method bodies with per-statement types.
 
 3. **Build query indexes**:
    [`build_inferred_context_for_range`](@ref) wraps the annotated tree with
@@ -151,7 +151,8 @@ module TypeAnnotation
 
 using Core.IR
 using JET: CC, JET
-using ..JETLS: InferredContextCache, InferredContextCacheData, SyntaxTreeC, TraversalReturn
+using ..JETLS: InferredContextCache, InferredContextCacheData, SyntaxTreeC,
+    TraversalReturn, TreeAnnotations
 using ..JETLS: JETLS_DEBUG_LOWERING, JETLS_DEV_MODE, JL, JS
 using ..JETLS: get_name_val, iterate_toplevel_tree, jl_lower_for_scope_resolution, load,
     rewrite_local_closures_to_opaque, store!, traverse, unwrap_funcdef_sig
@@ -231,6 +232,9 @@ struct ASTTypeAnnotator <: CC.AbstractInterpreter
     # Consumer-side classifier for "user-written vs lowering-introduced" used by
     # `annotate_types!`. See `is_internal_binding_leaf` and `is_synthetic_destructure_stmt`.
     filter::SyntheticFilter
+    # Side tables receiving `annotate_types!` results; shared across all thunk
+    # interps of one inference pass.
+    annotations::TreeAnnotations
     # OC `Method` → body's `K"code_info"` subtree; built by `register_oc_body_trees!`.
     oc_body_trees::IdDict{Method,SyntaxTreeC}
     # Pending eager OC body annotations. `abstract_eval_new_opaque_closure` opens an
@@ -260,6 +264,7 @@ struct ASTTypeAnnotator <: CC.AbstractInterpreter
             ),
             opt_params::CC.OptimizationParams = CC.OptimizationParams(),
             inf_cache::Vector{CC.InferenceResult} = CC.InferenceResult[],
+            annotations::TreeAnnotations = TreeAnnotations(),
             oc_body_trees::IdDict{Method,SyntaxTreeC} = IdDict{Method,SyntaxTreeC}(),
             oc_body_annotation_states::IdDict{Method,OCBodyAnnotationState} = IdDict{Method,OCBodyAnnotationState}(),
             oc_argtype_observations::OCArgtypeTable = OCArgtypeTable(),
@@ -267,7 +272,7 @@ struct ASTTypeAnnotator <: CC.AbstractInterpreter
             oc_key_memo::IdDict{Method,Union{Nothing,OCArgtypeKey}} = IdDict{Method,Union{Nothing,OCArgtypeKey}}()
         )
         return new(world, inf_params, opt_params, inf_cache, toptree, topmi,
-            filter, oc_body_trees, oc_body_annotation_states,
+            filter, annotations, oc_body_trees, oc_body_annotation_states,
             oc_argtype_observations, oc_argtype_refinements, oc_key_memo)
     end
 end
@@ -696,18 +701,15 @@ end
 # user arguments have an intermediate `is_internal=true` local that would
 # misreport `true` if we stopped at the first hop.
 function is_internal_binding_leaf(filter::SyntheticFilter, leaf::SyntaxTreeC)
-    graph = JS.syntax_graph(leaf)
-    src = get(leaf, :source, nothing)
-    src isa JS.NodeId || return false
-    cur = SyntaxTreeC(graph, src)
-    JS.kind(cur) === JS.K"BindingId" || return false
-    last_binding = cur
+    src = leaf.source
+    src isa SyntaxTreeC || return false
+    JS.kind(src) === JS.K"BindingId" || return false
+    last_binding = src
     while true
-        nxt = get(last_binding, :source, nothing)
-        nxt isa JS.NodeId || break
-        st = SyntaxTreeC(graph, nxt)
-        JS.kind(st) === JS.K"BindingId" || break
-        last_binding = st
+        nxt = last_binding.source
+        nxt isa SyntaxTreeC || break
+        JS.kind(nxt) === JS.K"BindingId" || break
+        last_binding = nxt
     end
     return JL.get_binding(filter.bindings, last_binding).is_internal
 end
@@ -757,7 +759,8 @@ is_synthetic_arg_leaf(stmttree::SyntaxTreeC, leaf::SyntaxTreeC) =
     JS.byte_range(leaf) == JS.byte_range(stmttree)
 
 function annotate_types!(
-        citree::SyntaxTreeC, frame::CC.InferenceState, filter::SyntheticFilter
+        annotations::TreeAnnotations, citree::SyntaxTreeC, frame::CC.InferenceState,
+        filter::SyntheticFilter
     )
     if length(frame.src.code) != JS.numchildren(citree)
         return @warn "ASTTypeAnnotator: Can't annotate types for " frame.linfo
@@ -776,7 +779,7 @@ function annotate_types!(
         # annotating them (or their inner K"call" / args, below) would shadow
         # source-range queries.
         is_synthesized_stmt = is_synthetic_destructure_stmt(filter, stmttree)
-        is_synthesized_stmt || JS.setattr!(stmttree, :type, stmttype)
+        is_synthesized_stmt || (annotations.types[stmttree] = stmttype)
         if stmt isa Expr
             stmt.head === :meta && continue
             # TODO: properly annotate static-parameter references once CC supports
@@ -795,23 +798,23 @@ function annotate_types!(
                     # lowering-introduced (e.g. tuple destructure's
                     # `iterstate` / `rhs_tmp`) — those slot leaves share the
                     # user's RHS source position and would pollute queries.
-                    JS.setattr!(treeref[1], :type, stmttype)
+                    annotations.types[treeref[1]] = stmttype
                 end
                 stmt = stmt.args[2]
                 stmt isa Expr || continue
                 treeref = treeref[2]
-                is_synthesized_stmt || JS.setattr!(treeref, :type, stmttype)
+                is_synthesized_stmt || (annotations.types[treeref] = stmttype)
             end
             is_call = stmt.head === :call
             if is_call && !is_synthesized_stmt
                 matches = extract_call_matches(frame.stmt_info[i])
-                matches === nothing || JS.setattr!(treeref, :matches, matches)
+                matches === nothing || (annotations.matches[treeref] = matches)
             end
             for j = 1:length(stmt.args)
                 arg = stmt.args[j]
                 if arg isa SlotNumber && !is_internal_binding_leaf(filter, treeref[j])
                     argtyp = slot_type_at(arg, i, frame)
-                    JS.setattr!(treeref[j], :type, argtyp)
+                    annotations.types[treeref[j]] = argtyp
                 elseif (!is_synthesized_stmt && is_call && !(arg isa SSAValue) &&
                         !is_synthetic_arg_leaf(treeref, treeref[j]))
                     # `is_synthetic_arg_leaf` filters lowering-inserted leaves
@@ -823,7 +826,7 @@ function annotate_types!(
                     # SSAValue args are skipped separately since the producing stmt already
                     # annotates the value.
                     argtyp = CC.argextype(arg, frame.src, frame.sptypes)
-                    JS.setattr!(treeref[j], :type, argtyp)
+                    annotations.types[treeref[j]] = argtyp
                 end
             end
         elseif stmt isa ReturnNode
@@ -833,7 +836,7 @@ function annotate_types!(
             else
                 rettyp = CC.argextype(val, frame.src, frame.sptypes)
             end
-            JS.setattr!(stmttree, :type, rettyp)
+            annotations.types[stmttree] = rettyp
         end
     end
 end
@@ -841,7 +844,8 @@ end
 function CC.finishinfer!(frame::CC.InferenceState, interp::ASTTypeAnnotator, cycleid::Int)
     ret = @invoke CC.finishinfer!(frame::CC.InferenceState, interp::CC.AbstractInterpreter, cycleid::Int)
     if frame.linfo === interp.topmi
-        annotate_types!(interp.toptree[1], frame, interp.filter)
+        annotate_types!(interp.annotations, code_info_stmts(interp.toptree), frame,
+            interp.filter)
     else
         def = frame.linfo.def
         if def isa Method
@@ -871,8 +875,8 @@ function consume_oc_body_annotation_state!(interp::ASTTypeAnnotator, def::Method
     delete!(interp.oc_body_annotation_states, def)
     frame = @something state.last_frame return false
     oc_citree = get(interp.oc_body_trees, def, nothing)
-    # `oc_citree[1]` is the body block, matching `annotate_types!`'s contract.
-    oc_citree === nothing || annotate_types!(oc_citree[1], frame, interp.filter)
+    oc_citree === nothing || annotate_types!(
+        interp.annotations, code_info_stmts(oc_citree), frame, interp.filter)
     return true
 end
 
@@ -889,7 +893,7 @@ end
 function register_oc_body_trees!(
         oc_body_trees::IdDict{Method,SyntaxTreeC}, citree::SyntaxTreeC, src::CodeInfo
     )
-    block_citree = JS.kind(citree) === JS.K"code_info" ? citree[1] : citree
+    block_citree = JS.kind(citree) in JS.KSet"thunk code_info" ? code_info_stmts(citree) : citree
     JS.numchildren(block_citree) == length(src.code) || return oc_body_trees
     for i = 1:length(src.code)
         stmt = src.code[i]
@@ -914,6 +918,16 @@ function find_code_info_child(node::SyntaxTreeC)
         JS.kind(c) === JS.K"code_info" && return c
     end
     return nothing
+end
+
+# Unwrap a (possibly `K"thunk"`-wrapped) `K"code_info"` node to its statements
+# block: `K"code_info"` children are `[K"Slots", stmts::K"block"]`.
+function code_info_stmts(citree::SyntaxTreeC)
+    if JS.kind(citree) === JS.K"thunk"
+        citree = citree[1]
+    end
+    @assert JS.kind(citree) === JS.K"code_info"
+    return citree[2]
 end
 
 # Type annotation driver
@@ -973,7 +987,8 @@ end
 [`TypeAnnotation`](@ref) pipeline step 2: take `(ctx3, st3)` (typically from
 [`get_inferrable_tree`](@ref)) through the remaining JuliaLowering passes, run CC
 inference under the internal `ASTTypeAnnotator`, and return a `SyntaxTreeC`
-annotated with a `:type` attribute on each lowered statement. The walk recurses
+whose lowered statements carry `:type` annotations (recorded in the
+interpreter's `TreeAnnotations` side tables). The walk recurses
 into `Core.define_method` calls: each method body is inferred as its own anonymous
 thunk against argtypes statically evaluated from its sig svec.
 
@@ -1095,24 +1110,18 @@ function infer_lowered_tree(
         @static JETLS_DEV_MODE && @error "infer_toplevel_tree: Lowering failed" e
         @static JETLS_DEV_MODE && Base.showerror(stderr, e, catch_backtrace())
         return nothing
-    end |> prepare_type_attr
+    end
     lwr = JL.to_lowered_expr(inferrable_tree)
 
     Meta.isexpr(lwr, :thunk) || error("infer_toplevel_tree: Unexpected lowering result")
     src = lwr.args[1]::CodeInfo
 
+    annotations = TreeAnnotations()
     interp = infer_thunk!(inferrable_tree, src, context_module, nothing, world, filter,
-        observations, refinements, inf_cache)
-    infer_method_defs!(inferrable_tree, src, context_module, world, filter,
+        annotations, observations, refinements, inf_cache)
+    infer_method_defs!(inferrable_tree, src, context_module, world, filter, annotations,
         method_body_ranges, observations, refinements, inf_cache)
     return interp
-end
-
-prepare_type_attr(st::SyntaxTreeC) = let g = JL.syntax_graph(st)
-    attrs = Dict(pairs(g.attributes))
-    attrs[:type] = Dict{Int, Any}()
-    attrs[:matches] = Dict{Int, Vector{Core.MethodMatch}}()
-    return SyntaxTreeC(JL.SyntaxGraph(g.edge_ranges, g.edges, attrs), st._id)
 end
 
 # `argtypes === nothing` keeps the `InferenceResult`'s default argtypes (intended
@@ -1120,13 +1129,15 @@ end
 function infer_thunk!(
         tree::SyntaxTreeC, src::CodeInfo, context_module::Module,
         argtypes::Union{Nothing,Vector{Any}}, world::UInt, filter::SyntheticFilter,
+        annotations::TreeAnnotations,
         observations::OCArgtypeTable, refinements::Union{Nothing,OCArgtypeTable},
         inf_cache::Vector{CC.InferenceResult}
     )
     strip_latestworld!(src)
     mi = construct_toplevel_mi(src, context_module)
     interp = ASTTypeAnnotator(world, tree, mi, filter;
-        oc_argtype_observations=observations, oc_argtype_refinements=refinements, inf_cache)
+        annotations, oc_argtype_observations=observations,
+        oc_argtype_refinements=refinements, inf_cache)
     register_oc_body_trees!(interp.oc_body_trees, tree, src)
     result = CC.InferenceResult(mi)
     if argtypes !== nothing
@@ -1222,11 +1233,12 @@ end
 
 function infer_method_defs!(
         inferred::SyntaxTreeC, src::CodeInfo, context_module::Module, world::UInt,
-        filter::SyntheticFilter, method_body_ranges::MethodBodyRangeIndex,
+        filter::SyntheticFilter, annotations::TreeAnnotations,
+        method_body_ranges::MethodBodyRangeIndex,
         observations::OCArgtypeTable, refinements::Union{Nothing,OCArgtypeTable},
         inf_cache::Vector{CC.InferenceResult}
     )
-    block = inferred[1]
+    block = code_info_stmts(inferred)
     nstmts = JS.numchildren(block)
     nstmts == length(src.code) || return
     for i = 1:nstmts
@@ -1249,7 +1261,7 @@ function infer_method_defs!(
             resolve_method_argtypes(sig_ref, src, nargs, context_module, world),
             Any[Any for _ in 1:nargs])
         infer_thunk!(body_tree, body_codeinfo, context_module, argtypes, world, filter,
-            observations, refinements, inf_cache)
+            annotations, observations, refinements, inf_cache)
     end
     return
 end
@@ -1437,14 +1449,16 @@ end
 
 """
     InferredTreeContext(
-            inferred_tree::SyntaxTreeC, ctx3::JL.VariableAnalysisContext,
-            st3::SyntaxTreeC, surface_kind_index::Dict{UnitRange{Int},JS.Kind},
+            inferred_tree::SyntaxTreeC, annotations::TreeAnnotations,
+            ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC,
+            surface_kind_index::Dict{UnitRange{Int},JS.Kind},
             macrocall_types::Dict{UnitRange{Int},Vector{Any}}
         ) -> ctx::InferredTreeContext
 
-[`TypeAnnotation`](@ref) pipeline step 3: wrap an annotated `inferred_tree` (from
-[`infer_toplevel_tree`](@ref)) plus the post-scope-resolution `ctx3` / `st3` (from
-[`get_inferrable_tree`](@ref)) and provenance indexes built before pruning,
+[`TypeAnnotation`](@ref) pipeline step 3: wrap the `inferred_tree` and its
+`annotations` side tables (from the interpreter driven by
+[`infer_toplevel_tree`](@ref)) plus the post-scope-resolution `ctx3` / `st3`
+(from [`get_inferrable_tree`](@ref)) and pre-built provenance indexes,
 yielding a query handle that [`get_type_for_range`](@ref) and friends can answer
 in \$O(1)\$ per call (or \$O(log N)\$ for the branching case).
 
@@ -1464,7 +1478,8 @@ as new queries demand different indexes.
 See the [`TypeAnnotation`](@ref) module docstring for the full pipeline.
 """
 function InferredTreeContext(
-        inferred_tree::SyntaxTreeC, ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC,
+        inferred_tree::SyntaxTreeC, annotations::TreeAnnotations,
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC,
         surface_kind_index::Dict{UnitRange{Int},JS.Kind},
         macrocall_types::Dict{UnitRange{Int},Vector{Any}}
     )
@@ -1472,8 +1487,6 @@ function InferredTreeContext(
     return_first_bytes = Int[]
     return_nodes = SyntaxTreeC[]
 
-    # These indexes retain tree nodes, so they must be built from the pruned tree;
-    # otherwise the context would keep the unpruned graph alive.
     traverse(inferred_tree) do st::SyntaxTreeC
         rng = JS.byte_range(st)
         push!(get!(Vector{SyntaxTreeC}, by_byte_range, rng), st)
@@ -1492,12 +1505,13 @@ function InferredTreeContext(
 
     user_return_form_ranges = collect_user_return_form_ranges(st3)
 
-    oc_body_scope = Dict{Int,UnitRange{Int}}()
+    oc_body_scope = Dict{SyntaxTreeC,UnitRange{Int}}()
     populate_oc_body_scope!(oc_body_scope, inferred_tree, nothing)
-    oc_argument_binding_types = collect_oc_argument_binding_types(ctx3, inferred_tree)
+    oc_argument_binding_types =
+        collect_oc_argument_binding_types(ctx3, inferred_tree, annotations)
 
     return InferredTreeContext(
-        inferred_tree, surface_kind_index, by_byte_range,
+        inferred_tree, annotations, surface_kind_index, by_byte_range,
         macrocall_types, return_first_bytes, return_nodes,
         user_return_form_ranges, oc_body_scope, oc_argument_binding_types)
 end
@@ -1508,9 +1522,9 @@ end
 # collapses onto the very expression it wraps, and letting the wrapper claim the range
 # would drop the query into `tmerge_at_range`, merging loop/closure scaffolding types
 # into the user-visible result.
-const DISPATCH_SURFACE_KINDS = JS.KSet"macrocall call dotcall tuple ' do typed_comprehension for while function macro = comparison && || if ?"
+const DISPATCH_SURFACE_KINDS = JS.KSet"macrocall call dotcall tuple ' do juxtapose typed_comprehension for while function macro = comparison && || if ?"
 
-function collect_provenance_indexes(inferred_tree::SyntaxTreeC)
+function collect_provenance_indexes(inferred_tree::SyntaxTreeC, annotations::TreeAnnotations)
     surface_kind_index = Dict{UnitRange{Int},JS.Kind}()
     macrocall_types = Dict{UnitRange{Int},Vector{Any}}()
     traverse(inferred_tree) do st::SyntaxTreeC
@@ -1524,9 +1538,10 @@ function collect_provenance_indexes(inferred_tree::SyntaxTreeC)
                 (!(existing in DISPATCH_SURFACE_KINDS) && pk in DISPATCH_SURFACE_KINDS))
                 surface_kind_index[prov_rng] = pk
             end
-            if (JS.kind(st) === JS.K"call" && JS.hasattr(st, :type) &&
+            typ = get(annotations.types, st, nothing)
+            if (JS.kind(st) === JS.K"call" && typ !== nothing &&
                 JS.kind(prov) === JS.K"macrocall")
-                push!(get!(Vector{Any}, macrocall_types, JS.byte_range(prov)), st.type)
+                push!(get!(Vector{Any}, macrocall_types, JS.byte_range(prov)), typ)
             end
         end
         return nothing
@@ -1540,11 +1555,11 @@ end
 # scope; entering its `K"code_info"` child overrides the inherited scope so an inner OC's
 # body is attributed to the inner method, not the outer.
 function populate_oc_body_scope!(
-        scope::Dict{Int,UnitRange{Int}},
+        scope::Dict{SyntaxTreeC,UnitRange{Int}},
         node::SyntaxTreeC,
         current::Union{Nothing,UnitRange{Int}},
     )
-    current === nothing || (scope[node._id] = current)
+    current === nothing || (scope[node] = current)
     JS.is_leaf(node) && return
     if JS.kind(node) === JS.K"opaque_closure_method"
         method_range = JS.byte_range(node)
@@ -1561,9 +1576,10 @@ function populate_oc_body_scope!(
 end
 
 function collect_oc_argument_binding_types(
-        ctx3::JL.VariableAnalysisContext, inferred_tree::SyntaxTreeC
+        ctx3::JL.VariableAnalysisContext, inferred_tree::SyntaxTreeC,
+        annotations::TreeAnnotations
     )
-    oc_argtypes = collect_oc_argtypes_by_binding(inferred_tree)
+    oc_argtypes = collect_oc_argtypes_by_binding(inferred_tree, annotations)
     binding_types = Dict{UnitRange{Int},Any}()
     isempty(oc_argtypes) && return binding_types
     lambda_ranges = collect_lambda_ranges(ctx3)
@@ -1575,7 +1591,7 @@ function collect_oc_argument_binding_types(
         name = binfo.name
         typ = get(oc_argtypes, (lambda_range, Symbol(name)), nothing)
         typ === nothing && continue
-        binding = SyntaxTreeC(ctx3.graph, binfo.node_id)
+        binding = binfo.node_id
         JS.kind(binding) === JS.K"BindingId" || continue
         binding_types[JS.byte_range(binding)] = typ
     end
@@ -1585,20 +1601,22 @@ end
 function collect_lambda_ranges(ctx3::JL.VariableAnalysisContext)
     ranges = Dict{Int,UnitRange{Int}}()
     for scope in ctx3.scopes
-        node = SyntaxTreeC(ctx3.graph, scope.node_id)
-        JS.kind(node) === JS.K"lambda" || continue
+        node = scope.node_id
+        JS.kind(node) in JS.KSet"lambda toplevel_lambda generated_lambda" || continue
         ranges[scope.lambda_id] = JS.byte_range(node)
     end
     return ranges
 end
 
-function collect_oc_argtypes_by_binding(inferred_tree::SyntaxTreeC)
+function collect_oc_argtypes_by_binding(
+        inferred_tree::SyntaxTreeC, annotations::TreeAnnotations
+    )
     body_ranges_by_surface = collect_oc_body_ranges_by_surface(inferred_tree)
     oc_argtypes = Dict{Tuple{UnitRange{Int},Symbol},Any}()
     traverse(inferred_tree) do st::SyntaxTreeC
         JS.kind(st) === JS.K"new_opaque_closure" || return nothing
-        JS.hasattr(st, :type) || return nothing
-        entry = @something oc_argtypes_for_node(st.type, JS.byte_range(st)) return nothing
+        typ = @something get(annotations.types, st, nothing) return nothing
+        entry = @something oc_argtypes_for_node(typ, JS.byte_range(st)) return nothing
         body_ranges = get(Vector{UnitRange{Int}}, body_ranges_by_surface, entry.range)
         for i = 1:length(entry.argnames)
             typ = entry.argtypes[i]
@@ -1754,17 +1772,19 @@ function build_inferred_context(
         caller::AbstractString = "build_inferred_context"
     )
     (; ctx3, st3) = @something get_inferrable_tree(st0, context_module, world; caller) return nothing
-    inferred = @something infer_toplevel_tree(ctx3, st3, st0, context_module; world) return nothing
-    # `JS.prune` minimizes provenance, so collect query-dispatch indexes first.
-    surface_kind_index, macrocall_types = collect_provenance_indexes(inferred)
-    return InferredTreeContext(JS.prune(inferred), ctx3, st3, surface_kind_index, macrocall_types)
+    interp = @something _infer_toplevel_tree(ctx3, st3, st0, context_module; world) return nothing
+    inferred = interp.toptree
+    annotations = interp.annotations
+    surface_kind_index, macrocall_types = collect_provenance_indexes(inferred, annotations)
+    return InferredTreeContext(
+        inferred, annotations, ctx3, st3, surface_kind_index, macrocall_types)
 end
 
 """
     get_type_for_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
 
 [`TypeAnnotation`](@ref) pipeline step 4: look up the inferred type at surface byte range `rng`.
-Returns `nothing` if no lowered node corresponding to `rng` carries a `:type` attribute.
+Returns `nothing` if no lowered node corresponding to `rng` carries a `:type` annotation.
 
 Build the [`InferredTreeContext`](@ref) once per inferred tree and reuse it across queries
 — see the [`TypeAnnotation`](@ref) module docstring for the full pipeline.
@@ -1796,7 +1816,9 @@ function get_type_for_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
     surface_kind = surface_kind_at_range(ctx, rng)
     if surface_kind === JS.K"macrocall"
         return type_for_macroexpansion(ctx, rng)
-    elseif surface_kind in JS.KSet"call dotcall tuple ' do"
+    elseif surface_kind in JS.KSet"call dotcall tuple ' do juxtapose"
+        # `juxtapose`: parse-tree provenance retains the parser kind for `2x`,
+        # which desugars to a `K"call"` in the inferred tree.
         return type_for_call(ctx, rng)
     elseif surface_kind === JS.K"typed_comprehension"
         return type_for_typed_comprehension(ctx, rng)
@@ -1851,8 +1873,8 @@ function type_for_call(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
     typ = nothing
     for st in get(ctx.by_byte_range, rng, ())
         JS.kind(st) === JS.K"call" || continue
-        JS.hasattr(st, :type) || continue
-        typ = st.type
+        ntyp = @something get(ctx.annotations.types, st, nothing) continue
+        typ = ntyp
     end
     return typ
 end
@@ -1874,9 +1896,9 @@ end
 function type_for_typed_comprehension(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
     for st in get(ctx.by_byte_range, rng, ())
         JS.kind(st) === JS.K"call" || continue
-        JS.hasattr(st, :type) || continue
-        wt = CC.widenconst(st.type)
-        wt !== Union{} && wt <: Array && return st.type
+        typ = @something get(ctx.annotations.types, st, nothing) continue
+        wt = CC.widenconst(typ)
+        wt !== Union{} && wt <: Array && return typ
     end
     return nothing
 end
@@ -1898,8 +1920,7 @@ function type_for_branching(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
     typ = nothing
     # (1) equality match — any lowered kind, including merge-slot `K"="`.
     for st in get(ctx.by_byte_range, rng, ())
-        JS.hasattr(st, :type) || continue
-        ntyp = st.type
+        ntyp = @something get(ctx.annotations.types, st, nothing) continue
         typ = typ === nothing ? ntyp : CC.tmerge(ntyp, typ)
     end
     # (2) containment match — `K"return"` strictly inside `rng`, excluding
@@ -1917,8 +1938,7 @@ function type_for_branching(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
         form_rng = find_outermost_user_return_form(
             ctx.user_return_form_ranges, first_byte:last_byte)
         form_rng !== nothing && strictly_contains(rng, form_rng) && continue
-        JS.hasattr(st, :type) || continue
-        ntyp = st.type
+        ntyp = @something get(ctx.annotations.types, st, nothing) continue
         typ = typ === nothing ? ntyp : CC.tmerge(ntyp, typ)
     end
     return typ
@@ -1955,14 +1975,13 @@ function type_for_funcdef(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
     typ = nothing
     for st in get(ctx.by_byte_range, rng, ())
         body_tree = @something method_body_tree(st) continue
-        JS.numchildren(body_tree) >= 1 || continue
-        block = body_tree[1]
+        JS.numchildren(body_tree) >= 2 || continue
+        block = body_tree[2]
         for j = 1:JS.numchildren(block)
             stmt = block[j]
-            if JS.kind(stmt) === JS.K"return" && JS.hasattr(stmt, :type)
-                ntyp = stmt.type
-                typ = typ === nothing ? ntyp : CC.tmerge(ntyp, typ)
-            end
+            JS.kind(stmt) === JS.K"return" || continue
+            ntyp = @something get(ctx.annotations.types, stmt, nothing) continue
+            typ = typ === nothing ? ntyp : CC.tmerge(ntyp, typ)
         end
     end
     return typ
@@ -1981,9 +2000,8 @@ function type_for_oc_body_return_at_range(
         first_byte > last(rng) && break
         st = ctx.return_nodes[i]
         JS.last_byte(st) <= last(rng) || continue
-        get(ctx.oc_body_scope, st._id, nothing) === rng || continue
-        JS.hasattr(st, :type) || continue
-        ntyp = st.type
+        get(ctx.oc_body_scope, st, nothing) === rng || continue
+        ntyp = @something get(ctx.annotations.types, st, nothing) continue
         typ = typ === nothing ? ntyp : CC.tmerge(ntyp, typ)
     end
     return typ
@@ -2014,15 +2032,14 @@ function tmerge_at_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
         # (`Const(Any)` etc.) must not leak into surface queries.
         JS.kind(st) === JS.K"core" && continue
         has_binding_slot && JS.kind(st) === JS.K"Symbol" && continue
-        JS.hasattr(st, :type) || continue
-        if is_oc_site && get(ctx.oc_body_scope, st._id, nothing) !== rng
+        ntyp = @something get(ctx.annotations.types, st, nothing) continue
+        if is_oc_site && get(ctx.oc_body_scope, st, nothing) !== rng
             continue
         end
         # Synthetic `Core.Typeof(funcname)` overlaps the function name's byte
         # range; `tmerge`ing `Const(Type{T})` into `Const(T)` would surface
         # `Union{T, Type{T}}` for def-site name queries.
         is_synthetic_typeof_scaffolding(st) && continue
-        ntyp = st.type
         typ = typ === nothing ? ntyp : CC.tmerge(ntyp, typ)
     end
     return typ
@@ -2046,7 +2063,7 @@ end
 
 Look up the `Core.MethodMatch`es CC's dispatch produced for the call site at
 surface byte range `rng`. Returns `nothing` if no lowered `K"call"` node at
-`rng` carries a `:matches` attribute — the surface isn't a call site, the
+`rng` carries a `:matches` annotation — the surface isn't a call site, the
 lookup hit a non-method-dispatch `CallInfo` (`InvokeCallInfo`, `OpaqueClosureCallInfo`,
 `ApplyCallInfo`, …), or inference couldn't see the callee at all.
 
@@ -2065,8 +2082,8 @@ function get_matches_for_range(ctx::InferredTreeContext, rng::UnitRange{<:Intege
         last_call = st
     end
     last_call === nothing && return nothing
-    JS.hasattr(last_call, :matches) || return nothing
-    return last_call.matches::Vector{Core.MethodMatch}
+    matches = @something get(ctx.annotations.matches, last_call, nothing) return nothing
+    return matches::Vector{Core.MethodMatch}
 end
 
 function opaque_closure_argtypes(@nospecialize(typ))

--- a/src/analysis/cfg-analysis.jl
+++ b/src/analysis/cfg-analysis.jl
@@ -491,13 +491,13 @@ function linearize_cfg_events!(
     elseif k == JS.K"lambda"
         # Handle captured variables from outer scope by recursing into lambda body
         # We don't know when/if the closure is called, so wrap in an uncertain branch
-        nested_lb = ex3.lambda_bindings::JL.LambdaBindings
+        nested_lb = JL.lambda_bindings(ex3[1])
         has_outer_capture = any(is_capt && id in candidates for (id, is_capt) in nested_lb.locals_capt)
-        if has_outer_capture && JS.numchildren(ex3) >= 3
+        if has_outer_capture && JS.numchildren(ex3) >= 4
             skip_label = cfg_make_label!(lin)
             cfg_emit_gotoifnot!(lin, skip_label)
             let saved = undef_save_cond_implied(lin)
-                linearize_cfg_events!(lin, ctx3, ex3[3], candidates, allow_noreturn_optimization)
+                linearize_cfg_events!(lin, ctx3, ex3[4], candidates, allow_noreturn_optimization)
                 undef_restore_cond_implied!(lin, saved)
             end
             cfg_emit_label!(lin, skip_label)
@@ -773,7 +773,7 @@ function collect_closure_captured_vars(body::SyntaxTreeC, candidates::Set{JL.IdT
     result = Set{JL.IdTag}()
     traverse(body) do st::SyntaxTreeC
         JS.kind(st) == JS.K"lambda" || return nothing
-        nested_lb = st.lambda_bindings::JL.LambdaBindings
+        nested_lb = JL.lambda_bindings(st[1])
         for (id, is_capt) in nested_lb.locals_capt
             if is_capt && id in candidates
                 push!(result, id)
@@ -872,9 +872,9 @@ function build_lambda_cfg(
         ctx3::JL.VariableAnalysisContext, lambda_st3::SyntaxTreeC;
         allow_noreturn_optimization::Vector{Symbol} = Symbol[]
     )
-    JS.kind(lambda_st3) == JS.K"lambda" || return nothing
+    JS.kind(lambda_st3) in JS.KSet"lambda toplevel_lambda" || return nothing
 
-    lambda_bindings = lambda_st3.lambda_bindings::JL.LambdaBindings
+    lambda_bindings = JL.lambda_bindings(lambda_st3[1])
     candidates = Set{JL.IdTag}()
     for (id, from_outer_lambda) in lambda_bindings.locals_capt
         from_outer_lambda && continue
@@ -884,16 +884,16 @@ function build_lambda_cfg(
         end
     end
 
-    closure_captured = if JS.numchildren(lambda_st3) >= 3
-        collect_closure_captured_vars(lambda_st3[3], candidates)
+    closure_captured = if JS.numchildren(lambda_st3) >= 4
+        collect_closure_captured_vars(lambda_st3[4], candidates)
     else
         Set{JL.IdTag}()
     end
 
     lin = EventLinearizer()
-    if JS.numchildren(lambda_st3) >= 3
+    if JS.numchildren(lambda_st3) >= 4
         linearize_cfg_events!(
-            lin, ctx3, lambda_st3[3], candidates, allow_noreturn_optimization)
+            lin, ctx3, lambda_st3[4], candidates, allow_noreturn_optimization)
     end
     cfg_finalize!(lin)
 
@@ -1118,7 +1118,7 @@ function analyze_all_lambdas(
     dead_store_info = Dict{JL.BindingInfo, DeadStoreInfo}()
     unreachable_statements = Set{SyntaxTreeC}()
     traverse(st3) do st3′::SyntaxTreeC
-        if JS.kind(st3′) == JS.K"lambda"
+        if JS.kind(st3′) in JS.KSet"lambda toplevel_lambda"
             analyze_lambda!(
                 undef_info, dead_store_info, unreachable_statements,
                 ctx3, st3′, allow_noreturn_optimization)

--- a/src/analysis/cfg-analysis.jl
+++ b/src/analysis/cfg-analysis.jl
@@ -38,7 +38,7 @@
 struct BlockEvent
     kind::Symbol
     var_id::JL.IdTag
-    st::SyntaxTreeC
+    st::SyntaxTree
 end
 
 # Per-variable, per-block event entry stored in `LambdaCFG.var_events`.
@@ -47,7 +47,7 @@ end
 struct VarEvent
     kind::Symbol
     block_id::Int
-    st::SyntaxTreeC
+    st::SyntaxTree
 end
 
 # A `K"block"` child statement together with the CFG blocks execution
@@ -56,7 +56,7 @@ end
 struct StatementRecord
     before_block::Int
     after_block::Int
-    st::SyntaxTreeC
+    st::SyntaxTree
 end
 
 mutable struct EventBlock
@@ -136,7 +136,7 @@ function cfg_add_edge!(lin::EventLinearizer, from::Int, to::Int)
     end
 end
 
-function cfg_emit_event!(lin::EventLinearizer, event_kind::Symbol, var_id::JL.IdTag, st::SyntaxTreeC)
+function cfg_emit_event!(lin::EventLinearizer, event_kind::Symbol, var_id::JL.IdTag, st::SyntaxTree)
     lin.blocks[lin.current_block].event = BlockEvent(event_kind, var_id, st)
     # Create a new block to ensure proper ordering.
     # This allows the path-based analysis to track intra-block event order:
@@ -236,8 +236,8 @@ end
 # Walk the top-level operands of a condition expression, unwrapping
 # EST `K"block"` wrappers and descending through `&&` chains (all
 # operands must be true in the true branch).
-function for_each_cond_operand(@specialize(callback), cond::SyntaxTreeC)
-    traverse(cond) do node::SyntaxTreeC
+function for_each_cond_operand(@specialize(callback), cond::SyntaxTree)
+    traverse(cond) do node::SyntaxTree
         k = JS.kind(node)
         if k == JS.K"&&" || (k == JS.K"block" && JS.numchildren(node) == 1)
             return # descend into children
@@ -247,7 +247,7 @@ function for_each_cond_operand(@specialize(callback), cond::SyntaxTreeC)
     end
 end
 
-function undef_is_not_call(ctx3::JL.VariableAnalysisContext, cond::SyntaxTreeC)
+function undef_is_not_call(ctx3::JL.VariableAnalysisContext, cond::SyntaxTree)
     JS.kind(cond) == JS.K"call" || return false
     JS.numchildren(cond) == 2 || return false
     func = cond[1]
@@ -257,7 +257,7 @@ function undef_is_not_call(ctx3::JL.VariableAnalysisContext, cond::SyntaxTreeC)
 end
 
 function undef_emit_isdefined_hint!(
-        lin::EventLinearizer, arg::SyntaxTreeC, candidates::Set{JL.IdTag}
+        lin::EventLinearizer, arg::SyntaxTree, candidates::Set{JL.IdTag}
     )
     JS.kind(arg) == JS.K"BindingId" || return
     vid = var_id(arg)
@@ -267,7 +267,7 @@ end
 # Emit `:isdefined` hints for condition branches where `@isdefined(var)` is true.
 function undef_emit_isdefined_hints!(
         lin::EventLinearizer, ctx3::JL.VariableAnalysisContext,
-        cond::SyntaxTreeC, candidates::Set{JL.IdTag}, branch_value::Bool
+        cond::SyntaxTree, candidates::Set{JL.IdTag}, branch_value::Bool
     )
     k = JS.kind(cond)
     if k == JS.K"block" && JS.numchildren(cond) == 1
@@ -290,9 +290,9 @@ end
 # Collect all BindingId var_ids asserted true by a condition.
 # Returns `true` if every operand is a BindingId (for recording),
 # `false` otherwise (lookup still uses the collected ids).
-function undef_cond_binding_ids!(result::Vector{JL.IdTag}, cond::SyntaxTreeC)
+function undef_cond_binding_ids!(result::Vector{JL.IdTag}, cond::SyntaxTree)
     all_bindings = Ref(true)
-    for_each_cond_operand(cond) do operand::SyntaxTreeC
+    for_each_cond_operand(cond) do operand::SyntaxTree
         if JS.kind(operand) == JS.K"BindingId"
             push!(result, var_id(operand))
         else
@@ -306,7 +306,7 @@ end
 # Returns `nothing` when the node is not a definition or the LHS is not a BindingId.
 # This is the single source of truth for "what counts as a local variable definition"
 # used by both event linearization and correlated condition recording.
-function undef_direct_assign_var_id(node::SyntaxTreeC)
+function undef_direct_assign_var_id(node::SyntaxTree)
     k = JS.kind(node)
     if (k == JS.K"=" || k == JS.K"function_decl") && JS.numchildren(node) >= 1
         lhs = node[1]
@@ -321,7 +321,7 @@ end
 # in a branch. Only considers assignments at the top level of `K"block"` nodes,
 # not those nested inside conditionals/loops.
 function undef_collect_branch_direct_assigns(
-        branch::SyntaxTreeC, candidates::Set{JL.IdTag}
+        branch::SyntaxTree, candidates::Set{JL.IdTag}
     )
     result = Set{JL.IdTag}()
     undef_scan_direct_assigns!(result, branch, candidates)
@@ -329,7 +329,7 @@ function undef_collect_branch_direct_assigns(
 end
 
 function undef_scan_direct_assigns!(
-        result::Set{JL.IdTag}, node::SyntaxTreeC, candidates::Set{JL.IdTag}
+        result::Set{JL.IdTag}, node::SyntaxTree, candidates::Set{JL.IdTag}
     )
     var_id = undef_direct_assign_var_id(node)
     if !isnothing(var_id)
@@ -358,7 +358,7 @@ end
 # Extracts all BindingId operands asserted true by the condition and checks
 # if any recorded implication key is a subset.
 function undef_emit_cond_implied_hints!(
-        lin::EventLinearizer, cond::SyntaxTreeC, candidates::Set{JL.IdTag}
+        lin::EventLinearizer, cond::SyntaxTree, candidates::Set{JL.IdTag}
     )
     isempty(lin.cond_implies_defined) && return
     cond_vars = JL.IdTag[]
@@ -394,7 +394,7 @@ function undef_record_cond_implies!(
 end
 
 function linearize_cfg_events!(
-        lin::EventLinearizer, ctx3::JL.VariableAnalysisContext, ex3::SyntaxTreeC,
+        lin::EventLinearizer, ctx3::JL.VariableAnalysisContext, ex3::SyntaxTree,
         candidates::Set{JL.IdTag}, allow_noreturn_optimization::Vector{Symbol}
     )
     k = JS.kind(ex3)
@@ -769,9 +769,9 @@ end
 # closure does not correctly block assignments that come after the closure
 # definition, leading to false-positive dead store reports.  Variables
 # identified here are excluded from dead store analysis.
-function collect_closure_captured_vars(body::SyntaxTreeC, candidates::Set{JL.IdTag})
+function collect_closure_captured_vars(body::SyntaxTree, candidates::Set{JL.IdTag})
     result = Set{JL.IdTag}()
-    traverse(body) do st::SyntaxTreeC
+    traverse(body) do st::SyntaxTree
         JS.kind(st) == JS.K"lambda" || return nothing
         nested_lb = JL.lambda_bindings(st[1])
         for (id, is_capt) in nested_lb.locals_capt
@@ -869,7 +869,7 @@ end
 # Construct the `LambdaCFG` for `lambda_st3`.
 # The returned CFG is shared between `analyze_local_def_use!` and `analyze_unreachable!`.
 function build_lambda_cfg(
-        ctx3::JL.VariableAnalysisContext, lambda_st3::SyntaxTreeC;
+        ctx3::JL.VariableAnalysisContext, lambda_st3::SyntaxTree;
         allow_noreturn_optimization::Vector{Symbol} = Symbol[]
     )
     JS.kind(lambda_st3) in JS.KSet"lambda toplevel_lambda" || return nothing
@@ -921,7 +921,7 @@ end
 # `unreachable_statements` every recorded statement whose entry and exit CFG blocks are
 # both unreachable from the lambda entry.
 function analyze_unreachable!(
-        unreachable_statements::Set{SyntaxTreeC}, cfg::LambdaCFG
+        unreachable_statements::Set{SyntaxTree}, cfg::LambdaCFG
     )
     reachable = compute_reachable_blocks(cfg.lin.blocks)
     for rec in cfg.lin.statement_blocks
@@ -937,18 +937,18 @@ end
 Information about a local variable's definition/use sites and undef status.
 
 Fields:
-- `defs::Vector{SyntaxTreeC}`: Definition sites (assignments, function declarations)
-- `undef_uses::Vector{Pair{Bool,SyntaxTreeC}}`: Use sites on undef paths.
+- `defs::Vector{SyntaxTree}`: Definition sites (assignments, function declarations)
+- `undef_uses::Vector{Pair{Bool,SyntaxTree}}`: Use sites on undef paths.
   Each entry is `is_strict => use_tree`:
   - `true => tree`: Variable is definitely undefined at `tree`
   - `false => tree`: Variable may be undefined at `tree`
 """
 struct UndefInfo
-    defs::Vector{SyntaxTreeC}
-    undef_uses::Vector{Pair{Bool,SyntaxTreeC}}
+    defs::Vector{SyntaxTree}
+    undef_uses::Vector{Pair{Bool,SyntaxTree}}
 end
 
-UndefInfo() = UndefInfo(SyntaxTreeC[], Pair{Bool,SyntaxTreeC}[])
+UndefInfo() = UndefInfo(SyntaxTree[], Pair{Bool,SyntaxTree}[])
 
 """
     DeadStoreInfo
@@ -956,11 +956,11 @@ UndefInfo() = UndefInfo(SyntaxTreeC[], Pair{Bool,SyntaxTreeC}[])
 Information about dead store assignments for a local variable.
 
 Fields:
-- `dead_defs::Vector{SyntaxTreeC}`: Assignment sites whose values are
+- `dead_defs::Vector{SyntaxTree}`: Assignment sites whose values are
   never read on any CFG path (dead stores).
 """
 struct DeadStoreInfo
-    dead_defs::Vector{SyntaxTreeC}
+    dead_defs::Vector{SyntaxTree}
 end
 
 # Run undef-analysis and dead-store analysis for every local binding tracked by
@@ -982,11 +982,11 @@ function analyze_local_def_use!(
             continue
         end
 
-        defs = SyntaxTreeC[]
+        defs = SyntaxTree[]
         assign_blocks = BitSet()       # for undef (includes :isdefined)
         real_assign_blocks = BitSet()  # for dead store (only :assign)
         use_blocks = BitSet()
-        event_trees = Dict{Int,SyntaxTreeC}()
+        event_trees = Dict{Int,SyntaxTree}()
         for evt in evts
             event_trees[evt.block_id] = evt.st
             if evt.kind === :assign
@@ -1002,15 +1002,15 @@ function analyze_local_def_use!(
 
         # --- Undef analysis ---
         if isempty(use_blocks)
-            undef_info[binfo] = UndefInfo(defs, Pair{Bool,SyntaxTreeC}[])
+            undef_info[binfo] = UndefInfo(defs, Pair{Bool,SyntaxTree}[])
         elseif isempty(assign_blocks)
-            undef_uses = Pair{Bool,SyntaxTreeC}[true => event_trees[ub] for ub in use_blocks]
+            undef_uses = Pair{Bool,SyntaxTree}[true => event_trees[ub] for ub in use_blocks]
             undef_info[binfo] = UndefInfo(defs, undef_uses)
         else
             reached = cfg_reachable_targets(cfg.lin.blocks, 1, use_blocks, assign_blocks, visited)
             if !isempty(reached)
                 min_assign_block = minimum(assign_blocks)
-                undef_uses = Pair{Bool,SyntaxTreeC}[]
+                undef_uses = Pair{Bool,SyntaxTree}[]
                 for ub in reached
                     is_strict = ub < min_assign_block &&
                                 cfg_is_must_execute(cfg.lin.blocks, ub, cfg.exit_blocks, visited)
@@ -1018,7 +1018,7 @@ function analyze_local_def_use!(
                 end
                 undef_info[binfo] = UndefInfo(defs, undef_uses)
             else
-                undef_info[binfo] = UndefInfo(defs, Pair{Bool,SyntaxTreeC}[])
+                undef_info[binfo] = UndefInfo(defs, Pair{Bool,SyntaxTree}[])
             end
         end
 
@@ -1027,7 +1027,7 @@ function analyze_local_def_use!(
            isempty(use_blocks) || isempty(real_assign_blocks)
             continue
         end
-        dead_defs = SyntaxTreeC[]
+        dead_defs = SyntaxTree[]
         other_assigns = BitSet()
         for def_block_id in real_assign_blocks
             empty!(other_assigns)
@@ -1054,8 +1054,8 @@ end
 function analyze_lambda!(
         undef_info::Dict{JL.BindingInfo, UndefInfo},
         dead_store_info::Dict{JL.BindingInfo, DeadStoreInfo},
-        unreachable_statements::Set{SyntaxTreeC},
-        ctx3::JL.VariableAnalysisContext, lambda_st3::SyntaxTreeC,
+        unreachable_statements::Set{SyntaxTree},
+        ctx3::JL.VariableAnalysisContext, lambda_st3::SyntaxTree,
         allow_noreturn_optimization::Vector{Symbol}
     )
     cfg = @something build_lambda_cfg(ctx3, lambda_st3; allow_noreturn_optimization) return
@@ -1086,7 +1086,7 @@ all three CFG-aware analyses on it:
 
 - **Unreachable-code analysis** — collects `K"block"` children whose
   CFG block is not reachable from the lambda entry. Returned as
-  `Set{SyntaxTreeC}`. Because the CFG accurately models
+  `Set{SyntaxTree}`. Because the CFG accurately models
   expression-nested control transfers, patterns like
   `return cnd ? @goto(fallback) : println("Return"); @label fallback; <code>`
   correctly keep `<code>` reachable via the goto edge.
@@ -1098,7 +1098,7 @@ per-lambda intermediate dicts/sets are allocated and merged.
 # Arguments
 - `ctx3::JL.VariableAnalysisContext`: the variable-analysis context
   produced by JuliaLowering's scope-resolution pass.
-- `st3::SyntaxTreeC`: scope-resolved syntax tree to analyze. Top-
+- `st3::SyntaxTree`: scope-resolved syntax tree to analyze. Top-
   level (non-lambda) constructs are skipped.
 - `allow_noreturn_optimization::Vector{Symbol}`: globals (typically
   function names) whose calls should be treated as guaranteed
@@ -1111,13 +1111,13 @@ Macro-expanded code is best fed in after `_remove_macrocalls` for old-style macr
 expression positions that this analysis is not designed to handle correctly.
 """
 function analyze_all_lambdas(
-        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC;
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTree;
         allow_noreturn_optimization::Vector{Symbol} = Symbol[]
     )
     undef_info = Dict{JL.BindingInfo, UndefInfo}()
     dead_store_info = Dict{JL.BindingInfo, DeadStoreInfo}()
-    unreachable_statements = Set{SyntaxTreeC}()
-    traverse(st3) do st3′::SyntaxTreeC
+    unreachable_statements = Set{SyntaxTree}()
+    traverse(st3) do st3′::SyntaxTree
         if JS.kind(st3′) in JS.KSet"lambda toplevel_lambda"
             analyze_lambda!(
                 undef_info, dead_store_info, unreachable_statements,

--- a/src/analysis/occurrence-analysis.jl
+++ b/src/analysis/occurrence-analysis.jl
@@ -1,6 +1,6 @@
 """
     compute_binding_occurrences(
-            ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, world::UInt;
+            ctx3::JL.VariableAnalysisContext, st3::SyntaxTree, world::UInt;
             include_global_bindings::Bool = false,
             generated_resolutions::Union{Nothing,Vector{InertResolution}} = nothing
         ) -> binding_occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}}
@@ -10,7 +10,7 @@ Analyze a lowered syntax tree to find all occurrences of local and argument bind
 This function traverses the syntax tree `st3` and records `occurrence::BindingOccurrence`s
 for each local and argument binding within `st3`, where `occurrence` have the following
 information:
-- `occurrence.tree::SyntaxTreeC`: Syntax tree for this occurrence of the binding
+- `occurrence.tree::SyntaxTree`: Syntax tree for this occurrence of the binding
 - `occurrence.kind::Symbol`
   - `:decl` - explicit declarations like `local x`
   - `:def` - assignments or function arguments
@@ -37,7 +37,7 @@ a set of `BindingOccurrence` objects that record where and how the binding appea
     variable diagnostics or comprehensive binding analysis.
 """
 function compute_binding_occurrences(
-        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, world::UInt;
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTree, world::UInt;
         include_global_bindings::Bool = false,
         generated_resolutions::Union{Nothing,Vector{InertResolution}} = nothing
     )
@@ -166,7 +166,7 @@ self-recursive calls, which have distinct byte ranges.
 const SkipRecording = Dict{JL.BindingInfo,UnitRange{Int}}
 
 function may_record_occurrence!(occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
-        kind::Symbol, st::SyntaxTreeC, ctx3::JL.VariableAnalysisContext;
+        kind::Symbol, st::SyntaxTree, ctx3::JL.VariableAnalysisContext;
         skip_recording::Union{Nothing,SkipRecording} = nothing
     )
     if JS.kind(st) === JS.K"BindingId"
@@ -178,7 +178,7 @@ function may_record_occurrence!(occurrences::Dict{JL.BindingInfo,Set{BindingOccu
 end
 
 function _may_record_occurrence!(occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
-        kind::Symbol, st::SyntaxTreeC, binfo::JL.BindingInfo;
+        kind::Symbol, st::SyntaxTree, binfo::JL.BindingInfo;
         skip_recording::Union{Nothing,SkipRecording} = nothing
     )
     haskey(occurrences, binfo) || return
@@ -197,7 +197,7 @@ is_kwsorter_func(b::JL.BindingInfo) = startswith(b.name, '#') && endswith(b.name
 
 function compute_binding_occurrences!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
-        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC;
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTree;
         include_global_bindings::Bool = false,
         skip_recording_uses::Union{Nothing,SkipRecording} = nothing
     )
@@ -356,13 +356,13 @@ function get_cached_global_binding_occurrences(
 end
 
 function find_global_binding_occurrences_from_tree!(
-        state::ServerState, uri::URI, fi::FileInfo, st0_top::SyntaxTreeC, binfo::JL.BindingInfo;
+        state::ServerState, uri::URI, fi::FileInfo, st0_top::SyntaxTree, binfo::JL.BindingInfo;
         lookup_func = gen_lookup_out_of_scope!(state, uri),
     )
     cached = get_cached_global_binding_occurrences(state, uri, binfo)
     cached === nothing || return cached
     globals = BindingOccurrencesResult()
-    iterate_toplevel_tree(st0_top) do st0::SyntaxTreeC
+    iterate_toplevel_tree(st0_top) do st0::SyntaxTree
         binding_occurrences = @something get_binding_occurrences!(
             state, uri, fi, st0; lookup_func) return
         add_global_binding_occurrences!(globals, binding_occurrences)
@@ -410,7 +410,7 @@ end
 # pass a custom `lookup_func` use isolated `ServerState` instances and
 # therefore don't collide with the production cache.
 function get_binding_occurrences!(
-        state::ServerState, uri::URI, fi::FileInfo, st0::SyntaxTreeC;
+        state::ServerState, uri::URI, fi::FileInfo, st0::SyntaxTree;
         lookup_func = gen_lookup_out_of_scope!(state, uri),
     )
     cache_uri = canonical_cache_uri(state, uri)
@@ -440,7 +440,7 @@ function get_binding_occurrences!(
 end
 
 function compute_full_binding_occurrences(
-        state::ServerState, uri::URI, fi::FileInfo, st0::SyntaxTreeC;
+        state::ServerState, uri::URI, fi::FileInfo, st0::SyntaxTree;
         lookup_func = gen_lookup_out_of_scope!(state, uri),
     )
     soft_scope = is_notebook_cell_uri(state, uri) ||
@@ -487,9 +487,9 @@ end
 
 function collect_struct_inner_constructor_occurrences!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
-        ctx3::JL.VariableAnalysisContext, st0::SyntaxTreeC
+        ctx3::JL.VariableAnalysisContext, st0::SyntaxTree
     )
-    foreach_struct_inner_constructor(st0) do name_node::SyntaxTreeC, constructor_node::SyntaxTreeC
+    foreach_struct_inner_constructor(st0) do name_node::SyntaxTree, constructor_node::SyntaxTree
         binding = @something _find_internal_global_binding_at_source(ctx3, name_node) return true
         binfo = JL.get_binding(ctx3, binding)
         boccs = get!(Set{BindingOccurrence}, occurrences, binfo)
@@ -502,14 +502,14 @@ end
 
 # Standalone `BindingInfo` key (id 0, never registered with a `Bindings`) for
 # surface-only occurrences that lowering doesn't produce bindings for.
-surface_global_binfo(name::String, node::SyntaxTreeC, mod::Module) =
+surface_global_binfo(name::String, node::SyntaxTree, mod::Module) =
     JL.BindingInfo(JL.IdTag(0), name, :global, node, mod, nothing, 0,
         false, false, false, false, false, false, false, false, false, false,
         false, false, false)
 
 function collect_export_public_occurrences!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
-        st0::SyntaxTreeC, context_module::Module
+        st0::SyntaxTree, context_module::Module
     )
     JS.kind(st0) in JS.KSet"export public" || return occurrences
     for i = 1:JS.numchildren(st0)
@@ -525,9 +525,9 @@ end
 
 function collect_import_using_occurrences!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
-        st0::SyntaxTreeC, context_module::Module
+        st0::SyntaxTree, context_module::Module
     )
-    foreach_local_import_identifier(st0) do id_st::SyntaxTreeC
+    foreach_local_import_identifier(st0) do id_st::SyntaxTree
         name = @something get_name_val(id_st) return
         binfo = surface_global_binfo(name, id_st, context_module)
         target_set = get!(Set{BindingOccurrence}, occurrences, binfo)
@@ -549,9 +549,9 @@ end
 # not descended into.
 function collect_import_export_occurrences!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
-        st0::SyntaxTreeC, context_module::Module
+        st0::SyntaxTree, context_module::Module
     )
-    traverse(st0) do st::SyntaxTreeC
+    traverse(st0) do st::SyntaxTree
         k = JS.kind(st)
         if k in JS.KSet"module quote"
             return traversal_no_recurse
@@ -569,10 +569,10 @@ end
 
 function collect_macrocall_occurrences!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
-        context_module::Module, world::UInt, st0::SyntaxTreeC;
+        context_module::Module, world::UInt, st0::SyntaxTree;
         soft_scope::Bool = false,
     )
-    traverse(st0) do st::SyntaxTreeC
+    traverse(st0) do st::SyntaxTree
         JS.kind(st) === JS.K"macrocall" || return nothing
         JS.numchildren(st) ≥ 1 || return nothing
         should_resolve_macrocall(
@@ -623,7 +623,7 @@ sync with target selection for references and rename.
 """
 function collect_inert_global_occurrences!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
-        st3::SyntaxTreeC, st0::SyntaxTreeC, context_module::Module, world::UInt,
+        st3::SyntaxTree, st0::SyntaxTree, context_module::Module, world::UInt,
         generated_resolutions::Vector{InertResolution};
         soft_scope::Bool = false,
     )
@@ -633,7 +633,7 @@ function collect_inert_global_occurrences!(
     end
 
     seen = Set{Tuple{JS.Kind,UnitRange{Int}}}()
-    traverse(st3) do inert_tree::SyntaxTreeC
+    traverse(st3) do inert_tree::SyntaxTree
         is_import_eval_call(inert_tree) && return traversal_no_recurse
         JS.kind(inert_tree) in JS.KSet"inert syntaxinert" || return nothing
         JS.numchildren(inert_tree) >= 1 || return nothing

--- a/src/analysis/occurrence-analysis.jl
+++ b/src/analysis/occurrence-analysis.jl
@@ -257,21 +257,22 @@ function compute_binding_occurrences!(
                 end
                 continue
             end
-        elseif k === JS.K"lambda"
+        elseif k in JS.KSet"lambda toplevel_lambda"
             # All blocks except the last one define arguments and static parameters,
             # so we recurse to avoid counting them as usage
-            if nc ≥ 2
-                arglist = st[1]
+            start_idx = 2 # skip the K"LambdaBindings" leaf
+            if nc ≥ 3
+                arglist = st[2]
                 for i = 1:JS.numchildren(arglist)
                     may_record_occurrence!(occurrences, :def, arglist[i], ctx3)
                 end
-                start_idx = 2
-                if nc ≥ 3
-                    sparamlist = st[2]
+                start_idx = 3
+                if nc ≥ 4
+                    sparamlist = st[3]
                     for i = 1:JS.numchildren(sparamlist)
                         may_record_occurrence!(occurrences, :def, sparamlist[i], ctx3)
                     end
-                    start_idx = 3
+                    start_idx = 4
                 end
             end
         elseif k === JS.K"="
@@ -499,6 +500,13 @@ function collect_struct_inner_constructor_occurrences!(
     return occurrences
 end
 
+# Standalone `BindingInfo` key (id 0, never registered with a `Bindings`) for
+# surface-only occurrences that lowering doesn't produce bindings for.
+surface_global_binfo(name::String, node::SyntaxTreeC, mod::Module) =
+    JL.BindingInfo(JL.IdTag(0), name, :global, node, mod, nothing, 0,
+        false, false, false, false, false, false, false, false, false, false,
+        false, false, false)
+
 function collect_export_public_occurrences!(
         occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
         st0::SyntaxTreeC, context_module::Module
@@ -508,7 +516,7 @@ function collect_export_public_occurrences!(
         child = st0[i]
         JS.kind(child) === JS.K"Identifier" || continue
         name = @something get_name_val(child) continue
-        binfo = JL.BindingInfo(0, name, :global, 0; mod=context_module)
+        binfo = surface_global_binfo(name, child, context_module)
         target_set = get!(Set{BindingOccurrence}, occurrences, binfo)
         push!(target_set, BindingOccurrence(child, :use))
     end
@@ -521,7 +529,7 @@ function collect_import_using_occurrences!(
     )
     foreach_local_import_identifier(st0) do id_st::SyntaxTreeC
         name = @something get_name_val(id_st) return
-        binfo = JL.BindingInfo(0, name, :global, 0; mod=context_module)
+        binfo = surface_global_binfo(name, id_st, context_module)
         target_set = get!(Set{BindingOccurrence}, occurrences, binfo)
         push!(target_set, BindingOccurrence(id_st, :decl))
         return

--- a/src/code-action.jl
+++ b/src/code-action.jl
@@ -73,9 +73,9 @@ function handle_CodeActionRequest(
     return send(server, CodeActionResponse(; id = msg.id, result = code_actions))
 end
 
-first_syntax_node(nodes::SyntaxListC) = isempty(nodes) ? nothing : nodes[1]
+first_syntax_node(nodes::SyntaxList) = isempty(nodes) ? nothing : nodes[1]
 
-function macrocall_at_range(st0_top::SyntaxTreeC, range::UnitRange{Int})
+function macrocall_at_range(st0_top::SyntaxTree, range::UnitRange{Int})
     macrocall = first_syntax_node(byte_ancestors(
         st -> JS.kind(st) === JS.K"macrocall", st0_top, range))
     macrocall !== nothing && return macrocall
@@ -135,15 +135,15 @@ function push_code_view_action!(
     return code_actions
 end
 
-function toplevel_contains_macrocall(st0::SyntaxTreeC)
-    found = traverse(st0) do st::SyntaxTreeC
+function toplevel_contains_macrocall(st0::SyntaxTree)
+    found = traverse(st0) do st::SyntaxTree
         JS.kind(st) === JS.K"macrocall" || return nothing
         return TraversalReturn(true; terminate=true)
     end
     return found === true
 end
 
-function macrocall_name(macrocall::SyntaxTreeC)
+function macrocall_name(macrocall::SyntaxTree)
     JS.numchildren(macrocall) >= 1 || return "macro"
     return JS.sourcetext(macrocall[1])
 end

--- a/src/code-views.jl
+++ b/src/code-views.jl
@@ -18,7 +18,7 @@ const MACRO_EXPANSION_CONTENT_PATH = "/macro-expanded.jl"
 # the default (call-site) expands a single macrocall one level, while `mode=toplevel`
 # recursively expands every macrocall in a lowerable top-level form. The byte range names
 # the macrocall or the top-level form respectively.
-function macro_expansion_content_uri(source_uri::URI, node::SyntaxTreeC; toplevel::Bool=false)
+function macro_expansion_content_uri(source_uri::URI, node::SyntaxTree; toplevel::Bool=false)
     range = JS.byte_range(node)
     parts = String[
         "source=$(LSP.URIs2.escapeuri(string(source_uri)))",
@@ -32,16 +32,16 @@ function macro_expansion_content_uri(source_uri::URI, node::SyntaxTreeC; topleve
         query = join(parts, '&'))
 end
 
-function find_macrocall_by_range(st0_top::SyntaxTreeC, range::UnitRange{<:Integer})
-    return traverse(st0_top) do st::SyntaxTreeC
+function find_macrocall_by_range(st0_top::SyntaxTree, range::UnitRange{<:Integer})
+    return traverse(st0_top) do st::SyntaxTree
         JS.kind(st) === JS.K"macrocall" || return nothing
         JS.byte_range(st) == range || return nothing
         return TraversalReturn(st; terminate=true)
     end
 end
 
-function find_toplevel_tree_by_range(st0_top::SyntaxTreeC, range::UnitRange{<:Integer})
-    return iterate_toplevel_tree(st0_top) do st0::SyntaxTreeC
+function find_toplevel_tree_by_range(st0_top::SyntaxTree, range::UnitRange{<:Integer})
+    return iterate_toplevel_tree(st0_top) do st0::SyntaxTree
         JS.byte_range(st0) == range || return nothing
         return TraversalReturn(st0; terminate=true)
     end
@@ -103,7 +103,7 @@ function strip_macro_expansion_linenums!(@nospecialize(x))
     return x
 end
 
-function print_macrocall_provenance(io::IO, macrocall::SyntaxTreeC)
+function print_macrocall_provenance(io::IO, macrocall::SyntaxTree)
     buf = IOBuffer()
     JL.showprov(buf, macrocall; note = "the macro call being expanded",
         context_lines_before=3, context_lines_after=3)
@@ -139,7 +139,7 @@ function print_expansion_error_trace(io::IO, @nospecialize(err), bt)
     return nothing
 end
 
-function format_macro_expansion_text(macrocall::SyntaxTreeC, @nospecialize expanded)
+function format_macro_expansion_text(macrocall::SyntaxTree, @nospecialize expanded)
     io = IOBuffer()
     println(io, "# Macro call:")
     print_macrocall_provenance(io, macrocall)
@@ -148,7 +148,7 @@ function format_macro_expansion_text(macrocall::SyntaxTreeC, @nospecialize expan
     return String(take!(io))
 end
 
-function format_macro_expansion_error_text(macrocall::SyntaxTreeC, @nospecialize(err), bt)
+function format_macro_expansion_error_text(macrocall::SyntaxTree, @nospecialize(err), bt)
     io = IOBuffer()
     println(io, "# Macro call:")
     print_macrocall_provenance(io, macrocall)
@@ -243,7 +243,7 @@ end
 
 const TYPE_ANNOTATION_CONTENT_PATH = "/type-annotated.jl"
 
-function type_annotation_content_uri(source_uri::URI, tree::SyntaxTreeC)
+function type_annotation_content_uri(source_uri::URI, tree::SyntaxTree)
     range = JS.byte_range(tree)
     query = join((
         "source=$(LSP.URIs2.escapeuri(string(source_uri)))",
@@ -257,7 +257,7 @@ function type_annotation_content_uri(source_uri::URI, tree::SyntaxTreeC)
 end
 
 function collect_type_annotation_hints(
-        state::ServerState, fi::FileInfo, uri::URI, tree::SyntaxTreeC
+        state::ServerState, fi::FileInfo, uri::URI, tree::SyntaxTree
     )
     startpos = offset_to_xy(fi, JS.first_byte(tree))
     endpos = offset_to_xy(fi, JS.last_byte(tree) + 1)

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -229,9 +229,9 @@ function to_completion(
         label_desc = "sparam"
     end
 
-    typeid = binding.type
-    if !isnothing(typeid)
-        label_detail = "::" * JS.sourcetext(SyntaxTreeC(JS.syntax_graph(st), typeid))
+    typenode = binding.type
+    if !isnothing(typenode)
+        label_detail = "::" * JS.sourcetext(typenode)
     end
 
     io = IOBuffer()

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -105,7 +105,7 @@ mutable struct CompletionCtx
 
     # Eagerly populated by the constructor.
     const offset::Int
-    const st0_top::SyntaxTreeC
+    const st0_top::SyntaxTree
     const context_module::Module
     const world::UInt
     const postprocessor::LSPostProcessor
@@ -114,7 +114,7 @@ mutable struct CompletionCtx
     # Lazily populated. `isdefiend` check distinguishes "not yet computed" from
     # "computed but the underlying build returned `nothing`".
     inferred_ctx::Union{Nothing,InferredTreeContext}
-    cursor_bindings::Union{Nothing,Vector{Tuple{JL.BindingInfo,SyntaxTreeC,Int}}}
+    cursor_bindings::Union{Nothing,Vector{Tuple{JL.BindingInfo,SyntaxTree,Int}}}
 
     function CompletionCtx(
             state::ServerState, uri::URI, fi::FileInfo, pos::Position,
@@ -149,7 +149,7 @@ end
 # source where the cursor's incomplete `.partial` accessor is removed, instead of
 # teaching generic AST repair every parser-recovery shape around `prefix.│`.
 function get_dotprefix_inferred_ctx(
-        comp_ctx::CompletionCtx, dotprefix::SyntaxTreeC; caller::AbstractString
+        comp_ctx::CompletionCtx, dotprefix::SyntaxTree; caller::AbstractString
     )
     hole_start = JS.last_byte(dotprefix) + 1
     hole_end = property_completion_hole_end(comp_ctx.fi, comp_ctx.offset, hole_start)
@@ -208,7 +208,7 @@ end
 # =================
 
 function to_completion(
-        binding::JL.BindingInfo, st::SyntaxTreeC, sort_offset::Int,
+        binding::JL.BindingInfo, st::SyntaxTree, sort_offset::Int,
         uri::URI, fi::FileInfo
     )
     label_kind = CompletionItemKind.Variable
@@ -671,7 +671,7 @@ end
 # call completions (method signatures and keyword arguments)
 # ==========================================================
 
-function extract_param_text(p::SyntaxTreeC)
+function extract_param_text(p::SyntaxTree)
      k = JS.kind(p)
     if k === JS.K"Identifier"
         return get_name_val(p)
@@ -751,7 +751,7 @@ function cursor_equals_position(ca::CallArgs, b::Int)
     return nothing
 end
 
-function extract_kwarg_name_str(p::SyntaxTreeC)
+function extract_kwarg_name_str(p::SyntaxTree)
     node = @something extract_kwarg_name(p; sig=true) return nothing
     return get_name_val(node)
 end

--- a/src/declaration.jl
+++ b/src/declaration.jl
@@ -50,7 +50,7 @@ end
 
 """
     find_declaration(server, uri, fi, pos; soft_scope, fallback_to_definition=false) ->
-        Union{Tuple{Vector{Location}, SyntaxTreeC}, Nothing}
+        Union{Tuple{Vector{Location}, SyntaxTree}, Nothing}
 
 Core routine behind `textDocument/declaration`. On success returns the
 declaration locations for the symbol at `pos` (source-level `:decl`

--- a/src/definition.jl
+++ b/src/definition.jl
@@ -103,7 +103,7 @@ end
 
 """
     find_definition(server, uri, fi, pos; soft_scope) ->
-        Union{Tuple{Vector{Location}, SyntaxTreeC}, Nothing}
+        Union{Tuple{Vector{Location}, SyntaxTree}, Nothing}
 
 Core routine behind `textDocument/definition`. On success returns
 `(locations, origin_node)` where `origin_node` is the syntax-tree node that
@@ -195,8 +195,8 @@ end
 # is unresolvable (e.g. typo, or rename without re-running full-analysis), so
 # Phase 2's binding pass takes over.
 function find_call_dispatch_definitions(
-        state::ServerState, uri::URI, st0::SyntaxTreeC,
-        node::SyntaxTreeC, ctx::InferredTreeContext,
+        state::ServerState, uri::URI, st0::SyntaxTree,
+        node::SyntaxTree, ctx::InferredTreeContext,
     )
     call_node = @something enclosing_call_for_matches(st0, node) return nothing
     matches = @something get_matches_for_range(ctx, JS.byte_range(call_node)) return nothing
@@ -213,7 +213,7 @@ end
 # `nothing` when no binding was selected or no `:def` was reachable from
 # the binding info.
 function find_binding_definitions(
-        server::Server, uri::URI, fi::FileInfo, st0::SyntaxTreeC,
+        server::Server, uri::URI, fi::FileInfo, st0::SyntaxTree,
         offset::Int, context_module::Module, world::UInt;
         soft_scope::Bool = false
     )
@@ -271,7 +271,7 @@ end
 #   for call-like surfaces.
 function find_value_definitions(
         state::ServerState, uri::URI, context_module::Module,
-        node::SyntaxTreeC, rng::UnitRange{Int},
+        node::SyntaxTree, rng::UnitRange{Int},
         ctx::Union{Nothing,InferredTreeContext}, world::UInt,
     )
     if ctx === nothing
@@ -297,7 +297,7 @@ end
 # at Phase 3, jump to the matched operator dispatch instead.
 function find_operator_dispatch_definitions(
         state::ServerState, uri::URI,
-        node::SyntaxTreeC, rng::UnitRange{Int},
+        node::SyntaxTree, rng::UnitRange{Int},
         ctx::InferredTreeContext,
     )
     JS.kind(node) in _OPERATOR_CALL_KINDS || return nothing

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -561,7 +561,7 @@ end
 # lowering diagnostic
 # ===================
 
-const JL_MACRO_FILE = only(methods(JL.expand_macro, (JL.MacroExpansionContext, SyntaxTreeC))).file
+const JL_MACRO_FILE = only(methods(JL.expand_macro, (JL.MacroExpansionContext, SyntaxTree))).file
 function scrub_expand_macro_stacktrace(stacktrace::Vector{Base.StackTraces.StackFrame})
     idx = @something findfirst(stacktrace) do stackframe::Base.StackTraces.StackFrame
         stackframe.func === :expand_macro && stackframe.file === JL_MACRO_FILE
@@ -641,10 +641,10 @@ end
 # sit under a `K"parameters"` node, so we track that during the walk.
 # An explicit stack is used (instead of recursion) so we don't risk overflowing
 # the C stack on pathologically deep user input.
-function compute_kwarg_type_annotation_names(st0::SyntaxTreeC)
+function compute_kwarg_type_annotation_names(st0::SyntaxTree)
     type_names = Dict{Tuple{Int,Int},Set{String}}()
     locations = Set{Tuple{Int,Int}}()
-    stack = Tuple{SyntaxTreeC,Bool}[(st0, false)]
+    stack = Tuple{SyntaxTree,Bool}[(st0, false)]
     while !isempty(stack)
         (node, in_parameters) = pop!(stack)
         k = JS.kind(node)
@@ -701,7 +701,7 @@ function has_matching_argument_binding(
     return false
 end
 
-function is_assignment_expression(st::SyntaxTreeC)
+function is_assignment_expression(st::SyntaxTree)
     k = JS.kind(st)
     k === JS.K"=" && return true
     if k === JS.K"unknown_head"
@@ -711,29 +711,29 @@ function is_assignment_expression(st::SyntaxTreeC)
     return false
 end
 
-same_syntax_range(a::SyntaxTreeC, b::SyntaxTreeC) =
+same_syntax_range(a::SyntaxTree, b::SyntaxTree) =
     JS.kind(a) === JS.kind(b) && JS.byte_range(a) == JS.byte_range(b)
 
-function is_last_child(parent::SyntaxTreeC, child::SyntaxTreeC)
+function is_last_child(parent::SyntaxTree, child::SyntaxTree)
     n = JS.numchildren(parent)
     n == 0 && return false
     return same_syntax_range(parent[n], child)
 end
 
-function is_tail_branch_child(parent::SyntaxTreeC, child::SyntaxTreeC)
+function is_tail_branch_child(parent::SyntaxTree, child::SyntaxTree)
     for i in 2:JS.numchildren(parent)
         same_syntax_range(parent[i], child) && return true
     end
     return false
 end
 
-function assignment_expression_for_prov(st0::SyntaxTreeC, prov::SyntaxTreeC)
+function assignment_expression_for_prov(st0::SyntaxTree, prov::SyntaxTree)
     assignments = byte_ancestors(is_assignment_expression, st0, JS.byte_range(prov))
     isempty(assignments) && return nothing
     return first(assignments)
 end
 
-function is_struct_type_parameter_declaration(st0::SyntaxTreeC, prov::SyntaxTreeC)
+function is_struct_type_parameter_declaration(st0::SyntaxTree, prov::SyntaxTree)
     ancestors = byte_ancestors(st0, JS.byte_range(prov))
     for i = 2:length(ancestors)
         curly = ancestors[i]
@@ -766,7 +766,7 @@ function is_struct_type_parameter_declaration(st0::SyntaxTreeC, prov::SyntaxTree
 end
 
 function tail_returned_assignment_kind(
-        st0::SyntaxTreeC, assignment::Union{Nothing,SyntaxTreeC}
+        st0::SyntaxTree, assignment::Union{Nothing,SyntaxTree}
     )
     isnothing(assignment) && return :none
     ancestors = byte_ancestors(st0, JS.byte_range(assignment))
@@ -807,7 +807,7 @@ function unused_assignment_message(bn::String, tail_kind::Symbol)
 end
 
 function return_insert_data(
-        assignment::SyntaxTreeC, fi::FileInfo, bn::String, tail_kind::Symbol
+        assignment::SyntaxTree, fi::FileInfo, bn::String, tail_kind::Symbol
     )
     tail_kind === :simple || return nothing, nothing
     range = jsobj_to_range(assignment, fi)
@@ -815,15 +815,15 @@ function return_insert_data(
     return range.var"end", "\n$(indent)return $bn"
 end
 
-function collect_binding_ids!(ids::Set{JL.IdTag}, st::SyntaxTreeC)
-    traverse(st) do node::SyntaxTreeC
+function collect_binding_ids!(ids::Set{JL.IdTag}, st::SyntaxTree)
+    traverse(st) do node::SyntaxTree
         JS.kind(node) === JS.K"BindingId" && push!(ids, JL.syntax_id(node))
         return nothing
     end
     return ids
 end
 
-function method_typevars(ctx3::JL.VariableAnalysisContext, method::SyntaxTreeC)
+function method_typevars(ctx3::JL.VariableAnalysisContext, method::SyntaxTree)
     JS.kind(method) === JS.K"method" && JS.numchildren(method) == 3 || return nothing
     arg_types = method[2]
     is_core_svec_call(arg_types) || return nothing
@@ -844,10 +844,10 @@ end
 
 function analyze_unconstrained_static_parameters!(
         diagnostics::Vector{Diagnostic}, fi::FileInfo, ctx3::JL.VariableAnalysisContext,
-        st3::SyntaxTreeC, reported::Set{LoweringDiagnosticKey}
+        st3::SyntaxTree, reported::Set{LoweringDiagnosticKey}
     )
-    methods = Tuple{SyntaxTreeC,Vector{JL.IdTag}}[]
-    traverse(st3) do node::SyntaxTreeC
+    methods = Tuple{SyntaxTree,Vector{JL.IdTag}}[]
+    traverse(st3) do node::SyntaxTree
         result = method_typevars(ctx3, node)
         result === nothing || push!(methods, result)
         return nothing
@@ -897,7 +897,7 @@ function analyze_unconstrained_static_parameters!(
 end
 
 function analyze_unused_bindings!(
-        diagnostics::Vector{Diagnostic}, fi::FileInfo, st0::SyntaxTreeC, ctx3::JL.VariableAnalysisContext,
+        diagnostics::Vector{Diagnostic}, fi::FileInfo, st0::SyntaxTree, ctx3::JL.VariableAnalysisContext,
         binding_occurrences::Dict{JL.BindingInfo,Set{BindingOccurrence}},
         has_implicit_args::Bool, reported::Set{LoweringDiagnosticKey},
         kwarg_type_names::Dict{Tuple{Int,Int},Set{String}},
@@ -966,7 +966,7 @@ function analyze_unused_bindings!(
 end
 
 function analyze_unused_assignments!(
-        diagnostics::Vector{Diagnostic}, fi::FileInfo, st0::SyntaxTreeC,
+        diagnostics::Vector{Diagnostic}, fi::FileInfo, st0::SyntaxTree,
         dead_store_info::Dict{JL.BindingInfo, DeadStoreInfo},
         reported::Set{LoweringDiagnosticKey};
         allow_unused_underscore::Bool,
@@ -1137,7 +1137,7 @@ function analyze_undefined_local_bindings!(
 end
 
 function compute_unused_variable_data(
-        assignment::SyntaxTreeC, fi::FileInfo, bn::String, tail_kind::Symbol
+        assignment::SyntaxTree, fi::FileInfo, bn::String, tail_kind::Symbol
     )
     JS.numchildren(assignment) ≥ 2 || return nothing
 
@@ -1176,7 +1176,7 @@ end
 
 function analyze_captured_boxes!(
         diagnostics::Vector{Diagnostic}, uri::URI, fi::FileInfo,
-        ctx4::JL.ClosureConversionCtx, st3::SyntaxTreeC,
+        ctx4::JL.ClosureConversionCtx, st3::SyntaxTree,
         reported::Set{LoweringDiagnosticKey}
     )
     for binfo in ctx4.bindings.info
@@ -1218,7 +1218,7 @@ function is_captured_binding(binfo::JL.BindingInfo, ctx4::JL.ClosureConversionCt
 end
 
 function find_capture_sites(
-        st3::SyntaxTreeC, binfo::JL.BindingInfo, ctx4::JL.ClosureConversionCtx,
+        st3::SyntaxTree, binfo::JL.BindingInfo, ctx4::JL.ClosureConversionCtx,
         uri::URI, fi::FileInfo
     )
     relatedInformation = DiagnosticRelatedInformation[]
@@ -1227,7 +1227,7 @@ function find_capture_sites(
             haskey(lambda.locals_capt, binfo.id) || continue
             lambda.locals_capt[binfo.id] || continue
             # Find the lambda in st3 that has matching lambda_bindings.self
-            traverse(st3) do node3::SyntaxTreeC
+            traverse(st3) do node3::SyntaxTree
                 JS.kind(node3) === JS.K"lambda" || return nothing
                 JS.numchildren(node3) >= 1 || return nothing
                 lbnode = node3[1]
@@ -1235,7 +1235,7 @@ function find_capture_sites(
                 lambda_bindings = JL.lambda_bindings(lbnode)
                 lambda_bindings.self == lambda.self || return nothing
                 # Find references to binfo.id inside this lambda
-                traverse(node3) do inner::SyntaxTreeC
+                traverse(node3) do inner::SyntaxTree
                     if JS.kind(inner) === JS.K"BindingId" && JL.syntax_id(inner) == binfo.id
                         varprov = last(JL.flattened_provenance(inner))
                         push!(relatedInformation, DiagnosticRelatedInformation(;
@@ -1286,9 +1286,9 @@ const SORT_IMPORTS_MAX_LINE_LENGTH = 92
 const SORT_IMPORTS_INDENT = "    "
 
 function analyze_unsorted_imports!(
-        diagnostics::Vector{Diagnostic}, fi::FileInfo, st0::SyntaxTreeC
+        diagnostics::Vector{Diagnostic}, fi::FileInfo, st0::SyntaxTree
     )
-    traverse(st0) do st0′::SyntaxTreeC
+    traverse(st0) do st0′::SyntaxTree
         kind = JS.kind(st0′)
         if kind ∉ JS.KSet"import using export public"
             return nothing
@@ -1314,7 +1314,7 @@ function analyze_unsorted_imports!(
 end
 
 function generate_sorted_import_text(
-        node::SyntaxTreeC, sorted_name_keys::Vector{Pair{SyntaxTreeC,String}},
+        node::SyntaxTree, sorted_name_keys::Vector{Pair{SyntaxTree,String}},
         base_indent::String
     )
     kind = JS.kind(node)
@@ -1367,11 +1367,11 @@ end
 # `return f(@goto label); @label label; ...` are correctly recognized as
 # reachable via the goto edge.
 function analyze_unreachable_code!(
-        diagnostics::Vector{Diagnostic}, fi::FileInfo, st3::SyntaxTreeC,
-        unreachable_statements::Set{SyntaxTreeC}
+        diagnostics::Vector{Diagnostic}, fi::FileInfo, st3::SyntaxTree,
+        unreachable_statements::Set{SyntaxTree}
     )
     isempty(unreachable_statements) && return
-    traverse(st3) do st3′::SyntaxTreeC
+    traverse(st3) do st3′::SyntaxTree
         JS.kind(st3′) === JS.K"block" || return nothing
         nchildren = JS.numchildren(st3′)
         first_unreach_idx = 0
@@ -1437,9 +1437,9 @@ end
 # `compile_body` (linear IR pass), which JETLS doesn't run. Mirror that
 # check against `st3` so unresolved gotos still surface as diagnostics.
 function analyze_unresolved_gotos!(
-        diagnostics::Vector{Diagnostic}, fi::FileInfo, st3::SyntaxTreeC
+        diagnostics::Vector{Diagnostic}, fi::FileInfo, st3::SyntaxTree
     )
-    traverse(st3) do st3′::SyntaxTreeC
+    traverse(st3) do st3′::SyntaxTree
         JS.kind(st3′) in JS.KSet"lambda toplevel_lambda" || return nothing
         JS.numchildren(st3′) >= 4 || return nothing
         check_lambda_gotos!(diagnostics, fi, st3′[4])
@@ -1448,7 +1448,7 @@ function analyze_unresolved_gotos!(
 end
 
 function check_lambda_gotos!(
-        diagnostics::Vector{Diagnostic}, fi::FileInfo, body3::SyntaxTreeC
+        diagnostics::Vector{Diagnostic}, fi::FileInfo, body3::SyntaxTree
     )
     gotos, labels = collect_gotos_labels(body3)
     label_names = Set{String}(name for (name, _) in labels)
@@ -1486,15 +1486,15 @@ function check_lambda_gotos!(
     end
 end
 
-function collect_gotos_labels(st3::SyntaxTreeC)
-    gotos = Tuple{String,SyntaxTreeC}[]
-    labels = Tuple{String,SyntaxTreeC}[]
+function collect_gotos_labels(st3::SyntaxTree)
+    gotos = Tuple{String,SyntaxTree}[]
+    labels = Tuple{String,SyntaxTree}[]
     collect_gotos_labels!(gotos, labels, st3)
     return gotos, labels
 end
 function collect_gotos_labels!(
-        gotos::Vector{Tuple{String,SyntaxTreeC}}, labels::Vector{Tuple{String,SyntaxTreeC}},
-        st3::SyntaxTreeC
+        gotos::Vector{Tuple{String,SyntaxTree}}, labels::Vector{Tuple{String,SyntaxTree}},
+        st3::SyntaxTree
     )
     traverse(st3) do node
         k = JS.kind(node)
@@ -1567,7 +1567,7 @@ end
 
 function per_stmt_diagnostics!(
         diagnostics::Vector{Diagnostic}, candidates::Vector{UndefGlobalCandidate},
-        uri::URI, fi::FileInfo, st0::SyntaxTreeC, context_module::Module, world::UInt,
+        uri::URI, fi::FileInfo, st0::SyntaxTree, context_module::Module, world::UInt,
         analyzer::Union{Nothing,LSAnalyzer}, postprocessor::LSPostProcessor;
         skip_analysis_requiring_context::Bool = false,
         allow_unused_underscore::Bool = true,
@@ -1719,7 +1719,7 @@ function compute_unit_def_used_names(
         end
         search_st0_top = build_syntax_tree(search_fi)
 
-        iterate_toplevel_tree(search_st0_top) do st0::SyntaxTreeC
+        iterate_toplevel_tree(search_st0_top) do st0::SyntaxTree
             binding_occurrences = @something get_binding_occurrences!(
                 state, search_uri, search_fi, st0) return
             context_module = get_context_module(state, search_uri, offset_to_xy(search_fi, JS.first_byte(st0)))
@@ -1828,7 +1828,7 @@ end
 
 function analyze_unused_imports!(
         diagnostics::Vector{Diagnostic}, def_used_names_cache::DefUsedNamesCache,
-        server::Server, uri::URI, fi::FileInfo, st0_top::SyntaxTreeC;
+        server::Server, uri::URI, fi::FileInfo, st0_top::SyntaxTree;
         skip_context_check::Bool = false # used by tests only
     )
     mod_imported_names = collect_explicit_imports_by_module(server.state, uri, fi, st0_top)
@@ -1838,10 +1838,10 @@ function analyze_unused_imports!(
 end
 
 function collect_explicit_imports_by_module(
-        state::ServerState, uri::URI, fi::FileInfo, st0_top::SyntaxTreeC
+        state::ServerState, uri::URI, fi::FileInfo, st0_top::SyntaxTree
     )
     mod_imported_names = Dict{Module,Dict{String,Vector{ImportInfo}}}()
-    traverse(st0_top) do st0::SyntaxTreeC
+    traverse(st0_top) do st0::SyntaxTree
         JS.kind(st0) ∈ JS.KSet"import using" || return nothing
         context_module = get_context_module(state, uri, offset_to_xy(fi, JS.first_byte(st0)))
         for (name, name_range, delete_range) in collect_explicit_import_names(st0, fi)
@@ -1859,7 +1859,7 @@ end
 # Returns tuples of (name, name_range, delete_range).
 # For single imports like `using M: x`, delete_range covers the entire import statement.
 # For multiple imports like `using M: x, y`, delete_range covers the name plus comma/whitespace.
-function collect_explicit_import_names(st0::SyntaxTreeC, fi::FileInfo)
+function collect_explicit_import_names(st0::SyntaxTree, fi::FileInfo)
     kind = JS.kind(st0)
     names = Tuple{String,Range,Range}[]
     kind ∈ JS.KSet"import using" || return names
@@ -1924,7 +1924,7 @@ end
 # `ctx3` is alive. `analyze_unused_imports!` and the cross-file emit step run later in
 # `toplevel_lowering_diagnostics!` because they depend on sibling files in the unit.
 function compute_per_file_diagnostics(
-        server::Server, uri::URI, file_info::FileInfo, st0_top::SyntaxTreeC,
+        server::Server, uri::URI, file_info::FileInfo, st0_top::SyntaxTree,
         cancel_flag::CancelFlag;
         lookup_func = nothing
     )
@@ -1937,7 +1937,7 @@ function compute_per_file_diagnostics(
         collect_explicit_imports_by_module(server.state, uri, file_info, st0_top)
     allow_unused_underscore = get_config(server, :diagnostic, :allow_unused_underscore)
     soft_scope = is_notebook_cell_uri(server.state, uri)
-    iterate_toplevel_tree(st0_top) do st0::SyntaxTreeC
+    iterate_toplevel_tree(st0_top) do st0::SyntaxTree
         is_cancelled(cancel_flag) && return traversal_terminator
         pos = offset_to_xy(file_info, JS.first_byte(st0))
         (; context_module, world, analyzer, postprocessor) =
@@ -1984,7 +1984,7 @@ function get_per_file_diagnostics!(
 end
 
 function get_per_file_diagnostics!(
-        server::Server, uri::URI, file_info::FileInfo, st0_top::SyntaxTreeC,
+        server::Server, uri::URI, file_info::FileInfo, st0_top::SyntaxTree,
         cancel_flag::CancelFlag;
         lookup_func = nothing
     )

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -817,7 +817,7 @@ end
 
 function collect_binding_ids!(ids::Set{JL.IdTag}, st::SyntaxTreeC)
     traverse(st) do node::SyntaxTreeC
-        JS.kind(node) === JS.K"BindingId" && push!(ids, JL._binding_id(node))
+        JS.kind(node) === JS.K"BindingId" && push!(ids, JL.syntax_id(node))
         return nothing
     end
     return ids
@@ -828,13 +828,13 @@ function method_typevars(ctx3::JL.VariableAnalysisContext, method::SyntaxTreeC)
     arg_types = method[2]
     is_core_svec_call(arg_types) || return nothing
     lambda = method[3]
-    JS.kind(lambda) === JS.K"lambda" && JS.numchildren(lambda) >= 2 || return nothing
-    sparams = lambda[2]
+    JS.kind(lambda) === JS.K"lambda" && JS.numchildren(lambda) >= 3 || return nothing
+    sparams = lambda[3]
     JS.kind(sparams) === JS.K"block" || return nothing
     typevar_ids = JL.IdTag[]
     for sparam in JS.children(sparams)
         JS.kind(sparam) === JS.K"BindingId" || continue
-        sp_id = JL._binding_id(sparam)
+        sp_id = JL.syntax_id(sparam)
         typevar_id = get(ctx3.sp_typevars, sp_id, nothing)
         typevar_id === nothing || push!(typevar_ids, typevar_id)
     end
@@ -1229,12 +1229,14 @@ function find_capture_sites(
             # Find the lambda in st3 that has matching lambda_bindings.self
             traverse(st3) do node3::SyntaxTreeC
                 JS.kind(node3) === JS.K"lambda" || return nothing
-                JS.hasattr(node3, :lambda_bindings) || return nothing
-                lambda_bindings = node3.lambda_bindings::JL.LambdaBindings
+                JS.numchildren(node3) >= 1 || return nothing
+                lbnode = node3[1]
+                JS.kind(lbnode) === JS.K"LambdaBindings" || return nothing
+                lambda_bindings = JL.lambda_bindings(lbnode)
                 lambda_bindings.self == lambda.self || return nothing
                 # Find references to binfo.id inside this lambda
                 traverse(node3) do inner::SyntaxTreeC
-                    if JS.kind(inner) === JS.K"BindingId" && JL._binding_id(inner) == binfo.id
+                    if JS.kind(inner) === JS.K"BindingId" && JL.syntax_id(inner) == binfo.id
                         varprov = last(JL.flattened_provenance(inner))
                         push!(relatedInformation, DiagnosticRelatedInformation(;
                             location = Location(; uri, range = jsobj_to_range(varprov, fi)),
@@ -1438,9 +1440,9 @@ function analyze_unresolved_gotos!(
         diagnostics::Vector{Diagnostic}, fi::FileInfo, st3::SyntaxTreeC
     )
     traverse(st3) do st3′::SyntaxTreeC
-        JS.kind(st3′) === JS.K"lambda" || return nothing
-        JS.numchildren(st3′) >= 3 || return nothing
-        check_lambda_gotos!(diagnostics, fi, st3′[3])
+        JS.kind(st3′) in JS.KSet"lambda toplevel_lambda" || return nothing
+        JS.numchildren(st3′) >= 4 || return nothing
+        check_lambda_gotos!(diagnostics, fi, st3′[4])
         return nothing
     end
 end

--- a/src/document-highlight.jl
+++ b/src/document-highlight.jl
@@ -90,7 +90,7 @@ document_highlight_kind(occurrence::AnyBindingOccurrence) =
 
 function global_document_highlights!(
         highlights′::Dict{Range,DocumentHighlightKind.Ty},
-        state::ServerState, uri::URI, fi::FileInfo, st0_top::SyntaxTreeC,
+        state::ServerState, uri::URI, fi::FileInfo, st0_top::SyntaxTree,
         binfo::JL.BindingInfo,
     )
     for occurrence in find_global_binding_occurrences_from_tree!(state, uri, fi, st0_top, binfo)
@@ -102,7 +102,7 @@ end
 function local_document_highlights!(
         highlights′::Dict{Range,DocumentHighlightKind.Ty},
         state::ServerState, uri::URI, fi::FileInfo,
-        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC,
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTree,
         binfo::JL.BindingInfo, world::UInt,
     )
     binding_occurrences = compute_binding_occurrences(ctx3, st3, world)

--- a/src/document-link.jl
+++ b/src/document-link.jl
@@ -46,7 +46,7 @@ function collect_include_document_links!(
     )
     basedir = dirname(uri2filename(uri))
     st0_top = build_syntax_tree(fi)
-    traverse(st0_top) do node::SyntaxTreeC
+    traverse(st0_top) do node::SyntaxTree
         string_node = @something include_path_string_node(node) return
         resolved = @something resolve_path_string_literal(string_node, basedir) return
         range, _ = unadjust_range(state, uri, jsobj_to_range(string_node, fi))
@@ -59,7 +59,7 @@ end
 # If `node` is an `include("path")` call with a single non-interpolated string
 # argument, return that `K"String"` node. Otherwise return `nothing`.
 # Interpolated strings (e.g. `"$x.jl"`) parse into `K"string"` and are skipped.
-function include_path_string_node(node::SyntaxTreeC)
+function include_path_string_node(node::SyntaxTree)
     JS.kind(node) === JS.K"call" || return nothing
     JS.numchildren(node) == 2 || return nothing
     callee = node[1]

--- a/src/document-symbol.jl
+++ b/src/document-symbol.jl
@@ -686,7 +686,7 @@ function extract_testset_symbol!(
     description = if isnothing(description_node)
         ""
     elseif JS.kind(description_node) === JS.K"String"
-        JS.hasattr(description_node, :value) ? description_node.value::String : ""
+        description_node.value isa String ? description_node.value::String : ""
     else
         @something extract_string_content(description_node) ""
     end
@@ -729,7 +729,7 @@ function extract_string_content(st0::SyntaxTreeC)
     first_child = st0[1]
     if JS.numchildren(st0) == 1 && JS.kind(first_child) === JS.K"String"
         # Simple string without interpolation
-        return JS.hasattr(first_child, :value) ? first_child.value::String : nothing
+        return first_child.value isa String ? first_child.value::String : nothing
     else
         # Interpolated string - extract content from source text
         src = JS.sourcetext(st0)
@@ -1116,7 +1116,7 @@ function extract_child_scope_symbols!(
     for child_id in child_ids
         child_id in lctx.func_scope_ids && continue
         1 ≤ child_id ≤ length(ctx3.scopes) || continue
-        construct = find_scope_construct(ctx3, ctx3.scopes[child_id], lctx.parent_map, lctx.node_map)
+        construct = find_scope_construct(ctx3.scopes[child_id], lctx.parent_map, lctx.node_map)
         if construct === nothing
             push!(transparent_ids, child_id)
             continue
@@ -1217,8 +1217,7 @@ function _classify_try_clause(
     )
     1 ≤ scope_id ≤ length(ctx3.scopes) || return "try"
     scope = ctx3.scopes[scope_id]
-    scope_st = SyntaxTreeC(JS.syntax_graph(ctx3), scope.node_id)
-    prov = JS.flattened_provenance(scope_st)
+    prov = JS.flattened_provenance(scope.node_id)
     isempty(prov) && return "try"
     source_node = first(prov)
     fb = JS.first_byte(source_node)
@@ -1235,12 +1234,11 @@ function _classify_try_clause(
 end
 
 function find_scope_construct(
-        ctx3::JL.VariableAnalysisContext, scope::JL.ScopeInfo,
+        scope::JL.ScopeInfo,
         parent_map::Dict{Tuple{Int,Int},SyntaxTreeC},
         node_map::Dict{Tuple{Int,Int},SyntaxTreeC}
     )
-    scope_st = SyntaxTreeC(JS.syntax_graph(ctx3), scope.node_id)
-    prov = JS.flattened_provenance(scope_st)
+    prov = JS.flattened_provenance(scope.node_id)
     isempty(prov) && return nothing
     source_node = first(prov)
     k = JS.kind(source_node)
@@ -1334,13 +1332,12 @@ function find_anon_func_scope_ids(
     is_anonymous_function_rhs(rhs) || return nothing
     anon_body = rhs[JS.numchildren(rhs)]
     anon_fb, anon_lb = JS.first_byte(anon_body), JS.last_byte(anon_body)
-    graph = JS.syntax_graph(ctx3)
     for (func_bid, scope_ids) in func_to_scopes
         binfo = JL.get_binding(ctx3, func_bid)
         binfo.is_internal || continue
         for scope_id in scope_ids
             1 ≤ scope_id ≤ length(ctx3.scopes) || continue
-            scope_node = SyntaxTreeC(graph, ctx3.scopes[scope_id].node_id)
+            scope_node = ctx3.scopes[scope_id].node_id
             if JS.first_byte(scope_node) == anon_fb && JS.last_byte(scope_node) == anon_lb
                 return scope_ids
             end

--- a/src/document-symbol.jl
+++ b/src/document-symbol.jl
@@ -92,7 +92,7 @@ function invalidate_document_symbol_cache!(state::ServerState, uri::URI)
 end
 
 function extract_document_symbols(
-        st0_top::SyntaxTreeC, fi::FileInfo, context_module::Module, world::UInt
+        st0_top::SyntaxTree, fi::FileInfo, context_module::Module, world::UInt
     )
     @assert JS.kind(st0_top) === JS.K"toplevel"
     symbols = DocumentSymbol[]
@@ -102,7 +102,7 @@ function extract_document_symbols(
 end
 
 function extract_toplevel_symbols!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo,
         context_module::Module, world::UInt
     )
     for i = 1:JS.numchildren(st0)
@@ -111,7 +111,7 @@ function extract_toplevel_symbols!(
 end
 
 function extract_toplevel_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo,
         context_module::Module, world::UInt
     )
     k = JS.kind(st0)
@@ -150,7 +150,7 @@ function extract_toplevel_symbol!(
 end
 
 function extract_module_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo,
         parent_context_module::Module, world::UInt
     )
     JS.numchildren(st0) ≥ 3 || return nothing
@@ -181,7 +181,7 @@ function extract_module_symbol!(
 end
 
 function extract_function_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo,
         context_module::Module, world::UInt
     )
     JS.numchildren(st0) ≥ 1 || return nothing
@@ -201,7 +201,7 @@ function extract_function_symbol!(
     return nothing
 end
 
-function extract_function_name(sig::SyntaxTreeC)
+function extract_function_name(sig::SyntaxTree)
     sig = unwrap_funcdef_sig(sig)
     k = JS.kind(sig)
     if k === JS.K"call"
@@ -231,7 +231,7 @@ function extract_function_name(sig::SyntaxTreeC)
     return nothing
 end
 
-function extract_dotted_name(node::SyntaxTreeC)
+function extract_dotted_name(node::SyntaxTree)
     k = JS.kind(node)
     if JS.is_identifier(k)
         return get_name_val(node)
@@ -253,7 +253,7 @@ function extract_dotted_name(node::SyntaxTreeC)
 end
 
 function extract_macro_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo,
         context_module::Module, world::UInt
     )
     JS.numchildren(st0) ≥ 1 || return nothing
@@ -284,7 +284,7 @@ function extract_macro_symbol!(
 end
 
 function extract_struct_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo,
         context_module::Module, world::UInt
     )
     JS.numchildren(st0) ≥ 2 || return nothing
@@ -328,7 +328,7 @@ function extract_struct_symbol!(
 end
 
 function extract_struct_field!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo
     )
     field_node = st0
     k = JS.kind(st0)
@@ -352,7 +352,7 @@ function extract_struct_field!(
 end
 
 function extract_abstract_type_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo
     )
     JS.numchildren(st0) ≥ 1 || return nothing
     name_node = def_node = st0[1]
@@ -376,7 +376,7 @@ function extract_abstract_type_symbol!(
 end
 
 function extract_primitive_type_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo
     )
     JS.numchildren(st0) ≥ 2 || return nothing
     def_node = st0[1]
@@ -398,7 +398,7 @@ function extract_primitive_type_symbol!(
 end
 
 function extract_const_symbols!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo,
         context_module::Module, world::UInt
     )
     JS.numchildren(st0) ≥ 1 || return nothing
@@ -415,7 +415,7 @@ function extract_const_symbols!(
 end
 
 function extract_global_symbols!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo,
         context_module::Module, world::UInt
     )
     JS.numchildren(st0) ≥ 1 || return nothing
@@ -438,8 +438,8 @@ function extract_global_symbols!(
 end
 
 function extract_assignment_symbols!(
-        symbols::Vector{DocumentSymbol}, lhs::SyntaxTreeC,
-        rhs::Union{SyntaxTreeC,Nothing}, range::Range, kind::SymbolKind.Ty,
+        symbols::Vector{DocumentSymbol}, lhs::SyntaxTree,
+        rhs::Union{SyntaxTree,Nothing}, range::Range, kind::SymbolKind.Ty,
         detail::AbstractString, fi::FileInfo, context_module::Module, world::UInt
     )
     children = if rhs !== nothing && JS.kind(rhs) === JS.K"let"
@@ -505,7 +505,7 @@ function extract_assignment_symbols!(
 end
 
 function extract_toplevel_assignment_symbols!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo,
         context_module::Module, world::UInt
     )
     JS.numchildren(st0) ≥ 2 || return nothing
@@ -527,7 +527,7 @@ end
 
 # Short-form function definition: `f(x) = x` or `f(x) where T = x`
 function extract_short_function_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo,
         context_module::Module, world::UInt
     )
     JS.numchildren(st0) ≥ 2 || return nothing
@@ -552,7 +552,7 @@ extract_while_symbol!(args...) = extract_namespace_symbol!(args..., "while ")
 extract_for_symbol!(args...) = extract_namespace_symbol!(args..., "for ")
 
 function extract_namespace_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo,
         context_module::Module, world::UInt, prefix::AbstractString
     )
     JS.numchildren(st0) ≥ 2 || return nothing
@@ -572,10 +572,10 @@ function extract_namespace_symbol!(
 end
 
 function extract_if_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo,
         context_module::Module, world::UInt;
         prefix::AbstractString = "if ",
-        range_node::SyntaxTreeC = st0
+        range_node::SyntaxTree = st0
     )
     JS.numchildren(st0) ≥ 2 || return nothing
     children = DocumentSymbol[]
@@ -592,7 +592,7 @@ function extract_if_symbol!(
 end
 
 function extract_if_children!(
-        children::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        children::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo,
         context_module::Module, world::UInt
     )
     for i in 2:JS.numchildren(st0)
@@ -608,7 +608,7 @@ function extract_if_children!(
 end
 
 function extract_macrocalls_from_block!(
-        symbols::Vector{DocumentSymbol}, st::SyntaxTreeC, fi::FileInfo,
+        symbols::Vector{DocumentSymbol}, st::SyntaxTree, fi::FileInfo,
         context_module::Module, world::UInt
     )
     for i = 1:JS.numchildren(st)
@@ -621,7 +621,7 @@ function extract_macrocalls_from_block!(
 end
 
 function extract_macrocall_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo,
         context_module::Module, world::UInt
     )
     macro_name = get_macrocall_name(st0)
@@ -640,7 +640,7 @@ function extract_macrocall_symbol!(
 end
 
 function extract_static_if_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo,
         context_module::Module, world::UInt
     )
     JS.numchildren(st0) ≥ 3 || return nothing
@@ -651,7 +651,7 @@ function extract_static_if_symbol!(
     return nothing
 end
 
-function get_macrocall_name(st0::SyntaxTreeC)
+function get_macrocall_name(st0::SyntaxTree)
     JS.numchildren(st0) ≥ 1 || return nothing
     macro_node = st0[1]
     if JS.kind(macro_node) === JS.K"."
@@ -668,7 +668,7 @@ function get_macrocall_name(st0::SyntaxTreeC)
 end
 
 function extract_testset_symbol!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo,
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo,
         context_module::Module, world::UInt
     )
     JS.numchildren(st0) ≥ 3 || return nothing
@@ -723,7 +723,7 @@ function extract_testset_symbol!(
     return nothing
 end
 
-function extract_string_content(st0::SyntaxTreeC)
+function extract_string_content(st0::SyntaxTree)
     JS.kind(st0) === JS.K"string" || return nothing
     JS.numchildren(st0) ≥ 1 || return nothing
     first_child = st0[1]
@@ -737,7 +737,7 @@ function extract_string_content(st0::SyntaxTreeC)
     end
 end
 
-function extract_test_symbol!(symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo)
+function extract_test_symbol!(symbols::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo)
     JS.numchildren(st0) ≥ 3 || return nothing
     expr_node = st0[3]
     expr_text = lstrip(JS.sourcetext(expr_node))
@@ -750,7 +750,7 @@ function extract_test_symbol!(symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC,
     return nothing
 end
 
-function extract_enum_symbol!(symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, fi::FileInfo)
+function extract_enum_symbol!(symbols::Vector{DocumentSymbol}, st0::SyntaxTree, fi::FileInfo)
     JS.numchildren(st0) ≥ 3 || return nothing
     type_node = st0[3]
     name_node = type_node
@@ -774,7 +774,7 @@ function extract_enum_symbol!(symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC,
 end
 
 function extract_enum_value!(
-        symbols::Vector{DocumentSymbol}, st0::SyntaxTreeC, enum_name::String, fi::FileInfo
+        symbols::Vector{DocumentSymbol}, st0::SyntaxTree, enum_name::String, fi::FileInfo
     )
     if JS.kind(st0) === JS.K"block"
         for i = 1:JS.numchildren(st0)
@@ -799,7 +799,7 @@ end
 
 # Binding-based extraction for scoped children (function body, let block, etc.)
 function extract_scoped_children(
-        st0::SyntaxTreeC, fi::FileInfo, context_module::Module, world::UInt;
+        st0::SyntaxTree, fi::FileInfo, context_module::Module, world::UInt;
         soft_scope::Bool = false
     )
     (; ctx3) = try
@@ -814,14 +814,14 @@ function extract_scoped_children(
     return @somereal extract_local_symbols_from_scopes(ctx3, parent_map, node_map, fi, root_range) Some(nothing)
 end
 
-build_node_maps(st0::SyntaxTreeC) =
-    build_node_maps!(Dict{Tuple{Int,Int},SyntaxTreeC}(),
-                     Dict{Tuple{Int,Int},SyntaxTreeC}(), st0, nothing)
+build_node_maps(st0::SyntaxTree) =
+    build_node_maps!(Dict{Tuple{Int,Int},SyntaxTree}(),
+                     Dict{Tuple{Int,Int},SyntaxTree}(), st0, nothing)
 function build_node_maps!(
-        parent_map::Dict{Tuple{Int,Int},SyntaxTreeC},
-        node_map::Dict{Tuple{Int,Int},SyntaxTreeC},
-        st0::SyntaxTreeC,
-        parent::Union{Nothing,SyntaxTreeC}
+        parent_map::Dict{Tuple{Int,Int},SyntaxTree},
+        node_map::Dict{Tuple{Int,Int},SyntaxTree},
+        st0::SyntaxTree,
+        parent::Union{Nothing,SyntaxTree}
     )
     fb, lb = JS.first_byte(st0), JS.last_byte(st0)
     if !(iszero(fb) && iszero(lb))
@@ -894,8 +894,8 @@ end
 
 struct LocalScopeContext
     ctx3::JL.VariableAnalysisContext
-    parent_map::Dict{Tuple{Int,Int},SyntaxTreeC}
-    node_map::Dict{Tuple{Int,Int},SyntaxTreeC}
+    parent_map::Dict{Tuple{Int,Int},SyntaxTree}
+    node_map::Dict{Tuple{Int,Int},SyntaxTree}
     scope_children::Dict{Int,Vector{Int}}
     func_scope_ids::Set{Int}
     func_to_scopes::Dict{Int,Vector{Int}}
@@ -907,8 +907,8 @@ end
 function LocalScopeContext(
         lctx::LocalScopeContext;
         ctx3::JL.VariableAnalysisContext = lctx.ctx3,
-        parent_map::Dict{Tuple{Int, Int}, SyntaxTreeC} = lctx.parent_map,
-        node_map::Dict{Tuple{Int, Int}, SyntaxTreeC} = lctx.node_map,
+        parent_map::Dict{Tuple{Int, Int}, SyntaxTree} = lctx.parent_map,
+        node_map::Dict{Tuple{Int, Int}, SyntaxTree} = lctx.node_map,
         scope_children::Dict{Int, Vector{Int}} = lctx.scope_children,
         func_scope_ids::Set{Int} = lctx.func_scope_ids,
         func_to_scopes::Dict{Int, Vector{Int}} = lctx.func_to_scopes,
@@ -924,8 +924,8 @@ function LocalScopeContext(
 end
 
 function extract_local_symbols_from_scopes(
-        ctx3::JL.VariableAnalysisContext, parent_map::Dict{Tuple{Int,Int},SyntaxTreeC},
-        node_map::Dict{Tuple{Int,Int},SyntaxTreeC},
+        ctx3::JL.VariableAnalysisContext, parent_map::Dict{Tuple{Int,Int},SyntaxTree},
+        node_map::Dict{Tuple{Int,Int},SyntaxTree},
         fi::FileInfo, root_range::Tuple{Int,Int}=(0,0)
     )
     scopes = ctx3.scopes
@@ -1111,7 +1111,7 @@ function extract_child_scope_symbols!(
     # (e.g. a for loop creates scope_blocks for both iteration vars and body).
     # Scopes without a construct (or whose construct is already processed)
     # are collected as "transparent" and their bindings are inlined.
-    construct_groups = Dict{Tuple{Int,Int},Tuple{SyntaxTreeC,Vector{Int}}}()
+    construct_groups = Dict{Tuple{Int,Int},Tuple{SyntaxTree,Vector{Int}}}()
     transparent_ids = Int[]
     for child_id in child_ids
         child_id in lctx.func_scope_ids && continue
@@ -1147,7 +1147,7 @@ function extract_child_scope_symbols!(
 end
 
 function push_namespace_symbol!(
-        symbols::Vector{DocumentSymbol}, construct::SyntaxTreeC,
+        symbols::Vector{DocumentSymbol}, construct::SyntaxTree,
         children::Vector{DocumentSymbol}, fi::FileInfo
     )
     JS.numchildren(construct) ≥ 1 || return nothing
@@ -1173,7 +1173,7 @@ const TRY_CLAUSE_POSITIONS =
     (("try", 1), ("catch", 3), ("else", 5), ("finally", 4))
 
 function push_try_namespace_symbol!(
-        symbols::Vector{DocumentSymbol}, try_node::SyntaxTreeC,
+        symbols::Vector{DocumentSymbol}, try_node::SyntaxTree,
         lctx::LocalScopeContext, group_ids::Vector{Int}
     )
     (; ctx3, fi) = lctx
@@ -1213,7 +1213,7 @@ end
 
 function _classify_try_clause(
         ctx3::JL.VariableAnalysisContext, scope_id::Int,
-        try_node::SyntaxTreeC
+        try_node::SyntaxTree
     )
     1 ≤ scope_id ≤ length(ctx3.scopes) || return "try"
     scope = ctx3.scopes[scope_id]
@@ -1235,8 +1235,8 @@ end
 
 function find_scope_construct(
         scope::JL.ScopeInfo,
-        parent_map::Dict{Tuple{Int,Int},SyntaxTreeC},
-        node_map::Dict{Tuple{Int,Int},SyntaxTreeC}
+        parent_map::Dict{Tuple{Int,Int},SyntaxTree},
+        node_map::Dict{Tuple{Int,Int},SyntaxTree}
     )
     prov = JS.flattened_provenance(scope.node_id)
     isempty(prov) && return nothing
@@ -1261,7 +1261,7 @@ function find_scope_construct(
 end
 
 function extract_argument_detail(
-        parent_map::Dict{Tuple{Int,Int},SyntaxTreeC}, fb::Int, lb::Int
+        parent_map::Dict{Tuple{Int,Int},SyntaxTree}, fb::Int, lb::Int
     )
     parent = get(parent_map, (fb, lb), nothing)
     detail = nothing
@@ -1280,7 +1280,7 @@ function extract_argument_detail(
 end
 
 function extract_local_variable_detail(
-        parent_map::Dict{Tuple{Int,Int},SyntaxTreeC}, fb::Int, lb::Int
+        parent_map::Dict{Tuple{Int,Int},SyntaxTree}, fb::Int, lb::Int
     )
     parent = get(parent_map, (fb, lb), nothing)
     detail = nothing
@@ -1318,11 +1318,11 @@ function extract_local_variable_detail(
     return detail
 end
 
-is_anonymous_function_rhs(st::SyntaxTreeC) = JS.kind(st) === JS.K"->" ||
+is_anonymous_function_rhs(st::SyntaxTree) = JS.kind(st) === JS.K"->" ||
     (JS.kind(st) === JS.K"function" && JS.numchildren(st) ≥ 1 && JS.kind(st[1]) !== JS.K"call")
 
 function find_anon_func_scope_ids(
-        parent_map::Dict{Tuple{Int,Int},SyntaxTreeC}, fb::Int, lb::Int,
+        parent_map::Dict{Tuple{Int,Int},SyntaxTree}, fb::Int, lb::Int,
         func_to_scopes::Dict{Int,Vector{Int}}, ctx3::JL.VariableAnalysisContext
     )
     parent = @something get(parent_map, (fb, lb), nothing) return nothing

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -42,11 +42,11 @@ function cache_file_info!(
     prev_testsetinfos = prev_fi === nothing ? EMPTY_TESTSETINFOS : prev_fi.testsetinfos
 
     filename = uri2filename(uri)
-    st0 = JS.build_tree(JS.SyntaxTree, parsed_stream; filename)
-    testsetinfos, any_deleted = compute_testsetinfos!(server, st0, prev_testsetinfos)
-
-    fi = FileInfo(version, parsed_stream, filename, state.encoding, testsetinfos;
-        syntax_tree0=st0, inferred_context_cache=InferredContextCache())
+    fi0 = FileInfo(version, parsed_stream, filename, state.encoding;
+        cache_tree0=true, inferred_context_cache=InferredContextCache())
+    testsetinfos, any_deleted = compute_testsetinfos!(
+        server, fi0.syntax_tree0::SyntaxTreeC, prev_testsetinfos)
+    fi = FileInfo(fi0; testsetinfos)
     store!(state.file_cache) do cache
         Base.PersistentDict(cache, uri => fi), nothing
     end

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -45,7 +45,7 @@ function cache_file_info!(
     fi0 = FileInfo(version, parsed_stream, filename, state.encoding;
         cache_tree0=true, inferred_context_cache=InferredContextCache())
     testsetinfos, any_deleted = compute_testsetinfos!(
-        server, fi0.syntax_tree0::SyntaxTreeC, prev_testsetinfos)
+        server, fi0.syntax_tree0::SyntaxTree, prev_testsetinfos)
     fi = FileInfo(fi0; testsetinfos)
     store!(state.file_cache) do cache
         Base.PersistentDict(cache, uri => fi), nothing

--- a/src/hover.jl
+++ b/src/hover.jl
@@ -230,7 +230,7 @@ binding_kind_label(kind::Symbol) =
     kind === :static_parameter ? "(static parameter)" :
     kind === :local ? "(local)" : "(global)"
 
-function symbol_literal_container(st0_top::SyntaxTreeC, node::SyntaxTreeC)
+function symbol_literal_container(st0_top::SyntaxTree, node::SyntaxTree)
     JS.is_identifier(node) || return nothing
     bas = @something byte_ancestors(st0_top, first(JS.byte_range(node))) return nothing
     length(bas) ≥ 2 || return nothing
@@ -288,7 +288,7 @@ end
 # matched, or when the signature can't be stripped cleanly. Used to narrow
 # the hover docstring lookup from "all overloads merged" to
 # "(generic + the specific method's docs)".
-function call_doc_sig(ctx::InferredTreeContext, st0_top::SyntaxTreeC, node::SyntaxTreeC)
+function call_doc_sig(ctx::InferredTreeContext, st0_top::SyntaxTree, node::SyntaxTree)
     call_node = @something enclosing_call_for_matches(st0_top, node) return nothing
     matches = @something get_matches_for_range(ctx, JS.byte_range(call_node)) return nothing
     # Require a single matched method — for ambiguous dispatch (union splits,
@@ -304,7 +304,7 @@ end
 # whose left-hand side is an instance, looks up the per-field docstring on
 # the LHS's inferred type via [`lookup_field_doc`](@ref).
 function lookup_doc_for_identifier(
-        node::SyntaxTreeC, context_module::Module, ctx::Union{Nothing,InferredTreeContext},
+        node::SyntaxTree, context_module::Module, ctx::Union{Nothing,InferredTreeContext},
         @nospecialize(sig), world::UInt
     )
     if JS.kind(node) === JS.K"." && JS.numchildren(node) ≥ 2
@@ -340,7 +340,7 @@ end
 # for nested chains (`Base.Compiler.…`). `ctx === nothing` (toplevel failed to
 # lower) skips the inference fallback and only uses the direct lookup.
 function resolve_dot_prefix_module(
-        dotprefix::SyntaxTreeC, context_module::Module,
+        dotprefix::SyntaxTree, context_module::Module,
         ctx::Union{Nothing,InferredTreeContext}, world::UInt
     )
     if JS.is_identifier(dotprefix) && (nv = get_name_val(dotprefix)) !== nothing

--- a/src/inlay-hint.jl
+++ b/src/inlay-hint.jl
@@ -164,10 +164,10 @@ end
 
 function type_inlay_hints!(
         inlay_hints::Vector{InlayHint}, state::ServerState, fi::FileInfo,
-        st0_top::SyntaxTreeC, uri::URI, range::Range
+        st0_top::SyntaxTree, uri::URI, range::Range
     )
     nontrivia_index = build_nontrivia_byte_index(fi.parsed_stream)
-    iterate_toplevel_tree(st0_top) do st0::SyntaxTreeC
+    iterate_toplevel_tree(st0_top) do st0::SyntaxTree
         # Skip toplevel def whose source is fully outside of the requested visible viewport.
         startpos = offset_to_xy(fi, JS.first_byte(st0))
         endpos = offset_to_xy(fi, JS.last_byte(st0) + 1)
@@ -196,7 +196,7 @@ end
 # traversal doesn't expose parent links. Record role-specific ranges first,
 # then consult them during postorder emission.
 function collect_type_inlay_hints!(
-        inlay_hints::Vector{InlayHint}, st0::SyntaxTreeC, ctx::InferredTreeContext,
+        inlay_hints::Vector{InlayHint}, st0::SyntaxTree, ctx::InferredTreeContext,
         fi::FileInfo, uri::URI, range::Range, postprocessor::LSPostProcessor,
         nontrivia_index::Vector{Int} = build_nontrivia_byte_index(fi.parsed_stream);
         # Keep inline labels glanceable even for deeply nested inferred types.
@@ -215,7 +215,7 @@ function collect_type_inlay_hints!(
     # same source range; avoid duplicate labels like `::String::String`.
     emitted_ranges = Set{UnitRange{Int}}()
     label_cache = IdDict{Any,String}()
-    traverse(st0) do node::SyntaxTreeC
+    traverse(st0) do node::SyntaxTree
         JS.kind(node) === JS.K"Value" && return nothing
         if JS.kind(node) === JS.K"." && JS.numchildren(node) >= 2
             push!(paren_wrap_ranges, JS.byte_range(node[1]))
@@ -331,7 +331,7 @@ function collect_type_inlay_hints!(
         end
     end
 
-    traverse(st0, #=postorder=#true) do node::SyntaxTreeC
+    traverse(st0, #=postorder=#true) do node::SyntaxTree
         k = JS.kind(node)
         k === JS.K"Value" && return nothing
 
@@ -453,7 +453,7 @@ end
 
 # Detect function-definition shapes under decorating macrocalls. Unlike
 # `funcdef_call_node`, this accepts user-written return annotations.
-function is_funcdef_decl(node::SyntaxTreeC)
+function is_funcdef_decl(node::SyntaxTree)
     k = JS.kind(node)
     if k === JS.K"function" || k === JS.K"macro"
         return true
@@ -471,14 +471,14 @@ function is_funcdef_decl(node::SyntaxTreeC)
 end
 
 # Locate the `K"="` iteration binding inside a comprehension generator/filter.
-function comprehension_iter_spec(node::SyntaxTreeC)
+function comprehension_iter_spec(node::SyntaxTree)
     JS.numchildren(node) >= 2 || return nothing
     spec = node[2]
     JS.kind(spec) === JS.K"filter" && JS.numchildren(spec) >= 2 && (spec = spec[2])
     return JS.kind(spec) === JS.K"=" ? spec : nothing
 end
 
-function funcdef_call_node(funcdef::SyntaxTreeC)
+function funcdef_call_node(funcdef::SyntaxTree)
     JS.numchildren(funcdef) >= 1 || return nothing
     sig = funcdef[1]
     while JS.kind(sig) === JS.K"where"
@@ -492,14 +492,14 @@ end
 
 # Byte range of the user-written signature, including `where` and return-type
 # wrappers, for suppressing hints inside declaration syntax.
-function funcdef_sig_range(funcdef::SyntaxTreeC)
+function funcdef_sig_range(funcdef::SyntaxTree)
     JS.numchildren(funcdef) >= 1 || return nothing
     sig = funcdef[1]
     JS.kind(unwrap_funcdef_sig(sig)) === JS.K"call" || return nothing
     return JS.byte_range(sig)
 end
 
-function should_annotate_type(node::SyntaxTreeC, @nospecialize(typ))
+function should_annotate_type(node::SyntaxTree, @nospecialize(typ))
     typ isa Core.Const || return true
     val = typ.val
     is_const_literal_node(node, val) && return false
@@ -507,7 +507,7 @@ function should_annotate_type(node::SyntaxTreeC, @nospecialize(typ))
     return true
 end
 
-function is_const_literal_node(node::SyntaxTreeC, @nospecialize(val))
+function is_const_literal_node(node::SyntaxTree, @nospecialize(val))
     k = JS.kind(node)
     JS.is_literal(k) && return true
     k === JS.K"inert" && return true
@@ -530,7 +530,7 @@ is_const_binding_value(@nospecialize val) =
 
 # Register both variables and destructuring wrappers so the regular postorder
 # pass doesn't emit duplicate or wrapper-level iteration hints.
-function register_for_loop_vars!(callee_ranges::Set{UnitRange{Int}}, lhs::SyntaxTreeC)
+function register_for_loop_vars!(callee_ranges::Set{UnitRange{Int}}, lhs::SyntaxTree)
     k = JS.kind(lhs)
     if k === JS.K"Identifier"
         push!(callee_ranges, JS.byte_range(lhs))
@@ -554,7 +554,7 @@ end
 # `Any` entries on simple parameters are skipped (an unrefined slot adds no information
 # over the bare name); user-annotated (`K"::"`) parameters are left untouched.
 function emit_lambda_param_hints!(
-        inlay_hints::Vector{InlayHint}, lambda::SyntaxTreeC,
+        inlay_hints::Vector{InlayHint}, lambda::SyntaxTree,
         ctx::InferredTreeContext, fi::FileInfo, uri::URI, range::Range,
         nontrivia_index::Vector{Int}, postprocessor::LSPostProcessor,
         emitted_ranges::Set{UnitRange{Int}}, label_cache::IdDict{Any,String},
@@ -609,7 +609,7 @@ function emit_lambda_param_hints!(
 end
 
 function emit_lambda_param_hint!(
-        inlay_hints::Vector{InlayHint}, p::SyntaxTreeC, ctx::InferredTreeContext,
+        inlay_hints::Vector{InlayHint}, p::SyntaxTree, ctx::InferredTreeContext,
         fi::FileInfo, uri::URI, range::Range, nontrivia_index::Vector{Int},
         postprocessor::LSPostProcessor, label_cache::IdDict{Any,String},
         maxdepth::Int, maxwidth::Int, lazy_tooltips::Bool
@@ -631,7 +631,7 @@ end
 # and by destructured closure parameters. `K"..."` (slurp) and `K"::"` (user-annotated)
 # components are left untouched.
 function emit_destructure_var_hints!(
-        inlay_hints::Vector{InlayHint}, lhs::SyntaxTreeC,
+        inlay_hints::Vector{InlayHint}, lhs::SyntaxTree,
         ctx::InferredTreeContext, fi::FileInfo, uri::URI, range::Range,
         nontrivia_index::Vector{Int}, postprocessor::LSPostProcessor,
         emitted_ranges::Set{UnitRange{Int}}, label_cache::IdDict{Any,String},
@@ -653,7 +653,7 @@ function emit_destructure_var_hints!(
 end
 
 function emit_destructure_var_hint!(
-        inlay_hints::Vector{InlayHint}, lvar::SyntaxTreeC,
+        inlay_hints::Vector{InlayHint}, lvar::SyntaxTree,
         ctx::InferredTreeContext, fi::FileInfo, uri::URI, range::Range,
         nontrivia_index::Vector{Int}, postprocessor::LSPostProcessor,
         emitted_ranges::Set{UnitRange{Int}}, label_cache::IdDict{Any,String},
@@ -673,7 +673,7 @@ function emit_destructure_var_hint!(
 end
 
 # Ternary and block-form `if` both parse as `K"if"`; distinguish by first token.
-function is_ternary(node::SyntaxTreeC, fi::FileInfo)
+function is_ternary(node::SyntaxTree, fi::FileInfo)
     JS.kind(node) === JS.K"if" || return false
     tc = @something next_nontrivia(fi.parsed_stream, JS.first_byte(node)) return false
     return JS.kind(tc) !== JS.K"if"
@@ -683,12 +683,12 @@ end
 # `x, y::T` parses as `x, (y::T)`. The parser sets `PARENS_FLAG` on
 # `K"tuple"` exactly when it's surrounded by `(` `)` (independent of any
 # nested tuple's parens), so checking the flag is the precise discriminator.
-is_open_tuple(node::SyntaxTreeC) =
+is_open_tuple(node::SyntaxTree) =
     JS.kind(node) === JS.K"tuple" && !JS.has_flags(node, JS.PARENS_FLAG)
 
 # Recover dropped `K"parens"` nodes from neighboring tokens. A preceding `(` is
 # decorative unless it belongs to a call, index, or chained-call form.
-function is_decoratively_parenthesized(node::SyntaxTreeC, fi::FileInfo)
+function is_decoratively_parenthesized(node::SyntaxTree, fi::FileInfo)
     ps = fi.parsed_stream
     fb = JS.first_byte(node)
     open_tc = @something prev_nontrivia(ps, fb - 1; pass_newlines=true) return false
@@ -708,7 +708,7 @@ end
 
 # Byte position one past the source `)` that follows `node`. Caller must have
 # already verified parenthesization via `is_decoratively_parenthesized`.
-function byte_past_close_paren(node::SyntaxTreeC, fi::FileInfo)
+function byte_past_close_paren(node::SyntaxTree, fi::FileInfo)
     lb = JS.last_byte(node)
     close_tc = next_nontrivia(fi.parsed_stream, lb + 1; pass_newlines=true)
     return JS.last_byte(close_tc) + 1
@@ -719,7 +719,7 @@ in_verbatim_range(byterng::UnitRange{Int}, verbatim_ranges::Set{UnitRange{Int}})
     any(rng -> byterng ⊆ rng, verbatim_ranges)
 
 function emit_type_hint!(
-        inlay_hints::Vector{InlayHint}, node::SyntaxTreeC, @nospecialize(typ), fi::FileInfo,
+        inlay_hints::Vector{InlayHint}, node::SyntaxTree, @nospecialize(typ), fi::FileInfo,
         uri::URI, nontrivia_index::Vector{Int}, endpos::Position,
         postprocessor::LSPostProcessor, label_cache::IdDict{Any,String},
         maxdepth::Int, maxwidth::Int, lazy_tooltips::Bool, type_range::UnitRange{Int};
@@ -727,7 +727,7 @@ function emit_type_hint!(
         close_paren_before_type::Bool = false,
         close_paren_after_type::Bool = false,
         # Prefix unary calls pass the argument so the operator stays outside the wrap.
-        paren_start_node::SyntaxTreeC = node,
+        paren_start_node::SyntaxTree = node,
     )
     if open_paren
         n_parens = max(close_paren_before_type + close_paren_after_type, 1)
@@ -762,7 +762,7 @@ function emit_type_hint!(
 end
 
 # Find the first non-trivia token start at or after the node's byte range.
-function first_token_byte(node::SyntaxTreeC, nontrivia_index::Vector{Int})
+function first_token_byte(node::SyntaxTree, nontrivia_index::Vector{Int})
     fb = JS.first_byte(node)
     idx = searchsortedfirst(nontrivia_index, fb)
     idx > length(nontrivia_index) && return fb

--- a/src/notebook.jl
+++ b/src/notebook.jl
@@ -50,9 +50,8 @@ end
 function cache_notebook_file_info!(server::Server, notebook_uri::URI, notebook_info::NotebookInfo)
     state = server.state
     parsed_stream = ParseStream!(notebook_info.concat.source)
-    st0 = JS.build_tree(JS.SyntaxTree, parsed_stream; filename=uri2filename(notebook_uri))
     fi = FileInfo(notebook_info.version, parsed_stream, notebook_uri, notebook_info.encoding;
-        syntax_tree0=st0, inferred_context_cache=InferredContextCache())
+        cache_tree0=true, inferred_context_cache=InferredContextCache())
     store!(state.file_cache) do cache
         Base.PersistentDict(cache, notebook_uri => fi), fi
     end

--- a/src/rename.jl
+++ b/src/rename.jl
@@ -387,7 +387,7 @@ end
 
 function collect_global_rename_edits_in_file!(
         seen_edits::Set{Tuple{URI,Range,String}}, state::ServerState, uri::URI, fi::FileInfo,
-        st0_top::SyntaxTreeC, binfo::JL.BindingInfo, newName::String
+        st0_top::SyntaxTree, binfo::JL.BindingInfo, newName::String
     )
     ismacro = startswith(binfo.name, '@')
     for occurrence in find_global_binding_occurrences_from_tree!(state, uri, fi, st0_top, binfo)
@@ -429,10 +429,10 @@ end
 # - `:implicit_bare`  — bare source name in `using M`, `using M, N`, or `using M.N` where
 #                       `using ... as ...` is not legal syntax; fall back to a standard replace
 #                       (breaks code, but matches the rename policy for implicit imports).
-function classify_import_rename(st0_top::SyntaxTreeC, id_byte_range::UnitRange{Int}, kind::Symbol)
+function classify_import_rename(st0_top::SyntaxTree, id_byte_range::UnitRange{Int}, kind::Symbol)
     kind === :decl || return :regular
     bas = byte_ancestors(st0_top, id_byte_range)
-    import_stmt_idx = findfirst(b::SyntaxTreeC -> JS.kind(b) in JS.KSet"import using", bas)
+    import_stmt_idx = findfirst(b::SyntaxTree -> JS.kind(b) in JS.KSet"import using", bas)
     isnothing(import_stmt_idx) && return :regular
     has_colon = false
     for i = 1:import_stmt_idx-1
@@ -458,11 +458,11 @@ end
 # surrounding `K"as"` node, return the LSP range covering ` as <alias>` so a
 # single empty-text edit can delete it. Otherwise return `nothing`.
 function collapse_alias_to_source(
-        st0_top::SyntaxTreeC, id_byte_range::UnitRange{Int}, fi::FileInfo,
+        st0_top::SyntaxTree, id_byte_range::UnitRange{Int}, fi::FileInfo,
         newName::String, ismacro::Bool
     )
     bas = byte_ancestors(st0_top, id_byte_range)
-    as_idx = @something findfirst(b::SyntaxTreeC -> JS.kind(b) === JS.K"as", bas) return nothing
+    as_idx = @something findfirst(b::SyntaxTree -> JS.kind(b) === JS.K"as", bas) return nothing
     as_node = bas[as_idx]
     JS.numchildren(as_node) >= 2 || return nothing
     source_path = as_node[1]

--- a/src/semantic-tokens.jl
+++ b/src/semantic-tokens.jl
@@ -126,7 +126,7 @@ function compute_semantic_tokens(
     # For range requests, convert the LSP range to a byte range so we can
     # cheaply skip toplevel statements that don't overlap.
     range_bytes = range === nothing ? nothing : range_to_byte_range(fi, range)
-    iterate_toplevel_tree(st0_top) do st0::SyntaxTreeC
+    iterate_toplevel_tree(st0_top) do st0::SyntaxTree
         if range_bytes !== nothing && !overlaps_byte_range(st0, range_bytes)
             return
         end
@@ -141,7 +141,7 @@ function compute_semantic_tokens(
     return encode_semantic_tokens(raw)
 end
 
-function overlaps_byte_range(st0::SyntaxTreeC, byte_range::UnitRange{Int})
+function overlaps_byte_range(st0::SyntaxTree, byte_range::UnitRange{Int})
     JS.last_byte(st0) < first(byte_range) && return false
     JS.first_byte(st0) > last(byte_range) && return false
     return true
@@ -182,7 +182,7 @@ end
 
 function collect_semantic_tokens_for_occurrences!(
         raw::Vector{SemanticTokenTuple}, state::ServerState, uri::URI, fi::FileInfo,
-        occs::BindingOccurrencesResult, st0::SyntaxTreeC,
+        occs::BindingOccurrencesResult, st0::SyntaxTree,
     )
     # `:local` aliases for type parameters cover a superset of the corresponding
     # `:typevar` / `:static_parameter` occurrences — and for plain
@@ -209,7 +209,7 @@ function collect_semantic_tokens_for_occurrences!(
     return raw
 end
 
-function collect_type_param_names_from_tree!(names::Set{String}, st0::SyntaxTreeC)
+function collect_type_param_names_from_tree!(names::Set{String}, st0::SyntaxTree)
     traverse(st0) do node
         k = JS.kind(node)
         if k === JS.K"struct" && JS.numchildren(node) >= 2

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -30,14 +30,14 @@ end
 # =====
 
 """
-    flatten_args(call::SyntaxTreeC) -> (args::SyntaxListC, first_kwarg_i::Int, has_semicolon::Bool) or nothing
+    flatten_args(call::SyntaxTree) -> (args::SyntaxList, first_kwarg_i::Int, has_semicolon::Bool) or nothing
 
-Return `(args::SyntaxListC, first_kwarg_i::Int, has_semicolon::Bool)`,
+Return `(args::SyntaxList, first_kwarg_i::Int, has_semicolon::Bool)`,
 one `SyntaxTree` per argument to call.
 Ignore function name and `K"error"` (e.g. missing closing paren).
 `has_semicolon` is true if the call contains a `K"parameters"` node (explicit semicolon).
 """
-function flatten_args(call::SyntaxTreeC)
+function flatten_args(call::SyntaxTree)
     while JS.kind(call) === JS.K"where"
         call = call[1]
     end
@@ -46,7 +46,7 @@ function flatten_args(call::SyntaxTreeC)
         # than `K"call"`, skip them for now
         return nothing
     end
-    usable = (arg::SyntaxTreeC) -> JS.kind(arg) ∉ JS.KSet"error Value"
+    usable = (arg::SyntaxTree) -> JS.kind(arg) ∉ JS.KSet"error Value"
     # In new EST, dotcall `f.(args)` is represented as `K"."` with children
     # `[func, tuple(args...)]`, so we unwrap the tuple to get the actual args.
     if JS.kind(call) === JS.K"." && JS.numchildren(call) ≥ 2 && JS.kind(call[2]) === JS.K"tuple"
@@ -86,7 +86,7 @@ Get `K"Identifier"` tree from a kwarg tree (child of `K"call"` or `K"parameters"
  (kw (:: a T) 1) => a  # only when sig=true
 ```
 """
-function extract_kwarg_name(arg::SyntaxTreeC; sig::Bool=false)
+function extract_kwarg_name(arg::SyntaxTree; sig::Bool=false)
     ret = identifier_like(arg)
     isnothing(ret) || return ret
     if JS.kind(arg) === JS.K"=" || JS.kind(arg) === JS.K"kw"
@@ -104,7 +104,7 @@ function extract_kwarg_name(arg::SyntaxTreeC; sig::Bool=false)
     return nothing
 end
 
-function identifier_like(st::SyntaxTreeC)
+function identifier_like(st::SyntaxTree)
     if JS.kind(st) === JS.K"Identifier"
         return st
     elseif JS.kind(st) === JS.K"var"
@@ -129,7 +129,7 @@ Keywords should be ignored if `cursor` is within the keyword's name.
 Note: the `=` form doesn't always correspond to a keyword arg after macro
 expansion, but signature help is only used on unexpanded code.
 """
-function find_kws(args::SyntaxListC, kw_i::Int; sig=false, cursor::Int=-1)
+function find_kws(args::SyntaxList, kw_i::Int; sig=false, cursor::Int=-1)
     out = Dict{String, Int}()
     for i in (sig ? (kw_i:lastindex(args)) : eachindex(args))
         JS.kind(args[i]) ∉ JS.KSet"= kw" && i < kw_i && continue
@@ -160,7 +160,7 @@ Information from a call site's arguments for filtering method signatures.
 - `kind`: Item in `CALL_KINDS`
 """
 struct CallArgs
-    args::SyntaxListC
+    args::SyntaxList
     kw_i::Int
     pos_map::Dict{Int, Tuple{Int, Union{Int, Nothing}}}
     pos_args_lb::Int
@@ -168,7 +168,7 @@ struct CallArgs
     kw_map::Dict{String, Int}
     has_semicolon::Bool
     kind::JS.Kind
-    function CallArgs(st0::SyntaxTreeC, cursor::Int=-1)
+    function CallArgs(st0::SyntaxTree, cursor::Int=-1)
         @assert -1 ∉ JS.byte_range(st0)
         args, kw_i, has_semicolon = @something flatten_args(st0) begin
             println(stderr, JS.sourcetext(st0))
@@ -269,7 +269,7 @@ end
 # =======================
 
 function make_paraminfo(
-        param::SyntaxTreeC, active_argtree::Union{Nothing,SyntaxTreeC},
+        param::SyntaxTree, active_argtree::Union{Nothing,SyntaxTree},
         @nospecialize(active_argtype), postprocessor::LSPostProcessor
     )
     label = let r = JS.byte_range(param)
@@ -417,7 +417,7 @@ end
 
 const empty_siginfos = SignatureInformation[]
 
-function is_relevant_call(call::SyntaxTreeC)
+function is_relevant_call(call::SyntaxTree)
     JS.kind(call) in CALL_KINDS &&
         # don't show help for a+b, M', etc., where call[1] isn't the function
         !(JS.is_infix_op_call(call) || JS.is_postfix_op_call(call)) &&
@@ -428,7 +428,7 @@ end
 
 # If parents of our call are like (macro/function (where (where... (call |) ...))),
 # we're actually in a declaration, and shouldn't show signature help.
-function call_is_decl(_bas::SyntaxListC, i::Int, _basᵢ::SyntaxTreeC = _bas[i])
+function call_is_decl(_bas::SyntaxList, i::Int, _basᵢ::SyntaxTree = _bas[i])
     JS.kind(_basᵢ) != JS.K"call" && return false
     j = i + 1
     while j <= lastindex(_bas) && JS.kind(_bas[j]) === JS.K"where"
@@ -442,7 +442,7 @@ end
 
 # Find cases where a macro call is not surrounded by parentheses
 # and the current cursor position is on a different line from the `@` macro call
-function is_crossline_noparen_macrocall(call::SyntaxTreeC, cursor_byte::Int)
+function is_crossline_noparen_macrocall(call::SyntaxTree, cursor_byte::Int)
     return noparen_macrocall(call) && let source_file = JS.sourcefile(call)
         # Check if cursor is on a different line from the @ symbol
         source_file isa JS.SourceFile && JS.numchildren(call) ≥ 1 &&
@@ -458,7 +458,7 @@ call expression, e.g. `foo(#=hi=# |`, `@bar |`.  A more accurate description
 would be: return the nearest call in `st0` such that stuff inserted at the
 cursor would be descendents of it.
 """
-function cursor_call(ps::JS.ParseStream, st0::SyntaxTreeC, b::Int)
+function cursor_call(ps::JS.ParseStream, st0::SyntaxTree, b::Int)
     # disable signature help if invoked within comment scope
     tc = token_before_offset(ps, b)
     if !isnothing(tc) && JS.kind(tc) === JS.K"Comment"
@@ -491,7 +491,7 @@ function cursor_call(ps::JS.ParseStream, st0::SyntaxTreeC, b::Int)
         bas = byte_ancestors(st0, pnb)
         # If the previous nontrivia byte is part of a call or macrocall, and it is
         # missing a closing paren, use that.
-        i = findfirst(st::SyntaxTreeC -> is_relevant_call(st) && !noparen_macrocall(st), bas)
+        i = findfirst(st::SyntaxTree -> is_relevant_call(st) && !noparen_macrocall(st), bas)
         if !isnothing(i)
             basᵢ = bas[i]
             if JS.is_error(JS.children(basᵢ)[end])
@@ -595,7 +595,7 @@ function cursor_siginfos(
     call = cursor_call(fi.parsed_stream, st0, b)
     isnothing(call) && return empty_siginfos
     after_semicolon = let
-        params_i = findfirst(st::SyntaxTreeC -> JS.kind(st) === JS.K"parameters", JS.children(call))
+        params_i = findfirst(st::SyntaxTree -> JS.kind(st) === JS.K"parameters", JS.children(call))
         !isnothing(params_i) && b > JS.first_byte(call[params_i])
     end
 
@@ -631,7 +631,7 @@ function cursor_siginfos(
     if past_pos_args && !after_semicolon
         active_arg = false # before semicolon, highlight next positional arg
     else
-        active_arg = findfirst(a::SyntaxTreeC -> JS.first_byte(a) <= b <= JS.last_byte(a) + 1, ca.args)
+        active_arg = findfirst(a::SyntaxTree -> JS.first_byte(a) <= b <= JS.last_byte(a) + 1, ca.args)
         if active_arg === nothing && after_semicolon
             active_arg = true # after semicolon, highlight next keyword arg
         end

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -55,8 +55,8 @@ function flatten_args(call::SyntaxTreeC)
         orig = filter(usable, JS.children(call)[2:end])
     end
 
-    args = JS.SyntaxList(orig.graph)
-    kw_children = JS.SyntaxList(orig.graph)
+    args = JS.SyntaxList()
+    kw_children = JS.SyntaxList()
     has_semicolon = false
     for i in eachindex(orig)
         if JS.kind(orig[i]) === JS.K"parameters"
@@ -437,7 +437,7 @@ function call_is_decl(_bas::SyntaxListC, i::Int, _basᵢ::SyntaxTreeC = _bas[i])
     return j <= lastindex(_bas) &&
         # `=` covers short-form function definitions like `f(x) = 1`
         JS.kind(_bas[j]) in JS.KSet"macro function =" &&
-        _bas[j-1]._id == _bas[j][1]._id
+        _bas[j-1] === _bas[j][1]
 end
 
 # Find cases where a macro call is not surrounded by parentheses

--- a/src/testrunner/testrunner.jl
+++ b/src/testrunner/testrunner.jl
@@ -123,7 +123,7 @@ function compute_testsetinfos!(
 end
 
 function find_executable_testsets(st0_top::SyntaxTreeC)
-    testsets = JS.SyntaxList(JS.syntax_graph(st0_top))
+    testsets = JS.SyntaxList()
     traverse(st0_top) do st0::SyntaxTreeC
         if JS.kind(st0) in JS.KSet"function macro"
             # avoid visit inside function scope

--- a/src/testrunner/testrunner.jl
+++ b/src/testrunner/testrunner.jl
@@ -30,7 +30,7 @@ function summary_testrunner_result(result::TestRunnerResult)
 end
 
 testset_name(testsetinfo::TestsetInfo) = testset_name(testsetinfo.st0)
-function testset_name(testset::SyntaxTreeC)
+function testset_name(testset::SyntaxTree)
     desc = testset_description_node(testset)
     isnothing(desc) && return ""
     if JS.kind(desc) === JS.K"String"
@@ -40,7 +40,7 @@ function testset_name(testset::SyntaxTreeC)
     end
 end
 testset_line(testsetinfo::TestsetInfo) = testset_line(testsetinfo.st0)
-function testset_line(testset::SyntaxTreeC)
+function testset_line(testset::SyntaxTree)
     desc = testset_description_node(testset)
     return isnothing(desc) ? JS.source_line(testset) : JS.source_line(desc)
 end
@@ -48,7 +48,7 @@ end
 # Find the description string node of a `@testset` macrocall.
 # Returns `K"String"` for simple literals (sourcetext has no quotes)
 # or `K"string"` for interpolated strings (sourcetext includes quotes).
-function testset_description_node(testset::SyntaxTreeC)
+function testset_description_node(testset::SyntaxTree)
     for i = 2:JS.numchildren(testset)
         child = testset[i]
         if JS.kind(child) in JS.KSet"string String"
@@ -59,7 +59,7 @@ function testset_description_node(testset::SyntaxTreeC)
 end
 
 """
-    compute_testsetinfos!(server::Server, st0::SyntaxTreeC, prev_testsetinfos::Vector{TestsetInfo})
+    compute_testsetinfos!(server::Server, st0::SyntaxTree, prev_testsetinfos::Vector{TestsetInfo})
 
 Compute new testsetinfos from the syntax tree, preserving test results from
 previous testsetinfos where testset names match. Clears extra diagnostics for
@@ -69,7 +69,7 @@ Returns `(testsetinfos, any_deleted)` where `any_deleted` indicates whether any
 diagnostics were cleared.
 """
 function compute_testsetinfos!(
-        server::Server, st0::SyntaxTreeC, prev_testsetinfos::Vector{TestsetInfo}
+        server::Server, st0::SyntaxTree, prev_testsetinfos::Vector{TestsetInfo}
     )
     new_testsets = find_executable_testsets(st0)
     m = length(new_testsets)
@@ -122,9 +122,9 @@ function compute_testsetinfos!(
     return testsetinfos, any_deleted
 end
 
-function find_executable_testsets(st0_top::SyntaxTreeC)
+function find_executable_testsets(st0_top::SyntaxTree)
     testsets = JS.SyntaxList()
-    traverse(st0_top) do st0::SyntaxTreeC
+    traverse(st0_top) do st0::SyntaxTree
         if JS.kind(st0) in JS.KSet"function macro"
             # avoid visit inside function scope
             return traversal_no_recurse
@@ -258,7 +258,7 @@ function testrunner_testcase_code_actions!(
         code_actions::Vector{Union{CodeAction,Command}}, uri::URI, fi::FileInfo, action_range::Range
     )
     st0_top = build_syntax_tree(fi)
-    traverse(st0_top) do st0::SyntaxTreeC
+    traverse(st0_top) do st0::SyntaxTree
         if JS.kind(st0) in JS.KSet"function macro"
             # avoid visit inside function scope
             return traversal_no_recurse

--- a/src/type-definition.jl
+++ b/src/type-definition.jl
@@ -51,7 +51,7 @@ end
 
 """
     find_type_definition(server, uri, fi, pos) ->
-        (locations::Vector{Location}, origin_node::SyntaxTreeC) or nothing
+        (locations::Vector{Location}, origin_node::SyntaxTree) or nothing
 
 Core routine behind `textDocument/typeDefinition`. Returns the locations of the
 type definition for the expression at `pos` together with the origin node used

--- a/src/types.jl
+++ b/src/types.jl
@@ -53,8 +53,22 @@ function build_line_starts(textbuf::Vector{UInt8})
     return starts
 end
 
+# Side tables for the per-node analysis results `TypeAnnotation` records on the
+# inferred tree. A fresh instance is created per inference pass (matching the
+# pre-standard-tree behavior of starting each pass with empty `:type`/`:matches`
+# graph attributes), and the final pass's instance is owned by
+# `InferredTreeContext`, so annotations never outlive the analysis nor mutate
+# nodes shared with other trees.
+struct TreeAnnotations
+    types::Dict{SyntaxTreeC,Any}
+    matches::Dict{SyntaxTreeC,Vector{Core.MethodMatch}}
+end
+TreeAnnotations() = TreeAnnotations(
+    Dict{SyntaxTreeC,Any}(), Dict{SyntaxTreeC,Vector{Core.MethodMatch}}())
+
 struct InferredTreeContext
     inferred_tree::SyntaxTreeC
+    annotations::TreeAnnotations
     # `byte_range => kind` for the surface node each lowered node was lowered
     # from (first element of `JS.flattened_provenance`). First-write-wins,
     # mirroring a `traverse`-then-pick-first lookup.
@@ -82,7 +96,7 @@ struct InferredTreeContext
     # only when the OC whose body it's in has the queried byte range — so inner-OC noise
     # inside an outer OC body (e.g. multi-`for` comprehension, closure-of-closure) is
     # filtered when querying at the inner OC's range.
-    oc_body_scope::Dict{Int,UnitRange{Int}}
+    oc_body_scope::Dict{SyntaxTreeC,UnitRange{Int}}
     # Refined OC argument types keyed by argument binding byte range.
     oc_argument_binding_types::Dict{UnitRange{Int},Any}
 end
@@ -100,7 +114,7 @@ struct FileInfo
     filename::String
     encoding::LSP.PositionEncodingKind.Ty
     testsetinfos::Vector{TestsetInfo}
-    # Pruned `st0` cache for synchronized documents. Access through
+    # `st0` cache for synchronized documents. Access through
     # `build_syntax_tree`, which returns a copy safe for lowering. Unsynced files
     # keep this `nothing`; workspace-wide hot paths should rely on summary caches
     # instead of retaining `st0` for every file.
@@ -126,7 +140,6 @@ struct FileInfo
             syntax_tree0::Union{Nothing,SyntaxTreeC} = nothing,
             inferred_context_cache::Union{Nothing,InferredContextCache} = nothing
         )
-        syntax_tree0 = syntax_tree0 === nothing ? nothing : JS.prune(syntax_tree0)
         line_starts = build_line_starts(parsed_stream.textbuf)
         new(version, parsed_stream, filename, encoding, testsetinfos, syntax_tree0,
             inferred_context_cache, line_starts)

--- a/src/types.jl
+++ b/src/types.jl
@@ -114,15 +114,16 @@ struct FileInfo
     filename::String
     encoding::LSP.PositionEncodingKind.Ty
     testsetinfos::Vector{TestsetInfo}
-    # `st0` cache for synchronized documents. Access through
-    # `build_syntax_tree`, which returns a copy safe for lowering. Unsynced files
-    # keep this `nothing`; workspace-wide hot paths should rely on summary caches
-    # instead of retaining `st0` for every file.
+    # `st0` cache for synchronized documents, built from `parsed_stream` when the
+    # constructor is given `cache_tree0=true`. Access through `build_syntax_tree`,
+    # which returns a copy safe for lowering. Unsynced files keep this `nothing`;
+    # workspace-wide hot paths should rely on summary caches instead of retaining
+    # `st0` for every file.
     syntax_tree0::Union{Nothing,SyntaxTreeC}
     # Intentionally unbounded within a `FileInfo`: synced documents usually receive
     # repeated type queries for the same top-level tree. Content updates replace the
     # whole `FileInfo`, and full-analysis updates clear this cache so old analysis
-    # worlds can be released. Unlike the pruned `syntax_tree0` cache, inferred
+    # worlds can be released. Unlike the `syntax_tree0` cache, inferred
     # contexts are several times heavier; e.g. caching them for unsynced workspace
     # files would retain roughly 140 MiB for JETLS' own `src/`, so keep this `nothing`
     # outside synchronized documents.
@@ -137,9 +138,11 @@ struct FileInfo
             version::Int, parsed_stream::JS.ParseStream, filename::AbstractString,
             encoding::LSP.PositionEncodingKind.Ty = LSP.PositionEncodingKind.UTF16,
             testsetinfos::Vector{TestsetInfo} = EMPTY_TESTSETINFOS;
-            syntax_tree0::Union{Nothing,SyntaxTreeC} = nothing,
+            cache_tree0::Bool = false,
             inferred_context_cache::Union{Nothing,InferredContextCache} = nothing
         )
+        syntax_tree0 = cache_tree0 ?
+            JS.build_tree(JS.SyntaxTree, parsed_stream; filename) : nothing
         line_starts = build_line_starts(parsed_stream.textbuf)
         new(version, parsed_stream, filename, encoding, testsetinfos, syntax_tree0,
             inferred_context_cache, line_starts)

--- a/src/types.jl
+++ b/src/types.jl
@@ -15,10 +15,10 @@ struct TestsetResult
 end
 
 struct TestsetInfo
-    st0::SyntaxTreeC
+    st0::SyntaxTree
     result::TestsetResult
-    TestsetInfo(st0::SyntaxTreeC) = new(st0)
-    TestsetInfo(st0::SyntaxTreeC, result::TestsetResult) = new(st0, result)
+    TestsetInfo(st0::SyntaxTree) = new(st0)
+    TestsetInfo(st0::SyntaxTree, result::TestsetResult) = new(st0, result)
 end
 
 const EMPTY_TESTSETINFOS = TestsetInfo[]
@@ -60,14 +60,14 @@ end
 # `InferredTreeContext`, so annotations never outlive the analysis nor mutate
 # nodes shared with other trees.
 struct TreeAnnotations
-    types::Dict{SyntaxTreeC,Any}
-    matches::Dict{SyntaxTreeC,Vector{Core.MethodMatch}}
+    types::Dict{SyntaxTree,Any}
+    matches::Dict{SyntaxTree,Vector{Core.MethodMatch}}
 end
 TreeAnnotations() = TreeAnnotations(
-    Dict{SyntaxTreeC,Any}(), Dict{SyntaxTreeC,Vector{Core.MethodMatch}}())
+    Dict{SyntaxTree,Any}(), Dict{SyntaxTree,Vector{Core.MethodMatch}}())
 
 struct InferredTreeContext
-    inferred_tree::SyntaxTreeC
+    inferred_tree::SyntaxTree
     annotations::TreeAnnotations
     # `byte_range => kind` for the surface node each lowered node was lowered
     # from (first element of `JS.flattened_provenance`). First-write-wins,
@@ -76,7 +76,7 @@ struct InferredTreeContext
     # Every lowered node keyed by its own `byte_range`, in preorder. The
     # preorder property is load-bearing for the "last `K"call"` wins"
     # semantics in `type_for_call`.
-    by_byte_range::Dict{UnitRange{Int}, Vector{SyntaxTreeC}}
+    by_byte_range::Dict{UnitRange{Int}, Vector{SyntaxTree}}
     # Result types from typed `K"call"` nodes whose first provenance is a
     # `K"macrocall"`, keyed by the macrocall's `byte_range`.
     macrocall_types::Dict{UnitRange{Int}, Vector{Any}}
@@ -85,7 +85,7 @@ struct InferredTreeContext
     # User-vs-synthetic classification is derived per-query from
     # `user_return_form_ranges` below — @mlechu's idea.
     return_first_bytes::Vector{Int}
-    return_nodes::Vector{SyntaxTreeC}
+    return_nodes::Vector{SyntaxTree}
     # Byte ranges of every user-written `K"return"` surface form in `st3`
     # (`st3` not `st0` so macro-expansion-introduced `K"return"`s are included).
     # Consumed by `type_for_branching`.
@@ -96,7 +96,7 @@ struct InferredTreeContext
     # only when the OC whose body it's in has the queried byte range — so inner-OC noise
     # inside an outer OC body (e.g. multi-`for` comprehension, closure-of-closure) is
     # filtered when querying at the inner OC's range.
-    oc_body_scope::Dict{SyntaxTreeC,UnitRange{Int}}
+    oc_body_scope::Dict{SyntaxTree,UnitRange{Int}}
     # Refined OC argument types keyed by argument binding byte range.
     oc_argument_binding_types::Dict{UnitRange{Int},Any}
 end
@@ -119,7 +119,7 @@ struct FileInfo
     # which returns a copy safe for lowering. Unsynced files keep this `nothing`;
     # workspace-wide hot paths should rely on summary caches instead of retaining
     # `st0` for every file.
-    syntax_tree0::Union{Nothing,SyntaxTreeC}
+    syntax_tree0::Union{Nothing,SyntaxTree}
     # Intentionally unbounded within a `FileInfo`: synced documents usually receive
     # repeated type queries for the same top-level tree. Content updates replace the
     # whole `FileInfo`, and full-analysis updates clear this cache so old analysis
@@ -756,12 +756,12 @@ function ConfigManagerData(
 end
 
 struct BindingOccurrence
-    tree::SyntaxTreeC
+    tree::SyntaxTree
     kind::Symbol
 end
 
 # Types for binding occurrences cache.
-# IMPORTANT: We must not cache full `SyntaxTreeC` or `JL.BindingInfo` objects
+# IMPORTANT: We must not cache full `SyntaxTree` or `JL.BindingInfo` objects
 # as they hold references to large internal structures (syntax graphs, lowering
 # contexts). Instead, we extract only the essential information needed for
 # LSP features, i.e. mainly binding kind and location information.
@@ -778,7 +778,7 @@ end
 
 A lightweight representation of syntax tree location information.
 This struct stores only the byte range and source location, implementing the
-minimum `SyntaxTreeC` API (`first_byte`, `last_byte`, `source_location`)
+minimum `SyntaxTree` API (`first_byte`, `last_byte`, `source_location`)
 required by [`jsobj_to_range`](@ref) that convert syntax tree to LSP `Range` objects.
 """
 struct CachedSyntaxTree
@@ -786,7 +786,7 @@ struct CachedSyntaxTree
     lb::Int
     line::Int
     column::Int
-    function CachedSyntaxTree(st::SyntaxTreeC)
+    function CachedSyntaxTree(st::SyntaxTree)
         return new(JS.first_byte(st), JS.last_byte(st), JS.source_location(st)...)
     end
 end

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -1,10 +1,22 @@
+"""
+    copy_syntax_tree(st0::SyntaxTreeC) -> SyntaxTreeC
+
+Lightweight per-read copy for shared syntax tree caches. The lowering pipeline
+mutates nodes in place (`JL.rebase_layers` runs `JS.fill_context!` on
+context-free trees), so readers of a shared cache must lower a copy.
+`JS.mktree` rebuilds every node while sharing the `source` chain —
+`fill_context!` recurses only over `children`, so the cached original stays
+untouched — and is ~10x cheaper than `JS.copy_ast`, which would also deep-copy
+the parse tree behind `source`. Nodes aliased within the tree are duplicated
+(the same normalization `JS.unalias_nodes` performs).
+"""
+copy_syntax_tree(st0::SyntaxTreeC) = JS.mktree(st0)
+
 function build_syntax_tree(fi::FileInfo)
     if fi.syntax_tree0 === nothing
         return JS.build_tree(JS.SyntaxTree, fi.parsed_stream; filename=fi.filename)
     end
-    # The lowering pipeline can mutate nodes in place (e.g. `JS.fill_context!`),
-    # so we need to create a copy for each read to avoid race conditions.
-    return JS.copy_ast(fi.syntax_tree0)
+    return copy_syntax_tree(fi.syntax_tree0)
 end
 
 # kinds whose `value` holds the identifier name (see `JL.syntax_name`)

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -1,5 +1,5 @@
 """
-    copy_syntax_tree(st0::SyntaxTreeC) -> SyntaxTreeC
+    copy_syntax_tree(st0::SyntaxTree) -> SyntaxTree
 
 Lightweight per-read copy for shared syntax tree caches. The lowering pipeline
 mutates nodes in place (`JL.rebase_layers` runs `JS.fill_context!` on
@@ -10,7 +10,7 @@ untouched — and is ~10x cheaper than `JS.copy_ast`, which would also deep-copy
 the parse tree behind `source`. Nodes aliased within the tree are duplicated
 (the same normalization `JS.unalias_nodes` performs).
 """
-copy_syntax_tree(st0::SyntaxTreeC) = JS.mktree(st0)
+copy_syntax_tree(st0::SyntaxTree) = JS.mktree(st0)
 
 function build_syntax_tree(fi::FileInfo)
     if fi.syntax_tree0 === nothing
@@ -25,27 +25,27 @@ Identifier Placeholder Symbol core top globalref symboliclabel symbolicgoto
 unknown_head oldsymbolicgoto
 """
 
-has_name_val(st::SyntaxTreeC) = JS.kind(st) in NAME_VAL_KINDS
-get_name_val(st::SyntaxTreeC, default=nothing) = has_name_val(st) ? st.value::String : default
-name_val(st::SyntaxTreeC) = st.value::String
+has_name_val(st::SyntaxTree) = JS.kind(st) in NAME_VAL_KINDS
+get_name_val(st::SyntaxTree, default=nothing) = has_name_val(st) ? st.value::String : default
+name_val(st::SyntaxTree) = st.value::String
 
-var_id(st::SyntaxTreeC) = JL.syntax_id(st)
+var_id(st::SyntaxTree) = JL.syntax_id(st)
 
 get_source_text(ps::JS.ParseStream) = JS.sourcetext(JS.SourceFile(ps))
 document_text(fi::FileInfo) = get_source_text(fi.parsed_stream)
 document_range(fi::FileInfo) = jsobj_to_range(fi.parsed_stream, fi)
 
 """
-    trim_error_nodes(st0::SyntaxTreeC) -> SyntaxTreeC
+    trim_error_nodes(st0::SyntaxTree) -> SyntaxTree
 
 Strip parser-recovery (`K"error"`) nodes from `st0` and fix the structural shapes that
 the strip would otherwise leave malformed for JuliaLowering — i.e. [`without_kinds`](@ref)
 and [`repair_after_trim`](@ref) in sequence. Apply this to a surface AST before handing it
 to a lowering pass that needs to tolerate incomplete user input.
 """
-trim_error_nodes(st0::SyntaxTreeC) = repair_after_trim(without_kinds(st0, JS.KSet"error"))
+trim_error_nodes(st0::SyntaxTree) = repair_after_trim(without_kinds(st0, JS.KSet"error"))
 
-function _without_kinds(st::SyntaxTreeC, kinds::Tuple{Vararg{JS.Kind}})
+function _without_kinds(st::SyntaxTree, kinds::Tuple{Vararg{JS.Kind}})
     if JS.kind(st) in kinds
         return (nothing, true)
     elseif JS.is_leaf(st)
@@ -66,19 +66,19 @@ function _without_kinds(st::SyntaxTreeC, kinds::Tuple{Vararg{JS.Kind}})
 end
 
 """
-    without_kinds(st::SyntaxTreeC, kinds::Tuple{Vararg{JS.Kind}}) -> trimmed::SyntaxTreeC
+    without_kinds(st::SyntaxTree, kinds::Tuple{Vararg{JS.Kind}}) -> trimmed::SyntaxTree
 
 Return a tree where all nodes of `kinds` are trimmed.
 Should not modify any nodes, and should not create new nodes unnecessarily.
 """
-function without_kinds(st::SyntaxTreeC, kinds::Tuple{Vararg{JS.Kind}})
+function without_kinds(st::SyntaxTree, kinds::Tuple{Vararg{JS.Kind}})
     return (JS.kind(st) in kinds ?
         JL.@ast(_, st, [JS.K"TOMBSTONE"]) :
-        _without_kinds(st, kinds)[1])::SyntaxTreeC
+        _without_kinds(st, kinds)[1])::SyntaxTree
 end
 
 """
-    repair_after_trim(st0::SyntaxTreeC) -> SyntaxTreeC
+    repair_after_trim(st0::SyntaxTree) -> SyntaxTree
 
 Walk `st0` and fix structural shapes that JuliaLowering would reject after
 [`without_kinds`](@ref) has trimmed parser-recovery (`K"error"`) nodes. Each
@@ -105,11 +105,11 @@ Not yet handled because the malformed shape needs more than a child-collapse:
 Add new branches in [`_repair_node`](@ref) when these cause downstream
 breakage in practice.
 """
-function repair_after_trim(st0::SyntaxTreeC)
-    return _repair_after_trim(st0)::SyntaxTreeC
+function repair_after_trim(st0::SyntaxTree)
+    return _repair_after_trim(st0)::SyntaxTree
 end
 
-function _repair_after_trim(st0::SyntaxTreeC)
+function _repair_after_trim(st0::SyntaxTree)
     JS.is_leaf(st0) && return st0
     new_children = JS.SyntaxList()
     changed = false
@@ -125,7 +125,7 @@ end
 
 # Per-kind repair rules. Each rule returns the replacement node when it applies,
 # or `nothing` to fall through to the default reconstruction.
-function _repair_node(st0::SyntaxTreeC, new_children::JS.SyntaxList)
+function _repair_node(st0::SyntaxTree, new_children::JS.SyntaxList)
     k = JS.kind(st0)
     if k === JS.K"." && length(new_children) == 2 && _is_empty_non_leaf(new_children[2])
         return new_children[1]
@@ -141,9 +141,9 @@ function _repair_node(st0::SyntaxTreeC, new_children::JS.SyntaxList)
     return nothing
 end
 
-_is_empty_non_leaf(st0::SyntaxTreeC) = !JS.is_leaf(st0) && JS.numchildren(st0) == 0
+_is_empty_non_leaf(st0::SyntaxTree) = !JS.is_leaf(st0) && JS.numchildren(st0) == 0
 
-function _unwrap_interpolations(st::SyntaxTreeC)
+function _unwrap_interpolations(st::SyntaxTree)
     k = JS.kind(st)
     if k === JS.K"$"
         if JS.numchildren(st) >= 1
@@ -169,11 +169,11 @@ Return a tree where `JS.K"\$"` interpolation nodes are replaced by their content
 Unlike `without_kinds` which removes nodes entirely, this preserves the child
 so that parent nodes (e.g. dot expressions like `x.\$name`) remain well-formed.
 """
-function unwrap_interpolations(st::SyntaxTreeC)
+function unwrap_interpolations(st::SyntaxTree)
     return first(_unwrap_interpolations(st))
 end
 
-function is_macrocall_st0(st0::SyntaxTreeC, names::AbstractString...; from::Union{Nothing,Module}=nothing)
+function is_macrocall_st0(st0::SyntaxTree, names::AbstractString...; from::Union{Nothing,Module}=nothing)
     JS.kind(st0) === JS.K"macrocall" || return false
     JS.numchildren(st0) >= 1 || return false
     macro_name = st0[1]
@@ -185,9 +185,9 @@ function is_macrocall_st0(st0::SyntaxTreeC, names::AbstractString...; from::Unio
     return nv in names && (isnothing(from) || macro_name.mod === from)
 end
 
-is_mainfunc0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@main")
+is_mainfunc0(st0::SyntaxTree) = is_macrocall_st0(st0, "@main")
 
-function resolve_macrocall_object(context_module::Module, world::UInt, st0::SyntaxTreeC)
+function resolve_macrocall_object(context_module::Module, world::UInt, st0::SyntaxTree)
     JS.kind(st0) === JS.K"macrocall" || return nothing
     JS.numchildren(st0) >= 1 || return nothing
     macro_const = resolve_global_const(context_module, world, st0[1])
@@ -204,26 +204,26 @@ function is_macro_object_binding(
 end
 
 function is_macrocall_binding0(
-        context_module::Module, world::UInt, st0::SyntaxTreeC,
+        context_module::Module, world::UInt, st0::SyntaxTree,
         defining_module::Module, name::Symbol
     )
     macro_object = @something resolve_macrocall_object(context_module, world, st0) return false
     return is_macro_object_binding(macro_object, world, defining_module, name)
 end
 
-is_generated0(context_module::Module, world::UInt, st0::SyntaxTreeC) =
+is_generated0(context_module::Module, world::UInt, st0::SyntaxTree) =
     is_macrocall_binding0(context_module, world, st0, Base, Symbol("@generated"))
 
-is_ateval0(context_module::Module, world::UInt, st0::SyntaxTreeC) =
+is_ateval0(context_module::Module, world::UInt, st0::SyntaxTree) =
     is_macrocall_binding0(context_module, world, st0, Base, Symbol("@eval"))
 
-is_nospecialize_or_specialize_macrocall0(st0::SyntaxTreeC) =
+is_nospecialize_or_specialize_macrocall0(st0::SyntaxTree) =
     is_macrocall_st0(st0, "@nospecialize", "@specialize")
 
-is_macro0(st0::SyntaxTreeC) = JS.kind(st0) === JS.K"macro"
+is_macro0(st0::SyntaxTree) = JS.kind(st0) === JS.K"macro"
 
 function is_new_style_macrocall0(
-        context_module::Module, world::UInt, st0::SyntaxTreeC
+        context_module::Module, world::UInt, st0::SyntaxTree
     )
     macro_object = @something resolve_macrocall_object(context_module, world, st0) return false
     return any(NEW_STYLE_MACRO_BINDINGS) do (defining_module, name)
@@ -231,16 +231,16 @@ function is_new_style_macrocall0(
     end
 end
 
-is_doc0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@doc"; from=Core)
-is_doc0_any(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@doc") # Explicit `@doc` can have any module set.
+is_doc0(st0::SyntaxTree) = is_macrocall_st0(st0, "@doc"; from=Core)
+is_doc0_any(st0::SyntaxTree) = is_macrocall_st0(st0, "@doc") # Explicit `@doc` can have any module set.
 
-is_cmd0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@cmd"; from=Core)
+is_cmd0(st0::SyntaxTree) = is_macrocall_st0(st0, "@cmd"; from=Core)
 
-is_static0(context_module::Module, world::UInt, st0::SyntaxTreeC) =
+is_static0(context_module::Module, world::UInt, st0::SyntaxTree) =
     is_macrocall_binding0(context_module, world, st0, Base, Symbol("@static"))
 
 """
-    collect_import_names(st0::SyntaxTreeC) -> Vector{Pair{SyntaxTreeC, String}}
+    collect_import_names(st0::SyntaxTree) -> Vector{Pair{SyntaxTree, String}}
 
 Return pairs of `(node, sort_key)` for the named items of an
 `import`/`using`/`export`/`public` statement: the child node representing
@@ -248,9 +248,9 @@ each item alongside its sort key (see [`get_import_sort_key`](@ref)).
 For `using M: a, b` returns entries for `a` and `b`; for `using M.A` (no
 `:`) returns entries for the imported path nodes.
 """
-function collect_import_names(st0::SyntaxTreeC)
+function collect_import_names(st0::SyntaxTree)
     kind = JS.kind(st0)
-    names = Pair{SyntaxTreeC, String}[]
+    names = Pair{SyntaxTree, String}[]
     if kind in JS.KSet"import using"
         nchildren = JS.numchildren(st0)
         if nchildren == 1
@@ -277,7 +277,7 @@ function collect_import_names(st0::SyntaxTreeC)
 end
 
 """
-    foreach_local_import_identifier(f, st0::SyntaxTreeC)
+    foreach_local_import_identifier(f, st0::SyntaxTree)
 
 Invoke `f(id_st)` once for each locally-introduced identifier of an
 `import`/`using` statement `st0`. Covers every form that actually binds
@@ -290,7 +290,7 @@ a name in the current scope:
 - `using A: x as y` — the alias `y`
 - `import A: x as y` — likewise
 """
-function foreach_local_import_identifier(f, st0::SyntaxTreeC)
+function foreach_local_import_identifier(f, st0::SyntaxTree)
     kind = JS.kind(st0)
     kind in JS.KSet"import using" || return
     nchildren = JS.numchildren(st0)
@@ -314,7 +314,7 @@ function foreach_local_import_identifier(f, st0::SyntaxTreeC)
 end
 
 """
-    get_local_import_identifier(st0::SyntaxTreeC) -> Union{SyntaxTreeC, Nothing}
+    get_local_import_identifier(st0::SyntaxTree) -> Union{SyntaxTree, Nothing}
 
 Return the `K"Identifier"` node that represents the local binding introduced
 by a single element of an `import`/`using` statement, or `nothing` if the
@@ -326,7 +326,7 @@ path children (`using A.B` → path `A.B`) and the names listed after `:`
   or `..` prefixes of forms like `.A` / `..A.B`)
 - `K"as"` (inside a colon list) — the alias
 """
-function get_local_import_identifier(st0::SyntaxTreeC)
+function get_local_import_identifier(st0::SyntaxTree)
     kind = JS.kind(st0)
     if kind === JS.K"as"
         # `using M: a as b` -> identifier for "b"
@@ -347,7 +347,7 @@ function get_local_import_identifier(st0::SyntaxTreeC)
     end
 end
 
-function get_import_sort_key(st0::SyntaxTreeC)
+function get_import_sort_key(st0::SyntaxTree)
     kind = JS.kind(st0)
     if kind === JS.K"as"
         return get_import_sort_key(st0[1])
@@ -369,7 +369,7 @@ function get_import_sort_key(st0::SyntaxTreeC)
 end
 
 """
-    is_import_eval_call(st3::SyntaxTreeC) -> Bool
+    is_import_eval_call(st3::SyntaxTree) -> Bool
 
 Return `true` when `st3` is a `K"call"` to JuliaLowering's `eval_import` /
 `eval_using` runtime helpers, which `import` / `using` statements desugar into.
@@ -378,7 +378,7 @@ Because they are compiler-generated rather than user-authored quoted code, inert
 traversals skip such calls so module paths are not mistaken for ordinary global
 references (e.g. `import A.B` nested in an `if`/`begin` block).
 """
-function is_import_eval_call(st3::SyntaxTreeC)
+function is_import_eval_call(st3::SyntaxTree)
     JS.kind(st3) === JS.K"call" || return false
     JS.numchildren(st3) ≥ 1 || return false
     head = st3[1]
@@ -387,7 +387,7 @@ function is_import_eval_call(st3::SyntaxTreeC)
     return val === JL.eval_import || val === JL.eval_using
 end
 
-function is_nospecialize_or_specialize_macrocall3(st3::SyntaxTreeC)
+function is_nospecialize_or_specialize_macrocall3(st3::SyntaxTree)
     JS.kind(st3) === JS.K"macrocall" || return false
     JS.numchildren(st3) >= 1 || return false
     macro_name = st3[1]
@@ -399,7 +399,7 @@ function is_nospecialize_or_specialize_macrocall3(st3::SyntaxTreeC)
 end
 
 function _remove_macrocalls(
-        context_module::Union{Nothing,Module}, world::UInt, st0::SyntaxTreeC;
+        context_module::Union{Nothing,Module}, world::UInt, st0::SyntaxTree;
         strip_static::Bool = false
     )
     if JS.kind(st0) === JS.K"macrocall"
@@ -472,7 +472,7 @@ function _remove_macrocalls(
 end
 
 """
-    desugar_main_macrocall(st0::SyntaxTreeC) -> Tuple{SyntaxTreeC, Bool}
+    desugar_main_macrocall(st0::SyntaxTree) -> Tuple{SyntaxTree, Bool}
 
 If `st0` is a `function (@main)(args...) ... end`, `(@main)(args...) = ...`,
 `function @main(args...) ... end`, or `@main(args...) = ...` definition, replace
@@ -482,7 +482,7 @@ This avoids macro expansion failure when multiple standalone files defining
 `@main` are analyzed in the same session — the second file's sandbox module
 already has `main` imported from the first, causing `@main` expansion to error.
 """
-function desugar_main_macrocall(st0::SyntaxTreeC)
+function desugar_main_macrocall(st0::SyntaxTree)
     k = JS.kind(st0)
     if k === JS.K"function"
         JS.numchildren(st0) >= 1 || return (st0, false)
@@ -527,9 +527,9 @@ end
 
 """
     remove_macrocalls(
-        context_module::Module, world::UInt, st0::SyntaxTreeC;
+        context_module::Module, world::UInt, st0::SyntaxTree;
         strip_static::Bool=false
-    ) -> SyntaxTreeC
+    ) -> SyntaxTree
 
 Convert each old-style `macrocall` node to a `block` node, keeping the arguments intact
 so that identifiers passed to macros retain their original source locations. Macro names
@@ -579,7 +579,7 @@ any bindings or control flow the macros themselves would have introduced.
     of this transformation is expected to shrink.
 """
 function remove_macrocalls(
-        context_module::Module, world::UInt, st0::SyntaxTreeC;
+        context_module::Module, world::UInt, st0::SyntaxTree;
         strip_static::Bool = false
     )
     return first(_remove_macrocalls(context_module, world, st0; strip_static))
@@ -591,7 +591,7 @@ end
 # annotations like `f(x::T)` live inside the call's args, so this pass doesn't touch them.
 # On malformed input (a wrapper with no children) the wrapper is returned as-is, so callers'
 # kind checks naturally filter it without a separate `nothing` branch.
-function unwrap_funcdef_sig(node::SyntaxTreeC)
+function unwrap_funcdef_sig(node::SyntaxTree)
     while true
         k = JS.kind(node)
         if (k === JS.K"where" || k === JS.K"::") && JS.numchildren(node) ≥ 1
@@ -602,13 +602,13 @@ function unwrap_funcdef_sig(node::SyntaxTreeC)
     end
 end
 
-function foreach_struct_inner_constructor(@specialize(callback), st0::SyntaxTreeC)
+function foreach_struct_inner_constructor(@specialize(callback), st0::SyntaxTree)
     name_node = @something struct_name_node(st0) return true
     name = @something get_name_val(name_node) return true
     JS.numchildren(st0) ≥ 3 || return true
     body = st0[3]
     for i = 1:JS.numchildren(body)
-        keep_going = foreach_wrapped_function_name(body[i]) do constructor_node::SyntaxTreeC
+        keep_going = foreach_wrapped_function_name(body[i]) do constructor_node::SyntaxTree
             get_name_val(constructor_node) == name || return true
             return callback(name_node, constructor_node)
         end
@@ -617,7 +617,7 @@ function foreach_struct_inner_constructor(@specialize(callback), st0::SyntaxTree
     return true
 end
 
-function struct_name_node(st0::SyntaxTreeC)
+function struct_name_node(st0::SyntaxTree)
     JS.kind(st0) === JS.K"struct" && JS.numchildren(st0) ≥ 2 || return nothing
     node = st0[2]
     if JS.kind(node) === JS.K"<:" && JS.numchildren(node) ≥ 1
@@ -629,7 +629,7 @@ function struct_name_node(st0::SyntaxTreeC)
     return JS.is_identifier(node) ? node : nothing
 end
 
-function foreach_wrapped_function_name(@specialize(callback), st0::SyntaxTreeC)
+function foreach_wrapped_function_name(@specialize(callback), st0::SyntaxTree)
     name_node = function_definition_name_node(st0)
     name_node === nothing || return callback(name_node)
     JS.kind(st0) in JS.KSet"macrocall block" || return true
@@ -640,7 +640,7 @@ function foreach_wrapped_function_name(@specialize(callback), st0::SyntaxTreeC)
     return true
 end
 
-function function_definition_name_node(st0::SyntaxTreeC)
+function function_definition_name_node(st0::SyntaxTree)
     k = JS.kind(st0)
     if (k === JS.K"function" || k === JS.K"=") && JS.numchildren(st0) ≥ 1
         sig = unwrap_funcdef_sig(st0[1])
@@ -655,7 +655,7 @@ function function_definition_name_node(st0::SyntaxTreeC)
 end
 
 # Collect the `name_val` of every `K"Identifier"` node reachable from `st` into `names`.
-function collect_identifier_names!(names::Set{String}, st::SyntaxTreeC)
+function collect_identifier_names!(names::Set{String}, st::SyntaxTree)
     traverse(st) do node
         if JS.kind(node) === JS.K"Identifier"
             name = get_name_val(node)
@@ -668,11 +668,11 @@ end
 
 # `K"core"` leaves can't appear in user-written source (`Core.x` lowers through
 # `K"globalref"`), so these match only lowering-generated references.
-function is_core_ref(node::SyntaxTreeC, name::String)
+function is_core_ref(node::SyntaxTree, name::String)
     return JS.kind(node) === JS.K"core" && get_name_val(node) == name
 end
 
-function is_core_svec_call(call_node::SyntaxTreeC)
+function is_core_svec_call(call_node::SyntaxTree)
     JS.numchildren(call_node) >= 1 || return false
     return is_core_ref(call_node[1], "svec")
 end
@@ -681,9 +681,9 @@ end
 Like `Base.unique`, but over node identities, and with this comment promising
 that the lowest-index copy of each node is kept.
 """
-function deduplicate_syntaxlist(sl::SyntaxListC)
+function deduplicate_syntaxlist(sl::SyntaxList)
     sl2 = JS.SyntaxList()
-    seen = Set{SyntaxTreeC}()
+    seen = Set{SyntaxTree}()
     for st in sl
         if !(st in seen)
             push!(sl2, st)
@@ -694,7 +694,7 @@ function deduplicate_syntaxlist(sl::SyntaxListC)
 end
 
 """
-    traverse(callback, st::SyntaxTreeC, postorder::Bool=false)
+    traverse(callback, st::SyntaxTree, postorder::Bool=false)
 
 Traverse a `SyntaxTree`, calling `callback(node)` on each node.
 By default traverses in pre-order (parent before children).
@@ -710,7 +710,7 @@ The `callback` can control traversal by returning one of:
 The stored value from the last `TraversalReturn` is returned from `traverse`
 (or `nothing` if no `TraversalReturn` was used).
 """
-function traverse(@specialize(callback), st::SyntaxTreeC, postorder::Bool=false)
+function traverse(@specialize(callback), st::SyntaxTree, postorder::Bool=false)
     stack = JS.SyntaxList(st)
     if postorder
         _traverse_postorder(callback, stack)
@@ -729,7 +729,7 @@ struct TraversalNoRecurse end
 const traversal_terminator = TraversalTerminator()
 const traversal_no_recurse = TraversalNoRecurse()
 
-function _traverse_preorder(@specialize(callback), stack::SyntaxListC)
+function _traverse_preorder(@specialize(callback), stack::SyntaxList)
     local retval = nothing
     while !isempty(stack)
         x = pop!(stack)
@@ -753,7 +753,7 @@ function _traverse_preorder(@specialize(callback), stack::SyntaxListC)
     return retval
 end
 
-function _traverse_postorder(@specialize(callback), stack::SyntaxListC)
+function _traverse_postorder(@specialize(callback), stack::SyntaxList)
     local retval = nothing
     output = JS.SyntaxList()
     while !isempty(stack)
@@ -779,7 +779,7 @@ end
 # TODO use something like `JuliaInterpreter.ExprSplitter`
 
 """
-    iterate_toplevel_tree(callback, st0_top::SyntaxTreeC)
+    iterate_toplevel_tree(callback, st0_top::SyntaxTree)
 
 Walk each lowerable top-level subtree of `st0_top` (descending into `K"toplevel"`,
 `K"module"`, and docstring wrappers) and invoke `callback(st0)` on every leaf.
@@ -793,7 +793,7 @@ The `callback` can control iteration by returning one of:
 The stored value from the last `TraversalReturn` is returned (or `nothing` if no
 `TraversalReturn` was used).
 """
-function iterate_toplevel_tree(callback, st0_top::SyntaxTreeC)
+function iterate_toplevel_tree(callback, st0_top::SyntaxTree)
     retval = nothing
     sl = JS.SyntaxList(st0_top)
     while !isempty(sl)
@@ -847,8 +847,8 @@ function iterate_toplevel_tree(callback, st0_top::SyntaxTreeC)
 end
 
 """
-    byte_ancestors([flt,] st::SyntaxTreeC, rng::UnitRange{Int})
-    byte_ancestors([flt,] st::SyntaxTreeC, byte::Integer)
+    byte_ancestors([flt,] st::SyntaxTree, rng::UnitRange{Int})
+    byte_ancestors([flt,] st::SyntaxTree, byte::Integer)
 
 Get a SyntaxList of `SyntaxTree`s containing certain bytes.
 
@@ -862,7 +862,7 @@ that satisfy the predicate.
 """
 byte_ancestors(args...) = byte_ancestors(Returns(true), args...)
 
-function byte_ancestors(flt, st::SyntaxTreeC, rng::UnitRange{<:Integer})
+function byte_ancestors(flt, st::SyntaxTree, rng::UnitRange{<:Integer})
     sl = JS.SyntaxList()
     if rng ⊆ JS.byte_range(st) && flt(st)
         push!(sl, st)
@@ -879,24 +879,24 @@ function byte_ancestors(flt, st::SyntaxTreeC, rng::UnitRange{<:Integer})
     # delete later duplicates when sorted parent->child
     return reverse!(deduplicate_syntaxlist(sl))
 end
-byte_ancestors(flt, st::SyntaxTreeC, byte::Integer) = byte_ancestors(flt, st, byte:byte)
+byte_ancestors(flt, st::SyntaxTree, byte::Integer) = byte_ancestors(flt, st, byte:byte)
 
 """
-    lowerable_toplevel_at(st0_top::SyntaxTreeC, offset::Integer) -> st::Union{SyntaxTreeC, Nothing}
+    lowerable_toplevel_at(st0_top::SyntaxTree, offset::Integer) -> st::Union{SyntaxTree, Nothing}
 
 Return the lowerable top-level subtree of `st0_top` whose byte range contains `offset`, or
 `nothing` if no such subtree exists. Equivalent to running [`iterate_toplevel_tree`](@ref)
 and picking the first hit whose byte range contains `offset`, with an `offset - 1` retry
 for cursor positions just past the last token of a statement (e.g. `export foo│\\n`).
 """
-function lowerable_toplevel_at(st0_top::SyntaxTreeC, offset::Integer)
+function lowerable_toplevel_at(st0_top::SyntaxTree, offset::Integer)
     result = _lowerable_toplevel_at(st0_top, offset)
     result !== nothing && return result
     return offset > 1 ? _lowerable_toplevel_at(st0_top, offset - 1) : nothing
 end
 
-function _lowerable_toplevel_at(st0_top::SyntaxTreeC, offset::Integer)
-    return iterate_toplevel_tree(st0_top) do st0::SyntaxTreeC
+function _lowerable_toplevel_at(st0_top::SyntaxTree, offset::Integer)
+    return iterate_toplevel_tree(st0_top) do st0::SyntaxTree
         offset in JS.byte_range(st0) || return nothing
         return TraversalReturn(st0; terminate=true)
     end
@@ -1169,20 +1169,20 @@ end
 # TODO: This is used so that `r"foo"|` or `r"foo" |` don't show signature help,
 # but this edge case might be acceptable given that `r"foo" anything|` shouldn't
 # show signature help
-is_special_macrocall(st0::SyntaxTreeC) =
+is_special_macrocall(st0::SyntaxTree) =
     JS.kind(st0) === JS.K"macrocall" && JS.numchildren(st0) >= 1 &&
     let mname = JS.kind(st0[1]) === JS.K"." && JS.numchildren(st0[1]) === 2 ? st0[1][2] : st0[1]
         mname_s = get_name_val(mname, "")
         endswith(mname_s, "_str") || endswith(mname_s, "_cmd")
     end
 
-noparen_macrocall(st0::SyntaxTreeC) =
+noparen_macrocall(st0::SyntaxTree) =
     JS.kind(st0) === JS.K"macrocall" &&
     !JS.has_flags(st0, JS.PARENS_FLAG) &&
     !is_special_macrocall(st0)
 
 """
-    select_target_identifier(st0::SyntaxTreeC, offset::Integer) -> target::Union{SyntaxTreeC,Nothing}
+    select_target_identifier(st0::SyntaxTree, offset::Integer) -> target::Union{SyntaxTree,Nothing}
 
 Determine the identifier node that the user most likely intends to navigate to,
 or `nothing` if no suitable one is found. `st0` must be a `SyntaxTree` before
@@ -1193,7 +1193,7 @@ For dot expressions, walks up through `K"."` to pick the larger dotted prefix
 like `var│` or `func│(5)` are handled by [`select_target_node`](@ref)'s
 `offset - 1` fallback.
 """
-function select_target_identifier(st0::SyntaxTreeC, offset::Integer)
+function select_target_identifier(st0::SyntaxTree, offset::Integer)
     filter = function (bas)
         JS.is_identifier(first(bas))
     end
@@ -1216,7 +1216,7 @@ function select_target_identifier(st0::SyntaxTreeC, offset::Integer)
     return select_target_node(filter, selector, st0, offset)
 end
 
-function select_target_string(st0::SyntaxTreeC, offset::Integer)
+function select_target_string(st0::SyntaxTree, offset::Integer)
     filter = function (bas)
         JS.kind(first(bas)) === JS.K"String"
     end
@@ -1227,8 +1227,8 @@ function select_target_string(st0::SyntaxTreeC, offset::Integer)
 end
 
 """
-    select_enclosing_call(st0::SyntaxTreeC, offset::Integer) ->
-        target::Union{SyntaxTreeC, Nothing}
+    select_enclosing_call(st0::SyntaxTree, offset::Integer) ->
+        target::Union{SyntaxTree, Nothing}
 
 Innermost surface form whose value is the result of a callable application
 whose byte range contains `offset`. Covers:
@@ -1252,7 +1252,7 @@ byte range) match when both yield a hit. This makes `func(args)│` and
 at the cursor, rather than to whichever enclosing form also happens to
 span that byte.
 """
-function select_enclosing_call(st0::SyntaxTreeC, offset::Integer)
+function select_enclosing_call(st0::SyntaxTree, offset::Integer)
     a = _innermost_call_at(st0, offset)
     offset > 0 || return a
     b = _innermost_call_at(st0, offset - 1)
@@ -1282,7 +1282,7 @@ const _CALL_LIKE_KINDS = JS.KSet"""
     typed_vcat typed_hcat typed_comprehension
     """
 
-function _innermost_call_at(st0::SyntaxTreeC, offset::Integer)
+function _innermost_call_at(st0::SyntaxTree, offset::Integer)
     for b in byte_ancestors(st0, offset)
         JS.kind(b) in _CALL_LIKE_KINDS && return b
     end
@@ -1290,8 +1290,8 @@ function _innermost_call_at(st0::SyntaxTreeC, offset::Integer)
 end
 
 """
-    enclosing_call_for_matches(st0::SyntaxTreeC, node::SyntaxTreeC) ->
-        SyntaxTreeC | nothing
+    enclosing_call_for_matches(st0::SyntaxTree, node::SyntaxTree) ->
+        SyntaxTree | nothing
 
 Call node whose `:matches` annotation answers a query about `node`.
 Returns `nothing` when `node` isn't (and isn't the callee of) a call.
@@ -1306,7 +1306,7 @@ exactly matches `node`'s range is the call we want.
 The exact-match check rejects mid-callee positions like `Foo│.bar(x)` where `node` is
 `Foo` and `child[1]` is the larger `Foo.bar`.
 """
-function enclosing_call_for_matches(st0::SyntaxTreeC, node::SyntaxTreeC)
+function enclosing_call_for_matches(st0::SyntaxTree, node::SyntaxTree)
     JS.kind(node) in JS.KSet"call dotcall" && return node
     rng = JS.byte_range(node)
     for st in byte_ancestors(st0, first(rng))
@@ -1318,8 +1318,8 @@ function enclosing_call_for_matches(st0::SyntaxTreeC, node::SyntaxTreeC)
 end
 
 """
-    select_target_for_type_query(st0::SyntaxTreeC, offset::Integer) ->
-        target::Union{SyntaxTreeC, Nothing}
+    select_target_for_type_query(st0::SyntaxTree, offset::Integer) ->
+        target::Union{SyntaxTree, Nothing}
 
 Pick the AST node whose `JS.byte_range` should be passed to `get_type_for_range` for the
 cursor at `offset`. Falls back through:
@@ -1333,13 +1333,13 @@ cursor at `offset`. Falls back through:
 Intended as the canonical cursor → AST resolver for TypeAnnotation-based features
 (type definition, hover-type, etc.).
 """
-select_target_for_type_query(st0::SyntaxTreeC, offset::Integer) =
+select_target_for_type_query(st0::SyntaxTree, offset::Integer) =
     @something(
         select_target_identifier(st0, offset),
         return select_enclosing_call(st0, offset))
 
 """
-    resolve_path_string_literal(string_node::SyntaxTreeC, basedir::AbstractString)
+    resolve_path_string_literal(string_node::SyntaxTree, basedir::AbstractString)
         -> Union{Nothing, @NamedTuple{value::String, path::String}}
 
 If `string_node` is a non-interpolated string literal whose value joins with
@@ -1347,7 +1347,7 @@ If `string_node` is a non-interpolated string literal whose value joins with
 `path`. Otherwise return `nothing`.
 """
 function resolve_path_string_literal(
-        string_node::SyntaxTreeC, basedir::AbstractString
+        string_node::SyntaxTree, basedir::AbstractString
     )
     value = string_node.value
     value isa String || return nothing
@@ -1356,7 +1356,7 @@ function resolve_path_string_literal(
     return (; value, path)
 end
 
-function select_target_node(filter, selector, st0::SyntaxTreeC, offset::Integer)
+function select_target_node(filter, selector, st0::SyntaxTree, offset::Integer)
     bas = @somereal byte_ancestors(st0, offset) @goto minus1
     if !filter(bas)
         @label minus1
@@ -1371,13 +1371,13 @@ function select_target_node(filter, selector, st0::SyntaxTreeC, offset::Integer)
 end
 
 """
-    select_dotprefix_identifier(st::SyntaxTreeC, offset::Integer) -> dotprefix::Union{SyntaxTreeC,Nothing}
+    select_dotprefix_identifier(st::SyntaxTree, offset::Integer) -> dotprefix::Union{SyntaxTree,Nothing}
 
 If the code at `offset` position is dot accessor code, get the code being dot accessed.
 For example, `Base.show_│` returns the `SyntaxTree` of `Base`.
 If it's not dot accessor code, return `nothing`.
 """
-function select_dotprefix_identifier(st::SyntaxTreeC, offset::Integer)
+function select_dotprefix_identifier(st::SyntaxTree, offset::Integer)
     bas = byte_ancestors(st, offset-1)
     dotprefix = nothing
     for i = 1:length(bas)
@@ -1525,7 +1525,7 @@ function try_extract_field_line(node::JS.SyntaxNode, structname::Symbol, fname::
 end
 
 """
-    is_from_user_ast(provs::SyntaxListC) -> Bool
+    is_from_user_ast(provs::SyntaxList) -> Bool
 
 Determine whether a binding with the given provenances originates from user-written code.
 
@@ -1541,7 +1541,7 @@ like internal variables from `@ast`.
 !!! note
     This currently does not support old-style macros due to JuliaLowering limitations.
 """
-function is_from_user_ast(provs::SyntaxListC)
+function is_from_user_ast(provs::SyntaxList)
     length(provs) == 1 && return true
     fprov, lprov = first(provs), last(provs)
     JS.sourcefile(lprov) == JS.sourcefile(fprov) || return false
@@ -1549,7 +1549,7 @@ function is_from_user_ast(provs::SyntaxListC)
 end
 
 function is_noreturn_call(
-        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC,
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTree,
         allow_noreturn_optimization::Vector{Symbol}
     )
     JS.kind(st3) === JS.K"call" || return false

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -1,46 +1,27 @@
-# Lightweight copy function for SyntaxTree
-# This copies the SyntaxGraph's mutable structures (edge_ranges, edges, attributes)
-# but shares the immutable data within attribute dictionaries
-function copy_syntax_tree(st::SyntaxTreeC)
-    g = JS.syntax_graph(st)
-    new_attrs = Dict{Symbol,Dict{JL.IdTag,Any}}()
-    for (k, v) in pairs(g.attributes)
-        new_attrs[k] = copy(v)
-    end
-    new_graph = JS.SyntaxGraph(copy(g.edge_ranges), copy(g.edges), new_attrs)
-    return SyntaxTreeC(new_graph, st._id)
-end
-
 function build_syntax_tree(fi::FileInfo)
     if fi.syntax_tree0 === nothing
-        st0 = JS.build_tree(JS.SyntaxTree, fi.parsed_stream; filename=fi.filename)
-        return JS.prune(st0)
+        return JS.build_tree(JS.SyntaxTree, fi.parsed_stream; filename=fi.filename)
     end
-    # The lowering pipeline modifies the internal state of `st0`,
+    # The lowering pipeline can mutate nodes in place (e.g. `JS.fill_context!`),
     # so we need to create a copy for each read to avoid race conditions.
-    return copy_syntax_tree(fi.syntax_tree0)
+    return JS.copy_ast(fi.syntax_tree0)
 end
 
-has_name_val(st::SyntaxTreeC) = JS.hasattr(st, :name_val)
-get_name_val(st::SyntaxTreeC, default=nothing) = has_name_val(st) ? st.name_val::String : default
-name_val(st::SyntaxTreeC) = st.name_val::String
+# kinds whose `value` holds the identifier name (see `JL.syntax_name`)
+const NAME_VAL_KINDS = JS.KSet"""
+Identifier Placeholder Symbol core top globalref symboliclabel symbolicgoto
+unknown_head oldsymbolicgoto
+"""
 
-var_id(st::SyntaxTreeC) = st.var_id::JL.IdTag
+has_name_val(st::SyntaxTreeC) = JS.kind(st) in NAME_VAL_KINDS
+get_name_val(st::SyntaxTreeC, default=nothing) = has_name_val(st) ? st.value::String : default
+name_val(st::SyntaxTreeC) = st.value::String
+
+var_id(st::SyntaxTreeC) = JL.syntax_id(st)
 
 get_source_text(ps::JS.ParseStream) = JS.sourcetext(JS.SourceFile(ps))
 document_text(fi::FileInfo) = get_source_text(fi.parsed_stream)
 document_range(fi::FileInfo) = jsobj_to_range(fi.parsed_stream, fi)
-
-@static if JL.DEBUG
-    function ensure_jl_source_attr!(graph::JS.SyntaxGraph)
-        attrs = getfield(graph, :attributes)
-        if !haskey(attrs, :jl_source)
-            attrs[:jl_source] = Dict{Int,LineNumberNode}()
-        end
-    end
-else
-    ensure_jl_source_attr!(::JS.SyntaxGraph) = nothing
-end
 
 """
     trim_error_nodes(st0::SyntaxTreeC) -> SyntaxTreeC
@@ -58,7 +39,7 @@ function _without_kinds(st::SyntaxTreeC, kinds::Tuple{Vararg{JS.Kind}})
     elseif JS.is_leaf(st)
         return (st, false)
     end
-    new_children = JS.SyntaxList(JS.syntax_graph(st))
+    new_children = JS.SyntaxList()
     changed = false
     for child in JS.children(st)
         new_child, child_changed = _without_kinds(child, kinds)
@@ -79,9 +60,8 @@ Return a tree where all nodes of `kinds` are trimmed.
 Should not modify any nodes, and should not create new nodes unnecessarily.
 """
 function without_kinds(st::SyntaxTreeC, kinds::Tuple{Vararg{JS.Kind}})
-    ensure_jl_source_attr!(JS.syntax_graph(st))
     return (JS.kind(st) in kinds ?
-        JL.@ast(JS.syntax_graph(st), st, [JS.K"TOMBSTONE"]) :
+        JL.@ast(_, st, [JS.K"TOMBSTONE"]) :
         _without_kinds(st, kinds)[1])::SyntaxTreeC
 end
 
@@ -114,13 +94,12 @@ Add new branches in [`_repair_node`](@ref) when these cause downstream
 breakage in practice.
 """
 function repair_after_trim(st0::SyntaxTreeC)
-    ensure_jl_source_attr!(JS.syntax_graph(st0))
     return _repair_after_trim(st0)::SyntaxTreeC
 end
 
 function _repair_after_trim(st0::SyntaxTreeC)
     JS.is_leaf(st0) && return st0
-    new_children = JS.SyntaxList(JS.syntax_graph(st0))
+    new_children = JS.SyntaxList()
     changed = false
     for child in JS.children(st0)
         new_child = _repair_after_trim(child)
@@ -163,7 +142,7 @@ function _unwrap_interpolations(st::SyntaxTreeC)
     elseif JS.is_leaf(st)
         return (st, false)
     end
-    new_children = JS.SyntaxList(JS.syntax_graph(st))
+    new_children = JS.SyntaxList()
     changed = false
     for child in JS.children(st)
         new_child, child_changed = _unwrap_interpolations(child)
@@ -179,7 +158,6 @@ Unlike `without_kinds` which removes nodes entirely, this preserves the child
 so that parent nodes (e.g. dot expressions like `x.\$name`) remain well-formed.
 """
 function unwrap_interpolations(st::SyntaxTreeC)
-    ensure_jl_source_attr!(JS.syntax_graph(st))
     return first(_unwrap_interpolations(st))
 end
 
@@ -192,7 +170,7 @@ function is_macrocall_st0(st0::SyntaxTreeC, names::AbstractString...; from::Unio
     else
         JS.sourcetext(macro_name)
     end
-    return nv in names && (isnothing(from) || (JS.hasattr(macro_name, :mod) && macro_name.mod === from))
+    return nv in names && (isnothing(from) || macro_name.mod === from)
 end
 
 is_mainfunc0(st0::SyntaxTreeC) = is_macrocall_st0(st0, "@main")
@@ -420,7 +398,7 @@ function _remove_macrocalls(
         if is_new_style && !strip_current_static
             # Preserve this macrocall, but still remove old-style macros and `@static`
             # calls nested in its arguments.
-            new_children = JS.SyntaxList(JS.syntax_graph(st0))
+            new_children = JS.SyntaxList()
             push!(new_children, st0[1])
             changed = false
             for i = 2:JS.numchildren(st0)
@@ -444,7 +422,7 @@ function _remove_macrocalls(
             # but binding occurrence analysis still get correct results.
             return st0, false
         end
-        new_children = JS.SyntaxList(JS.syntax_graph(st0))
+        new_children = JS.SyntaxList()
         for i = 2:JS.numchildren(st0)
             # `$` interpolations at macrocall-argument position are legal only
             # because the macro will typically splice the argument into a
@@ -457,12 +435,12 @@ function _remove_macrocalls(
                 context_module, world, st0[i]; strip_static)
             push!(new_children, _unwrap_interpolations(stripped)[1])
         end
-        return JL.@ast(JS.syntax_graph(st0), st0, [JS.K"block" new_children...]), true
+        return JL.@ast(_, st0, [JS.K"block" new_children...]), true
     elseif JS.is_leaf(st0)
         return st0, false
     end
     (st0, changed) = desugar_main_macrocall(st0)
-    new_children = JS.SyntaxList(JS.syntax_graph(st0))
+    new_children = JS.SyntaxList()
     inner_context = if JS.kind(st0) === JS.K"module" && JS.numchildren(st0) >= 2
         module_const = context_module === nothing ? nothing :
             resolve_global_const(context_module, world, st0[2])
@@ -507,36 +485,32 @@ function desugar_main_macrocall(st0::SyntaxTreeC)
         # Parenthesized form: (@main)(args...) — macrocall is the callee
         JS.numchildren(call_node) >= 1 || return (st0, false)
         is_mainfunc0(call_node[1]) || return (st0, false)
-        g = JS.syntax_graph(st0)
-        main_id = JS.setattr!(
-            JS.newleaf(g, call_node[1], JS.K"Identifier"), :name_val, "main")
-        new_call_children = JS.SyntaxList(g)
+        main_id = JS.newleaf(call_node[1], JS.K"Identifier", "main")
+        new_call_children = JS.SyntaxList()
         push!(new_call_children, main_id)
         for i in 2:JS.numchildren(call_node)
             push!(new_call_children, call_node[i])
         end
-        new_call = JS.newnode(g, call_node, JS.K"call", new_call_children)
+        new_call = JS.newnode(call_node, JS.K"call", new_call_children)
     elseif is_mainfunc0(call_node)
         # No-parens form: @main(args...) — entire signature is a macrocall
-        g = JS.syntax_graph(st0)
-        main_id = JS.setattr!(
-            JS.newleaf(g, call_node[1], JS.K"Identifier"), :name_val, "main")
-        new_call_children = JS.SyntaxList(g)
+        main_id = JS.newleaf(call_node[1], JS.K"Identifier", "main")
+        new_call_children = JS.SyntaxList()
         push!(new_call_children, main_id)
         for i in 2:JS.numchildren(call_node)
             JS.kind(call_node[i]) === JS.K"Value" && continue
             push!(new_call_children, call_node[i])
         end
-        new_call = JS.newnode(g, call_node, JS.K"call", new_call_children)
+        new_call = JS.newnode(call_node, JS.K"call", new_call_children)
     else
         return (st0, false)
     end
-    new_children = JS.SyntaxList(g)
+    new_children = JS.SyntaxList()
     push!(new_children, new_call)
     for i in 2:JS.numchildren(st0)
         push!(new_children, st0[i])
     end
-    return (JS.newnode(g, st0, k, new_children), true)
+    return (JS.newnode(st0, k, new_children), true)
 end
 
 """
@@ -596,7 +570,6 @@ function remove_macrocalls(
         context_module::Module, world::UInt, st0::SyntaxTreeC;
         strip_static::Bool = false
     )
-    ensure_jl_source_attr!(JS.syntax_graph(st0))
     return first(_remove_macrocalls(context_module, world, st0; strip_static))
 end
 
@@ -693,16 +666,16 @@ function is_core_svec_call(call_node::SyntaxTreeC)
 end
 
 """
-Like `Base.unique`, but over node ids, and with this comment promising that the
-lowest-index copy of each node is kept.
+Like `Base.unique`, but over node identities, and with this comment promising
+that the lowest-index copy of each node is kept.
 """
 function deduplicate_syntaxlist(sl::SyntaxListC)
-    sl2 = JS.SyntaxList(sl.graph)
-    seen = Set{JS.NodeId}()
+    sl2 = JS.SyntaxList()
+    seen = Set{SyntaxTreeC}()
     for st in sl
-        if !(st._id in seen)
-            push!(sl2, st._id)
-            push!(seen, st._id)
+        if !(st in seen)
+            push!(sl2, st)
+            push!(seen, st)
         end
     end
     return sl2
@@ -770,7 +743,7 @@ end
 
 function _traverse_postorder(@specialize(callback), stack::SyntaxListC)
     local retval = nothing
-    output = JS.SyntaxList(stack.graph)
+    output = JS.SyntaxList()
     while !isempty(stack)
         x = pop!(stack)
         push!(output, x)
@@ -878,7 +851,7 @@ that satisfy the predicate.
 byte_ancestors(args...) = byte_ancestors(Returns(true), args...)
 
 function byte_ancestors(flt, st::SyntaxTreeC, rng::UnitRange{<:Integer})
-    sl = JS.SyntaxList(JS.syntax_graph(st))
+    sl = JS.SyntaxList()
     if rng ⊆ JS.byte_range(st) && flt(st)
         push!(sl, st)
     end
@@ -1364,7 +1337,6 @@ If `string_node` is a non-interpolated string literal whose value joins with
 function resolve_path_string_literal(
         string_node::SyntaxTreeC, basedir::AbstractString
     )
-    JS.hasattr(string_node, :value) || return nothing
     value = string_node.value
     value isa String || return nothing
     path = joinpath(basedir, value)

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -2,12 +2,12 @@
 # backwards through lowering to search for it.
 function binding_scope_layer(ctx3::JL.VariableAnalysisContext, binding::JL.BindingInfo)
     st3 = JL.binding_ex(ctx3, binding.id)
-    while st3.source isa SyntaxTreeC
+    while st3.source isa SyntaxTree
         context = st3.context
         if context !== nothing
             return (context::JS.SyntaxContext).layer
         end
-        st3 = st3.source::SyntaxTreeC
+        st3 = st3.source::SyntaxTree
     end
     return ctx3.layer
 end
@@ -53,7 +53,7 @@ end
 
 """
     jl_lower_for_scope_resolution(
-            context_module::Module, world::UInt, st0::SyntaxTreeC;
+            context_module::Module, world::UInt, st0::SyntaxTree;
             trim_error_nodes::Bool = true,
             recover_from_macro_errors::Bool = true,
             convert_closures::Bool = false,
@@ -77,7 +77,7 @@ Throw if lowering fails otherwise.
 Note that ctx objects share mutable information, so we only return `ctx3`
 """
 function jl_lower_for_scope_resolution(
-        context_module::Module, world::UInt, st0::SyntaxTreeC;
+        context_module::Module, world::UInt, st0::SyntaxTree;
         trim_error_nodes::Bool = true,
         recover_from_macro_errors::Bool = true,
         convert_closures::Bool = false,
@@ -102,7 +102,7 @@ function jl_lower_for_scope_resolution(
 end
 
 function _jl_lower_for_scope_resolution(
-        st0::SyntaxTreeC, st1::SyntaxTreeC, world::UInt;
+        st0::SyntaxTree, st1::SyntaxTree, world::UInt;
         convert_closures::Bool = false,
         soft_scope::Bool = false,
     )
@@ -122,7 +122,7 @@ as an ephemeral stack.)  We work around this by taking all available bindings
 and filtering out any that aren't declared in a scope containing the cursor.
 """
 function cursor_bindings(
-        st0_top::SyntaxTreeC, offset::Int, context_module::Module, world::UInt;
+        st0_top::SyntaxTree, offset::Int, context_module::Module, world::UInt;
         soft_scope::Bool = false
     )
     st0 = @something lowerable_toplevel_at(st0_top, offset) return nothing
@@ -140,10 +140,10 @@ function cursor_bindings(
     binfos = filter(binfo -> is_relevant(ctx3, binfo, offset), ctx3.bindings.info)
 
     # for each binding: binfo, all syntaxtrees containing it, and the scope it belongs to
-    bscopeinfos = Tuple{JL.BindingInfo, Union{SyntaxTreeC, Nothing}}[]
+    bscopeinfos = Tuple{JL.BindingInfo, Union{SyntaxTree, Nothing}}[]
     for binfo in binfos
         # TODO: find tree parents instead of byte parents?
-        bas = byte_ancestors(st2, JS.byte_range(JL.binding_ex(ctx3, binfo.id))) do st2′::SyntaxTreeC
+        bas = byte_ancestors(st2, JS.byte_range(JL.binding_ex(ctx3, binfo.id))) do st2′::SyntaxTree
             # find the innermost hard scope containing this binding decl.  we shouldn't
             # be in multiple overlapping scopes that are not direct ancestors; that
             # should indicate a provenance failure
@@ -197,8 +197,8 @@ end
 # These span the full signature byte range and should not be selected by cursor.
 const _IMPLICIT_BINDING_NAMES = ("__context__", "__module__", "__source__")
 
-function find_target_binding(ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, offset::Int)
-    return traverse(st3) do st3′::SyntaxTreeC
+function find_target_binding(ctx3::JL.VariableAnalysisContext, st3::SyntaxTree, offset::Int)
+    return traverse(st3) do st3′::SyntaxTree
         k = JS.kind(st3′)
         if k === JS.K"lambda" && is_kwcall_lambda(ctx3, st3′)
             # Don't select a binding with `kwcall` definition.
@@ -233,7 +233,7 @@ function find_target_binding(ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC,
     end
 end
 
-function is_kwcall_lambda(ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC)
+function is_kwcall_lambda(ctx3::JL.VariableAnalysisContext, st3::SyntaxTree)
     @assert JS.kind(st3) === JS.K"lambda" "Expected `lambda` kind"
     JS.numchildren(st3) ≥ 2 || return false
     arglist = st3[2]
@@ -254,7 +254,7 @@ function is_kwcall_lambda(ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC)
 end
 
 function _select_target_binding(
-        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, offset::Int
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTree, offset::Int
     )
     return @something(
         find_target_binding(ctx3, st3, offset),
@@ -264,7 +264,7 @@ end
 
 """
     select_target_binding(
-            st0_top::SyntaxTreeC, offset::Int, context_module::Module, world::UInt;
+            st0_top::SyntaxTree, offset::Int, context_module::Module, world::UInt;
             soft_scope::Bool = false
         ) -> Union{Nothing, NamedTuple}
 
@@ -274,7 +274,7 @@ contains `(; ctx3, st3, st0, binding)` where `binding` satisfies
 `JS.kind(binding) === JS.K"BindingId"`.
 """
 function select_target_binding(
-        st0_top::SyntaxTreeC, offset::Int, context_module::Module, world::UInt;
+        st0_top::SyntaxTree, offset::Int, context_module::Module, world::UInt;
         caller::AbstractString = "select_target_binding",
         soft_scope::Bool = false
     )
@@ -323,11 +323,11 @@ end
 # The normal method's `meta :generated` payload carries the exact binding of its
 # code-generator method. Use that semantic link rather than its mangled name.
 function generated_method_ids(
-        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTree
     )
     ids = Set{JL.IdTag}()
     generator_index = Base.fieldindex(JL.GeneratedFunctionStub, :gen) + 1
-    traverse(st3) do st3′::SyntaxTreeC
+    traverse(st3) do st3′::SyntaxTree
         JS.kind(st3′) in JS.KSet"inert syntaxinert" && return traversal_no_recurse
         JS.kind(st3′) === JS.K"meta" || return nothing
         JS.numchildren(st3′) == 2 || return nothing
@@ -348,7 +348,7 @@ function generated_method_ids(
     return ids
 end
 
-function generated_method_lambda(st3::SyntaxTreeC, method_ids::Set{JL.IdTag})
+function generated_method_lambda(st3::SyntaxTree, method_ids::Set{JL.IdTag})
     JS.kind(st3) === JS.K"method" || return nothing
     JS.numchildren(st3) >= 1 || return nothing
     method_name = st3[1]
@@ -361,10 +361,10 @@ function generated_method_lambda(st3::SyntaxTreeC, method_ids::Set{JL.IdTag})
 end
 
 function generated_lambda_argument_bindings(
-        ctx3::JL.VariableAnalysisContext, lambda::SyntaxTreeC
+        ctx3::JL.VariableAnalysisContext, lambda::SyntaxTree
     )
-    JS.numchildren(lambda) >= 2 || return Dict{String,SyntaxTreeC}()
-    args = Dict{String,SyntaxTreeC}()
+    JS.numchildren(lambda) >= 2 || return Dict{String,SyntaxTree}()
+    args = Dict{String,SyntaxTree}()
     for arg in JS.children(lambda[2])
         JS.kind(arg) === JS.K"BindingId" || continue
         binfo = JL.get_binding(ctx3, arg)
@@ -378,21 +378,21 @@ end
 
 struct InertResolution
     ctx3::JL.VariableAnalysisContext
-    st3::SyntaxTreeC
-    argument_remap::Dict{JL.BindingInfo,SyntaxTreeC}
+    st3::SyntaxTree
+    argument_remap::Dict{JL.BindingInfo,SyntaxTree}
     placeholder_name::String
     source_range::UnitRange{Int}
 end
 
 function synthetic_parameter_remap(
-        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC,
-        parameters::Dict{String,SyntaxTreeC}
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTree,
+        parameters::Dict{String,SyntaxTree}
     )
-    remap = Dict{JL.BindingInfo,SyntaxTreeC}()
+    remap = Dict{JL.BindingInfo,SyntaxTree}()
     isempty(parameters) && return remap
     # Synthetic parameters retain the source ranges of the generated arguments.
     # Same-named arguments in nested lambdas have their own source ranges.
-    traverse(st3) do node::SyntaxTreeC
+    traverse(st3) do node::SyntaxTree
         JS.kind(node) === JS.K"lambda" || return nothing
         for (name, binding) in generated_lambda_argument_bindings(ctx3, node)
             source = @something get(parameters, name, nothing) continue
@@ -404,12 +404,12 @@ function synthetic_parameter_remap(
     return remap
 end
 
-function _make_inert_placeholder(st3::SyntaxTreeC, placeholder_name::String)
+function _make_inert_placeholder(st3::SyntaxTree, placeholder_name::String)
     return JS.newleaf(st3, JS.K"Identifier", placeholder_name)
 end
 
 function _mask_inert_interpolations(
-        st3::SyntaxTreeC, placeholder_name::String, preserve_nested_interpolations::Bool,
+        st3::SyntaxTree, placeholder_name::String, preserve_nested_interpolations::Bool,
         quote_depth::Int = 0, syntax_quote_depth::Int = 0
     )
     kind = JS.kind(st3)
@@ -442,7 +442,7 @@ function _mask_inert_interpolations(
     return (changed ? JS.mknode(st3, new_children) : st3, changed)
 end
 mask_inert_interpolations(
-    st3::SyntaxTreeC, placeholder_name::String; preserve_nested_interpolations::Bool = false
+    st3::SyntaxTree, placeholder_name::String; preserve_nested_interpolations::Bool = false
 ) = first(_mask_inert_interpolations(st3, placeholder_name, preserve_nested_interpolations))
 
 # Replace direct interpolation subtrees in a lowered inert template with a
@@ -451,7 +451,7 @@ mask_inert_interpolations(
 # interpolations enclosed by their corresponding quote kind are kept for
 # JuliaLowering to resolve in the inert template's execution scope.
 function prepare_inert_template(
-        st3::SyntaxTreeC; preserve_nested_interpolations::Bool = false
+        st3::SyntaxTree; preserve_nested_interpolations::Bool = false
     )
     placeholder_name = String(gensym("JETLS_UNQUOTE_PLACEHOLDER"))
     template = mask_inert_interpolations(
@@ -460,8 +460,8 @@ function prepare_inert_template(
 end
 
 function resolve_inert_tree(
-        context_module::Module, world::UInt, inert_tree::SyntaxTreeC;
-        parameters::Dict{String,SyntaxTreeC} = Dict{String,SyntaxTreeC}(),
+        context_module::Module, world::UInt, inert_tree::SyntaxTree;
+        parameters::Dict{String,SyntaxTree} = Dict{String,SyntaxTree}(),
         hard_scope::Bool = false,
         soft_scope::Bool = false,
         preserve_nested_interpolations::Bool = false
@@ -491,7 +491,7 @@ function resolve_inert_tree(
         ires.ctx3, ires.st3, argument_remap, placeholder_name, source_range)
 end
 
-function contains_syntaxunquote(st::SyntaxTreeC)
+function contains_syntaxunquote(st::SyntaxTree)
     stack = JS.SyntaxList(st)
     while !isempty(stack)
         node = pop!(stack)
@@ -504,19 +504,19 @@ function contains_syntaxunquote(st::SyntaxTreeC)
 end
 
 function collect_generated_inert_resolutions(
-        ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC, world::UInt
+        ctx3::JL.VariableAnalysisContext, st3::SyntaxTree, world::UInt
     )
     resolutions = InertResolution[]
     seen = Set{Tuple{JS.Kind,UnitRange{Int}}}()
     method_ids = generated_method_ids(ctx3, st3)
     isempty(method_ids) && return resolutions
-    traverse(st3) do st3′::SyntaxTreeC
+    traverse(st3) do st3′::SyntaxTree
         lambda = @something generated_method_lambda(st3′, method_ids) return nothing
         args = generated_lambda_argument_bindings(ctx3, lambda)
         method_binfo = JL.get_binding(ctx3, st3′[1])
         context_module = method_binfo.mod
         context_module isa Module || return traversal_no_recurse
-        traverse(lambda) do node::SyntaxTreeC
+        traverse(lambda) do node::SyntaxTree
             is_import_eval_call(node) && return traversal_no_recurse
             JS.kind(node) in JS.KSet"inert syntaxinert" || return nothing
             if JS.kind(node) === JS.K"syntaxinert" && contains_syntaxunquote(node)
@@ -536,7 +536,7 @@ function collect_generated_inert_resolutions(
     return resolutions
 end
 
-function is_esc_call(st0::SyntaxTreeC)
+function is_esc_call(st0::SyntaxTree)
     JS.kind(st0) === JS.K"call" || return false
     JS.numchildren(st0) >= 1 || return false
     callee = st0[1]
@@ -551,7 +551,7 @@ function is_esc_call(st0::SyntaxTreeC)
     return get_name_val(rhs) == "esc"
 end
 
-function is_esc_enclosed_range(st0::SyntaxTreeC, range::UnitRange{Int})
+function is_esc_enclosed_range(st0::SyntaxTree, range::UnitRange{Int})
     for ancestor in byte_ancestors(st0, range)
         JS.byte_range(ancestor) == range && continue
         is_esc_call(ancestor) && return true
@@ -559,11 +559,11 @@ function is_esc_enclosed_range(st0::SyntaxTreeC, range::UnitRange{Int})
     return false
 end
 
-function is_quoted_range(st0::SyntaxTreeC, range::UnitRange{Int})
+function is_quoted_range(st0::SyntaxTree, range::UnitRange{Int})
     return any(a -> JS.kind(a) in JS.KSet"quote inert", byte_ancestors(st0, range))
 end
 
-function is_code_shaped_quote_range(st0::SyntaxTreeC, range::UnitRange{Int})
+function is_code_shaped_quote_range(st0::SyntaxTree, range::UnitRange{Int})
     for ancestor in byte_ancestors(st0, range)
         JS.kind(ancestor) in JS.KSet"quote inert" || continue
         JS.numchildren(ancestor) == 1 || return true
@@ -573,7 +573,7 @@ function is_code_shaped_quote_range(st0::SyntaxTreeC, range::UnitRange{Int})
 end
 
 function is_generated_inert_range(
-        context_module::Module, world::UInt, st0::SyntaxTreeC, range::UnitRange{Int}
+        context_module::Module, world::UInt, st0::SyntaxTree, range::UnitRange{Int}
     )
     return any(byte_ancestors(st0, range)) do ancestor
         is_generated0(context_module, world, ancestor)
@@ -581,7 +581,7 @@ function is_generated_inert_range(
 end
 
 function eval_input_info(
-        context_module::Module, world::UInt, st0::SyntaxTreeC, range::UnitRange{Int}
+        context_module::Module, world::UInt, st0::SyntaxTree, range::UnitRange{Int}
     )
     for ancestor in byte_ancestors(st0, range)
         is_ateval0(context_module, world, ancestor) || continue
@@ -598,7 +598,7 @@ end
 
 """
     inert_resolution_policy(
-        context_module::Module, world::UInt, st0::SyntaxTreeC, range::UnitRange{Int}
+        context_module::Module, world::UInt, st0::SyntaxTree, range::UnitRange{Int}
     ) -> Symbol
 
 Choose how to resolve bindings in an inert source range. This deliberately uses
@@ -626,7 +626,7 @@ occurrences. Generated-function inert code is handled separately with its
 synthetic function scope and argument remapping.
 """
 function inert_resolution_policy(
-        context_module::Module, world::UInt, st0::SyntaxTreeC, range::UnitRange{Int}
+        context_module::Module, world::UInt, st0::SyntaxTree, range::UnitRange{Int}
     )
     eval_input = eval_input_info(context_module, world, st0, range)
     if eval_input !== nothing
@@ -645,7 +645,7 @@ function inert_resolution_policy(
     return :unresolved
 end
 
-function quote_stage_depth(st0::SyntaxTreeC, range::UnitRange{Int})
+function quote_stage_depth(st0::SyntaxTree, range::UnitRange{Int})
     depth = 0
     for ancestor in byte_ancestors(st0, range)
         kind = JS.kind(ancestor)
@@ -661,7 +661,7 @@ end
 # `@eval` contributes an implicit quote stage. Interpolation removes a stage, so
 # a macrocall at depth zero executes in the surrounding lexical context.
 function should_resolve_macrocall(
-        context_module::Module, world::UInt, st0::SyntaxTreeC, range::UnitRange{Int}
+        context_module::Module, world::UInt, st0::SyntaxTree, range::UnitRange{Int}
     )
     eval_input = eval_input_info(context_module, world, st0, range)
     depth = quote_stage_depth(st0, range) + (eval_input === nothing ? 0 : 1)
@@ -680,7 +680,7 @@ function resolved_binding_at(resolution::InertResolution, offset::Int)
 end
 
 function select_inert_target_binding(
-        st0::SyntaxTreeC, ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC,
+        st0::SyntaxTree, ctx3::JL.VariableAnalysisContext, st3::SyntaxTree,
         offset::Int, context_module::Module, world::UInt;
         soft_scope::Bool = false
     )
@@ -720,10 +720,10 @@ end
 # Find the innermost `K"inert"` or `K"syntaxinert"` node in `st3` whose byte
 # range contains `offset`. Used to run fresh scope resolution on just that inert
 # subtree.
-function enclosing_inert_tree(st3::SyntaxTreeC, offset::Int)
-    best = Ref{Union{Nothing,SyntaxTreeC}}(nothing)
+function enclosing_inert_tree(st3::SyntaxTree, offset::Int)
+    best = Ref{Union{Nothing,SyntaxTree}}(nothing)
     best_len = Ref(typemax(Int))
-    traverse(st3) do st::SyntaxTreeC
+    traverse(st3) do st::SyntaxTree
         JS.kind(st) in JS.KSet"inert syntaxinert" || return nothing
         offset in JS.byte_range(st) || return nothing
         len = length(JS.byte_range(st))
@@ -739,7 +739,7 @@ end
 # Low-level lookup for lowering-generated bindings that reuse a source token.
 # Callers must establish that the source form is expected to have such a binding.
 function _find_internal_global_binding_at_source(
-        ctx3::JL.VariableAnalysisContext, name_node::SyntaxTreeC
+        ctx3::JL.VariableAnalysisContext, name_node::SyntaxTree
     )
     name = if JS.kind(name_node) === JS.K"BindingId"
         JL.get_binding(ctx3, name_node).name
@@ -757,10 +757,10 @@ function _find_internal_global_binding_at_source(
 end
 
 function select_struct_inner_constructor_binding(
-        ctx3::JL.VariableAnalysisContext, st0::SyntaxTreeC, offset::Int
+        ctx3::JL.VariableAnalysisContext, st0::SyntaxTree, offset::Int
     )
-    binding = Ref{Union{Nothing,SyntaxTreeC}}(nothing)
-    foreach_struct_inner_constructor(st0) do name_node::SyntaxTreeC, constructor_node::SyntaxTreeC
+    binding = Ref{Union{Nothing,SyntaxTree}}(nothing)
+    foreach_struct_inner_constructor(st0) do name_node::SyntaxTree, constructor_node::SyntaxTree
         offset in JS.byte_range(constructor_node) || return true
         binding[] = _find_internal_global_binding_at_source(ctx3, name_node)
         return false
@@ -769,11 +769,11 @@ function select_struct_inner_constructor_binding(
 end
 
 function select_macrocall_binding(
-        st0::SyntaxTreeC, offset::Int, context_module::Module, world::UInt;
+        st0::SyntaxTree, offset::Int, context_module::Module, world::UInt;
         caller::AbstractString = "select_macrocall_binding",
         soft_scope::Bool = false
     )
-    is_macrocall_name = (offset::Int) -> (st0′::SyntaxTreeC) ->
+    is_macrocall_name = (offset::Int) -> (st0′::SyntaxTree) ->
         JS.kind(st0′) === JS.K"macrocall" && JS.numchildren(st0′) ≥ 1 && !is_doc0(st0′) &&
         offset in JS.byte_range(st0′[1])
     bas = byte_ancestors(is_macrocall_name(offset), st0, offset)
@@ -808,11 +808,11 @@ end
 # Detect that case directly and lower just the single identifier under the
 # cursor so callers receive a normal `(ctx3, st3, st0, binding)` tuple.
 function select_export_public_binding(
-        st0::SyntaxTreeC, offset::Int, context_module::Module, world::UInt;
+        st0::SyntaxTree, offset::Int, context_module::Module, world::UInt;
         caller::AbstractString = "select_export_public_binding",
         soft_scope::Bool = false
     )
-    find_name_node = (offset::Int) -> (st0′::SyntaxTreeC) -> begin
+    find_name_node = (offset::Int) -> (st0′::SyntaxTree) -> begin
         JS.kind(st0′) in JS.KSet"export public" || return false
         for i = 1:JS.numchildren(st0′)
             c = st0′[i]
@@ -854,20 +854,20 @@ end
 # detect the cursor against `foreach_local_import_identifier` and lower the
 # single matching identifier to synthesize a normal binding tuple.
 function select_import_using_binding(
-        st0::SyntaxTreeC, offset::Int, context_module::Module, world::UInt;
+        st0::SyntaxTree, offset::Int, context_module::Module, world::UInt;
         caller::AbstractString = "select_import_using_binding",
         soft_scope::Bool = false
     )
-    find_name_node_at = function (offset::Int, st0′::SyntaxTreeC)
-        hit = Ref{Union{Nothing,SyntaxTreeC}}(nothing)
-        foreach_local_import_identifier(st0′) do id_st::SyntaxTreeC
+    find_name_node_at = function (offset::Int, st0′::SyntaxTree)
+        hit = Ref{Union{Nothing,SyntaxTree}}(nothing)
+        foreach_local_import_identifier(st0′) do id_st::SyntaxTree
             offset in JS.byte_range(id_st) || return
             hit[] = id_st
             return
         end
         return hit[]
     end
-    find_container = (offset::Int) -> (st0′::SyntaxTreeC) ->
+    find_container = (offset::Int) -> (st0′::SyntaxTree) ->
         JS.kind(st0′) in JS.KSet"import using" &&
             find_name_node_at(offset, st0′) !== nothing
     bas = byte_ancestors(find_container(offset), st0, offset)
@@ -896,18 +896,18 @@ end
 
 """
     select_target_binding_definitions(
-            st0_top::SyntaxTreeC, offset::Int, context_module::Module, world::UInt
-        ) -> nothing or (binding::SyntaxTreeC, definitions::SyntaxListC)
+            st0_top::SyntaxTree, offset::Int, context_module::Module, world::UInt
+        ) -> nothing or (binding::SyntaxTree, definitions::SyntaxList)
 
 Find the binding at the cursor position and return all of its definition sites.
 
 Returns `nothing` if lowering fails, no binding is found at the cursor, or the binding
 has no definitions. Otherwise returns a tuple of `(binding, definitions)` where:
-- `binding` is the `SyntaxTreeC` node representing the binding at the cursor
-- `definitions` is a `SyntaxListC` containing all definition sites for that binding
+- `binding` is the `SyntaxTree` node representing the binding at the cursor
+- `definitions` is a `SyntaxList` containing all definition sites for that binding
 """
 function select_target_binding_definitions(
-        st0_top::SyntaxTreeC, offset::Int, context_module::Module, world::UInt;
+        st0_top::SyntaxTree, offset::Int, context_module::Module, world::UInt;
         soft_scope::Bool = false, skip_global::Bool = false
     )
     (; ctx3, st3, binding) = @something select_target_binding(
@@ -918,15 +918,15 @@ function select_target_binding_definitions(
     return binding, definitions
 end
 
-is_same_binding(x::SyntaxTreeC, id::Int) = JS.kind(x) === JS.K"BindingId" && id == JL.syntax_id(x)
+is_same_binding(x::SyntaxTree, id::Int) = JS.kind(x) === JS.K"BindingId" && id == JL.syntax_id(x)
 
 is_local_binding(binfo::JL.BindingInfo) =
     binfo.kind in (:argument, :typevar, :static_parameter, :local)
 
 """
-    lookup_binding_definitions(st3::SyntaxTreeC, binfo::JL.BindingInfo) -> definitions::SyntaxListC
+    lookup_binding_definitions(st3::SyntaxTree, binfo::JL.BindingInfo) -> definitions::SyntaxList
 
-Find all definition sites for a given binding in the syntax tree. Returns a `SyntaxListC`
+Find all definition sites for a given binding in the syntax tree. Returns a `SyntaxList`
 containing the syntax nodes where the binding may be defined.
 
 This function traverses the syntax tree to collect `definitions` that tracks all the
@@ -934,7 +934,7 @@ assignment expressions (`=`) and function declarations where the binding may be 
 For `:argument`, `:typevar`, or `:static_parameter` bindings, `definitions` also includes
 the argument or type parameter declaration itself.
 """
-function lookup_binding_definitions(st3::SyntaxTreeC, binfo::JL.BindingInfo)
+function lookup_binding_definitions(st3::SyntaxTree, binfo::JL.BindingInfo)
     if binfo.kind in (:argument, :typevar, :static_parameter)
         sl = JS.SyntaxList(binfo.node_id)
     else
@@ -943,8 +943,8 @@ function lookup_binding_definitions(st3::SyntaxTreeC, binfo::JL.BindingInfo)
     return _lookup_binding_definitions!(sl, st3, binfo.id)
 end
 
-function _lookup_binding_definitions!(sl::SyntaxListC, st3::SyntaxTreeC, binding_id::Int)
-    traverse(st3) do st3′::SyntaxTreeC
+function _lookup_binding_definitions!(sl::SyntaxList, st3::SyntaxTree, binding_id::Int)
+    traverse(st3) do st3′::SyntaxTree
         if JS.kind(st3′) in JS.KSet"= kw" && JS.numchildren(st3′) ≥ 2
             lhs = st3′[1]
             if is_same_binding(lhs, binding_id)

--- a/src/utils/binding.jl
+++ b/src/utils/binding.jl
@@ -2,11 +2,12 @@
 # backwards through lowering to search for it.
 function binding_scope_layer(ctx3::JL.VariableAnalysisContext, binding::JL.BindingInfo)
     st3 = JL.binding_ex(ctx3, binding.id)
-    while get(st3, :source, nothing) isa JS.NodeId
-        if JS.hasattr(st3, :context)
-            return (st3.context::JS.SyntaxContext).layer
+    while st3.source isa SyntaxTreeC
+        context = st3.context
+        if context !== nothing
+            return (context::JS.SyntaxContext).layer
         end
-        st3 = SyntaxTreeC(JS.syntax_graph(st3), st3.source)
+        st3 = st3.source::SyntaxTreeC
     end
     return ctx3.layer
 end
@@ -154,7 +155,7 @@ function cursor_bindings(
     cursor_scopes = byte_ancestors(st2, offset)
 
     # ignore scopes we aren't in
-    filter!(((_, bs),) -> isnothing(bs) || bs._id in cursor_scopes.ids,
+    filter!(((_, bs),) -> isnothing(bs) || bs in cursor_scopes,
             bscopeinfos)
 
     # Now eliminate duplicates by name.
@@ -162,9 +163,9 @@ function cursor_bindings(
     # - If a static parameter and a local of the same name exist in the same
     #   scope (impossible in julia), the local is internal and should be ignored
     bdistances = map(((_, bs),) -> if isnothing(bs)
-                         lastindex(cursor_scopes.ids) + 1
+                         lastindex(cursor_scopes) + 1
                      else
-                         findfirst(cs -> bs._id === cs, cursor_scopes.ids)
+                         findfirst(cs -> bs === cs, cursor_scopes)
                      end,
                      bscopeinfos)
 
@@ -234,8 +235,8 @@ end
 
 function is_kwcall_lambda(ctx3::JL.VariableAnalysisContext, st3::SyntaxTreeC)
     @assert JS.kind(st3) === JS.K"lambda" "Expected `lambda` kind"
-    JS.numchildren(st3) ≥ 1 || return false
-    arglist = st3[1]
+    JS.numchildren(st3) ≥ 2 || return false
+    arglist = st3[2]
     na = JS.numchildren(arglist)
     return na ≥ 3 &&
         JS.kind(arglist[1]) === JS.K"BindingId" &&
@@ -362,9 +363,9 @@ end
 function generated_lambda_argument_bindings(
         ctx3::JL.VariableAnalysisContext, lambda::SyntaxTreeC
     )
-    JS.numchildren(lambda) >= 1 || return Dict{String,SyntaxTreeC}()
+    JS.numchildren(lambda) >= 2 || return Dict{String,SyntaxTreeC}()
     args = Dict{String,SyntaxTreeC}()
-    for arg in JS.children(lambda[1])
+    for arg in JS.children(lambda[2])
         JS.kind(arg) === JS.K"BindingId" || continue
         binfo = JL.get_binding(ctx3, arg)
         binfo.kind === :argument || continue
@@ -404,9 +405,7 @@ function synthetic_parameter_remap(
 end
 
 function _make_inert_placeholder(st3::SyntaxTreeC, placeholder_name::String)
-    placeholder = JS.newleaf(JS.syntax_graph(st3), st3, JS.K"Identifier")
-    placeholder = JS.setattr!(placeholder, :name_val, placeholder_name)
-    return placeholder
+    return JS.newleaf(st3, JS.K"Identifier", placeholder_name)
 end
 
 function _mask_inert_interpolations(
@@ -431,7 +430,7 @@ function _mask_inert_interpolations(
     child_quote_depth = quote_depth + (kind === JS.K"quote")
     child_syntax_quote_depth =
         syntax_quote_depth + (kind in JS.KSet"syntaxquote syntaxinert")
-    new_children = JS.SyntaxList(JS.syntax_graph(st3))
+    new_children = JS.SyntaxList()
     changed = false
     for child in JS.children(st3)
         new_child, child_changed = _mask_inert_interpolations(
@@ -454,7 +453,6 @@ mask_inert_interpolations(
 function prepare_inert_template(
         st3::SyntaxTreeC; preserve_nested_interpolations::Bool = false
     )
-    ensure_jl_source_attr!(JS.syntax_graph(st3))
     placeholder_name = String(gensym("JETLS_UNQUOTE_PLACEHOLDER"))
     template = mask_inert_interpolations(
         st3, placeholder_name; preserve_nested_interpolations)
@@ -472,15 +470,13 @@ function resolve_inert_tree(
     template, placeholder_name = prepare_inert_template(
         inert_tree[1]; preserve_nested_interpolations)
     input = if hard_scope || !isempty(parameters)
-        graph = JS.syntax_graph(inert_tree)
-        parameter_nodes = JS.SyntaxList(graph)
+        parameter_nodes = JS.SyntaxList()
         for (name, source) in parameters
-            parameter = JS.newleaf(graph, source, JS.K"Identifier")
-            parameter = JS.setattr!(parameter, :name_val, name)
+            parameter = JS.newleaf(source, JS.K"Identifier", name)
             push!(parameter_nodes, parameter)
         end
-        parameter_list = JL.@ast(graph, inert_tree, [JS.K"tuple" parameter_nodes...])
-        JL.@ast(graph, inert_tree, [JS.K"function" parameter_list template])
+        parameter_list = JL.@ast(_, inert_tree, [JS.K"tuple" parameter_nodes...])
+        JL.@ast(_, inert_tree, [JS.K"function" parameter_list template])
     else
         template
     end
@@ -922,7 +918,7 @@ function select_target_binding_definitions(
     return binding, definitions
 end
 
-is_same_binding(x::SyntaxTreeC, id::Int) = JS.kind(x) === JS.K"BindingId" && id == JL._binding_id(x)
+is_same_binding(x::SyntaxTreeC, id::Int) = JS.kind(x) === JS.K"BindingId" && id == JL.syntax_id(x)
 
 is_local_binding(binfo::JL.BindingInfo) =
     binfo.kind in (:argument, :typevar, :static_parameter, :local)
@@ -940,9 +936,9 @@ the argument or type parameter declaration itself.
 """
 function lookup_binding_definitions(st3::SyntaxTreeC, binfo::JL.BindingInfo)
     if binfo.kind in (:argument, :typevar, :static_parameter)
-        sl = JS.SyntaxList(JS.syntax_graph(st3), [binfo.node_id])
+        sl = JS.SyntaxList(binfo.node_id)
     else
-        sl = JS.SyntaxList(JS.syntax_graph(st3))
+        sl = JS.SyntaxList()
     end
     return _lookup_binding_definitions!(sl, st3, binfo.id)
 end

--- a/src/utils/jl-syntax-macros.jl
+++ b/src/utils/jl-syntax-macros.jl
@@ -10,7 +10,7 @@
 Like `JS.mapchildren(f, ex)`, but applies `f` only to children at the
 given `indices`, leaving other children unchanged.
 """
-function mapchildren(f, ex::SyntaxTreeC, indices::UnitRange{<:Integer})
+function mapchildren(f, ex::SyntaxTree, indices::UnitRange{<:Integer})
     i = Ref(0)
     JS.mapchildren(ex) do c
         i[] += 1
@@ -22,7 +22,7 @@ end
 # `TOMBSTONE` provenance anchor so generated syntax receives the macro-definition
 # layer while retaining the original macrocall's source range.
 function _macro_generated_source(ctx::JL.MacroContext)
-    mc = ctx.macrocall::SyntaxTreeC
+    mc = ctx.macrocall::SyntaxTree
     return JS.newleaf(JS.sourceref(mc), JS.K"TOMBSTONE")
 end
 
@@ -56,7 +56,7 @@ than the sink path.
 """
 
 struct MacroDiagnostic
-    node::SyntaxTreeC
+    node::SyntaxTree
     msg::String
     severity::DiagnosticSeverity.Ty
     code::String
@@ -88,7 +88,7 @@ const MACRO_DIAGNOSTIC_SINK =
     Base.ScopedValues.ScopedValue{Union{Nothing,Vector{MacroDiagnostic}}}(nothing)
 
 @noinline function push_macro_diagnostic!(
-        node::SyntaxTreeC, msg::AbstractString, severity::DiagnosticSeverity.Ty,
+        node::SyntaxTree, msg::AbstractString, severity::DiagnosticSeverity.Ty,
         code::String = LOWERING_MACRO_EXPANSION_ERROR_CODE
     )
     sink = MACRO_DIAGNOSTIC_SINK[]
@@ -98,29 +98,29 @@ const MACRO_DIAGNOSTIC_SINK =
 end
 
 """
-    push_macro_warning!(node::SyntaxTreeC, msg::AbstractString)
+    push_macro_warning!(node::SyntaxTree, msg::AbstractString)
 
 Push a `DiagnosticSeverity.Warning` entry anchored on `node` into
 [`MACRO_DIAGNOSTIC_SINK`](@ref) (no-op if the sink is unbound).
 
 $macro_issue_contract
 """
-push_macro_warning!(node::SyntaxTreeC, msg::AbstractString) =
+push_macro_warning!(node::SyntaxTree, msg::AbstractString) =
     push_macro_diagnostic!(node, msg, DiagnosticSeverity.Warning)
 
 """
-    push_macro_error!(node::SyntaxTreeC, msg::AbstractString)
+    push_macro_error!(node::SyntaxTree, msg::AbstractString)
 
 Push a `DiagnosticSeverity.Error` entry anchored on `node` into
 [`MACRO_DIAGNOSTIC_SINK`](@ref) (no-op if the sink is unbound).
 
 $macro_issue_contract
 """
-push_macro_error!(node::SyntaxTreeC, msg::AbstractString) =
+push_macro_error!(node::SyntaxTree, msg::AbstractString) =
     push_macro_diagnostic!(node, msg, DiagnosticSeverity.Error)
 
 """
-    push_inactive_code!(node::SyntaxTreeC, condval::Bool)
+    push_inactive_code!(node::SyntaxTree, condval::Bool)
 
 Report `node` — a branch dropped at macro expansion time, e.g. the not-taken
 side of an `@static` conditional — as `lowering/inactive-code` at Hint severity
@@ -130,7 +130,7 @@ grayed out. Unlike the issue helpers above this is purely informational: the
 code is intentionally inactive in the current environment, not a problem.
 `condval` is the value the governing condition evaluated to.
 """
-push_inactive_code!(node::SyntaxTreeC, condval::Bool) =
+push_inactive_code!(node::SyntaxTree, condval::Bool) =
     push_macro_diagnostic!(node,
         "Inactive `@static` branch (condition evaluated to `$condval`)",
         DiagnosticSeverity.Hint, LOWERING_INACTIVE_CODE)
@@ -188,19 +188,19 @@ const NEW_STYLE_MACRO_BINDINGS = (
 
 function Base.var"@specialize"(__context__::JL.MacroContext)
     JL.@ast(__context__,
-            __context__.macrocall::SyntaxTreeC,
+            __context__.macrocall::SyntaxTree,
             [JS.K"meta" "specialize"::JS.K"Identifier"])
 end
 
-function Base.var"@specialize"(__context__::JL.MacroContext, ex::SyntaxTreeC)
-    JL.@ast(__context__, __context__.macrocall::SyntaxTreeC, ex)
+function Base.var"@specialize"(__context__::JL.MacroContext, ex::SyntaxTree)
+    JL.@ast(__context__, __context__.macrocall::SyntaxTree, ex)
 end
 
 function Base.var"@specialize"(
         __context__::JL.MacroContext,
-        ex1::SyntaxTreeC, ex2::SyntaxTreeC, exs::SyntaxTreeC...
+        ex1::SyntaxTree, ex2::SyntaxTree, exs::SyntaxTree...
     )
-    JL.@ast(__context__, __context__.macrocall::SyntaxTreeC,
+    JL.@ast(__context__, __context__.macrocall::SyntaxTree,
             [JS.K"block" ex1 ex2 exs...])
 end
 
@@ -212,37 +212,37 @@ end
 # the wrapped expression flow through with its own provenance intact.
 # The 0-arg form keeps the `K"meta"` so scope resolution treats it like the original.
 function Base.var"@inline"(__context__::JL.MacroContext)
-    JL.@ast(__context__, __context__.macrocall::SyntaxTreeC,
+    JL.@ast(__context__, __context__.macrocall::SyntaxTree,
             [JS.K"meta" "inline"::JS.K"Identifier"])
 end
 
-function Base.var"@inline"(__context__::JL.MacroContext, ex::SyntaxTreeC)
+function Base.var"@inline"(__context__::JL.MacroContext, ex::SyntaxTree)
     JL.@ast(__context__, ex, ex)
 end
 
 function Base.var"@noinline"(__context__::JL.MacroContext)
-    JL.@ast(__context__, __context__.macrocall::SyntaxTreeC,
+    JL.@ast(__context__, __context__.macrocall::SyntaxTree,
             [JS.K"meta" "noinline"::JS.K"Identifier"])
 end
 
-function Base.var"@noinline"(__context__::JL.MacroContext, ex::SyntaxTreeC)
+function Base.var"@noinline"(__context__::JL.MacroContext, ex::SyntaxTree)
     JL.@ast(__context__, ex, ex)
 end
 
-function Base.var"@propagate_inbounds"(__context__::JL.MacroContext, ex::SyntaxTreeC)
+function Base.var"@propagate_inbounds"(__context__::JL.MacroContext, ex::SyntaxTree)
     JL.@ast(__context__, ex, ex)
 end
 
-function Base.var"@inbounds"(__context__::JL.MacroContext, ex::SyntaxTreeC)
+function Base.var"@inbounds"(__context__::JL.MacroContext, ex::SyntaxTree)
     JL.@ast(__context__, ex, ex)
 end
 
 # Keep the lock expression in the enclosing scope, but wrap only the protected
 # body in a local scope to mirror the `try` scope introduced by Base's macro.
 function Base.var"@lock"(
-        __context__::JL.MacroContext, lock::SyntaxTreeC, body::SyntaxTreeC
+        __context__::JL.MacroContext, lock::SyntaxTree, body::SyntaxTree
     )
-    mc = __context__.macrocall::SyntaxTreeC
+    mc = __context__.macrocall::SyntaxTree
     return JL.@ast(__context__, mc,
         [JS.K"block"
             lock
@@ -251,8 +251,8 @@ function Base.var"@lock"(
                 [JS.K"block" body]]])
 end
 
-function Base.var"@lock"(__context__::JL.MacroContext, args::SyntaxTreeC...)
-    mc = __context__.macrocall::SyntaxTreeC
+function Base.var"@lock"(__context__::JL.MacroContext, args::SyntaxTree...)
+    mc = __context__.macrocall::SyntaxTree
     push_macro_error!(mc, "@lock expects exactly two arguments: `lock body`")
     isempty(args) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
     return JL.@ast(__context__, mc, [JS.K"block" args...])
@@ -288,21 +288,21 @@ end
 # rejected so the user gets immediate LSP feedback.
 const _SPAWN_THREADPOOLS = ("interactive", "default", "samepool")
 
-function Base.Threads.var"@spawn"(__context__::JL.MacroContext, ex::SyntaxTreeC)
-    return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC,
+function Base.Threads.var"@spawn"(__context__::JL.MacroContext, ex::SyntaxTree)
+    return JL.@ast(__context__, __context__.macrocall::SyntaxTree,
         unwrap_interpolations(ex))
 end
 
 function Base.Threads.var"@spawn"(
         __context__::JL.MacroContext,
-        threadpool::SyntaxTreeC, ex::SyntaxTreeC
+        threadpool::SyntaxTree, ex::SyntaxTree
     )
     _validate_spawn_threadpool(threadpool)
-    return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC,
+    return JL.@ast(__context__, __context__.macrocall::SyntaxTree,
         [JS.K"block" threadpool unwrap_interpolations(ex)])
 end
 
-function _validate_spawn_threadpool(threadpool::SyntaxTreeC)
+function _validate_spawn_threadpool(threadpool::SyntaxTree)
     k = JS.kind(threadpool)
     if k === JS.K"Identifier"
         return # variable reference — assumed to evaluate to a Symbol at runtime
@@ -327,8 +327,8 @@ function _validate_spawn_threadpool(threadpool::SyntaxTreeC)
     nothing
 end
 
-function Base.Threads.var"@spawn"(__context__::JL.MacroContext, args::SyntaxTreeC...)
-    mc = __context__.macrocall::SyntaxTreeC
+function Base.Threads.var"@spawn"(__context__::JL.MacroContext, args::SyntaxTree...)
+    mc = __context__.macrocall::SyntaxTree
     push_macro_error!(mc, "wrong number of arguments in @spawn")
     # Recovery: flow whatever the user wrote through scope analysis. 0-arg →
     # `nothing`, ≥3-arg → a block of every arg so identifiers inside stay visible.
@@ -343,12 +343,12 @@ end
 # The block forms documented in `Base.@label` (`@label expr`, `@label name
 # expr`) are intentionally not supported here — the goto-target form is the
 # common case and the only one needed for most LSP analyses.
-function Base.var"@label"(__context__::JL.MacroContext, ex::SyntaxTreeC)
+function Base.var"@label"(__context__::JL.MacroContext, ex::SyntaxTree)
     if JS.kind(ex) !== JS.K"Identifier"
         push_macro_error!(ex, "@label requires an identifier")
         # Recovery: let the expression flow through so any identifier inside still
         # reaches scope analysis. Goto-target semantics are lost.
-        return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC, ex)
+        return JL.@ast(__context__, __context__.macrocall::SyntaxTree, ex)
     end
     # Keep the label token's exact range without inheriting its caller context, so
     # macro expansion records the originating `@label` call in `SyntaxContext`.
@@ -356,8 +356,8 @@ function Base.var"@label"(__context__::JL.MacroContext, ex::SyntaxTreeC)
     return JL.@ast(__context__, ex, [JS.K"symboliclabel"(src; context=nothing) ex])
 end
 
-function Base.var"@label"(__context__::JL.MacroContext, args::SyntaxTreeC...)
-    mc = __context__.macrocall::SyntaxTreeC
+function Base.var"@label"(__context__::JL.MacroContext, args::SyntaxTree...)
+    mc = __context__.macrocall::SyntaxTree
     push_macro_error!(mc,
         "@label currently only supports the `@label name` form")
     isempty(args) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
@@ -371,7 +371,7 @@ end
 # CFG, so LSP analyses (`lowering/unreachable-code`, `lowering/undef-local-var`, ...)
 # account for which paths each arg's body actually executes on.  The fresh `val_i` names
 # live in the macro's scope layer so they cannot clash with user code.
-function Base.var"@something"(__context__::JL.MacroContext, args::SyntaxTreeC...)
+function Base.var"@something"(__context__::JL.MacroContext, args::SyntaxTree...)
     src = _macro_generated_source(__context__)
     expr = JL.@ast(__context__, src,
         [JS.K"call"
@@ -403,8 +403,8 @@ end
 # JuliaSyntax, then copy each parsed interpolation back into the macro context
 # with source ranges remapped when source text is available and scope adopted
 # from the call site.
-function Base.var"@lazy_str"(__context__::JL.MacroContext, text::SyntaxTreeC)
-    mc = __context__.macrocall::SyntaxTreeC
+function Base.var"@lazy_str"(__context__::JL.MacroContext, text::SyntaxTree)
+    mc = __context__.macrocall::SyntaxTree
     if !(text.value isa String)
         push_macro_error!(text, "@lazy_str expects a string literal")
         return JL.@ast(__context__, mc, text)
@@ -425,17 +425,17 @@ function Base.var"@lazy_str"(__context__::JL.MacroContext, text::SyntaxTreeC)
         [JS.K"call" [JS.K"top" "LazyString"::JS.K"Identifier"] parts...])
 end
 
-function Base.var"@lazy_str"(__context__::JL.MacroContext, args::SyntaxTreeC...)
-    mc = __context__.macrocall::SyntaxTreeC
+function Base.var"@lazy_str"(__context__::JL.MacroContext, args::SyntaxTree...)
+    mc = __context__.macrocall::SyntaxTree
     push_macro_error!(mc, "@lazy_str expects exactly one string argument")
     isempty(args) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
     return JL.@ast(__context__, mc, [JS.K"block" args...])
 end
 
 function _lazy_str_parts(
-        ctx::JL.MacroContext, text::SyntaxTreeC, value::String, source_map::Dict{Int,Int}
+        ctx::JL.MacroContext, text::SyntaxTree, value::String, source_map::Dict{Int,Int}
     )
-    parts = SyntaxTreeC[]
+    parts = SyntaxTree[]
     isempty(value) && return parts
     lastidx = idx = firstindex(value)
     while true
@@ -550,7 +550,7 @@ function _lazy_str_skip_dedent(
 end
 
 function _lazy_str_literal_part(
-        text::SyntaxTreeC, value::String,
+        text::SyntaxTree, value::String,
         source_map::Dict{Int,Int}, startidx::Int, stopidx::Int
     )
     src = JS.sourceref(text)
@@ -562,7 +562,7 @@ function _lazy_str_literal_part(
 end
 
 function _lazy_str_parse_interpolation(
-        ctx::JL.MacroContext, text::SyntaxTreeC, value::String,
+        ctx::JL.MacroContext, text::SyntaxTree, value::String,
         source_map::Dict{Int,Int}, idx::Int
     )
     parsed, nextidx = try
@@ -582,7 +582,7 @@ function _lazy_str_parse_interpolation(
 end
 
 function _lazy_str_copy_with_source(
-        node::JS.SyntaxTree, text::SyntaxTreeC, src::JS.SourceRef,
+        node::JS.SyntaxTree, text::SyntaxTree, src::JS.SourceRef,
         value::String, source_map::Dict{Int,Int}
     )
     srcref = _lazy_str_source_ref(text, src, value, source_map, JS.first_byte(node), JS.last_byte(node))
@@ -599,7 +599,7 @@ function _lazy_str_copy_with_source(
 end
 
 function _lazy_str_source_ref(
-        text::SyntaxTreeC, src::JS.SourceRef, value::String, source_map::Dict{Int,Int},
+        text::SyntaxTree, src::JS.SourceRef, value::String, source_map::Dict{Int,Int},
         startidx::Int, stopbyte::Int
     )
     stopidx = thisind(value, stopbyte)
@@ -623,13 +623,13 @@ end
 # we mirror that leniency, but route extras through a leading `block` so identifiers
 # inside (e.g. an interpolated `"got $y"`) still get scope-resolved.
 function Base.var"@assert"(__context__::JL.MacroContext)
-    mc = __context__.macrocall::SyntaxTreeC
+    mc = __context__.macrocall::SyntaxTree
     push_macro_error!(mc, "@assert: at least one argument is required")
     return JL.@ast(__context__, mc, nothing::JS.K"Value")
 end
 
 function Base.var"@assert"(
-        __context__::JL.MacroContext, ex::SyntaxTreeC, msgs::SyntaxTreeC...
+        __context__::JL.MacroContext, ex::SyntaxTree, msgs::SyntaxTree...
     )
     src = _macro_generated_source(__context__)
     msg_arg = isempty(msgs) ?
@@ -652,8 +652,8 @@ end
 # user-written expression to flow through with its provenance intact, so we
 # drop the printing and route the args through a `block` whose final value
 # naturally matches Base's return semantics.
-function Base.var"@show"(__context__::JL.MacroContext, exs::SyntaxTreeC...)
-    mc = __context__.macrocall::SyntaxTreeC
+function Base.var"@show"(__context__::JL.MacroContext, exs::SyntaxTree...)
+    mc = __context__.macrocall::SyntaxTree
     isempty(exs) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
     length(exs) == 1 && return JL.@ast(__context__, mc, exs[1])
     return JL.@ast(__context__, mc, [JS.K"block" exs...])
@@ -684,49 +684,49 @@ end
 # error; surfacing the duplicate as a `lowering/macro-expansion-error` here
 # anchors the diagnostic on the user's `@info` call site instead.
 function Base.CoreLogging.var"@debug"(
-        __context__::JL.MacroContext, message::SyntaxTreeC, exs::SyntaxTreeC...
+        __context__::JL.MacroContext, message::SyntaxTree, exs::SyntaxTree...
     )
     return _logmsg_stub(__context__, (message, exs...), "@debug")
 end
 
 function Base.CoreLogging.var"@debug"(__context__::JL.MacroContext)
-    mc = __context__.macrocall::SyntaxTreeC
+    mc = __context__.macrocall::SyntaxTree
     push_macro_error!(mc, "@debug requires at least one argument: a `message`")
     return JL.@ast(__context__, mc, nothing::JS.K"Value")
 end
 
 function Base.CoreLogging.var"@info"(
-        __context__::JL.MacroContext, message::SyntaxTreeC, exs::SyntaxTreeC...
+        __context__::JL.MacroContext, message::SyntaxTree, exs::SyntaxTree...
     )
     return _logmsg_stub(__context__, (message, exs...), "@info")
 end
 
 function Base.CoreLogging.var"@info"(__context__::JL.MacroContext)
-    mc = __context__.macrocall::SyntaxTreeC
+    mc = __context__.macrocall::SyntaxTree
     push_macro_error!(mc, "@info requires at least one argument: a `message`")
     return JL.@ast(__context__, mc, nothing::JS.K"Value")
 end
 
 function Base.CoreLogging.var"@warn"(
-        __context__::JL.MacroContext, message::SyntaxTreeC, exs::SyntaxTreeC...
+        __context__::JL.MacroContext, message::SyntaxTree, exs::SyntaxTree...
     )
     return _logmsg_stub(__context__, (message, exs...), "@warn")
 end
 
 function Base.CoreLogging.var"@warn"(__context__::JL.MacroContext)
-    mc = __context__.macrocall::SyntaxTreeC
+    mc = __context__.macrocall::SyntaxTree
     push_macro_error!(mc, "@warn requires at least one argument: a `message`")
     return JL.@ast(__context__, mc, nothing::JS.K"Value")
 end
 
 function Base.CoreLogging.var"@error"(
-        __context__::JL.MacroContext, message::SyntaxTreeC, exs::SyntaxTreeC...
+        __context__::JL.MacroContext, message::SyntaxTree, exs::SyntaxTree...
     )
     return _logmsg_stub(__context__, (message, exs...), "@error")
 end
 
 function Base.CoreLogging.var"@error"(__context__::JL.MacroContext)
-    mc = __context__.macrocall::SyntaxTreeC
+    mc = __context__.macrocall::SyntaxTree
     push_macro_error!(mc, "@error requires at least one argument: a `message`")
     return JL.@ast(__context__, mc, nothing::JS.K"Value")
 end
@@ -735,14 +735,14 @@ end
 # expression (a `LogLevel` constant or computed value), so it still needs to
 # flow through to scope resolution.
 function Base.CoreLogging.var"@logmsg"(
-        __context__::JL.MacroContext, level::SyntaxTreeC, message::SyntaxTreeC,
-        exs::SyntaxTreeC...
+        __context__::JL.MacroContext, level::SyntaxTree, message::SyntaxTree,
+        exs::SyntaxTree...
     )
     return _logmsg_stub(__context__, (level, message, exs...), "@logmsg")
 end
 
-function Base.CoreLogging.var"@logmsg"(__context__::JL.MacroContext, args::SyntaxTreeC...)
-    mc = __context__.macrocall::SyntaxTreeC
+function Base.CoreLogging.var"@logmsg"(__context__::JL.MacroContext, args::SyntaxTree...)
+    mc = __context__.macrocall::SyntaxTree
     push_macro_error!(mc,
         "@logmsg requires at least two arguments: a `level` and a `message`")
     isempty(args) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
@@ -750,10 +750,10 @@ function Base.CoreLogging.var"@logmsg"(__context__::JL.MacroContext, args::Synta
 end
 
 function _logmsg_stub(
-        ctx::JL.MacroContext, exs::Tuple{Vararg{SyntaxTreeC}}, name::AbstractString
+        ctx::JL.MacroContext, exs::Tuple{Vararg{SyntaxTree}}, name::AbstractString
     )
-    mc = ctx.macrocall::SyntaxTreeC
-    children = SyntaxTreeC[]
+    mc = ctx.macrocall::SyntaxTree
+    children = SyntaxTree[]
     seen_kws = Set{String}()
     for ex in exs
         k = JS.kind(ex)
@@ -795,32 +795,32 @@ end
 # surface-syntax call. The same call shapes Base's `destructure_callex` handles are
 # accepted (`f(args...; kwargs...)`, `x.f`, `xs[i]`, `x.f = v`, `xs[i] = v`); other shapes
 # are rejected at expansion time with a clear message.
-function Base.var"@invoke"(__context__::JL.MacroContext, ex::SyntaxTreeC)
+function Base.var"@invoke"(__context__::JL.MacroContext, ex::SyntaxTree)
     destructured = _destructure_invoke_callex(__context__, ex, "@invoke")
     destructured === nothing &&
-        return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC, ex)
+        return JL.@ast(__context__, __context__.macrocall::SyntaxTree, ex)
     f, args, kwargs = destructured
     return _build_invoke_call(__context__, ex, f, args, kwargs)
 end
 
-function Base.var"@invoke"(__context__::JL.MacroContext, args::SyntaxTreeC...)
-    mc = __context__.macrocall::SyntaxTreeC
+function Base.var"@invoke"(__context__::JL.MacroContext, args::SyntaxTree...)
+    mc = __context__.macrocall::SyntaxTree
     push_macro_error!(mc,
         "@invoke expects exactly one argument: `f(args...; kwargs...)` (or one of `x.f`, `xs[i]`, `x.f = v`, `xs[i] = v`)")
     isempty(args) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
     return JL.@ast(__context__, mc, [JS.K"block" args...])
 end
 
-function Base.var"@invokelatest"(__context__::JL.MacroContext, ex::SyntaxTreeC)
+function Base.var"@invokelatest"(__context__::JL.MacroContext, ex::SyntaxTree)
     destructured = _destructure_invoke_callex(__context__, ex, "@invokelatest")
     destructured === nothing &&
-        return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC, ex)
+        return JL.@ast(__context__, __context__.macrocall::SyntaxTree, ex)
     f, args, kwargs = destructured
     return _build_invokelatest_call(__context__, f, args, kwargs)
 end
 
-function Base.var"@invokelatest"(__context__::JL.MacroContext, args::SyntaxTreeC...)
-    mc = __context__.macrocall::SyntaxTreeC
+function Base.var"@invokelatest"(__context__::JL.MacroContext, args::SyntaxTree...)
+    mc = __context__.macrocall::SyntaxTree
     push_macro_error!(mc,
         "@invokelatest expects exactly one argument: `f(args...; kwargs...)` (or one of `x.f`, `xs[i]`, `x.f = v`, `xs[i] = v`)")
     isempty(args) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
@@ -834,13 +834,13 @@ end
 # Returns `nothing` when `ex` doesn't match any accepted shape; the caller is
 # responsible for falling back to a recovery expansion.
 function _destructure_invoke_callex(
-        ctx::JL.MacroContext, ex::SyntaxTreeC, m::AbstractString
+        ctx::JL.MacroContext, ex::SyntaxTree, m::AbstractString
     )
     k = JS.kind(ex)
     if k === JS.K"call"
         f = ex[1]
-        args = SyntaxTreeC[]
-        kwargs = SyntaxTreeC[]
+        args = SyntaxTree[]
+        kwargs = SyntaxTree[]
         for i in 2:JS.numchildren(ex)
             child = ex[i]
             ck = JS.kind(child)
@@ -858,27 +858,27 @@ function _destructure_invoke_callex(
     elseif k === JS.K"."
         # `x.f` -> getproperty(x, :f). `ex[2]` is the `K"inert"`-wrapped field name.
         f = JL.@ast(ctx, ex, [JS.K"top" "getproperty"::JS.K"Identifier"])
-        return f, SyntaxTreeC[ex[1], ex[2]], SyntaxTreeC[]
+        return f, SyntaxTree[ex[1], ex[2]], SyntaxTree[]
     elseif k === JS.K"ref"
         # `xs[i, j, ...]` -> getindex(xs, i, j, ...).
         f = JL.@ast(ctx, ex, [JS.K"top" "getindex"::JS.K"Identifier"])
-        args = SyntaxTreeC[ex[i] for i in 1:JS.numchildren(ex)]
-        return f, args, SyntaxTreeC[]
+        args = SyntaxTree[ex[i] for i in 1:JS.numchildren(ex)]
+        return f, args, SyntaxTree[]
     elseif k === JS.K"=" && JS.numchildren(ex) == 2
         lhs, rhs = ex[1], ex[2]
         lhs_k = JS.kind(lhs)
         if lhs_k === JS.K"."
             # `x.f = v` -> setproperty!(x, :f, v).
             f = JL.@ast(ctx, ex, [JS.K"top" "setproperty!"::JS.K"Identifier"])
-            return f, SyntaxTreeC[lhs[1], lhs[2], rhs], SyntaxTreeC[]
+            return f, SyntaxTree[lhs[1], lhs[2], rhs], SyntaxTree[]
         elseif lhs_k === JS.K"ref"
             # `xs[i, ...] = v` -> setindex!(xs, v, i, ...).
-            args = SyntaxTreeC[lhs[1], rhs]
+            args = SyntaxTree[lhs[1], rhs]
             for i in 2:JS.numchildren(lhs)
                 push!(args, lhs[i])
             end
             f = JL.@ast(ctx, ex, [JS.K"top" "setindex!"::JS.K"Identifier"])
-            return f, args, SyntaxTreeC[]
+            return f, args, SyntaxTree[]
         end
         push_macro_error!(ex,
             "$m: expected a `setproperty!` expression `x.f = v` or `setindex!` expression `x[i] = v`")
@@ -893,11 +893,11 @@ end
 # arg has its annotation stripped, with `T` going into the types tuple; a bare `x` arg
 # gets `Core.Typeof(x)` as its placeholder type.
 function _build_invoke_call(
-        ctx::JL.MacroContext, srcref::SyntaxTreeC,
-        f::SyntaxTreeC, args::Vector{SyntaxTreeC}, kwargs::Vector{SyntaxTreeC}
+        ctx::JL.MacroContext, srcref::SyntaxTree,
+        f::SyntaxTree, args::Vector{SyntaxTree}, kwargs::Vector{SyntaxTree}
     )
-    types = SyntaxTreeC[]
-    new_args = SyntaxTreeC[]
+    types = SyntaxTree[]
+    new_args = SyntaxTree[]
     for arg in args
         if JS.kind(arg) === JS.K"::" && JS.numchildren(arg) == 2
             push!(new_args, arg[1])
@@ -910,7 +910,7 @@ function _build_invoke_call(
     end
     types_tuple = JL.@ast(ctx, srcref,
         [JS.K"curly" [JS.K"core" "Tuple"::JS.K"Identifier"] types...])
-    mc = ctx.macrocall::SyntaxTreeC
+    mc = ctx.macrocall::SyntaxTree
     if isempty(kwargs)
         return JL.@ast(ctx, mc, [JS.K"call"
             [JS.K"core" "invoke"::JS.K"Identifier"]
@@ -931,9 +931,9 @@ end
 # affect what user identifiers reach scope/type analysis.
 function _build_invokelatest_call(
         ctx::JL.MacroContext,
-        f::SyntaxTreeC, args::Vector{SyntaxTreeC}, kwargs::Vector{SyntaxTreeC}
+        f::SyntaxTree, args::Vector{SyntaxTree}, kwargs::Vector{SyntaxTree}
     )
-    mc = ctx.macrocall::SyntaxTreeC
+    mc = ctx.macrocall::SyntaxTree
     if isempty(kwargs)
         return JL.@ast(ctx, mc, [JS.K"call"
             [JS.K"top" "invokelatest"::JS.K"Identifier"]
@@ -950,24 +950,24 @@ end
 # New-style `@kwdef` macro that preserves provenance information.
 # This strips default values from struct fields and generates keyword constructors,
 # matching the semantics of Base.@kwdef.
-function Base.var"@kwdef"(__context__::JL.MacroContext, ex::SyntaxTreeC)
+function Base.var"@kwdef"(__context__::JL.MacroContext, ex::SyntaxTree)
     if JS.kind(ex) !== JS.K"struct"
         push_macro_error!(ex, "Invalid usage of @kwdef")
         # Recovery: let the argument flow through unchanged so e.g. a half-typed
         # struct or an accidentally-decorated function still reaches scope analysis.
-        return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC, ex)
+        return JL.@ast(__context__, __context__.macrocall::SyntaxTree, ex)
     end
 
     # EST struct children: [Value(is_mutable), type_sig, body]
     type_sig = ex[2]
     type_body = ex[3]
 
-    field_names = SyntaxTreeC[]
-    field_defaults = Union{Nothing,SyntaxTreeC}[]
-    stripped = SyntaxTreeC[]
+    field_names = SyntaxTree[]
+    field_defaults = Union{Nothing,SyntaxTree}[]
+    stripped = SyntaxTree[]
     _kwdef_collect_fields!(__context__, type_body, field_names, field_defaults, stripped)
 
-    stripped_body = JL.@ast(__context__, type_body::SyntaxTreeC,
+    stripped_body = JL.@ast(__context__, type_body::SyntaxTree,
                            [JS.K"block" stripped...])
     new_struct = mapchildren(_ -> stripped_body, ex, 3:3)
 
@@ -978,14 +978,14 @@ function Base.var"@kwdef"(__context__::JL.MacroContext, ex::SyntaxTreeC)
     constructors = _kwdef_make_constructors(
         __context__, type_sig, field_names, field_defaults)
 
-    return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC,
+    return JL.@ast(__context__, __context__.macrocall::SyntaxTree,
                    [JS.K"block" new_struct constructors...])
 end
 
 function _kwdef_collect_fields!(
-        ctx::JL.MacroContext, body::SyntaxTreeC, field_names::Vector{SyntaxTreeC},
-        field_defaults::Vector{Union{Nothing,SyntaxTreeC}},
-        stripped::Vector{SyntaxTreeC}
+        ctx::JL.MacroContext, body::SyntaxTree, field_names::Vector{SyntaxTree},
+        field_defaults::Vector{Union{Nothing,SyntaxTree}},
+        stripped::Vector{SyntaxTree}
     )
     for field in JS.children(body)
         k = JS.kind(field)
@@ -1012,8 +1012,8 @@ function _kwdef_collect_fields!(
 end
 
 function _kwdef_push_field!(
-        decl::SyntaxTreeC, default::SyntaxTreeC, field_names::Vector{SyntaxTreeC},
-        field_defaults::Vector{Union{Nothing,SyntaxTreeC}}
+        decl::SyntaxTree, default::SyntaxTree, field_names::Vector{SyntaxTree},
+        field_defaults::Vector{Union{Nothing,SyntaxTree}}
     )
     name = _kwdef_extract_name(decl)
     if name !== nothing
@@ -1022,7 +1022,7 @@ function _kwdef_push_field!(
     end
 end
 
-function _kwdef_extract_name(st::SyntaxTreeC)
+function _kwdef_extract_name(st::SyntaxTree)
     while true
         k = JS.kind(st)
         if k === JS.K"Identifier"
@@ -1037,16 +1037,16 @@ function _kwdef_extract_name(st::SyntaxTreeC)
 end
 
 function _kwdef_make_constructors(
-        ctx::JL.MacroContext, type_sig::SyntaxTreeC, field_names::Vector{SyntaxTreeC},
-        field_defaults::Vector{Union{Nothing,SyntaxTreeC}}
+        ctx::JL.MacroContext, type_sig::SyntaxTree, field_names::Vector{SyntaxTree},
+        field_defaults::Vector{Union{Nothing,SyntaxTree}}
     )
-    mc = __source__ = ctx.macrocall::SyntaxTreeC
+    mc = __source__ = ctx.macrocall::SyntaxTree
 
     if JS.kind(type_sig) === JS.K"<:"
         type_sig = type_sig[1]
     end
 
-    params = SyntaxTreeC[]
+    params = SyntaxTree[]
     for (name, default) in zip(field_names, field_defaults)
         if default !== nothing
             push!(params, JL.@ast(ctx, name, [JS.K"kw" name default]))
@@ -1061,11 +1061,11 @@ function _kwdef_make_constructors(
         body = JL.@ast(ctx, mc, [JS.K"block"
             [JS.K"call" type_sig field_names...]
         ])
-        return SyntaxTreeC[JL.@ast(ctx, mc, [JS.K"function" sig body])]
+        return SyntaxTree[JL.@ast(ctx, mc, [JS.K"function" sig body])]
     elseif JS.kind(type_sig) === JS.K"curly"
         S = type_sig[1]
-        P = SyntaxTreeC[type_sig[i] for i::Int in 2:JS.numchildren(type_sig)]
-        Q = SyntaxTreeC[JS.kind(p) === JS.K"<:" ? p[1] : p for p in P]
+        P = SyntaxTree[type_sig[i] for i::Int in 2:JS.numchildren(type_sig)]
+        Q = SyntaxTree[JS.kind(p) === JS.K"<:" ? p[1] : p for p in P]
         SQ = JL.@ast(ctx, type_sig, [JS.K"curly" S Q...])
 
         # def1: S(; a=default, b) = S(a, b)
@@ -1083,12 +1083,12 @@ function _kwdef_make_constructors(
         ])
         def2 = JL.@ast(ctx, mc, [JS.K"function" sig2 body2])
 
-        return SyntaxTreeC[def1, def2]
+        return SyntaxTree[def1, def2]
     else
         # Recovery: emit no constructors. The bare (stripped) struct definition
         # still reaches downstream lowering.
         push_macro_error!(type_sig, "Invalid type signature for @kwdef")
-        return SyntaxTreeC[]
+        return SyntaxTree[]
     end
 end
 
@@ -1102,10 +1102,10 @@ end
 # `@test_logs`) we keep only the kw RHS so any user-written identifier there still gets
 # scope-resolved (e.g. `broken=flag` flows `flag` through to undef-var / reference
 # analysis), and drop the `K"="` wrapper itself so it doesn't reach later lowering passes.
-function Test.var"@test"(__context__::JL.MacroContext, ex::SyntaxTreeC, kws::SyntaxTreeC...)
-    mc = __context__.macrocall::SyntaxTreeC
+function Test.var"@test"(__context__::JL.MacroContext, ex::SyntaxTree, kws::SyntaxTree...)
+    mc = __context__.macrocall::SyntaxTree
     seen_broken = seen_skip = seen_context = nothing
-    rhss = SyntaxTreeC[]
+    rhss = SyntaxTree[]
     # Base `extract_broken_skip_kws` hard-errors on dup or `skip`+`broken`; we report
     # as Error but keep every RHS in the block so identifiers inside (e.g. dup values)
     # still reach scope analysis.
@@ -1136,10 +1136,10 @@ function Test.var"@test"(__context__::JL.MacroContext, ex::SyntaxTreeC, kws::Syn
 end
 
 function Test.var"@test_broken"(
-        __context__::JL.MacroContext, ex::SyntaxTreeC, kws::SyntaxTreeC...
+        __context__::JL.MacroContext, ex::SyntaxTree, kws::SyntaxTree...
     )
-    mc = __context__.macrocall::SyntaxTreeC
-    rhss = SyntaxTreeC[]
+    mc = __context__.macrocall::SyntaxTree
+    rhss = SyntaxTree[]
     for kw in kws
         _validate_test_kw(kw) === nothing && continue
         push!(rhss, kw[2])
@@ -1149,10 +1149,10 @@ function Test.var"@test_broken"(
 end
 
 function Test.var"@test_skip"(
-        __context__::JL.MacroContext, ex::SyntaxTreeC, kws::SyntaxTreeC...
+        __context__::JL.MacroContext, ex::SyntaxTree, kws::SyntaxTree...
     )
-    mc = __context__.macrocall::SyntaxTreeC
-    rhss = SyntaxTreeC[]
+    mc = __context__.macrocall::SyntaxTree
+    rhss = SyntaxTree[]
     for kw in kws
         _validate_test_kw(kw) === nothing && continue
         push!(rhss, kw[2])
@@ -1162,14 +1162,14 @@ function Test.var"@test_skip"(
 end
 
 function Test.var"@test_throws"(
-        __context__::JL.MacroContext, extype::SyntaxTreeC, ex::SyntaxTreeC
+        __context__::JL.MacroContext, extype::SyntaxTree, ex::SyntaxTree
     )
-    return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC,
+    return JL.@ast(__context__, __context__.macrocall::SyntaxTree,
         [JS.K"block" extype ex])
 end
 
-function Test.var"@test_throws"(__context__::JL.MacroContext, args::SyntaxTreeC...)
-    mc = __context__.macrocall::SyntaxTreeC
+function Test.var"@test_throws"(__context__::JL.MacroContext, args::SyntaxTree...)
+    mc = __context__.macrocall::SyntaxTree
     push_macro_error!(mc,
         "@test_throws expects exactly two arguments: `extype` and `ex`")
     isempty(args) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
@@ -1177,24 +1177,24 @@ function Test.var"@test_throws"(__context__::JL.MacroContext, args::SyntaxTreeC.
 end
 
 function Test.var"@test_warn"(
-        __context__::JL.MacroContext, msg::SyntaxTreeC, ex::SyntaxTreeC
+        __context__::JL.MacroContext, msg::SyntaxTree, ex::SyntaxTree
     )
-    return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC,
+    return JL.@ast(__context__, __context__.macrocall::SyntaxTree,
         [JS.K"block" msg ex])
 end
 
-function Test.var"@test_nowarn"(__context__::JL.MacroContext, ex::SyntaxTreeC)
-    return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC, ex)
+function Test.var"@test_nowarn"(__context__::JL.MacroContext, ex::SyntaxTree)
+    return JL.@ast(__context__, __context__.macrocall::SyntaxTree, ex)
 end
 
-function Test.var"@test_logs"(__context__::JL.MacroContext, args::SyntaxTreeC...)
-    mc = __context__.macrocall::SyntaxTreeC
+function Test.var"@test_logs"(__context__::JL.MacroContext, args::SyntaxTree...)
+    mc = __context__.macrocall::SyntaxTree
     if isempty(args)
         push_macro_error!(mc, "@test_logs needs at least one argument")
         return JL.@ast(__context__, mc, nothing::JS.K"Value")
     end
     body = last(args)
-    block_children = SyntaxTreeC[]
+    block_children = SyntaxTree[]
     for i in 1:length(args)-1
         arg = args[i]
         if JS.kind(arg) === JS.K"="
@@ -1208,44 +1208,44 @@ function Test.var"@test_logs"(__context__::JL.MacroContext, args::SyntaxTreeC...
     return JL.@ast(__context__, mc, [JS.K"block" block_children...])
 end
 
-function Test.var"@test_deprecated"(__context__::JL.MacroContext, ex::SyntaxTreeC)
-    return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC, ex)
+function Test.var"@test_deprecated"(__context__::JL.MacroContext, ex::SyntaxTree)
+    return JL.@ast(__context__, __context__.macrocall::SyntaxTree, ex)
 end
 
 function Test.var"@test_deprecated"(
-        __context__::JL.MacroContext, pattern::SyntaxTreeC, ex::SyntaxTreeC
+        __context__::JL.MacroContext, pattern::SyntaxTree, ex::SyntaxTree
     )
-    return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC,
+    return JL.@ast(__context__, __context__.macrocall::SyntaxTree,
         [JS.K"block" pattern ex])
 end
 
-function Test.var"@test_deprecated"(__context__::JL.MacroContext, args::SyntaxTreeC...)
-    mc = __context__.macrocall::SyntaxTreeC
+function Test.var"@test_deprecated"(__context__::JL.MacroContext, args::SyntaxTree...)
+    mc = __context__.macrocall::SyntaxTree
     push_macro_error!(mc,
         "@test_deprecated expects one or two arguments: `[pattern] expr`")
     isempty(args) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
     return JL.@ast(__context__, mc, [JS.K"block" args...])
 end
 
-function Test.var"@inferred"(__context__::JL.MacroContext, ex::SyntaxTreeC)
-    return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC, ex)
+function Test.var"@inferred"(__context__::JL.MacroContext, ex::SyntaxTree)
+    return JL.@ast(__context__, __context__.macrocall::SyntaxTree, ex)
 end
 
 function Test.var"@inferred"(
-        __context__::JL.MacroContext, allow::SyntaxTreeC, ex::SyntaxTreeC
+        __context__::JL.MacroContext, allow::SyntaxTree, ex::SyntaxTree
     )
-    return JL.@ast(__context__, __context__.macrocall::SyntaxTreeC,
+    return JL.@ast(__context__, __context__.macrocall::SyntaxTree,
         [JS.K"block" allow ex])
 end
 
-function Test.var"@inferred"(__context__::JL.MacroContext, args::SyntaxTreeC...)
-    mc = __context__.macrocall::SyntaxTreeC
+function Test.var"@inferred"(__context__::JL.MacroContext, args::SyntaxTree...)
+    mc = __context__.macrocall::SyntaxTree
     push_macro_error!(mc, "@inferred expects one or two arguments: `[allow] ex`")
     isempty(args) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
     return JL.@ast(__context__, mc, [JS.K"block" args...])
 end
 
-function _validate_test_kw(kw::SyntaxTreeC)
+function _validate_test_kw(kw::SyntaxTree)
     if JS.kind(kw) !== JS.K"="
         push_macro_error!(kw, "invalid test macro call: expected `keyword=value`")
         return nothing
@@ -1262,8 +1262,8 @@ function _validate_test_kw(kw::SyntaxTreeC)
     return name_val(name)
 end
 
-function Test.var"@testset"(__context__::JL.MacroContext, args::SyntaxTreeC...)
-    mc = __context__.macrocall::SyntaxTreeC
+function Test.var"@testset"(__context__::JL.MacroContext, args::SyntaxTree...)
+    mc = __context__.macrocall::SyntaxTree
     if isempty(args)
         push_macro_error!(mc, "No arguments to @testset")
         return JL.@ast(__context__, mc, nothing::JS.K"Value")
@@ -1319,7 +1319,7 @@ function Test.var"@testset"(__context__::JL.MacroContext, args::SyntaxTreeC...)
             [JS.K"block" body]])
 end
 
-function _validate_testset_option(arg::SyntaxTreeC)
+function _validate_testset_option(arg::SyntaxTree)
     if JS.numchildren(arg) != 2
         push_macro_error!(arg, "@testset: malformed option")
         return nothing
@@ -1347,15 +1347,15 @@ const _ASSUME_EFFECTS_SETTINGS = (
 )
 
 function Base.var"@assume_effects"(__context__::JL.MacroContext)
-    mc = __context__.macrocall::SyntaxTreeC
+    mc = __context__.macrocall::SyntaxTree
     push_macro_error!(mc, "@assume_effects: at least one argument is required")
     return JL.@ast(__context__, mc, nothing::JS.K"Value")
 end
 
 function Base.var"@assume_effects"(
-        __context__::JL.MacroContext, args::SyntaxTreeC...
+        __context__::JL.MacroContext, args::SyntaxTree...
     )
-    mc = __context__.macrocall::SyntaxTreeC
+    mc = __context__.macrocall::SyntaxTree
     for i in 1:length(args)-1
         _validate_assume_effect_setting(args[i])
     end
@@ -1373,7 +1373,7 @@ function Base.var"@assume_effects"(
     return JL.@ast(__context__, mc, lastex)
 end
 
-function _validate_assume_effect_setting(setting::SyntaxTreeC)
+function _validate_assume_effect_setting(setting::SyntaxTree)
     # Base hard-errors on either of these via `compute_assumed_setting`; we report as
     # Error but let the body still flow through, since the setting only affects effect
     # metadata which the LSP analyses don't consume.
@@ -1388,7 +1388,7 @@ function _validate_assume_effect_setting(setting::SyntaxTreeC)
     return nothing
 end
 
-function _is_recognized_assume_effect_setting(setting::SyntaxTreeC)
+function _is_recognized_assume_effect_setting(setting::SyntaxTree)
     name = _extract_assume_effect_setting_name(setting)
     return name !== nothing && name in _ASSUME_EFFECTS_SETTINGS
 end
@@ -1396,7 +1396,7 @@ end
 # Strip any number of `!` negations, then check for the symbol-literal shape
 # `:foo` (an `inert` node wrapping an `Identifier`). Returns the bare name
 # as a `String`, or `nothing` if the shape doesn't match.
-function _extract_assume_effect_setting_name(setting::SyntaxTreeC)
+function _extract_assume_effect_setting_name(setting::SyntaxTree)
     while JS.kind(setting) === JS.K"call" && JS.numchildren(setting) == 2
         op = setting[1]
         JS.kind(op) === JS.K"Identifier" && get_name_val(op) === "!" || break
@@ -1432,8 +1432,8 @@ end
 const _STATIC_IF_KINDS = JS.KSet"if elseif ?"
 const _STATIC_COND_KINDS = JS.KSet"if elseif ? && ||"
 
-function Base.var"@static"(__context__::JL.MacroContext, ex::SyntaxTreeC)
-    mc = __context__.macrocall::SyntaxTreeC
+function Base.var"@static"(__context__::JL.MacroContext, ex::SyntaxTree)
+    mc = __context__.macrocall::SyntaxTree
     if JS.kind(ex) ∉ _STATIC_COND_KINDS
         push_macro_error!(ex, "invalid @static macro")
         return JL.@ast(__context__, mc, ex)
@@ -1464,8 +1464,8 @@ function Base.var"@static"(__context__::JL.MacroContext, ex::SyntaxTreeC)
     end
 end
 
-function Base.var"@static"(__context__::JL.MacroContext, args::SyntaxTreeC...)
-    mc = __context__.macrocall::SyntaxTreeC
+function Base.var"@static"(__context__::JL.MacroContext, args::SyntaxTree...)
+    mc = __context__.macrocall::SyntaxTree
     push_macro_error!(mc, "invalid @static macro")
     isempty(args) && return JL.@ast(__context__, mc, nothing::JS.K"Value")
     return JL.@ast(__context__, mc, [JS.K"block" args...])
@@ -1477,8 +1477,8 @@ end
 # a fresh base context before running the condition through JuliaLowering's pipeline.
 # Base lets evaluation errors propagate out of expansion; we recover per the macro issue
 # contract.
-function _static_eval_cond(ctx::JL.MacroContext, cond::SyntaxTreeC)
-    sc = (ctx.macrocall::SyntaxTreeC).context::JS.SyntaxContext
+function _static_eval_cond(ctx::JL.MacroContext, cond::SyntaxTree)
+    sc = (ctx.macrocall::SyntaxTree).context::JS.SyntaxContext
     base_mod = JS.base_layer(sc).mod
     eval_cond = JS.fill_context(cond, JS.SyntaxContext(base_mod, sc.version))
     val = try

--- a/src/utils/jl-syntax-macros.jl
+++ b/src/utils/jl-syntax-macros.jl
@@ -5,14 +5,14 @@
 # TODO: @boundscheck, @simd
 
 """
-    mapchildren(f, ctx, ex, indices::UnitRange{Int})
+    mapchildren(f, ex, indices::UnitRange{Int})
 
-Like `JS.mapchildren(f, ctx, ex)`, but applies `f` only to children at the
+Like `JS.mapchildren(f, ex)`, but applies `f` only to children at the
 given `indices`, leaving other children unchanged.
 """
-function mapchildren(f, ctx, ex::SyntaxTreeC, indices::UnitRange{<:Integer})
+function mapchildren(f, ex::SyntaxTreeC, indices::UnitRange{<:Integer})
     i = Ref(0)
-    JS.mapchildren(ctx, ex) do c
+    JS.mapchildren(ex) do c
         i[] += 1
         i[] in indices ? f(c) : c
     end
@@ -23,7 +23,7 @@ end
 # layer while retaining the original macrocall's source range.
 function _macro_generated_source(ctx::JL.MacroContext)
     mc = ctx.macrocall::SyntaxTreeC
-    return JS.newleaf(ctx, JS.sourceref(mc), JS.K"TOMBSTONE")
+    return JS.newleaf(JS.sourceref(mc), JS.K"TOMBSTONE")
 end
 
 const macro_issue_contract = """
@@ -353,7 +353,7 @@ function Base.var"@label"(__context__::JL.MacroContext, ex::SyntaxTreeC)
     # Keep the label token's exact range without inheriting its caller context, so
     # macro expansion records the originating `@label` call in `SyntaxContext`.
     src = JS.sourceref(ex)
-    return JL.@ast(__context__, ex, [JS.K"symboliclabel"(src) ex])
+    return JL.@ast(__context__, ex, [JS.K"symboliclabel"(src; context=nothing) ex])
 end
 
 function Base.var"@label"(__context__::JL.MacroContext, args::SyntaxTreeC...)
@@ -405,7 +405,7 @@ end
 # from the call site.
 function Base.var"@lazy_str"(__context__::JL.MacroContext, text::SyntaxTreeC)
     mc = __context__.macrocall::SyntaxTreeC
-    if !JS.hasattr(text, :value) || !(text.value isa String)
+    if !(text.value isa String)
         push_macro_error!(text, "@lazy_str expects a string literal")
         return JL.@ast(__context__, mc, text)
     end
@@ -442,24 +442,24 @@ function _lazy_str_parts(
         dollar = findnext('$', value, idx)
         dollar === nothing && break
         if lastidx < dollar
-            push!(parts, _lazy_str_literal_part(ctx, text, value, source_map, lastidx, prevind(value, dollar)))
+            push!(parts, _lazy_str_literal_part(text, value, source_map, lastidx, prevind(value, dollar)))
         end
         atom_start = nextind(value, dollar)
         if atom_start > lastindex(value)
             push_macro_error!(text, "@lazy_str: invalid interpolation")
-            push!(parts, _lazy_str_literal_part(ctx, text, value, source_map, dollar, lastindex(value)))
+            push!(parts, _lazy_str_literal_part(text, value, source_map, dollar, lastindex(value)))
             return parts
         end
         parsed, nextidx = @something _lazy_str_parse_interpolation(
             ctx, text, value, source_map, atom_start) begin
-            push!(parts, _lazy_str_literal_part(ctx, text, value, source_map, dollar, lastindex(value)))
+            push!(parts, _lazy_str_literal_part(text, value, source_map, dollar, lastindex(value)))
             return parts
         end
         push!(parts, parsed)
         lastidx = idx = nextidx
     end
     if lastidx <= lastindex(value)
-        push!(parts, _lazy_str_literal_part(ctx, text, value, source_map, lastidx, lastindex(value)))
+        push!(parts, _lazy_str_literal_part(text, value, source_map, lastidx, lastindex(value)))
     end
     return parts
 end
@@ -550,15 +550,15 @@ function _lazy_str_skip_dedent(
 end
 
 function _lazy_str_literal_part(
-        ctx::JL.MacroContext, text::SyntaxTreeC, value::String,
+        text::SyntaxTreeC, value::String,
         source_map::Dict{Int,Int}, startidx::Int, stopidx::Int
     )
     src = JS.sourceref(text)
     if src isa JS.SourceRef
         srcref = _lazy_str_source_ref(text, src, value, source_map, startidx, stopidx)
-        return JS.newleaf(ctx, srcref, JS.K"String", value[startidx:stopidx])
+        return JS.newleaf(srcref, JS.K"String", value[startidx:stopidx])
     end
-    return JS.newleaf(ctx, text, JS.K"String", value[startidx:stopidx])
+    return JS.newleaf(text, JS.K"String", value[startidx:stopidx])
 end
 
 function _lazy_str_parse_interpolation(
@@ -574,32 +574,28 @@ function _lazy_str_parse_interpolation(
     end
     src = JS.sourceref(text)
     copied = if src isa JS.SourceRef
-        _lazy_str_copy_with_source(ctx, parsed, text, src, value, source_map)
+        _lazy_str_copy_with_source(parsed, text, src, value, source_map)
     else
-        JL.copy_ast(ctx, parsed)
+        parsed
     end
     return JL.adopt_scope(ctx.macrocall, copied), nextidx
 end
 
 function _lazy_str_copy_with_source(
-        ctx::JL.MacroContext, node::JS.SyntaxTree, text::SyntaxTreeC, src::JS.SourceRef,
+        node::JS.SyntaxTree, text::SyntaxTreeC, src::JS.SourceRef,
         value::String, source_map::Dict{Int,Int}
     )
     srcref = _lazy_str_source_ref(text, src, value, source_map, JS.first_byte(node), JS.last_byte(node))
-    out = if JS.is_leaf(node)
-        JS.newleaf(ctx, srcref, JS.kind(node))
+    children = if JS.is_leaf(node)
+        nothing
     else
-        children = JS.SyntaxList(ctx)
+        cs = JS.SyntaxList()
         for child in JS.children(node)
-            push!(children, _lazy_str_copy_with_source(ctx, child, text, src, value, source_map))
+            push!(cs, _lazy_str_copy_with_source(child, text, src, value, source_map))
         end
-        JS.newnode(ctx, srcref, JS.kind(node), children)
+        cs
     end
-    for attr in JS.attrnames(node)
-        attr === :source && continue
-        JS.setattr!(out, attr, getproperty(node, attr))
-    end
-    return out
+    return JL.@mknode(node; source=srcref, children)
 end
 
 function _lazy_str_source_ref(
@@ -973,7 +969,7 @@ function Base.var"@kwdef"(__context__::JL.MacroContext, ex::SyntaxTreeC)
 
     stripped_body = JL.@ast(__context__, type_body::SyntaxTreeC,
                            [JS.K"block" stripped...])
-    new_struct = mapchildren(_ -> stripped_body, __context__, ex, 3:3)
+    new_struct = mapchildren(_ -> stripped_body, ex, 3:3)
 
     if isempty(field_names)
         return new_struct
@@ -1001,7 +997,7 @@ function _kwdef_collect_fields!(
                JS.kind(field[1]) === JS.K"="
             inner = field[1]
             _kwdef_push_field!(inner[1], inner[2], field_names, field_defaults)
-            push!(stripped, mapchildren(_ -> inner[1], ctx, field, 1:1))
+            push!(stripped, mapchildren(_ -> inner[1], field, 1:1))
         elseif k === JS.K"block"
             _kwdef_collect_fields!(ctx, field, field_names, field_defaults, stripped)
         else

--- a/src/utils/type-annotation-utils.jl
+++ b/src/utils/type-annotation-utils.jl
@@ -74,7 +74,7 @@ function closure_argnames(po::Core.PartialOpaque, nargs::Int)
 end
 
 """
-    resolve_global_const(context_module::Module, world::UInt, node::SyntaxTreeC) ->
+    resolve_global_const(context_module::Module, world::UInt, node::SyntaxTree) ->
         Core.Const | nothing
 
 Best-effort static lookup of a `K"Identifier"` or `K"."` dotted-path node as a
@@ -93,7 +93,7 @@ inputs need real inference, which the caller already attempted.
 `world` pins the binding lookup so concurrent analysis updates can't make this
 fallback observe a newer world than the rest of the request.
 """
-function resolve_global_const(context_module::Module, world::UInt, node::SyntaxTreeC)
+function resolve_global_const(context_module::Module, world::UInt, node::SyntaxTree)
     if JS.kind(node) === JS.K"Identifier" && has_name_val(node)
         sym = Symbol(name_val(node))
         Base.invoke_in_world(world, isdefinedglobal, context_module, sym) || return nothing

--- a/test/analysis/test_Closure2Opaque.jl
+++ b/test/analysis/test_Closure2Opaque.jl
@@ -15,7 +15,7 @@ function rewrite_lower_eval(code::AbstractString)
     fi = JETLS.FileInfo(1, code, @__FILE__)
     st0_top = JETLS.build_syntax_tree(fi)
     last_value = Ref{Any}(nothing)
-    last_st3_oc = Ref{Union{JETLS.SyntaxTreeC,Nothing}}(nothing)
+    last_st3_oc = Ref{Union{JETLS.SyntaxTree,Nothing}}(nothing)
     world = Base.get_world_counter()
     JETLS.iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
         result = JETLS.TypeAnnotation.get_inferrable_tree(st0, context_module, world)
@@ -41,7 +41,7 @@ function rewrite_only(code::AbstractString)
     context_module = lowering_module
     fi = JETLS.FileInfo(1, code, @__FILE__)
     st0_top = JETLS.build_syntax_tree(fi)
-    last_st3_oc = Ref{Union{JETLS.SyntaxTreeC,Nothing}}(nothing)
+    last_st3_oc = Ref{Union{JETLS.SyntaxTree,Nothing}}(nothing)
     world = Base.get_world_counter()
     JETLS.iterate_toplevel_tree(st0_top) do st0::JS.SyntaxTree
         result = JETLS.TypeAnnotation.get_inferrable_tree(st0, context_module, world)
@@ -55,7 +55,7 @@ end
 
 # Count `K"_opaque_closure"` nodes in `tree`. Used to verify the rewrite emits
 # exactly one OC per source-level closure (no synthetic duplication).
-function count_opaque_closures(tree::JETLS.SyntaxTreeC)
+function count_opaque_closures(tree::JETLS.SyntaxTree)
     n = JS.kind(tree) === JS.K"_opaque_closure" ? 1 : 0
     if !JS.is_leaf(tree)
         for c in JS.children(tree)

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -176,7 +176,7 @@ end
             for (; ctx3, st3, st0) in results
                 @test ctx3 isa JL.VariableAnalysisContext
                 @test st3 isa JS.SyntaxTree
-                @test infer_toplevel_tree(ctx3, st3, st0, @__MODULE__) isa JETLS.SyntaxTreeC
+                @test infer_toplevel_tree(ctx3, st3, st0, @__MODULE__) isa JETLS.SyntaxTree
             end
         end
     end

--- a/test/jsjl-utils.jl
+++ b/test/jsjl-utils.jl
@@ -51,16 +51,3 @@ end
 jldebug(context_module::Module, s::AbstractString, stop::Int=5) =
     jldebug(context_module, jlparse(s; rule=:statement), stop)
 jldebug(args...) = jldebug(@__MODULE__, args...)
-
-# Select a node by ID from a tree (its underlying graph), graph, or ctx
-function jlnode(g::JL.SyntaxGraph, i::JS.NodeId)
-    t = JS.SyntaxTree(g, i)
-    # show(stdout, MIME("text/x.sexpression"), t)
-    return t
-end
-function jlnode(st::JS.SyntaxTree, i::JS.NodeId)
-    return JS.SyntaxTree(st._graph, i)
-end
-function jlnode(ctx::T where {T<:JL.AbstractLoweringContext}, i::JS.NodeId)
-    return JS.SyntaxTree(ctx.graph, i)
-end

--- a/test/utils/test_ast.jl
+++ b/test/utils/test_ast.jl
@@ -674,7 +674,6 @@ end
     let node = get_target_string("include(\"fo│o.jl\")")
         @test node !== nothing
         @test JS.kind(node) === JS.K"String"
-        @test JS.hasattr(node, :value)
         @test node.value == "foo.jl"
     end
     let node = get_target_string("x = \"hello│ world\"")

--- a/test/utils/test_jl_syntax_macros.jl
+++ b/test/utils/test_jl_syntax_macros.jl
@@ -1462,16 +1462,16 @@ const STATIC_COND_FLAG = true
 end
 
 module static_macro_module
-using JETLS: JL, JS, SyntaxTreeC
+using JETLS: JL, JS, SyntaxTree
 const STATIC_COND_FLAG = false
-function var"@wrapped_static"(ctx::JL.MacroContext, ex::SyntaxTreeC)
-    mc = ctx.macrocall::SyntaxTreeC
+function var"@wrapped_static"(ctx::JL.MacroContext, ex::SyntaxTree)
+    mc = ctx.macrocall::SyntaxTree
     src = JS.sourceref(mc)
     return JL.@ast(ctx, mc, [JS.K"macrocall"(src; context=nothing)
         "@static"::JS.K"Identifier" mc[2] ex])
 end
 function var"@generated_static"(ctx::JL.MacroContext)
-    mc = ctx.macrocall::SyntaxTreeC
+    mc = ctx.macrocall::SyntaxTree
     src = JS.newleaf(JS.sourceref(mc), JS.K"TOMBSTONE")
     return JL.@ast(ctx, src, [JS.K"macrocall"
         "@static"::JS.K"Identifier" mc[2]

--- a/test/utils/test_jl_syntax_macros.jl
+++ b/test/utils/test_jl_syntax_macros.jl
@@ -48,7 +48,7 @@ function has_qualified_name(
     found = Ref(false)
     JETLS.traverse(st) do node::JS.SyntaxTree
         if (JS.kind(node) === qualifier && JS.numchildren(node) == 1 &&
-            get(node[1], :name_val, nothing) == name)
+            JETLS.get_name_val(node[1]) == name)
             found[] = true
         end
         return nothing
@@ -1467,12 +1467,12 @@ const STATIC_COND_FLAG = false
 function var"@wrapped_static"(ctx::JL.MacroContext, ex::SyntaxTreeC)
     mc = ctx.macrocall::SyntaxTreeC
     src = JS.sourceref(mc)
-    return JL.@ast(ctx, mc, [JS.K"macrocall"(src)
+    return JL.@ast(ctx, mc, [JS.K"macrocall"(src; context=nothing)
         "@static"::JS.K"Identifier" mc[2] ex])
 end
 function var"@generated_static"(ctx::JL.MacroContext)
     mc = ctx.macrocall::SyntaxTreeC
-    src = JS.newleaf(ctx, JS.sourceref(mc), JS.K"TOMBSTONE")
+    src = JS.newleaf(JS.sourceref(mc), JS.K"TOMBSTONE")
     return JL.@ast(ctx, src, [JS.K"macrocall"
         "@static"::JS.K"Identifier" mc[2]
         [JS.K"?"


### PR DESCRIPTION
JuliaLang/julia#62474 rewrites `SyntaxTree` as a self-contained
standard tree: `SyntaxGraph`/`NodeId` and the open attribute
machinery (`hasattr`/`setattr!`/`attrnames`), `prune`, and the
`SyntaxTree` type parameter are removed; `name_val`/`var_id`/`id`
are unified into the `value` field; post-`resolve_scopes` lambdas
gain a `K"LambdaBindings"` first child (args/sparams/body shift by
one) with the `is_toplevel_thunk` attribute replaced by the
`K"toplevel_lambda"` kind; `K"code_info"` carries a `K"Slots"` leaf
plus the statement block, and top-level lowering results are wrapped
in `K"thunk"`. JETLS's tree utilities and lowering-based analyses
relied on all of these, so it could not load against the new
revision.

This change redefines `SyntaxTreeC`/`SyntaxListC` as plain
`JS.SyntaxTree`/`JS.SyntaxList` and ports every graph-based idiom to
the new APIs: node construction goes through `JS.newleaf`/
`JS.newnode`/`JL.@mknode` without ctx/graph arguments, the
`name_val`/`var_id` accessors map to the unified `value` field
(`JL.syntax_name`/`JL.syntax_id`), node-id-keyed tables and dedup
sets key on node identity instead, `BindingInfo.node_id`/
`ScopeInfo.node_id` are used directly as trees, and lambda/
`code_info` consumers follow the new child layouts (matching
`K"toplevel_lambda"` where the top-level thunk lambda was previously
included). `TypeAnnotation` records its `:type`/`:matches` results
in node-identity-keyed side tables (`TreeAnnotations`) instead of
injecting graph attribute tables; a fresh instance per inference
pass preserves the old per-pass attribute reset, and the final
pass's tables are owned by `InferredTreeContext`, so annotations
never outlive the analysis nor mutate nodes shared with other trees.
`get_type_for_range` learns the `K"juxtapose"` surface kind, whose
provenance now retains the parser kind. `prune` calls are dropped
(unreachable nodes are simply GC'd now) and the race-safety copy in
`build_syntax_tree` uses `JS.copy_ast` — still required because
`JL.rebase_layers` fills `context` in place on context-free trees.

The JS/JL `[sources]` pins are bumped to `b531c73d15`, which stacks
compatibility fixes on top of the JuliaLang/julia#62474 merge commit
(`b47d48aeaa`), pending proper upstreaming: qualifying `fieldindex`
in `@mknode` for Julia 1.12 compatibility, a single-load
`JS.children` that avoids leaking `Union{Nothing}` into inference,
and `syntax_flags` preservation in `_green_to_est` (operator
infix/prefix and parenthesization flags were dropped on rebuilt
nodes, breaking `is_infix_op_call`-based error-recovery repair,
`noparen_macrocall`, and operator inlay hints).

Beyond parity, the new representation makes lowering itself several
times faster, which shows up directly in the end-to-end latency of
lowering-based LSP features: e.g. against
`test/test_lowering_diagnostic.jl`, `textDocument/diagnostic`
dropped from 108.6ms to 66.8ms and
`textDocument/semanticTokens/full` from 206.5ms to 66.3ms per
request. Verified with `jetls check` (clean) and the full test
suite.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>