### PR TITLE
hover/completions: Fix `AbstractBindingState` placeholder leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Hover and completion no longer append Base's auto-generated type summary for global bindings, matching how local bindings have always been rendered.
 
+- Fixed hover for script globals whose values full-analysis only tracks abstractly: hover no longer leaks the internal `JET.AbstractBindingState` placeholder and now shows the analyzed binding type (e.g. `release_commit :: String`) and any attached docstring.
+
+- Fixed the same placeholder leaking into resolved completion items for such globals: completion documentation, kind, and detail now reflect the analyzed binding. Signature help, goto-definition, and dot-prefix completion also resolve these bindings now.
+
 ## 2026-08-02
 
 - Commit: [`b74025b`](https://github.com/aviatesk/JETLS.jl/commit/b74025b)

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -1052,6 +1052,12 @@ function resolve_global_completion_item(
     if isnothing(detail) || isnothing(kind)
         if Base.invoke_in_world(world, isdefinedglobal, context_module, name)::Bool
             obj = Base.invoke_in_world(world, getglobal, context_module, name)
+            if obj isa JET.AbstractBindingState
+                # Classify by the analyzed const value when available; otherwise fall
+                # through to the `isconst` branch (these placeholders are always `const`).
+                statetyp = abstract_binding_state_typ(obj)
+                obj = statetyp isa Core.Const ? statetyp.val : nothing
+            end
             if obj isa Type
                 if obj in builtin_types
                     detail = "[builtin type]"

--- a/src/utils/type-annotation-utils.jl
+++ b/src/utils/type-annotation-utils.jl
@@ -74,6 +74,20 @@ function closure_argnames(po::Core.PartialOpaque, nargs::Int)
 end
 
 """
+    abstract_binding_state_typ(binding_state::JET.AbstractBindingState) ->
+        lattice element or nothing
+
+JET's script analysis materializes non-concretized global `const` bindings as
+`JET.AbstractBindingState` placeholders in the analyzed module's namespace (see
+the "Concretize `AbstractBindingState`" HACK notes in JET). Reflection that
+reads such a binding's value should surface the analysis-inferred binding type
+stored in the state instead of the placeholder itself. Returns `nothing` when
+the state carries no type.
+"""
+abstract_binding_state_typ(binding_state::JET.AbstractBindingState) =
+    isdefined(binding_state, :typ) ? binding_state.typ : nothing
+
+"""
     global_binding_typ(binfo::JL.BindingInfo, world::UInt) ->
         lattice element or nothing
 
@@ -83,34 +97,43 @@ carries no inferred type, and whose `K"BindingId"` node
 [`resolve_global_const`](@ref) doesn't accept either.
 
 Mirrors what inference reports at a *reference* to the same binding: the
-constant value for a `const` binding, and the declared binding type otherwise.
+constant value for a `const` binding (unwrapping `JET.AbstractBindingState`
+placeholders via [`abstract_binding_state_typ`](@ref)), and the declared
+binding type otherwise.
 """
 function global_binding_typ(binfo::JL.BindingInfo, world::UInt)
     mod = @something binfo.mod return nothing
     name = Symbol(binfo.name)
     Base.invoke_in_world(world, isdefinedglobal, mod, name) || return nothing
     if Base.invoke_in_world(world, isconst, mod, name)
-        return Core.Const(Base.invoke_in_world(world, getglobal, mod, name))
+        value = Base.invoke_in_world(world, getglobal, mod, name)
+        value isa JET.AbstractBindingState && return abstract_binding_state_typ(value)
+        return Core.Const(value)
     end
     return Base.invoke_in_world(world, Core.get_binding_type, mod, name)
 end
 
 """
     resolve_global_const(context_module::Module, world::UInt, node::SyntaxTree) ->
-        Core.Const | nothing
+        lattice element or nothing
 
 Best-effort static lookup of a `K"Identifier"` or `K"."` dotted-path node as a
-`Core.Const` value by walking the dotted path against `context_module`. Used as a fallback
-for features (signature help, call completion, definition, …) when the
-[`TypeAnnotation`](@ref) pipeline can't supply a type — either because the
-surrounding toplevel failed to lower (e.g. a method definition with unused
-where-vars), or because the identifier doesn't survive lowering (most notably
-macro names after macroexpansion).
+type-inference lattice element (usually `Core.Const`) by walking the dotted
+path against `context_module`. Used as a fallback for features (signature help,
+call completion, definition, …) when the [`TypeAnnotation`](@ref) pipeline
+can't supply a type — either because the surrounding toplevel failed to lower
+(e.g. a method definition with unused where-vars), or because the identifier
+doesn't survive lowering (most notably macro names after macroexpansion).
 
 Handles plain identifiers (`f`, `@m`), module-qualified macros (`Base.@show`)
 and nested module paths (`Foo.Bar.f`). Returns `nothing` for anything more
 complex (calls in node position, parametric type applications, …) — those
 inputs need real inference, which the caller already attempted.
+
+Script-analysis bindings materialized as `JET.AbstractBindingState` are
+unwrapped to the analysis-inferred binding type via
+[`abstract_binding_state_typ`](@ref), so the result is not necessarily a
+`Core.Const`.
 
 `world` pins the binding lookup so concurrent analysis updates can't make this
 fallback observe a newer world than the rest of the request.
@@ -119,7 +142,9 @@ function resolve_global_const(context_module::Module, world::UInt, node::SyntaxT
     if JS.kind(node) === JS.K"Identifier" && has_name_val(node)
         sym = Symbol(name_val(node))
         Base.invoke_in_world(world, isdefinedglobal, context_module, sym) || return nothing
-        return Core.Const(Base.invoke_in_world(world, getglobal, context_module, sym))
+        val = Base.invoke_in_world(world, getglobal, context_module, sym)
+        val isa JET.AbstractBindingState && return abstract_binding_state_typ(val)
+        return Core.Const(val)
     elseif JS.kind(node) === JS.K"." && JS.numchildren(node) == 2
         prefix = node[1]
         suffix = node[2]

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -833,6 +833,44 @@ end
     end
 end
 
+# Script analysis materializes non-concretized global `const`s as
+# `JET.AbstractBindingState` placeholders in the analyzed module's namespace;
+# completion resolution must classify and document the analyzed binding instead
+# of leaking the placeholder's auto-generated summary.
+module completion_binding_state_fixture end
+Core.eval(completion_binding_state_fixture, Expr(:const, :virtualized_str_const,
+    JETLS.JET.AbstractBindingState(true, false, String)))
+Core.eval(completion_binding_state_fixture, Expr(:const, :virtualized_func_alias,
+    JETLS.JET.AbstractBindingState(true, false, Core.Const(cos))))
+Core.eval(completion_binding_state_fixture, Expr(:const, :virtualized_documented,
+    JETLS.JET.AbstractBindingState(true, false, String)))
+Core.eval(completion_binding_state_fixture,
+    :(Base.@doc "Virtualized binding docs." virtualized_documented))
+
+@testset "global completion with script-analysis binding state" begin
+    cnt = Ref(0)
+    with_completion_items("virtualized_│";
+            context_module = completion_binding_state_fixture) do (; result, state)
+        function resolve_label(label::String)
+            item = only(filter(it -> it.label == label, result.items))
+            return JETLS.resolve_completion_item(state, item)
+        end
+        resolved = resolve_label("virtualized_str_const")
+        @test resolved.detail == "[constant variable]"
+        @test resolved.kind == CompletionItemKind.Constant
+        @test resolved.documentation === nothing
+        resolved = resolve_label("virtualized_func_alias")
+        @test resolved.detail == "[function]"
+        @test resolved.kind == CompletionItemKind.Function
+        resolved = resolve_label("virtualized_documented")
+        @test resolved.documentation isa MarkupContent
+        @test occursin("Virtualized binding docs.", resolved.documentation.value)
+        @test !occursin("AbstractBindingState", resolved.documentation.value)
+        cnt[] += 1
+    end
+    @test cnt[] == 1
+end
+
 @testset "macro completion" begin
     # `@`-mark should trigger completion of macro names
     let text = """

--- a/test/test_hover.jl
+++ b/test/test_hover.jl
@@ -140,6 +140,13 @@ end
 module M_alias_const
     const mycos = cos
 end
+module M_abstract_binding_state end
+Core.eval(M_abstract_binding_state, Expr(:const, :release_commit,
+    JETLS.JET.AbstractBindingState(true, false, String)))
+Core.eval(M_abstract_binding_state, Expr(:const, :documented_release_commit,
+    JETLS.JET.AbstractBindingState(true, false, String)))
+Core.eval(M_abstract_binding_state,
+    :(Base.@doc "State-backed binding docs." documented_release_commit))
 module M_overloaded
     """Generic doc for `op`."""
     op(x) = x
@@ -226,6 +233,30 @@ end
             context_module = M_mutable_global)
         hover_test("typed_mutable_global│ = 42", "(global) typed_mutable_global :: $Int";
             context_module = M_mutable_global)
+    end
+
+    @testset "script-analysis binding state" begin
+        hover_test("release_commit│", "(global) release_commit :: String";
+            context_module = M_abstract_binding_state,
+            notpat = "AbstractBindingState")
+        hover_test("""
+            const release_commit│ = get(ENV, "DOCUMENTER_RELEASE_COMMIT", "")
+        """, "(global) release_commit :: String";
+            context_module = M_abstract_binding_state,
+            notpat = "AbstractBindingState")
+        hover_test("documented_release_commit│", "State-backed binding docs.";
+            context_module = M_abstract_binding_state,
+            notpat = "AbstractBindingState")
+        # The unused where-var `S` makes the surrounding toplevel fail to lower
+        # (`ctx === nothing`), so the dotted path goes through the
+        # `resolve_global_const` fallback, which must unwrap the placeholder too.
+        hover_test("""
+            function lowerfail(x::T) where {T,S}
+                M_abstract_binding_state.release_commit│
+            end
+            """, "release_commit :: String";
+            context_module = M_abstract_binding_state,
+            notpat = "AbstractBindingState")
     end
 
     @testset "non-existent identifier" begin


### PR DESCRIPTION
JET's script analysis materializes non-concretized global `const` bindings as `JET.AbstractBindingState` placeholders in the analyzed module's namespace (the "Concretize `AbstractBindingState`" HACK in JET). JETLS features that read globals via runtime reflection leaked those placeholders to the user. Hovering a script binding like

    const release_commit = get(ENV, "DOCUMENTER_RELEASE_COMMIT", "")

reported `release_commit :: JET.AbstractBindingState` instead of the analyzed binding type, and resolving its completion item labeled it "[constant variable]" even when the binding aliased a function.

This commit unwraps the placeholders at the shared reflection entry points. `resolve_global_const` and `global_binding_typ` now surface the analysis-inferred binding type through the new `abstract_binding_state_typ` helper, so the result is a lattice element that is not necessarily a `Core.Const`. The former covers the reflection fallbacks of hover, signature help, call completion, goto-definition, and dot-prefix completion — which previously offered the placeholder's own fields as property completions. Completion kind and detail classify via the analyzed const value when the state carries one, and otherwise fall back to the `isconst` branch, which always applies since JET only evaluates these placeholders into the module for `const` assignments.

Inference-backed paths needed no changes: the `TypeAnnotation` pipeline and `LSAnalyzer` already unwrap placeholder loads during inference (`concretize_abstract_binding_state_load` and JET's `abstract_eval_partition_load` override). Docstring lookup needed none either, since the `is_doc_binding_value` gate added in the previous commit already rejects these non-documentable values.