### PR TITLE
hover: Show global binding types at their definition site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 >
 > Note: Path glob patterns use `/` as the separator on all platforms, including Windows; backslashes are not supported as separators.
 
+### Fixed
+
+- Hover and completion no longer append Base's auto-generated type summary for global bindings, matching how local bindings have always been rendered.
+
 ## 2026-08-02
 
 - Commit: [`b74025b`](https://github.com/aviatesk/JETLS.jl/commit/b74025b)

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -1044,8 +1044,7 @@ function resolve_global_completion_item(
 
     (; context_module, world, postprocessor) = completion_resolver_info
     name = Symbol(data.name)
-    docs = postprocessor(Base.invoke_in_world(world,
-        Base.Docs.doc, Base.Docs.Binding(context_module, name))::Markdown.MD)
+    doc = lookup_doc_for_binding(context_module, name, #=sig=#nothing, world)
     (; labelDetails, detail) = item
     # This `kind` doesn't have much meaning in itself, but at least by setting `kind`,
     # we enable tree-sitter-based highlighting of the `label` in zed-julia
@@ -1087,8 +1086,9 @@ function resolve_global_completion_item(
     end
     supports_kind || (kind = item.kind)
     supports_detail || (detail = item.detail)
-    documentation = supports_documentation ?
-        MarkupContent(; kind = MarkupKind.Markdown, value = docs) : item.documentation
+    documentation = supports_documentation && doc !== nothing ?
+        MarkupContent(; kind = MarkupKind.Markdown, value = postprocessor(doc)) :
+        item.documentation
 
     return CompletionItem(item; labelDetails, kind, detail, documentation)
 end

--- a/src/hover.jl
+++ b/src/hover.jl
@@ -148,10 +148,22 @@ function _get_hover(
         # (`sv.value` → `Core.Const(sin)`), not the call's return type.
         typ = display_node === node ? display_typ : get_type_for_range(ctx, JS.byte_range(node))
     end
+    if type_str === nothing && display_node === node && binfo !== nothing && !is_local
+        # A global assignment LHS is a store, so its byte range carries no inferred type,
+        # and `node` is the lowered tree's `K"BindingId"` here, which the
+        # `resolve_global_const` fallback below doesn't handle either. Recover the
+        # type from the binding itself so a definition site shows what a reference shows.
+        binding_typ = global_binding_typ(binfo, world)
+        if binding_typ !== nothing
+            display_typ = typ = binding_typ
+            type_str = hover_type_string(binding_typ, JS.sourcetext(display_node))
+        end
+    end
     # Fallback when the TypeAnnotation pipeline can't supply a type
     if typ === nothing
         typ = resolve_global_const(context_module, world, node)
         if typ !== nothing && type_str === nothing && display_node === node
+            display_typ = typ
             type_str = hover_type_string(typ, JS.sourcetext(display_node))
         end
     end

--- a/src/utils/docs.jl
+++ b/src/utils/docs.jl
@@ -147,7 +147,10 @@ Returns `nothing` when the binding is undefined or when lookup throws.
 When the binding exists but has no docstring, [`lookup_doc_stripped`](@ref) strips
 the "No documentation found for ..." placeholder paragraph so the
 auto-generated method/type summary still surfaces without the placeholder
-noise.
+noise. That summary is only kept for the [`is_doc_binding_value`](@ref) kinds
+`lookup_doc_for_value` also accepts; for other values it merely restates the
+type already shown in the hover header, so those bindings return their stored
+docstrings alone.
 """
 function lookup_doc_for_binding(
         parentmod::Module, name::Symbol, @nospecialize(sig), world::UInt
@@ -158,6 +161,11 @@ function lookup_doc_for_binding(
     end
     try
         if sig === nothing
+            value = Base.invoke_in_world(world, getglobal, binding.mod, binding.var)
+            # Covers `JET.AbstractBindingState` placeholders too: script analysis
+            # virtualizes bindings into values that are never documentable, so their
+            # internal summary must not leak here.
+            is_doc_binding_value(value) || return narrow_doc_lookup(binding, Union{}, world)
             return lookup_doc_stripped(binding, world)
         end
         return narrow_doc_lookup(binding, sig, world)

--- a/src/utils/type-annotation-utils.jl
+++ b/src/utils/type-annotation-utils.jl
@@ -74,6 +74,28 @@ function closure_argnames(po::Core.PartialOpaque, nargs::Int)
 end
 
 """
+    global_binding_typ(binfo::JL.BindingInfo, world::UInt) ->
+        lattice element or nothing
+
+Type to display for a resolved global binding when a byte-range type query
+can't supply one — most notably at an assignment LHS, which is a store and so
+carries no inferred type, and whose `K"BindingId"` node
+[`resolve_global_const`](@ref) doesn't accept either.
+
+Mirrors what inference reports at a *reference* to the same binding: the
+constant value for a `const` binding, and the declared binding type otherwise.
+"""
+function global_binding_typ(binfo::JL.BindingInfo, world::UInt)
+    mod = @something binfo.mod return nothing
+    name = Symbol(binfo.name)
+    Base.invoke_in_world(world, isdefinedglobal, mod, name) || return nothing
+    if Base.invoke_in_world(world, isconst, mod, name)
+        return Core.Const(Base.invoke_in_world(world, getglobal, mod, name))
+    end
+    return Base.invoke_in_world(world, Core.get_binding_type, mod, name)
+end
+
+"""
     resolve_global_const(context_module::Module, world::UInt, node::SyntaxTree) ->
         Core.Const | nothing
 

--- a/test/test_hover.jl
+++ b/test/test_hover.jl
@@ -126,6 +126,10 @@ end
 module M_undoc_binding
     const undocumented_binding = 42
 end
+module M_mutable_global
+    mutable_global = 42
+    global typed_mutable_global::Int = 42
+end
 module M_doc_func
     """Documented method."""
     func(x::Int) = x
@@ -205,6 +209,23 @@ end
         hover_test("undocumented_binding│", "undocumented_binding";
             context_module = M_undoc_binding,
             notpat = "No documentation found")
+        # A plain value's auto-generated summary only restates the header type.
+        hover_test("undocumented_binding│", "(global) undocumented_binding :: $Int";
+            context_module = M_undoc_binding,
+            notpat = "Supertype Hierarchy")
+    end
+
+    # An assignment LHS carries no inferred type of its own, so a definition site
+    # shows the type a reference to the same binding shows.
+    @testset "global definition site" begin
+        hover_test("const undocumented_binding│ = 42", "(global) undocumented_binding :: $Int";
+            context_module = M_undoc_binding)
+        hover_test("const documented_binding│ = 42", "Documented binding.";
+            context_module = M_doc_binding)
+        hover_test("mutable_global│ = 42", "(global) mutable_global :: Any";
+            context_module = M_mutable_global)
+        hover_test("typed_mutable_global│ = 42", "(global) typed_mutable_global :: $Int";
+            context_module = M_mutable_global)
     end
 
     @testset "non-existent identifier" begin

--- a/test/utils/test_docs.jl
+++ b/test/utils/test_docs.jl
@@ -53,6 +53,10 @@ module M_docs_sample
     undoc(x::String) = x
 
     nodoc(x) = x  # binding with no docstring on any method
+
+    const plainvalue = 42  # non-documentable value, no docstring
+    """Doc for `documented_plainvalue`."""
+    const documented_plainvalue = 42
 end
 
 module M_field_doc_sample
@@ -218,6 +222,17 @@ end
         # The auto-generated summary that follows the placeholder should
         # survive so the hover surface still has something informative.
         @test occursin("nodoc", s)
+    end
+
+    # For values that aren't `is_doc_binding_value`, the auto-generated summary
+    # only restates the value's type, so just the stored docstrings come back.
+    @testset "plain value binding keeps only stored docs" begin
+        @test JETLS.lookup_doc_for_binding(M_docs_sample, :plainvalue, nothing, world) === nothing
+        md = JETLS.lookup_doc_for_binding(M_docs_sample, :documented_plainvalue, nothing, world)
+        @test md isa Markdown.MD
+        s = string(md)
+        @test occursin("Doc for `documented_plainvalue`.", s)
+        @test !occursin("Supertype Hierarchy", s)
     end
 end
 


### PR DESCRIPTION
Hovering a global binding's definition site showed no type at all. For

    const release_commit = get(ENV, "DOCUMENTER_RELEASE_COMMIT", "")

hovering `release_commit` on the left-hand side rendered just `(global) release_commit`, while hovering a reference to the same binding rendered `(global) release_commit :: String`. An assignment left-hand side is a store, so its byte range carries no inferred type of its own, and the `resolve_global_const` fallback cannot cover it either: when the cursor sits on a binding, hover works with the lowered tree's `K"BindingId"` node, which that helper does not accept.

The new `global_binding_typ` resolves the type from the binding itself so a definition site reports what a reference reports — the constant value for a `const` binding, and the declared binding type otherwise. Reading the current value for a non-`const` global would be misleading, since it can change after the hover.

`lookup_doc_for_binding` also gains the `is_doc_binding_value` gate that `lookup_doc_for_value` already applies, which brings global bindings in line with local ones. Hover skips the binding-based docstring lookup entirely for locals, so a local binding contributes docs only through the value-based lookup and its gate: `x = 42` shows no docs, while `c = cos` shows `cos`'s. Globals additionally ran the ungated binding-based lookup, so an undocumented `const x = 42` rendered an "`x` is of type `Int64`" section followed by `Int64`'s primitive-type summary and supertype hierarchy. Base's summary is still kept for function, module, and type bindings, where it carries the method and field lists. Resolved global completion items go through the same helper instead of calling `Base.Docs.doc` directly, so both surfaces agree.