### PR TITLE
jetls-client: Fix initialization-options schema generation

### DIFF
--- a/.github/workflows/JETLS.jl.yml
+++ b/.github/workflows/JETLS.jl.yml
@@ -9,8 +9,6 @@ on:
       - "test/**"
       - "LSP/**"
       - "Compiler/**"
-      - "schemas/**"
-      - "scripts/schema/**"
       - "Project.toml"
       - ".github/workflows/JETLS.jl.yml"
       - ".github/workflows/test-app.yml"
@@ -22,8 +20,6 @@ on:
       - "test/**"
       - "LSP/**"
       - "Compiler/**"
-      - "schemas/**"
-      - "scripts/schema/**"
       - "Project.toml"
       - ".github/workflows/JETLS.jl.yml"
       - ".github/workflows/test-app.yml"
@@ -166,9 +162,6 @@ jobs:
           version: "1"
           arch: x64
       - run: julia --startup-file=no Compiler/update-snapshots.jl --check
-
-  check_schemas:
-    uses: ./.github/workflows/check-schemas.yml
 
   jetls_self_check:
     name: Self diagnostics

--- a/.github/workflows/check-schemas.yml
+++ b/.github/workflows/check-schemas.yml
@@ -1,6 +1,26 @@
 name: Check schemas
 
 on:
+  push:
+    branches:
+      - master
+    paths:
+      - "src/**"
+      - "schemas/**"
+      - "scripts/schema/**"
+      - "jetls-client/package.json"
+      - "Project.toml"
+      - ".github/workflows/check-schemas.yml"
+  pull_request:
+    branches-ignore:
+      - release
+    paths:
+      - "src/**"
+      - "schemas/**"
+      - "scripts/schema/**"
+      - "jetls-client/package.json"
+      - "Project.toml"
+      - ".github/workflows/check-schemas.yml"
   workflow_call:
 
 jobs:

--- a/jetls-client/.gitattributes
+++ b/jetls-client/.gitattributes
@@ -1,0 +1,1 @@
+package-json.lock linguist-generated

--- a/jetls-client/CHANGELOG.md
+++ b/jetls-client/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
 - Diff: [`803b00834...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/803b00834...HEAD)
 
+### Fixed
+
+- Fixed auto-completion for `jetls-client.initializationOptions` in VS Code `settings.json`. The `analysis_overrides` option is now suggested instead of JSON Schema keywords such as `properties` and `required`.
+  The client checks all contributed setting schemas during development and publishing to prevent malformed schemas from being released.
+
 ## v0.6.0
 
 - Commit: [`803b00834`](https://github.com/aviatesk/JETLS.jl/commit/803b00834)

--- a/jetls-client/check-package-schema.mjs
+++ b/jetls-client/check-package-schema.mjs
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+import { URL } from 'node:url';
+import Ajv from 'ajv';
+
+const packageJson = JSON.parse(
+    fs.readFileSync(new URL('package.json', import.meta.url), 'utf8'));
+const contributedConfiguration = packageJson.contributes?.configuration;
+const configurationEntries = Array.isArray(contributedConfiguration)
+    ? contributedConfiguration
+    : [contributedConfiguration];
+const ajv = new Ajv({ allErrors: true, strict: false });
+const errors = [];
+
+for (const configuration of configurationEntries) {
+    for (const [name, schema] of Object.entries(configuration?.properties ?? {})) {
+        if (schema === null || typeof schema !== 'object' || Array.isArray(schema)) {
+            errors.push(`${name}: schema must be an object`);
+            continue;
+        }
+        if (!ajv.validateSchema(schema)) {
+            errors.push(`${name}:\n${ajv.errorsText(ajv.errors, { separator: '\n' })}`);
+        }
+    }
+}
+
+if (errors.length > 0) {
+    throw new Error(`Invalid VS Code configuration schemas:\n${errors.join('\n')}`);
+}

--- a/jetls-client/package-lock.json
+++ b/jetls-client/package-lock.json
@@ -16,6 +16,7 @@
         "@stylistic/eslint-plugin": "^5.10.0",
         "@types/node": "^26.1.0",
         "@types/vscode": "^1.96.0",
+        "ajv": "^8.20.0",
         "esbuild": "^0.28.0",
         "eslint": "^10.6.0",
         "typescript": "^6.0.3",
@@ -987,16 +988,16 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -1210,6 +1211,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
@@ -1240,6 +1258,13 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "10.4.0",
@@ -1325,6 +1350,23 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1466,9 +1508,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -1649,6 +1691,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/semver": {

--- a/jetls-client/package.json
+++ b/jetls-client/package.json
@@ -108,43 +108,39 @@
           "scope": "resource",
           "type": "object",
           "default": {},
-          "markdownDescription": "Static initialization options sent to JETLS during startup. These settings require a server restart to take effect.",
+          "markdownDescription": "Static initialization options that are set once at server startup and require a server restart to take effect. See [Initialization options](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options).",
           "properties": {
-            "additionalProperties": false,
-            "markdownDescription": "Static initialization options that are set once at server startup and require a server restart to take effect. See [Initialization options](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options).",
-            "properties": {
-              "analysis_overrides": {
-                "default": [],
-                "items": {
-                  "additionalProperties": false,
-                  "properties": {
-                    "full_analysis": {
-                      "default": false,
-                      "markdownDescription": "Whether matched files should use the Revise-based full-analysis mode. This requires `JETLS_DEV_MODE` because the analysis relies on Revise-tracked loaded modules. Defaults to false, which keeps files out of full analysis and uses `module_name` only as a lowering context when provided. This option is highly experimental, and its behavior and semantics may change in future releases.",
-                      "type": "boolean"
-                    },
-                    "module_name": {
-                      "markdownDescription": "Optional module name to associate with the matched files. By default this is used as an out-of-scope lowering context. When `full_analysis` is true, it selects the loaded module to analyze.",
-                      "type": "string"
-                    },
-                    "path": {
-                      "markdownDescription": "Glob pattern to match files for which analysis should be overridden (e.g., `src/**/*.jl`, `test/**/*.jl`). Patterns are matched against file paths relative to the workspace root. Supports globstar (`**`) for matching directories recursively.",
-                      "type": "string"
-                    }
+            "analysis_overrides": {
+              "default": [],
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "full_analysis": {
+                    "default": false,
+                    "markdownDescription": "Whether matched files should use the Revise-based full-analysis mode. This requires `JETLS_DEV_MODE` because the analysis relies on Revise-tracked loaded modules. Defaults to false, which keeps files out of full analysis and uses `module_name` only as a lowering context when provided. This option is highly experimental, and its behavior and semantics may change in future releases.",
+                    "type": "boolean"
                   },
-                  "required": [
-                    "path"
-                  ],
-                  "type": "object"
+                  "module_name": {
+                    "markdownDescription": "Optional module name to associate with the matched files. By default this is used as an out-of-scope lowering context. When `full_analysis` is true, it selects the loaded module to analyze.",
+                    "type": "string"
+                  },
+                  "path": {
+                    "markdownDescription": "Glob pattern to match files for which analysis should be overridden (e.g., `src/**/*.jl`, `test/**/*.jl`). Patterns are matched against file paths relative to the workspace root. Supports globstar (`**`) for matching directories recursively.",
+                    "type": "string"
+                  }
                 },
-                "markdownDescription": "Override full analysis behavior for specific file patterns. Primarily used as a temporary workaround to disable analysis for files affected by memory leak issues. Each override specifies a glob pattern, optionally a module name, and can opt back into full analysis. Note: This is an experimental feature that may be removed or changed in future versions.",
-                "type": "array"
-              }
-            },
-            "required": [],
-            "type": "object"
+                "required": [
+                  "path"
+                ],
+                "type": "object"
+              },
+              "markdownDescription": "Override full analysis behavior for specific file patterns. Primarily used as a temporary workaround to disable analysis for files affected by memory leak issues. Each override specifies a glob pattern, optionally a module name, and can opt back into full analysis. Note: This is an experimental feature that may be removed or changed in future versions.",
+              "type": "array"
+            }
           },
-          "order": 4
+          "order": 4,
+          "additionalProperties": false,
+          "required": []
         },
         "jetls-client.settings": {
           "scope": "resource",
@@ -404,9 +400,10 @@
   "scripts": {
     "build": "node esbuild.js --production",
     "build:watch": "node esbuild.js --watch",
-    "check": "npm run check:tsc && npm run check:lint",
+    "check": "npm run check:tsc && npm run check:lint && npm run check:package-schema",
     "check:tsc": "tsc --noEmit",
     "check:lint": "eslint",
+    "check:package-schema": "node check-package-schema.mjs",
     "clean": "rm -rf out *.vsix",
     "vscode:prepublish": "npm run check && npm run build"
   },
@@ -418,6 +415,7 @@
     "@stylistic/eslint-plugin": "^5.10.0",
     "@types/node": "^26.1.0",
     "@types/vscode": "^1.96.0",
+    "ajv": "^8.20.0",
     "esbuild": "^0.28.0",
     "eslint": "^10.6.0",
     "typescript": "^6.0.3",

--- a/scripts/schema/update-pkg-json.jl
+++ b/scripts/schema/update-pkg-json.jl
@@ -76,8 +76,8 @@ function update_package_json(
     result = deepcopy(package_json)
     result["contributes"]["configuration"]["properties"]["jetls-client.settings"]["properties"] =
         setting_schema
-    result["contributes"]["configuration"]["properties"]["jetls-client.initializationOptions"]["properties"] =
-        init_options_schema
+    init_options_config = result["contributes"]["configuration"]["properties"]["jetls-client.initializationOptions"]
+    merge!(init_options_config, init_options_schema)
     return result
 end
 


### PR DESCRIPTION
`jetls-client.initializationOptions` embedded the generated object schema inside its `properties` map. VS Code therefore suggested JSON Schema keywords such as `properties` and `required` instead of `analysis_overrides`.

Merge the generated initialization-options schema into the contributed setting itself. Add AJV validation to `npm run check` so malformed setting schemas fail development and prepublish checks.