### PR TITLE
completions: Fix LaTeX/emoji completion on Zed/Helix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed diagnostic path patterns and `analysis_overrides` on Windows, allowing forward-slash glob patterns to match files under the workspace root.
 
+- Fixed LaTeX/emoji completion in clients such as Zed and Helix whose completion filtering cannot handle the `\`/`^`/`:` characters: e.g. Unicode superscript completion like `\^a` now works (Closed https://github.com/aviatesk/JETLS.jl/issues/821).
+
 ## 2026-08-01
 
 - Commit: [`f64faec`](https://github.com/aviatesk/JETLS.jl/commit/f64faec)

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -6,6 +6,7 @@ const METHOD_COMPLETION_TRIGGER_CHARACTERS = ("(", ",", " ")
 const COMPLETION_TRIGGER_CHARACTERS = [
     "@",  # macro completion
     "\\", # LaTeX completion
+    "^",  # LaTeX superscript completion (e.g. `\^a`)
     ":",  # emoji completion
     ";",  # keyword argument completion
     ".",  # property / module-member completion
@@ -551,8 +552,8 @@ function get_backslash_offset(fi::FileInfo, pos::Position)
     end
 end
 
-# Add LaTeX and emoji completions to the items dictionary and return boolean indicating
-# whether any completions were added.
+# Add LaTeX and emoji completions to the items dictionary. Returns `nothing` when
+# the cursor is not in a backslash context, otherwise the `isIncomplete` flag.
 function add_emoji_latex_completions!(
         items::Dict{String,CompletionItem}, comp_ctx::CompletionCtx,
     )
@@ -562,6 +563,14 @@ function add_emoji_latex_completions!(
     edit_range, _ = unadjust_range(state, uri, Range(;
         start = backslash_pos,
         var"end" = pos))
+
+    # Filter server-side by the text typed since the backslash: non-VSCode clients
+    # (Zed, Helix) build their completion filter query from word characters before
+    # the cursor only, so keys containing `\`/`^`/`:` can never be matched by
+    # client-side filtering (aviatesk/JETLS.jl#821). Returning a filtered list with
+    # `isIncomplete = true` moves the filtering to the server; clients re-request
+    # it on each keystroke.
+    typed = String(fi.parsed_stream.textbuf[backslash_offset:comp_ctx.offset-1])
 
     # HACK Some clients (e.g., Zed) don't properly use `sortText` for completion items
     # containing `\\` or `:`, falling back to `label`-based sorting. For these clients,
@@ -590,13 +599,44 @@ function add_emoji_latex_completions!(
     end
 
     emojionly || foreach(REPL.REPLCompletions.latex_symbols) do (key, val)
+        is_subsequence(typed, key) || return
         items[key] = create_ci(key, val, false)
     end
     foreach(REPL.REPLCompletions.emoji_symbols) do (key, val)
+        is_subsequence(typed, key) || return
         items[key] = create_ci(key, val, true)
     end
 
-    # if we reached here, we have added all emoji and latex completions
+    # the list is filtered server-side, so further typing must recompute it
+    return #=isIncomplete=#true
+end
+
+# Subsequence predicate matching what client-side fuzzy matchers (VSCode, nucleo)
+# use as their filter condition: every character of `typed` must appear in `key`
+# in order (e.g. `\lpha` matches `\alpha`). Matching is case-insensitive so the
+# server retains every candidate accepted by clients such as Helix. This only
+# decides which candidates survive; ranking is left to the client's own scoring.
+function is_subsequence(typed::String, key::String)
+    next = @something iterate(typed) return true
+    for c in key
+        (tc, ts) = next
+        if lowercase(c) == lowercase(tc)
+            next = @something iterate(typed, ts) return true
+        end
+    end
+    return false
+end
+
+# `^` is registered as a trigger character solely so that clients reopen the
+# completion menu right after `\^` (LaTeX superscript completion): most clients
+# dismiss the menu when `^` is typed since it is not an identifier character.
+# When a `^`-triggered request was not consumed by `add_emoji_latex_completions!`,
+# the cursor is after a plain `^` (e.g. `x^│`): suppress the remaining completion
+# kinds so that typing the exponentiation operator doesn't pop up an unrelated menu.
+function suppress_plain_caret_trigger(context::Union{Nothing,CompletionContext})
+    context === nothing && return nothing
+    context.triggerKind == CompletionTriggerKind.TriggerCharacter || return nothing
+    context.triggerCharacter == "^" || return nothing
     return #=isIncomplete=#false
 end
 
@@ -1105,6 +1145,7 @@ function get_completion_items(
     # order matters; see local_completions!
     isIncomplete = @something(
         add_emoji_latex_completions!(items, comp_ctx),
+        suppress_plain_caret_trigger(context),
         call_completions!(items, comp_ctx),
         global_completions!(items, comp_ctx),
         local_completions!(items, comp_ctx),

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -1140,6 +1140,7 @@ end
             @test !any(items) do item
                 item.label == "function"
             end
+            @test result.isIncomplete
             cnt[] += 1
         end
         @test cnt[] == 1
@@ -1164,6 +1165,135 @@ end
                 item.label == "α"   || # should not include local completions
                 item.label == "β"   || # should not include local completions
                 item.label == "alpha" # should not even include LaTeX completions
+            end
+            @test result.isIncomplete
+            cnt[] += 1
+        end
+        @test cnt[] == 1
+    end
+
+    # server-side prefix filtering (aviatesk/JETLS.jl#821): clients like Zed/Helix
+    # build their filter query from word characters only, so keys containing
+    # `\`/`^`/`:` must be narrowed down by the server
+    let text = """
+        function foo(α, β)
+            \\^│
+        end
+        """
+        context = CompletionContext(;
+            triggerKind = CompletionTriggerKind.TriggerCharacter,
+            triggerCharacter = "^")
+        cnt = Ref(0)
+        with_completion_items(text; context) do (; result)
+            items = result.items
+            @test any(items) do item
+                item.label == "\\^a"
+            end
+            @test !any(items) do item
+                item.label == "\\alpha" # `\alpha` does not contain the typed `^`
+            end
+            @test result.isIncomplete
+            cnt[] += 1
+        end
+        @test cnt[] == 1
+    end
+
+    # filtering is case-insensitive and subsequence-based, so missing characters
+    # are tolerated as long as the typed characters appear in order
+    let text = """
+        function foo(α, β)
+            \\gama│
+        end
+        """
+        context = CompletionContext(;
+            triggerKind = CompletionTriggerKind.TriggerForIncompleteCompletions)
+        cnt = Ref(0)
+        with_completion_items(text; context) do (; result)
+            labels = Set(item.label for item in result.items)
+            @test "\\gamma" in labels
+            @test "\\Gamma" in labels
+            @test result.isIncomplete
+            cnt[] += 1
+        end
+        @test cnt[] == 1
+    end
+
+    let text = """
+        function foo(α, β)
+            \\alp│
+        end
+        """
+        context = CompletionContext(;
+            triggerKind = CompletionTriggerKind.TriggerForIncompleteCompletions)
+        cnt = Ref(0)
+        with_completion_items(text; context) do (; result)
+            items = result.items
+            @test any(items) do item
+                item.label == "\\alpha"
+            end
+            @test !any(items) do item
+                item.label == "\\beta" ||
+                item.label == "\\:pizza:"
+            end
+            @test result.isIncomplete
+            cnt[] += 1
+        end
+        @test cnt[] == 1
+    end
+
+    let text = """
+        function foo(α, β)
+            \\:piz│
+        end
+        """
+        context = CompletionContext(;
+            triggerKind = CompletionTriggerKind.TriggerForIncompleteCompletions)
+        cnt = Ref(0)
+        with_completion_items(text; context) do (; result)
+            items = result.items
+            @test any(items) do item
+                item.label == "\\:pizza:"
+            end
+            @test !any(items) do item
+                item.label == "\\:smile:"
+            end
+            @test result.isIncomplete
+            cnt[] += 1
+        end
+        @test cnt[] == 1
+    end
+
+    # `^` outside a backslash context (e.g. the exponentiation operator) should
+    # not pop up any completions
+    let text = """
+        function foo(α, β)
+            α^│
+        end
+        """
+        context = CompletionContext(;
+            triggerKind = CompletionTriggerKind.TriggerCharacter,
+            triggerCharacter = "^")
+        cnt = Ref(0)
+        with_completion_items(text; context) do (; result)
+            @test isempty(result.items)
+            @test !result.isIncomplete
+            cnt[] += 1
+        end
+        @test cnt[] == 1
+    end
+
+    # ... but a manual invocation right after `^` still gives normal completions
+    let text = """
+        function foo(α, β)
+            α^│
+        end
+        """
+        context = CompletionContext(;
+            triggerKind = CompletionTriggerKind.Invoked)
+        cnt = Ref(0)
+        with_completion_items(text; context) do (; result)
+            @test any(result.items) do item
+                item.label == "β"
             end
             cnt[] += 1
         end


### PR DESCRIPTION
Clients such as Zed and Helix build their completion filter query from word characters before the cursor only, so completion items keyed by strings containing `\`/`^`/`:` could never be matched by their client-side filtering. In particular Unicode superscript completion like `\^a` did not work at all outside VSCode: both clients also dismiss the completion menu when `^` is typed and, since `^` was not a trigger character, never reopened it (#821).

`add_emoji_latex_completions!` now narrows the candidates server-side to those whose key contains the typed text (from the backslash to the cursor) as a subsequence, and returns `isIncomplete = true` so clients re-request the list on each keystroke. The subsequence predicate `is_subsequence` mirrors the filter condition of client-side fuzzy matchers, keeping inputs like `\lpha` matching `\alpha`; `REPL.fuzzyscore` was rejected since its edit-distance scoring admits no usable threshold for partially typed input. `^` is also registered as a completion trigger character so the menu reopens right after `\^`, and the new `suppress_plain_caret_trigger` barrier returns no completions for `^`-triggered requests outside a backslash context (e.g. `x^`) to keep the exponentiation operator quiet.

Symbol-only keys such as `\^+` remain unsupported since clients never produce a query containing them. Tests cover the server-side filtering, the `isIncomplete` flag, and the caret trigger gate.

---

Closes aviatesk/JETLS.jl#821