### PR TITLE
Share dev-mode preferences and check release-environement preferences

### DIFF
--- a/.github/workflows/JETLS.jl.yml
+++ b/.github/workflows/JETLS.jl.yml
@@ -43,8 +43,10 @@ jobs:
       - uses: julia-actions/cache@v2
       - name: enable JETLS_DEV_MODE for tests
         run: |
-          sed -i 's/JETLS_DEV_MODE = false/JETLS_DEV_MODE = true/' \
-            test/LocalPreferences.toml
+          echo '
+          [JETLS]
+          JETLS_DEV_MODE = true
+          ' > test/LocalPreferences.toml
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
   test_app:
     if: github.event_name == 'pull_request' && github.event.action != 'closed'
     uses: ./.github/workflows/test-app.yml
+    with:
+      release-installation: true
 
   check_schemas:
     if: github.event_name == 'pull_request' && github.event.action != 'closed'

--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -2,8 +2,49 @@ name: Test app commands
 
 on:
   workflow_call:
+    inputs:
+      release-installation:
+        description: Test installation of the release app
+        type: boolean
+        required: false
+        default: false
 
 jobs:
+  test_release_installation:
+    name: Test release installation
+    if: inputs.release-installation
+    runs-on: ubuntu-latest
+    env:
+      JULIA_DEPOT_PATH: /tmp/jetls-depot
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: "1"
+          arch: x64
+      - name: Install current checkout
+        shell: julia --color=yes --startup-file=no {0}
+        run: |
+          using Pkg
+          Pkg.Registry.add("General")
+          Pkg.Apps.add(; path=pwd())
+          open(ENV["GITHUB_PATH"], "a") do io
+              println(io, joinpath(first(DEPOT_PATH), "bin"))
+          end
+      - name: Test installed configuration
+        shell: julia --color=yes --startup-file=no {0}
+        run: |
+          using Pkg
+          app_project = joinpath(first(DEPOT_PATH), "environments", "apps", "JETLS")
+          Pkg.activate(app_project)
+          using JETLS
+          @assert !JETLS.JETLS_DEV_MODE
+          @assert !JETLS.JETLS_TEST_MODE
+          @assert JETLS.PrecompileTools.workload_enabled(JETLS)
+      - name: Test installed executable
+        run: |
+          test "$(jetls --version)" = "JETLS version $(cat JETLS_VERSION)"
+
   test_jetls_serve:
     name: Test jetls serve
     runs-on: ubuntu-latest
@@ -11,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
-          version: "1.12" # most stable version
+          version: "1" # most stable version
           arch: x64
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@latest
@@ -26,7 +67,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
-          version: "1.12" # most stable version
+          version: "1" # most stable version
           arch: x64
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@latest
@@ -41,7 +82,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
-          version: "1.12" # most stable version
+          version: "1" # most stable version
           arch: x64
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@latest

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ Project.toml.bak
 Manifest.toml
 Manifest-*.toml
 LocalPreferences.toml
+!test/LocalPreferences.toml
 .envrc
 **/.JETLSConfig.toml
 !.JETLSConfig.toml

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -84,24 +84,29 @@ Note that error handling behavior (whether errors are caught or propagated) is
 controlled by `JETLS_TEST_MODE`, not `JETLS_DEV_MODE`.
 See the "[`JETLS_TEST_MODE`](#jetls_test_mode)" section for details.
 
-You can configure `JETLS_DEV_MODE` using Preferences.jl:
+`JETLS_DEV_MODE` defaults to `false` when no preference is configured. The
+master development project exports `JETLS_DEV_MODE = true` and
+`Revise.revise_structs = true`, so local checkouts automatically enable the
+Revise-based analysis used to develop JETLS. These development-only exported
+preferences are removed by `scripts/vendor-deps.jl` when preparing a release.
+
+You can override `JETLS_DEV_MODE` locally using Preferences.jl:
 ```julia-repl
 julia> using Preferences
 
-julia> Preferences.set_preferences!("JETLS", "JETLS_DEV_MODE" => true; force=true) # enable the dev mode
+julia> Preferences.set_preferences!("JETLS", "JETLS_DEV_MODE" => false; force = true)
 ```
-Alternatively, you can directly edit the LocalPreferences.toml file.
-
-While `JETLS_DEV_MODE` is disabled by default, we _strongly recommend enabling
-it during JETLS development_. For development work, we suggest creating the
-following LocalPreferences.toml file in the root directory of this repository:
-> LocalPreferences.toml
+Alternatively, create a `LocalPreferences.toml` file in the repository root:
 ```toml
 [JETLS]
-JETLS_DEV_MODE = true # enable the dev mode of JETLS
+JETLS_DEV_MODE = false
+```
 
+When testing JETLS with an unreleased Julia version, you may additionally need
+to enable JET's development mode locally:
+```toml
 [JET]
-JET_DEV_MODE = true # additionally, allow JET to be loaded on nightly
+JET_DEV_MODE = true
 ```
 
 ## `JETLS_TEST_MODE`
@@ -111,8 +116,8 @@ When `JETLS_TEST_MODE` is enabled, the server disables the `try`/`catch` error
 recovery in message handling, ensuring that errors are properly raised during
 tests rather than being suppressed.
 
-This mode is configured through LocalPreferences.toml and is automatically
-enabled in the test environment (see [test/LocalPreferences.toml](./test/LocalPreferences.toml)).
+This mode is exported by the test environment and automatically enabled there
+(see [`test/Project.toml`](./test/Project.toml)).
 
 The error handling behavior in `handle_message` follows this logic:
 - When `!JETLS_TEST_MODE`: Errors are caught and logged, allowing the server to continue running
@@ -445,6 +450,9 @@ The `prepare-release.sh` script automates the following steps:
    julia --startup-file=no --project=. scripts/vendor-deps.jl --source-branch=master --local
    ```
    This generates `vendor/` with local path references in `[sources]`.
+
+   The vendoring step also removes the development-only `JETLS_DEV_MODE` and
+   `Revise.revise_structs` preferences from the release `Project.toml`.
 
 3. Commit and push the vendor directory
    ```bash

--- a/Project.toml
+++ b/Project.toml
@@ -55,3 +55,9 @@ julia = "1.12.2 - 1.13"
 
 [apps.jetls]
 julia_flags = ["--startup-file=no", "--history-file=no", "--threads=auto"]
+
+[preferences.JETLS]
+JETLS_DEV_MODE = true
+
+[preferences.Revise]
+revise_structs = true

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -145,6 +145,7 @@ PR_BODY="This PR releases version \`$JETLS_VERSION\`.
 - [ ] \`release / test_app / Test jetls serve\`
 - [ ] \`release / test_app / Test jetls check\`
 - [ ] \`release / test_app / Test jetls schema\`
+- [ ] \`release / test_app / Test release installation\`
 - [ ] \`release / check_schemas / Check schemas are up to date\`
 
 ## Post-merge

--- a/scripts/vendor-deps.jl
+++ b/scripts/vendor-deps.jl
@@ -373,6 +373,43 @@ function update_workspace_project!(
     end
 end
 
+const DEVELOPMENT_PREFERENCE_KEYS = (
+    "JETLS" => "JETLS_DEV_MODE",
+    "Revise" => "revise_structs",
+)
+
+function remove_development_preferences!(project::Dict{String, Any})::Bool
+    preferences = get(project, "preferences", nothing)
+    preferences isa Dict{String, Any} || return false
+
+    modified = false
+    for (package_name, preference_key) in DEVELOPMENT_PREFERENCE_KEYS
+        package_preferences = get(preferences, package_name, nothing)
+        package_preferences isa Dict{String, Any} || continue
+        if haskey(package_preferences, preference_key)
+            delete!(package_preferences, preference_key)
+            isempty(package_preferences) && delete!(preferences, package_name)
+            modified = true
+        end
+    end
+    modified && isempty(preferences) && delete!(project, "preferences")
+    return modified
+end
+
+function validate_no_development_preferences(project::Dict{String, Any})
+    preferences = get(project, "preferences", nothing)
+    preferences isa Dict{String, Any} || return nothing
+
+    for (package_name, preference_key) in DEVELOPMENT_PREFERENCE_KEYS
+        package_preferences = get(preferences, package_name, nothing)
+        package_preferences isa Dict{String, Any} || continue
+        if haskey(package_preferences, preference_key)
+            error("Development preference $package_name.$preference_key leaked into release Project.toml")
+        end
+    end
+    return nothing
+end
+
 function update_project_with_vendored_deps(
         uuid_mapping::Dict{UUID, UUID},
         all_vendored_packages::Vector{Pair{String, UUID}},
@@ -381,6 +418,7 @@ function update_project_with_vendored_deps(
     )
     project_path = joinpath(CURRENT_DIR, "Project.toml")
     project = TOML.parsefile(project_path)
+    remove_development_preferences!(project)
 
     for (dep_name, dep_uuid_str) in project["deps"]
         dep_uuid = UUID(dep_uuid_str)
@@ -495,6 +533,14 @@ function vendor_dependencies_from_branch(config::Config)
     cp(main_path, backup_path; force=true)
     @info "Backed up Project.toml to $(basename(backup_path))"
 
+    project = TOML.parsefile(main_path)
+    if remove_development_preferences!(project)
+        open(main_path, "w") do io
+            TOML.print(io, project)
+        end
+        @info "Removed development-only preferences from release Project.toml"
+    end
+
     workspace_projects = get_workspace_projects()
     for workspace_name in workspace_projects
         workspace_path = joinpath(CURRENT_DIR, workspace_name)
@@ -545,6 +591,7 @@ function print_help()
     Effects:
       - Replace Project.toml files with versions from BRANCH when available,
         then rewrite their vendored dependency metadata
+      - Remove development-only preferences from the root Project.toml
       - Save fetched project files as Project.toml.bak before rewriting them
       - Run Pkg.update() before rebuilding the vendored dependency set
       - Replace package directories in vendor/ and remove stale directories
@@ -656,6 +703,7 @@ function vendor_loaded_packages(use_local_path::Bool, rev::Union{String, Nothing
     project_path = joinpath(CURRENT_DIR, "Project.toml")
     project = Pkg.Types.read_project(project_path)
     Pkg.Types.write_project(project, project_path)
+    validate_no_development_preferences(TOML.parsefile(project_path))
 
     @info "Vendor isolation complete!"
     @info "Vendored packages are in: $VENDOR_DIR"

--- a/test/LocalPreferences.toml
+++ b/test/LocalPreferences.toml
@@ -1,3 +1,0 @@
-[JETLS]
-JETLS_DEV_MODE = false
-JETLS_TEST_MODE = true # disable the `try/catch` in `handle_message` when testing

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -11,3 +11,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 InteractiveUtils = "1.11"
 Pkg = "1.11.0"
 Test = "1.11.0"
+
+[preferences.JETLS]
+JETLS_DEV_MODE = false
+JETLS_TEST_MODE = true # disable the `try/catch` in `handle_message` when testing


### PR DESCRIPTION
Contributors previously had to create local preference files to enable JETLS development mode and Revise's struct support. Committing those defaults directly would also enable development behavior in `Pkg.Apps` release installations.

Export the development preferences from the master `Project.toml`, move test-only values into `test/Project.toml`, and remove development keys while generating release projects. Add a release-only `Pkg.Apps` installation check that validates production preferences, precompile workloads, and the installed `jetls --version` command.

The release installation path was validated from an isolated depot against a temporary checkout of the `release` branch.