### PR TITLE
ci: Run the full test matrix on release PRs

### DIFF
--- a/.github/workflows/JETLS.jl.yml
+++ b/.github/workflows/JETLS.jl.yml
@@ -11,6 +11,7 @@ on:
       - "Compiler/**"
       - "Project.toml"
       - ".github/workflows/JETLS.jl.yml"
+      - ".github/workflows/test-matrix.yml"
       - ".github/workflows/test-app.yml"
   pull_request:
     branches-ignore:
@@ -22,60 +23,13 @@ on:
       - "Compiler/**"
       - "Project.toml"
       - ".github/workflows/JETLS.jl.yml"
+      - ".github/workflows/test-matrix.yml"
       - ".github/workflows/test-app.yml"
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false # don't stop CI even when one of them fails
-      matrix:
-        include:
-          - version: "1" # current stable
-            os: ubuntu-latest
-            arch: x64
-          - version: "1.12" # minimum version supported
-            os: ubuntu-latest
-            arch: x64
-          - version: "1.13-nightly" # next release
-            os: ubuntu-latest
-            arch: x64
-          # - version: "nightly" # dev
-          #   os: ubuntu-latest
-          #   arch: x64
-          - version: "1" # x86 ubuntu
-            os: ubuntu-latest
-            arch: x86
-          - version: "1" # x86 windows
-            os: windows-latest
-            arch: x86
-          - version: "1" # x64 windows
-            os: windows-latest
-            arch: x64
-          - version: "1" # x64 macOS
-            os: macos-latest
-            arch: x64
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
-      # - name: allow JET to be loaded on nightly
-      #   if: matrix.version == 'nightly'
-      #   run: |
-      #     echo '
-      #     [JET]
-      #     JET_DEV_MODE = true
-      #     ' > LocalPreferences.toml
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
-        with:
-          flags: JETLS.jl
+    uses: ./.github/workflows/test-matrix.yml
+    # run with the default inputs: `coverage: true`, `include-nightly: true`
 
   JETLS_DEV_MODE:
     name: Test with `JETLS_DEV_MODE = true`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,19 +15,11 @@ on:
 
 jobs:
   test:
-    name: Test JETLS.jl with release environment
     if: github.event_name == 'pull_request' && github.event.action != 'closed'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: "1.12" # most stable version
-          arch: x64
-      - uses: julia-actions/cache@v2
-
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+    uses: ./.github/workflows/test-matrix.yml
+    with:
+      coverage: false # coverage tracking is a master CI concern
+      include-nightly: false # an unreleased Julia must not block a release
 
   test_app:
     if: github.event_name == 'pull_request' && github.event.action != 'closed'

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -1,0 +1,100 @@
+name: Test matrix
+
+on:
+  workflow_call:
+    inputs:
+      coverage:
+        description: Collect coverage and upload it to Codecov
+        type: boolean
+        required: false
+        default: true
+      include-nightly:
+        description: Also test against the next Julia release
+        type: boolean
+        required: false
+        default: true
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false # don't stop CI even when one of them fails
+      matrix:
+        include:
+          - version: "1" # current stable
+            os: ubuntu-latest
+            arch: x64
+          - version: "1.12" # minimum version supported
+            os: ubuntu-latest
+            arch: x64
+          - version: "1" # x86 ubuntu
+            os: ubuntu-latest
+            arch: x86
+          - version: "1" # x86 windows
+            os: windows-latest
+            arch: x86
+          - version: "1" # x64 windows
+            os: windows-latest
+            arch: x64
+          - version: "1" # x64 macOS
+            os: macos-latest
+            arch: x64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+        with:
+          coverage: ${{ inputs.coverage }}
+      - uses: julia-actions/julia-processcoverage@v1
+        if: inputs.coverage
+      - uses: codecov/codecov-action@v5
+        if: inputs.coverage
+        with:
+          flags: JETLS.jl
+
+  # Kept separate from `test` so that callers gating a release can opt out:
+  # failures against an unreleased Julia should not block shipping.
+  test_nightly:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    if: inputs.include-nightly
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false # don't stop CI even when one of them fails
+      matrix:
+        include:
+          - version: "1.13-nightly" # next release
+            os: ubuntu-latest
+            arch: x64
+          # - version: "nightly" # dev
+          #   os: ubuntu-latest
+          #   arch: x64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v2
+      # - name: allow JET to be loaded on nightly
+      #   if: matrix.version == 'nightly'
+      #   run: |
+      #     echo '
+      #     [JET]
+      #     JET_DEV_MODE = true
+      #     ' > LocalPreferences.toml
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+        with:
+          coverage: ${{ inputs.coverage }}
+      - uses: julia-actions/julia-processcoverage@v1
+        if: inputs.coverage
+      - uses: codecov/codecov-action@v5
+        if: inputs.coverage
+        with:
+          flags: JETLS.jl

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -136,7 +136,12 @@ echo "==> Step 6: Creating pull request"
 PR_BODY="This PR releases version \`$JETLS_VERSION\`.
 
 ## Checklist
-- [ ] \`release / Test JETLS.jl with release environment\`
+- [ ] \`release / test / Julia 1 - ubuntu-latest - x64\`
+- [ ] \`release / test / Julia 1 - ubuntu-latest - x86\`
+- [ ] \`release / test / Julia 1 - windows-latest - x86\`
+- [ ] \`release / test / Julia 1 - windows-latest - x64\`
+- [ ] \`release / test / Julia 1 - macos-latest - x64\`
+- [ ] \`release / test / Julia 1.12 - ubuntu-latest - x64\`
 - [ ] \`release / test_app / Test jetls serve\`
 - [ ] \`release / test_app / Test jetls check\`
 - [ ] \`release / test_app / Test jetls schema\`


### PR DESCRIPTION
Release PRs were gated only on ubuntu x64 / Julia 1.12 while master CI covers the full platform matrix. A release PR merges the actual release environment, whose dependency resolution differs from master, so platform-specific breakage (e.g. Windows path handling) could slip through the release gate untested.

This change extracts the matrix test job into a reusable `test-matrix.yml` workflow (`workflow_call`) invoked from both `JETLS.jl.yml` and `release.yml`, following the existing pattern of `test-app.yml`/`check-schemas.yml` so the matrix cannot drift between the two callers. Two inputs control caller-specific behavior: `coverage` gates the Codecov steps (a master CI concern), and `include-nightly` gates testing against the next Julia release, which must not block shipping a release. The nightly entry lives in a separate `test_nightly` job because GitHub Actions processes matrix `exclude` before `include`, so an `include`-only matrix entry cannot be excluded conditionally. `release.yml` calls the workflow with both inputs disabled; `JETLS.jl.yml` uses the defaults (both enabled).

The checklist in `scripts/prepare-release.sh` is updated to the new check names (`release / test / Julia <version> - <os> - <arch>`), and the `JETLS.jl.yml` path filters now include `test-matrix.yml`. Note that any required status checks pinned to the old check names in branch protection need to be updated after this lands.