### PR TITLE
schema: Prevent npm from rewriting package metadata

### DIFF
--- a/jetls-client/check-package-schema.mjs
+++ b/jetls-client/check-package-schema.mjs
@@ -1,28 +1,47 @@
-import fs from 'node:fs';
-import { URL } from 'node:url';
-import Ajv from 'ajv';
+import fs from "node:fs";
+import { URL } from "node:url";
+import Ajv from "ajv";
 
-const packageJson = JSON.parse(
-    fs.readFileSync(new URL('package.json', import.meta.url), 'utf8'));
+const packageJsonText = fs.readFileSync(
+  new URL("package.json", import.meta.url),
+  "utf8",
+);
+const packageJson = JSON.parse(packageJsonText);
 const contributedConfiguration = packageJson.contributes?.configuration;
 const configurationEntries = Array.isArray(contributedConfiguration)
-    ? contributedConfiguration
-    : [contributedConfiguration];
+  ? contributedConfiguration
+  : [contributedConfiguration];
 const ajv = new Ajv({ allErrors: true, strict: false });
 const errors = [];
+const canonicalPackageJson = `${JSON.stringify(packageJson, null, 2)}\n`;
+
+if (packageJsonText !== canonicalPackageJson) {
+  errors.push(
+    "package.json is not stable under Node.js JSON round-tripping; " +
+      "npm/vsce would rewrite it",
+  );
+}
 
 for (const configuration of configurationEntries) {
-    for (const [name, schema] of Object.entries(configuration?.properties ?? {})) {
-        if (schema === null || typeof schema !== 'object' || Array.isArray(schema)) {
-            errors.push(`${name}: schema must be an object`);
-            continue;
-        }
-        if (!ajv.validateSchema(schema)) {
-            errors.push(`${name}:\n${ajv.errorsText(ajv.errors, { separator: '\n' })}`);
-        }
+  for (const [name, schema] of Object.entries(
+    configuration?.properties ?? {},
+  )) {
+    if (
+      schema === null ||
+      typeof schema !== "object" ||
+      Array.isArray(schema)
+    ) {
+      errors.push(`${name}: schema must be an object`);
+      continue;
     }
+    if (!ajv.validateSchema(schema)) {
+      errors.push(
+        `${name}:\n${ajv.errorsText(ajv.errors, { separator: "\n" })}`,
+      );
+    }
+  }
 }
 
 if (errors.length > 0) {
-    throw new Error(`Invalid VS Code configuration schemas:\n${errors.join('\n')}`);
+  throw new Error(`Extension package validation failed:\n${errors.join("\n")}`);
 }

--- a/jetls-client/package.json
+++ b/jetls-client/package.json
@@ -329,7 +329,7 @@
                   "type": "boolean"
                 },
                 "debounce": {
-                  "default": 1.0,
+                  "default": 1,
                   "markdownDescription": "Debounce time in seconds before triggering full analysis after a file save. Higher values reduce analysis frequency but may delay diagnostic updates.",
                   "type": "number"
                 }
@@ -353,8 +353,6 @@
                     "min_lines": {
                       "default": 25,
                       "markdownDescription": "Minimum number of lines a block must span before its `end`-tag inlay hint is displayed.",
-                      "maximum": 9223372036854775807,
-                      "minimum": -9223372036854775808,
                       "type": "integer"
                     }
                   },

--- a/schemas/config-toml.schema.json
+++ b/schemas/config-toml.schema.json
@@ -183,7 +183,7 @@
           "type": "boolean"
         },
         "debounce": {
-          "default": 1.0,
+          "default": 1,
           "description": "Debounce time in seconds before triggering full analysis after a file save. Higher values reduce analysis frequency but may delay diagnostic updates.",
           "type": "number"
         }
@@ -242,8 +242,6 @@
             "min_lines": {
               "default": 25,
               "description": "Minimum number of lines a block must span before its `end`-tag inlay hint is displayed.",
-              "maximum": 9223372036854775807,
-              "minimum": -9223372036854775808,
               "type": "integer"
             }
           },

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -6,6 +6,9 @@
     "Core.Float64": {
       "type": "number"
     },
+    "Core.Int64": {
+      "type": "integer"
+    },
     "Core.String": {
       "type": "string"
     },
@@ -193,7 +196,7 @@
             },
             "debounce": {
               "$ref": "#/$defs/Core.Float64",
-              "default": 1.0,
+              "default": 1,
               "description": "Debounce time in seconds before triggering full analysis after a file save. Higher values reduce analysis frequency but may delay diagnostic updates."
             }
           },
@@ -213,11 +216,9 @@
                   "description": "Enable or disable inlay hints displayed at block `end` keywords (e.g., `end # module Foo`). Supports: `module`, `function`, `macro`, `struct`, `if`, `let`, `for`, `while`, `@testset`."
                 },
                 "min_lines": {
+                  "$ref": "#/$defs/Core.Int64",
                   "default": 25,
-                  "description": "Minimum number of lines a block must span before its `end`-tag inlay hint is displayed.",
-                  "maximum": 9223372036854775807,
-                  "minimum": -9223372036854775808,
-                  "type": "integer"
+                  "description": "Minimum number of lines a block must span before its `end`-tag inlay hint is displayed."
                 }
               },
               "type": "object"

--- a/scripts/schema/Project.toml
+++ b/scripts/schema/Project.toml
@@ -6,7 +6,7 @@ Struct2JSONSchema = "6b9a66ba-ce23-4e49-9189-ad500babf267"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [sources]
-Struct2JSONSchema = {rev = "avi/allow-OrderedCollection-v2", url = "https://github.com/aviatesk/Struct2JSONSchema.jl"}
+Struct2JSONSchema = {rev = "avi/JS-compatibility", url = "https://github.com/aviatesk/Struct2JSONSchema.jl"}
 
 [compat]
-Struct2JSONSchema = "0.5.1"
+Struct2JSONSchema = "0.6"

--- a/scripts/schema/generate.jl
+++ b/scripts/schema/generate.jl
@@ -62,7 +62,7 @@ end
 
 function (@main)(args::Vector{String})
     target_arg, file_path, check_mode = parse_arguments(args)
-    gen_ctx = SchemaContext()
+    gen_ctx = SchemaContext(; javascript_safe_numbers = true)
     setup_ctx!(gen_ctx)
     schema_dict = generate_schema_dict(target_arg, gen_ctx)
 

--- a/scripts/schema/update-pkg-json.jl
+++ b/scripts/schema/update-pkg-json.jl
@@ -83,7 +83,7 @@ end
 
 function (@main)(args::Vector{String})
     file_path, check_mode = parse_arguments(args)
-    gen_ctx = SchemaContext()
+    gen_ctx = SchemaContext(; javascript_safe_numbers = true)
     setup_ctx!(gen_ctx)
 
     setting_schema, init_options_schema = generate_vscode_schemas(gen_ctx)


### PR DESCRIPTION
Generated configuration schemas embedded `1.0` defaults and integer bounds that JavaScript could not round-trip faithfully. `npm version`, as invoked by `vsce publish`, consequently rewrote `package.json` during release.

Use Struct2JSONSchema 0.6 (abap34/Struct2JSONSchema.jl#31) with its JavaScript-safe number profile for all schema entry points, then regenerate the standalone and VS Code schemas. Add a prepublish check that rejects package metadata which Node.js would rewrite.

Schema regeneration checks, the jetls-client checks, and a direct Node.js round-trip comparison all pass.