### PR TITLE
docs: Generate the configuration schema block during docs build

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -5,11 +5,13 @@ on:
     branches:
       - master
     paths:
+      - "src/**"
       - "docs/**"
       - "CHANGELOG.md"
       - ".github/workflows/Documentation.yml"
   pull_request:
     paths:
+      - "src/**"
       - "docs/**"
       - "CHANGELOG.md"
       - ".github/workflows/Documentation.yml"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -341,6 +341,14 @@ Both scripts support a `--check` flag that exits with an error
 if the output is out of date. CI runs them in this mode to
 ensure the generated files are kept in sync.
 
+Additionally, the TOML schema block shown in
+[`docs/src/configuration.md`](./docs/src/configuration.md)
+is generated during the docs build by
+[`docs/config-schema-block.jl`](./docs/config-schema-block.jl)
+, which asserts that its entries stay in sync with the config structs.
+When you add or remove config fields, update its entries as well,
+otherwise the docs build fails.
+
 ## Updating Compiler.jl snapshots
 
 JET and JETLS use the local [`Compiler`](./Compiler/) package. Its

--- a/docs/config-schema-block.jl
+++ b/docs/config-schema-block.jl
@@ -1,0 +1,217 @@
+# Generates the TOML schema block embedded in `src/configuration.md` via its `@eval`
+# code block. Entries and default values are derived from `JETLS.JETLSConfig` /
+# `JETLS.DEFAULT_CONFIG`, and the docs build fails when this file drifts from the
+# actual configuration structs:
+# - the displayed block, as well as its variant with all the commented-out entries
+#   enabled, must be valid TOML and parse into a valid `JETLSConfig`
+# - the entries must cover exactly the options reachable from `JETLSConfig`
+
+using JETLS
+using Markdown
+using TOML
+
+struct SchemaRow
+    key::String     # dotted option key claimed by this row ("" for table headers)
+    code::String    # TOML source text, without the trailing comment
+    comment::String
+    commented::Bool # displayed commented out (entry without a default value)
+    validate::Bool  # included in the validation rendering
+end
+
+function toml_repr(@nospecialize x)
+    if x isa Union{Bool, Int, Float64}
+        return string(x)
+    elseif x isa String
+        return repr(x)
+    elseif x isa Vector
+        isempty(x) || error("cannot render a non-empty array default: ", repr(x))
+        return "[]"
+    else
+        error("cannot render a default value of type ", typeof(x), ": ", repr(x))
+    end
+end
+
+function default_entry(path::Symbol...; comment::String, note::String = "", validate::Bool = true)
+    value = JETLS.getobjpath(JETLS.DEFAULT_CONFIG, path...)
+    code = string(last(path), " = ", toml_repr(value))
+    comment = string(comment, ", default: ", toml_repr(value), note)
+    return SchemaRow(join(path, '.'), code, comment, false, validate)
+end
+
+function example_entry(key::String, value::String; comment::String)
+    code = string(last(split(key, '.')), " = ", value)
+    return SchemaRow(key, code, comment, true, true)
+end
+
+table_header(name::String; comment::String = "", commented::Bool = false) =
+    SchemaRow("", "[$name]", comment, commented, true)
+
+array_header(name::String; comment::String = "") =
+    SchemaRow("", "[[$name]]", comment, true, true)
+
+# Schema directive honored by TOML language servers (e.g. tombi). Unlike the one in
+# this repository's own `.JETLSConfig.toml`, which points at `schemas/` relatively,
+# the documented block is meant to be copied into other projects, so it refers to
+# the released schema file
+const CONFIG_TOML_SCHEMA_URL =
+    "https://github.com/aviatesk/JETLS.jl/releases/latest/download/config-toml.schema.json"
+
+schema_directive() =
+    SchemaRow("", "#:schema $CONFIG_TOML_SCHEMA_URL", "", false, true)
+
+display_code(row::SchemaRow) = row.commented ? string("# ", row.code) : row.code
+
+# Renders `rows` (`SchemaRow`s and `nothing`s for blank lines) with all the trailing
+# comments aligned to the same column
+function render_display(rows::Vector{Union{Nothing, SchemaRow}})
+    width = maximum(
+        textwidth ∘ display_code,
+        (row for row in rows if row isa SchemaRow && !isempty(row.comment))
+    )
+    lines = String[]
+    for row in rows
+        if row === nothing
+            push!(lines, "")
+        else
+            code = display_code(row)
+            push!(
+                lines, isempty(row.comment) ? code :
+                    string(rpad(code, width + 1), "# ", row.comment)
+            )
+        end
+    end
+    return join(lines, '\n')
+end
+
+const SKIP_OPTIONS = ("initialization_options",) # documented in launching.md, not here
+
+strip_sentinels(@nospecialize T) = Base.typesplit(Base.typesplit(T, Nothing), Missing)
+
+function option_keys!(acc::Set{String}, ::Type{T}, prefix::String) where {T}
+    for i in 1:fieldcount(T)
+        name = String(fieldname(T, i)::Symbol)
+        startswith(name, "__") && continue # internal fields
+        key = isempty(prefix) ? name : string(prefix, '.', name)
+        key in SKIP_OPTIONS && continue
+        S = strip_sentinels(fieldtype(T, i))
+        if S == JETLS.FormatterConfig
+            push!(acc, key) # the string preset form
+            option_keys!(
+                acc, JETLS.CustomFormatterConfig,
+                string(key, '.', JETLS.CUSTOM_FORMATTER_ALIAS)
+            )
+        elseif S <: JETLS.ConfigSection
+            option_keys!(acc, S, key)
+        elseif S <: Vector && eltype(S) <: JETLS.ConfigSection
+            push!(acc, key) # the array itself (e.g. `patterns = []`)
+            option_keys!(acc, eltype(S), key)
+        else
+            push!(acc, key)
+        end
+    end
+    return
+end
+
+function toml_keys!(acc::Set{String}, dict::AbstractDict{String}, prefix::String)
+    for (key, value) in dict
+        path = isempty(prefix) ? key : string(prefix, '.', key)
+        if value isa AbstractDict{String}
+            toml_keys!(acc, value, path)
+        elseif value isa AbstractVector && all(Base.Fix2(isa, AbstractDict{String}), value)
+            foreach(elem::AbstractDict{String} -> toml_keys!(acc, elem, path), value)
+        else
+            push!(acc, path)
+        end
+    end
+end
+
+function assert_valid_config(toml_text::String)
+    result = JETLS.parse_config_dict(TOML.parse(toml_text))
+    result isa JETLS.JETLSConfig ||
+        error("the schema block is not a valid configuration: ", result)
+    return result
+end
+
+let rows = Union{Nothing, SchemaRow}[
+        schema_directive(),
+        nothing,
+        default_entry(:formatter; comment = "\"Runic\"/\"JuliaFormatter\"", validate = false),
+        nothing,
+        table_header("formatter.custom"; commented = true, comment = "table, alternative to the string preset form above"),
+        example_entry("formatter.custom.executable", "\"/path/to/formatter\""; comment = "string, required"),
+        example_entry("formatter.custom.executable_range", "\"/path/to/range-formatter\""; comment = "string, optional"),
+        nothing,
+        table_header("full_analysis"),
+        default_entry(:full_analysis, :debounce; comment = "number (seconds)"),
+        default_entry(:full_analysis, :auto_instantiate; comment = "boolean"),
+        nothing,
+        table_header("diagnostic"),
+        default_entry(:diagnostic, :enabled; comment = "boolean"),
+        default_entry(:diagnostic, :all_files; comment = "boolean"),
+        default_entry(:diagnostic, :allow_unused_underscore; comment = "boolean"),
+        default_entry(:diagnostic, :patterns; comment = "array of tables", validate = false),
+        nothing,
+        array_header("diagnostic.patterns"; comment = "table, an entry of the patterns array above"),
+        example_entry("diagnostic.patterns.pattern", "\"lowering/unused-.*\""; comment = "string, required"),
+        example_entry("diagnostic.patterns.match_by", "\"code\""; comment = "\"code\"/\"message\", required"),
+        example_entry("diagnostic.patterns.match_type", "\"regex\""; comment = "\"literal\"/\"regex\", required"),
+        example_entry("diagnostic.patterns.severity", "\"hint\""; comment = "\"error\"/\"warning\"/\"info\"/\"hint\"/\"off\" or 0-4, required"),
+        example_entry("diagnostic.patterns.path", "\"test/**/*.jl\""; comment = "string (glob), optional"),
+        nothing,
+        table_header("completion.latex_emoji"),
+        example_entry("completion.latex_emoji.strip_prefix", "true"; comment = "boolean, default: unset (auto-detect based on client)"),
+        nothing,
+        table_header("code_lens"),
+        default_entry(:code_lens, :references; comment = "boolean"),
+        default_entry(:code_lens, :testrunner; comment = "boolean"),
+        nothing,
+        table_header("inlay_hint.block_end"),
+        default_entry(:inlay_hint, :block_end, :enabled; comment = "boolean"),
+        default_entry(:inlay_hint, :block_end, :min_lines; comment = "integer"),
+        nothing,
+        table_header("inlay_hint.types"),
+        default_entry(:inlay_hint, :types, :enabled; comment = "boolean"),
+        nothing,
+        table_header("testrunner"),
+        default_entry(:testrunner, :executable; comment = "string", note = " (\"testrunner.bat\" on Windows)"),
+    ]
+
+    display_text = render_display(rows)
+    assert_valid_config(display_text)
+
+    schema_rows = SchemaRow[row for row in rows if row isa SchemaRow]
+    # The validation rendering enables all the commented-out entries and drops rows
+    # incompatible with them (the string preset form of `formatter` conflicts with
+    # the `[formatter.custom]` table, and `patterns = []` conflicts with the
+    # `[[diagnostic.patterns]]` entry)
+    validation_text = join((row.code for row in schema_rows if row.validate), '\n')
+    validation_dict = TOML.parse(validation_text)
+    assert_valid_config(validation_text)
+
+    covered = Set{String}()
+    toml_keys!(covered, validation_dict, "")
+    for row in schema_rows
+        if !row.validate && !isempty(row.key)
+            push!(covered, row.key)
+        end
+    end
+
+    expected = Set{String}()
+    option_keys!(expected, JETLS.JETLSConfig, "")
+
+    if covered != expected
+        error(
+            """
+            the schema block is out of sync with `JETLSConfig`:
+              missing options: $(join(sort!(collect(setdiff(expected, covered))), ", "))
+              unknown options: $(join(sort!(collect(setdiff(covered, expected))), ", "))
+            """
+        )
+    end
+
+    Markdown.parse("""
+    ```toml
+    $display_text
+    ```
+    """)
+end

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -7,45 +7,19 @@ JSON Schema files for all configuration surfaces are [also available](@ref confi
 
 ## [Configuration schema](@id config/schema)
 
-```toml
-formatter = "Runic"                # String preset: "Runic" (default) or "JuliaFormatter"
+The following schema lists all the available options.
+An entry that is not commented out shows the option's default value, while a
+commented-out entry is a form without a default value (an alternative form,
+an array entry, or an option whose default is unset), shown with an example
+value.
 
-[full_analysis]
-debounce = 1.0                     # number (seconds), default: 1.0
-auto_instantiate = true            # boolean, default: true
+The leading `#:schema` directive is honored by TOML language servers such as
+[tombi](https://github.com/tombi-toml/tombi), which use it to validate and
+complete `.JETLSConfig.toml` against the [JSON Schema](@ref config/schema-cli).
 
-[formatter.custom]                 # Or custom formatter configuration
-executable = ""                    # string (path), optional
-executable_range = ""              # string (path), optional
-
-[diagnostic]
-enabled = true                     # boolean, default: true
-all_files = true                   # boolean, default: true
-allow_unused_underscore = true     # boolean, default: true
-
-[[diagnostic.patterns]]
-pattern = ""                       # string, required
-match_by = ""                      # string, required, "code" or "message"
-match_type = ""                    # string, required, "literal" or "regex"
-severity = ""                      # string or number, required, "error"/"warning"/"warn"/"information"/"info"/"hint"/"off" or 0/1/2/3/4
-path = ""                          # string (optional), glob pattern for file paths
-
-[completion.latex_emoji]
-strip_prefix = false               # boolean, default: (unset) auto-detect
-
-[code_lens]
-references = false                 # boolean, default: false
-testrunner = true                  # boolean, default: true
-
-[inlay_hint.block_end]
-enabled = true                     # boolean, default: true
-min_lines = 25                     # integer, default: 25
-
-[inlay_hint.types]
-enabled = true                     # boolean, default: true
-
-[testrunner]
-executable = "testrunner"          # string, default: "testrunner" (or "testrunner.bat" on Windows)
+```@eval
+using JETLS
+Base.include(@__MODULE__, joinpath(pkgdir(JETLS), "docs", "config-schema-block.jl"))
 ```
 
 ## [Configuration reference](@id config/reference)


### PR DESCRIPTION
The TOML schema block in `docs/src/configuration.md` was written by hand and had drifted from the actual configuration. It was not even valid TOML: `formatter = "Runic"` defines a top-level key, and the later `[formatter.custom]` header then redefines the same key as a table, so copying the block into `.JETLSConfig.toml` fails to parse. The values were inconsistent too — some entries showed real defaults, while others used empty-string placeholders that are not valid values (`severity = ""`), and `strip_prefix = false` contradicted its own "default: (unset)" comment.

`docs/config-schema-block.jl` now derives the block from `JETLS.JETLSConfig` and `JETLS.DEFAULT_CONFIG` and renders it through an `@eval` block. The docs build fails when the block drifts: both the displayed text and a variant with every commented-out entry enabled must parse as a valid `JETLSConfig`, and the entry keys must cover exactly the options reachable from `JETLSConfig`. The trailing comments now follow one convention, where an entry that is not commented out shows the option's default value and a commented-out entry is a form without one. The procedure is recorded in `DEVELOPMENT.md` next to the existing schema regeneration steps.

The generated block also starts with a `#:schema` directive pointing at the released `config-toml.schema.json`, so a copy of it validates and completes in TOML language servers such as tombi. Unlike the directive in this repository's own `.JETLSConfig.toml`, it uses the release URL rather than a path into `schemas/`.

The `Documentation` workflow now also triggers on `src/**`. Its paths filter previously listed only `docs/**` and `CHANGELOG.md`, so a change to the config structs in `src/types.jl` would skip the docs job entirely and never run these assertions. The same gap meant that docstring-only changes never rebuilt the deployed documentation.