### PR TITLE
full-analysis: Add configurable concretization patterns

### DIFF
--- a/.JETLSConfig.toml
+++ b/.JETLSConfig.toml
@@ -66,6 +66,13 @@ match_type = "regex"
 severity = "off"
 path = "src/testrunner/testrunner-types.jl"
 
+[[full_analysis.concretization_patterns]]
+pattern = "const devbranch = x_"
+path = "docs/make.jl"
+[[full_analysis.concretization_patterns]]
+pattern = "const release_date = x_"
+path = "docs/make.jl"
+
 [initialization_options]
 reuse_native_inference = true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added a dedicated [`toplevel/missing-concretization`](https://aviatesk.github.io/JETLS.jl/release/diagnostic/#diagnostic/reference/toplevel/missing-concretization) diagnostic for top-level bindings whose concrete values JET needs during full analysis.
+  Users can configure now [`full_analysis.concretization_patterns`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/full_analysis/concretization_patterns) through `.JETLSConfig.toml` or LSP settings to evaluate selected top-level assignments in workspace files.
+  The diagnostic offers a quick fix that creates or updates `.JETLSConfig.toml` with a pattern scoped to the assignment file, and JETLS automatically reanalyzes affected analysis units after the setting changes.
+  (Closed https://github.com/aviatesk/JETLS.jl/issues/464)
+
 - Added the experimental `reuse_native_inference` [initialization option](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options) (disabled by default): when enabled, calls to methods defined outside the modules being analyzed reuse results from Julia's native inference cache instead of being analyzed recursively:
   ```toml
   # .JETLSConfig.toml example

--- a/LSP/src/basic-json-structures.jl
+++ b/LSP/src/basic-json-structures.jl
@@ -711,6 +711,22 @@ struct UnusedVariableData
 end
 export UnusedVariableData
 
+struct MissingConcretizationData
+    name::String
+    pattern::String
+    assignment_file::String
+end
+export MissingConcretizationData
+
+const DiagnosticData = Union{
+    AmbiguousSoftScopeData,
+    DeleteRangeData,
+    UnsortedImportData,
+    UnusedArgumentData,
+    UnusedVariableData,
+    MissingConcretizationData,
+}
+
 """
 Represents a diagnostic, such as a compiler error or warning.
 Diagnostic objects are only valid in the scope of a resource.
@@ -770,7 +786,7 @@ Diagnostic objects are only valid in the scope of a resource.
 
     - `@since` 3.16.0
     """
-    data::Union{AmbiguousSoftScopeData, DeleteRangeData, UnsortedImportData, UnusedArgumentData, UnusedVariableData, Nothing} = nothing
+    data::Union{DiagnosticData, Nothing} = nothing
 end
 
 # Command

--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
 Compiler = {path = "Compiler"}
-JET = {rev = "10ee8b8b", url = "https://github.com/aviatesk/JET.jl"}
+JET = {rev = "ddd935be", url = "https://github.com/aviatesk/JET.jl"}
 JuliaLowering = {rev = "4547955bd1", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
 JuliaSyntax = {rev = "4547955bd1", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
 LSP = {path = "LSP"}

--- a/docs/config-schema-block.jl
+++ b/docs/config-schema-block.jl
@@ -149,7 +149,7 @@ let rows = Union{Nothing, SchemaRow}[
         nothing,
         array_header("full_analysis.concretization_patterns"; comment = "table, an entry of the concretization patterns array above"),
         example_entry("full_analysis.concretization_patterns.pattern", "\"RandomType = x_\""; comment = "Julia expression pattern, required"),
-        example_entry("full_analysis.concretization_patterns.path", "\"src/random-type.jl\""; comment = "string (glob), optional"),
+        example_entry("full_analysis.concretization_patterns.path", "\"scripts/random-type.jl\""; comment = "string (glob), optional"),
         nothing,
         table_header("diagnostic"),
         default_entry(:diagnostic, :enabled; comment = "boolean"),

--- a/docs/config-schema-block.jl
+++ b/docs/config-schema-block.jl
@@ -145,6 +145,11 @@ let rows = Union{Nothing, SchemaRow}[
         table_header("full_analysis"),
         default_entry(:full_analysis, :debounce; comment = "number (seconds)"),
         default_entry(:full_analysis, :auto_instantiate; comment = "boolean"),
+        default_entry(:full_analysis, :concretization_patterns; comment = "array of tables", validate = false),
+        nothing,
+        array_header("full_analysis.concretization_patterns"; comment = "table, an entry of the concretization patterns array above"),
+        example_entry("full_analysis.concretization_patterns.pattern", "\"RandomType = x_\""; comment = "Julia expression pattern, required"),
+        example_entry("full_analysis.concretization_patterns.path", "\"src/random-type.jl\""; comment = "string (glob), optional"),
         nothing,
         table_header("diagnostic"),
         default_entry(:diagnostic, :enabled; comment = "boolean"),
@@ -183,8 +188,8 @@ let rows = Union{Nothing, SchemaRow}[
     schema_rows = SchemaRow[row for row in rows if row isa SchemaRow]
     # The validation rendering enables all the commented-out entries and drops rows
     # incompatible with them (the string preset form of `formatter` conflicts with
-    # the `[formatter.custom]` table, and `patterns = []` conflicts with the
-    # `[[diagnostic.patterns]]` entry)
+    # the `[formatter.custom]` table, and array defaults conflict with their
+    # corresponding array-of-tables entries)
     validation_text = join((row.code for row in schema_rows if row.validate), '\n')
     validation_dict = TOML.parse(validation_text)
     assert_valid_config(validation_text)

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -27,6 +27,7 @@ Base.include(@__MODULE__, joinpath(pkgdir(JETLS), "docs", "config-schema-block.j
 - [`[full_analysis]`](@ref config/full_analysis)
   - [`[full_analysis] debounce`](@ref config/full_analysis/debounce)
   - [`[full_analysis] auto_instantiate`](@ref config/full_analysis/auto_instantiate)
+  - [`[full_analysis] concretization_patterns`](@ref config/full_analysis/concretization_patterns)
 - [`formatter`](@ref config/formatter)
 - [`[diagnostic]`](@ref config/diagnostic)
   - [`[diagnostic] enabled`](@ref config/diagnostic/enabled)
@@ -81,6 +82,71 @@ When no manifest file exists, JETLS first creates a
 [full_analysis]
 auto_instantiate = false  # Disable automatic instantiation
 ```
+
+#### [`[full_analysis] concretization_patterns`](@id config/full_analysis/concretization_patterns)
+
+- **Type**: array of tables
+- **Default**: `[]`
+
+JETLS normally analyzes top-level code without evaluating every expression. If
+it needs the value of a global binding to define a later type or method, it may
+report `toplevel/missing-concretization`.
+
+For example, suppose `src/random-type.jl` contains:
+
+```julia
+RandomType = rand((Bool, Int))
+
+struct Container
+    value::RandomType
+end
+```
+
+To analyze `Container`, JETLS must know whether `RandomType` is `Bool` or `Int`.
+Declaring the binding as `const` can sometimes resolve this diagnostic: if JETLS
+infers a concrete value for the right-hand side, it can safely reuse that value
+later in the analysis. This does not help when the right-hand side cannot be
+inferred as a single concrete value.
+
+In this example, JETLS cannot infer a single concrete result for
+`rand((Bool, Int))`, so the diagnostic's quick fix can add the following entry
+to `.JETLSConfig.toml`:
+
+```toml
+[[full_analysis.concretization_patterns]]
+pattern = "RandomType = x_"
+path = "src/random-type.jl"
+```
+
+This tells JETLS to evaluate an assignment to `RandomType` while processing
+`src/random-type.jl`. In the pattern, `x_` matches any right-hand-side
+expression, including `rand((Bool, Int))` in this example.
+
+Each table contains:
+
+- `pattern` (required): A Julia expression pattern using
+  [MacroTools.jl expression matching syntax](https://fluxml.ai/MacroTools.jl/stable/pattern-matching/).
+- `path` (optional): A glob restricting the pattern to matching source files.
+  Paths are relative to the workspace root. Each included file is matched using
+  its own path, not the path of the file that included it. If `path` is omitted,
+  the pattern applies to every analyzed file inside the workspace. For example,
+  `path = "src/**/*.jl"` applies the pattern to Julia files under `src`.
+
+  !!! note "Path separator on Windows"
+      Use `/` as the path separator on all platforms, including Windows. Glob
+      syntax does not treat `\` as a path separator.
+
+Configured patterns apply only to files inside the workspace. Included files
+outside the workspace use only JET's built-in patterns. These entries supplement
+the built-in patterns; they do not replace them.
+
+!!! warning "Concretization executes code"
+    Concretization causes the JETLS analysis process to execute each matching
+    top-level expression instead of only analyzing it. Any side effects of that
+    expression, such as writing files, accessing the network, starting external
+    processes, or mutating global state, can therefore occur during analysis.
+    Full analysis may run again after a file is saved, so these effects may occur
+    more than once. Keep both `pattern` and `path` as specific as possible.
 
 ### [`formatter`](@id config/formatter)
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -88,11 +88,16 @@ auto_instantiate = false  # Disable automatic instantiation
 - **Type**: array of tables
 - **Default**: `[]`
 
-JETLS normally analyzes top-level code without evaluating every expression. If
-it needs the value of a global binding to define a later type or method, it may
-report `toplevel/missing-concretization`.
+During script-mode analysis, JETLS analyzes top-level code without evaluating
+every expression. If it needs the value of a global binding to define a later
+type or method, JETLS may report `toplevel/missing-concretization`.
 
-For example, suppose `src/random-type.jl` contains:
+By contrast, when analyzing package source code under `src/`, JETLS uses the
+catch-all concretization pattern `:(x_)` and evaluates all top-level code.
+Additional concretization patterns are therefore needed only for script-mode
+analysis.
+
+For example, suppose `scripts/random-type.jl` contains:
 
 ```julia
 RandomType = rand((Bool, Int))
@@ -115,11 +120,11 @@ to `.JETLSConfig.toml`:
 ```toml
 [[full_analysis.concretization_patterns]]
 pattern = "RandomType = x_"
-path = "src/random-type.jl"
+path = "scripts/random-type.jl"
 ```
 
 This tells JETLS to evaluate an assignment to `RandomType` while processing
-`src/random-type.jl`. In the pattern, `x_` matches any right-hand-side
+`scripts/random-type.jl`. In the pattern, `x_` matches any right-hand-side
 expression, including `rand((Bool, Int))` in this example.
 
 Each table contains:

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -999,10 +999,15 @@ on-save full analysis, at line granularity
 
 **Default severity**: `Error`
 
-Errors that occur when JETLS loads your code for analysis. This diagnostic is
-commonly reported in several scenarios:
+A general wrapper for errors that occur while JETLS loads and evaluates
+top-level code for analysis. This code identifies the phase in which the error
+occurred—top-level code loading—rather than a specific kind of error. The
+diagnostic message describes the underlying error.
 
-- Missing package dependencies (the most frequent cause)
+Common examples include:
+
+- Package-loading failures caused by missing, uninstantiated, or unresolved
+  dependencies (the most frequent cause)
 - Type definition failures
 - References to undefined names at the top level
 - Other errors during module evaluation
@@ -1016,36 +1021,43 @@ struct ToplevelError  # UndefVarError: `Unexisting` not defined in `JETLS`
 end
 
 using UnexistingPkg  # Package JETLS does not have UnexistingPkg in its dependencies:
-                     # - You may have a partially installed environment. Try `Pkg.instantiate()`
-                     # to ensure all packages in the environment are installed.
-                     # - Or, if you have JETLS checked out for development and have
-                     # added UnexistingPkg as a dependency but haven't updated your primary
-                     # environment's manifest file, try `Pkg.resolve()`.
-                     # - Otherwise you may need to report an issue with JETLS (JETLS toplevel/error)
+                     # [...]
+                     # (JETLS toplevel/error)
 ```
 
 These errors prevent JETLS from fully analyzing your code, which means
-[Inference diagnostic](@ref diagnostic/reference/inference) will not be available until
-the top-level errors are resolved. To fix these errors, ensure your package
-environment is properly set up by running `Pkg.instantiate()` in your package
-directory, and verify that your package can be loaded successfully in a Julia REPL.
+[Inference diagnostic](@ref diagnostic/reference/inference) will not be
+available until the top-level errors are resolved.
+
+!!! tip "Check the package environment"
+    A common case is an error indicating that a specific dependency cannot be
+    loaded from the analyzed package's environment. This can happen when the
+    environment has not been instantiated, or when `Project.toml` has changed
+    but `Manifest.toml` has not been resolved. Run `Pkg.instantiate()` for an
+    uninstantiated environment, or `Pkg.resolve()` when the manifest is out of
+    date. Finally, verify that the package can be loaded successfully in a Julia
+    REPL.
 
 #### [Missing concretization (`toplevel/missing-concretization`)](@id diagnostic/reference/toplevel/missing-concretization)
 
 **Default severity**: `Error`
 
-Reported when JET needs the actual value of a top-level binding while loading
-code for analysis, but the binding was not concretized. This often happens when
-a global binding is used to define a type or method and JET cannot determine the
-binding's concrete value during analysis.
+A specialized top-level error reported when JET needs the actual value of a
+top-level binding while loading code for analysis, but the binding was not
+concretized. This often happens when a global binding is used to define a type
+or method and JET cannot determine the binding's concrete value during analysis.
+This diagnostic is specific to script-mode analysis. Package analysis uses the
+catch-all concretization pattern `:(x_)` and evaluates all top-level code.
 
-For example, suppose `src/random-type.jl` contains:
+For example, suppose `scripts/random-type.jl` contains:
 
 ```julia
 RandomType = rand((Bool, Int))
 
 struct Container
-    value::RandomType
+    value::RandomType  # `Main.RandomType` must have a concrete value for JETLS top-level analysis.
+                       # [...]
+                       # (JETLS toplevel/missing-concretization)
 end
 ```
 
@@ -1066,7 +1078,7 @@ configuration to allow JETLS to evaluate the assignment during full analysis.
     ```toml
     [[full_analysis.concretization_patterns]]
     pattern = "RandomType = x_"
-    path = "src/random-type.jl"
+    path = "scripts/random-type.jl"
     ```
 
     The generated `path` identifies the source file containing the assignment.
@@ -1076,6 +1088,43 @@ configuration to allow JETLS to evaluate the assignment during full analysis.
     expression. See
     [`full_analysis.concretization_patterns`](@ref config/full_analysis/concretization_patterns)
     for details, including how patterns are matched and executed.
+
+!!! note "`UndefVarError` can be caused by missing concretization"
+    `toplevel/missing-concretization` is reported when JET can track a required
+    binding and determine that its concrete value is unavailable. An unevaluated
+    top-level call may instead create or import bindings indirectly, for example
+    through `@eval`. If JET cannot track those effects back to the call, it may
+    only observe that the binding is undefined and report
+    [`toplevel/error`](@ref diagnostic/reference/toplevel/error) with
+    `UndefVarError`.
+
+    For example, suppose `scripts/load-types.jl` contains:
+
+    ```julia
+    const type_name = :SomeType
+    load_types() = @eval using SomeModule: $type_name
+    load_types()
+
+    struct Container
+        value::SomeType  # UndefVarError: `SomeType` not defined in `Main`
+                         # [...]
+                         # (JETLS toplevel/error)
+    end
+    ```
+
+    Normal Julia execution calls `load_types()` and imports `SomeType`. During
+    script-mode analysis, however, the call is not evaluated unless selected for
+    concretization. Because the binding would be imported indirectly through
+    `@eval`, JET cannot associate the undefined `SomeType` with the unevaluated
+    call and reports the generic `toplevel/error` instead.
+
+    In this case, manually add the pattern to `.JETLSConfig.toml`:
+
+    ```toml
+    [[full_analysis.concretization_patterns]]
+    pattern = "load_types()"
+    path = "scripts/load-types.jl"
+    ```
 
 #### [Method overwrite (`toplevel/method-overwrite`)](@id diagnostic/reference/toplevel/method-overwrite)
 

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -214,6 +214,7 @@ Here is a summary table of the diagnostics explained in this section:
 | [`lowering/inactive-code`](@ref diagnostic/reference/lowering/inactive-code)                                   | `Hint`                | `JETLS/live`  | Code excluded by `@static` in the current environment  |
 | [`lowering/unsorted-import-names`](@ref diagnostic/reference/lowering/unsorted-import-names)                   | `Hint`                | `JETLS/live`  | Import/export names not sorted alphabetically          |
 | [`toplevel/error`](@ref diagnostic/reference/toplevel/error)                                                   | `Error`               | `JETLS/save`  | Errors during code loading                             |
+| [`toplevel/missing-concretization`](@ref diagnostic/reference/toplevel/missing-concretization)                 | `Error`               | `JETLS/save`  | Top-level code needs a non-concretized binding value   |
 | [`toplevel/method-overwrite`](@ref diagnostic/reference/toplevel/method-overwrite)                             | `Warning`             | `JETLS/save`  | Method definitions that overwrite previous ones        |
 | [`toplevel/abstract-field`](@ref diagnostic/reference/toplevel/abstract-field)                                 | `Information`         | `JETLS/save`  | Struct fields with abstract types                      |
 | [`inference/undef-global-var`](@ref diagnostic/reference/inference/undef-global-var)                           | `Warning`             | `JETLS/save`  | References to undefined global variables               |
@@ -1028,6 +1029,53 @@ These errors prevent JETLS from fully analyzing your code, which means
 the top-level errors are resolved. To fix these errors, ensure your package
 environment is properly set up by running `Pkg.instantiate()` in your package
 directory, and verify that your package can be loaded successfully in a Julia REPL.
+
+#### [Missing concretization (`toplevel/missing-concretization`)](@id diagnostic/reference/toplevel/missing-concretization)
+
+**Default severity**: `Error`
+
+Reported when JET needs the actual value of a top-level binding while loading
+code for analysis, but the binding was not concretized. This often happens when
+a global binding is used to define a type or method and JET cannot determine the
+binding's concrete value during analysis.
+
+For example, suppose `src/random-type.jl` contains:
+
+```julia
+RandomType = rand((Bool, Int))
+
+struct Container
+    value::RandomType
+end
+```
+
+JETLS needs the actual value of `RandomType` to analyze the definition of
+`Container`. Adding `const` can fix this diagnostic in some cases. However,
+JETLS can treat the value of a `const` binding as concrete only when its
+right-hand side can be inferred as a single concrete value. In this example,
+JETLS cannot infer a single concrete result for `rand((Bool, Int))`, so use the
+[`full_analysis.concretization_patterns`](@ref config/full_analysis/concretization_patterns)
+configuration to allow JETLS to evaluate the assignment during full analysis.
+
+!!! tip "Code action available"
+    Use the "Create `.JETLSConfig.toml` concretization pattern for
+    `RandomType`" code action. If the configuration file already exists, the
+    action starts with "Add" instead. It creates or updates the configuration
+    with this entry:
+
+    ```toml
+    [[full_analysis.concretization_patterns]]
+    pattern = "RandomType = x_"
+    path = "src/random-type.jl"
+    ```
+
+    The generated `path` identifies the source file containing the assignment.
+    This may differ from the file containing the diagnostic when the binding is
+    defined in an included file. Scoping the pattern this way prevents it from
+    affecting unrelated files. Here, `x_` matches any right-hand-side
+    expression. See
+    [`full_analysis.concretization_patterns`](@ref config/full_analysis/concretization_patterns)
+    for details, including how patterns are matched and executed.
 
 #### [Method overwrite (`toplevel/method-overwrite`)](@id diagnostic/reference/toplevel/method-overwrite)
 

--- a/jetls-client/package.json
+++ b/jetls-client/package.json
@@ -333,6 +333,29 @@
                   "markdownDescription": "Automatically run `Pkg.resolve()` and `Pkg.instantiate()` for uninstantiated packages (e.g., freshly cloned repos). Creates versioned manifest if needed.",
                   "type": "boolean"
                 },
+                "concretization_patterns": {
+                  "default": [],
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "path": {
+                        "markdownDescription": "Optional glob pattern to restrict this concretization pattern to matching source file paths, relative to the workspace root when available.",
+                        "type": "string"
+                      },
+                      "pattern": {
+                        "markdownDescription": "Julia expression pattern to force concretization, using JET/MacroTools pattern syntax (for example, `USE_PULSE = x_`).",
+                        "pattern": "\\S",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "pattern"
+                    ],
+                    "type": "object"
+                  },
+                  "markdownDescription": "Additional JET top-level concretization patterns. Each entry requires a Julia expression `pattern` and can use an optional `path` glob to restrict it to specific source files.",
+                  "type": "array"
+                },
                 "debounce": {
                   "default": 1,
                   "markdownDescription": "Debounce time in seconds before triggering full analysis after a file save. Higher values reduce analysis frequency but may delay diagnostic updates.",

--- a/schemas/config-toml.schema.json
+++ b/schemas/config-toml.schema.json
@@ -182,6 +182,29 @@
           "description": "Automatically run `Pkg.resolve()` and `Pkg.instantiate()` for uninstantiated packages (e.g., freshly cloned repos). Creates versioned manifest if needed.",
           "type": "boolean"
         },
+        "concretization_patterns": {
+          "default": [],
+          "description": "Additional JET top-level concretization patterns. Each entry requires a Julia expression `pattern` and can use an optional `path` glob to restrict it to specific source files.",
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "path": {
+                "description": "Optional glob pattern to restrict this concretization pattern to matching source file paths, relative to the workspace root when available.",
+                "type": "string"
+              },
+              "pattern": {
+                "description": "Julia expression pattern to force concretization, using JET/MacroTools pattern syntax (for example, `USE_PULSE = x_`).",
+                "pattern": "\\S",
+                "type": "string"
+              }
+            },
+            "required": [
+              "pattern"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
         "debounce": {
           "default": 1,
           "description": "Debounce time in seconds before triggering full analysis after a file save. Higher values reduce analysis frequency but may delay diagnostic updates.",

--- a/schemas/description.toml
+++ b/schemas/description.toml
@@ -24,6 +24,11 @@ path = "Optional glob pattern to restrict this configuration to specific files (
 [FullAnalysisConfig]
 debounce = "Debounce time in seconds before triggering full analysis after a file save. Higher values reduce analysis frequency but may delay diagnostic updates."
 auto_instantiate = "Automatically run `Pkg.resolve()` and `Pkg.instantiate()` for uninstantiated packages (e.g., freshly cloned repos). Creates versioned manifest if needed."
+concretization_patterns = "Additional JET top-level concretization patterns. Each entry requires a Julia expression `pattern` and can use an optional `path` glob to restrict it to specific source files."
+
+[ConcretizationPattern]
+pattern = "Julia expression pattern to force concretization, using JET/MacroTools pattern syntax (for example, `USE_PULSE = x_`)."
+path = "Optional glob pattern to restrict this concretization pattern to matching source file paths, relative to the workspace root when available."
 
 [TestRunnerConfig]
 executable = "Path to the TestRunner.jl executable. Defaults to `testrunner` (or `testrunner.bat` on Windows)."

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -194,6 +194,29 @@
               "default": true,
               "description": "Automatically run `Pkg.resolve()` and `Pkg.instantiate()` for uninstantiated packages (e.g., freshly cloned repos). Creates versioned manifest if needed."
             },
+            "concretization_patterns": {
+              "default": [],
+              "description": "Additional JET top-level concretization patterns. Each entry requires a Julia expression `pattern` and can use an optional `path` glob to restrict it to specific source files.",
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "path": {
+                    "$ref": "#/$defs/Glob.FilenameMatch{Core.String}",
+                    "description": "Optional glob pattern to restrict this concretization pattern to matching source file paths, relative to the workspace root when available."
+                  },
+                  "pattern": {
+                    "description": "Julia expression pattern to force concretization, using JET/MacroTools pattern syntax (for example, `USE_PULSE = x_`).",
+                    "pattern": "\\S",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "pattern"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
             "debounce": {
               "$ref": "#/$defs/Core.Float64",
               "default": 1,

--- a/scripts/schema/setup-schema-context.jl
+++ b/scripts/schema/setup-schema-context.jl
@@ -47,6 +47,12 @@ function setup_ctx!(ctx::SchemaContext)
     # `__pattern_value__` is an internal field and not appeared in the config file
     skip!(ctx, JETLS.DiagnosticPattern, :__pattern_value__)
 
+    skip!(ctx, JETLS.ConcretizationPattern, :__pattern_value__)
+    override_field!(ctx, JETLS.ConcretizationPattern, :pattern) do _
+        # JSON Schema regex requiring at least one non-whitespace character.
+        Dict("type" => "string", "pattern" => raw"\S")
+    end
+
     override_field!(ctx, JETLS.DiagnosticPattern, :match_by) do _
         Dict("type" => "string", "enum" => ["code", "message"])
     end

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -101,6 +101,7 @@ include("types.jl")
 
 include("utils/jl-syntax-macros.jl")
 include("utils/string.jl")
+include("utils/toml.jl")
 include("utils/path.jl")
 include("utils/pkg.jl")
 include("utils/JETLSTestModule.jl")

--- a/src/analysis/Interpreter.jl
+++ b/src/analysis/Interpreter.jl
@@ -66,9 +66,17 @@ function JET.ConcreteInterpreter(interp::LSInterpreter, state::JET.Interpretatio
         interp.activation_done, interp.warning_reports, interp.current_node, state)
 end
 JET.ToplevelAbstractAnalyzer(interp::LSInterpreter) = interp.analyzer
+function JET.concretization_patterns(interp::LSInterpreter, filename::AbstractString)
+    base_patterns = @invoke JET.concretization_patterns(
+        interp::JET.ConcreteInterpreter, filename::AbstractString)
+    configured_patterns = configured_concretization_patterns(interp.server, filename)
+    isempty(configured_patterns) && return base_patterns
+    return Any[base_patterns...; configured_patterns...]
+end
 function JET.ToplevelAbstractAnalyzer(
         interp::LSInterpreter, concretized::BitVector;
         refresh_local_cache::Bool = true,    # This option is used by JET v0.10. TODO We can remove this once we update JET to v0.11.
+        current_toplevel_assignment::Union{Nothing,JET.ToplevelAssignment} = nothing,
         reset_report_target_modules::Bool = true, # LSInterpreter specific option
     )
     if reset_report_target_modules
@@ -76,7 +84,22 @@ function JET.ToplevelAbstractAnalyzer(
     end
     return @invoke JET.ToplevelAbstractAnalyzer(
         interp::JET.ConcreteInterpreter, concretized::BitVector;
-        refresh_local_cache)
+        refresh_local_cache, current_toplevel_assignment)
+end
+
+function configured_concretization_patterns(
+        server::Server, filename::AbstractString
+    )
+    configured = JETLS.get_config(server, :full_analysis, :concretization_patterns)
+    isempty(configured) && return Any[]
+    path_for_glob = @something JETLS.relative_workspace_path_for_config(server, filename) return Any[]
+    patterns = Any[]
+    for pattern_config in configured
+        globpath = pattern_config.path
+        globpath !== nothing && !occursin(globpath, path_for_glob) && continue
+        push!(patterns, pattern_config.pattern)
+    end
+    return patterns
 end
 
 # overloads

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -384,6 +384,13 @@ function schedule_analysis!(
     )
     manager = server.state.analysis_manager
 
+    store!(manager.tracked_entries) do entries
+        get(entries, entry, nothing) == uri && return entries, nothing
+        new_entries = copy(entries)
+        new_entries[entry] = uri
+        return new_entries, nothing
+    end
+
     generation = invalidate ? increment_generation!(manager, entry) : get_generation(manager, entry)
 
     request = AnalysisRequest(
@@ -708,6 +715,12 @@ function cleanup_analysis_state!(server::Server, uri::URI)
 end
 
 function cleanup_analysis_entry_state!(manager::AnalysisManager, entry::AnalysisEntry)
+    store!(manager.tracked_entries) do entries
+        haskey(entries, entry) || return entries, nothing
+        new_entries = copy(entries)
+        delete!(new_entries, entry)
+        return new_entries, nothing
+    end
     store!(manager.debounced) do debounced
         haskey(debounced, entry) || return debounced, nothing
         timer, completion = debounced[entry]
@@ -921,15 +934,16 @@ function new_analysis_result(interp::LSInterpreter, result::JET.JETToplevelResul
     return analysis_result, replace_analysis_result
 end
 
-function request_reanalysis_for_cached_entries!(server::Server)
-    entries = Dict{AnalysisEntry,URI}()
-    for (uri, analysis_info) in load(server.state.analysis_manager.cache)
-        analysis_info isa AnalysisResult || continue
-        get!(entries, analysis_info.entry, uri)
-    end
-    for (_, uri) in entries
-        request_analysis!(server, uri, #=invalidate=#true;
-            debounce = 0.0, notify_diagnostics = true)
+function request_reanalysis_for_tracked_entries!(server::Server)
+    for (entry, uri) in load(server.state.analysis_manager.tracked_entries)
+        if supports(server, :window, :workDoneProgress)
+            request_analysis_progress!(
+                server, uri, #=invalidate=#true, entry,
+                #=notify_diagnostics=#true, #=debounce=#0.0)
+        else
+            schedule_analysis!(server, uri, entry, #=invalidate=#true;
+                debounce = 0.0, notify_diagnostics = true)
+        end
     end
     return nothing
 end

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -179,6 +179,10 @@ function handle_analysis_progress_response(
         server::Server, caller::AnalysisProgressCaller, cancel_flag::CancelFlag
     )
     (; uri, invalidate, entry, notify_diagnostics, debounce, token) = caller
+    if is_abandoned_analysis_target(server, uri, entry)
+        @static JETLS_DEV_MODE && @info "Ignored delayed progress response for closed editor-managed document" entry=progress_title(entry) uri
+        return nothing
+    end
     cancellable_token = CancellableToken(token, cancel_flag)
     schedule_analysis!(server, uri, entry, invalidate;
         cancellable_token, notify_diagnostics, debounce)
@@ -477,6 +481,7 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
 
     if is_abandoned_request(server, request)
         @static JETLS_DEV_MODE && @info "Skipped analysis for closed editor-managed document" entry=progress_title(request.entry) uri=request.uri
+        cleanup_analysis_entry_state!(manager, request.entry)
         @goto next_request
     end
 
@@ -529,6 +534,7 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
         # We just need to drop the methods this analysis just defined and skip the cache write.
         @static JETLS_DEV_MODE && @info "Discarding analysis result for closed editor-managed document" entry=progress_title(request.entry) uri=request.uri
         cleanup_prev_methods(analysis_result)
+        cleanup_analysis_entry_state!(manager, request.entry)
         @goto next_request
     end
 
@@ -636,24 +642,24 @@ function cleanup_prev_methods(prev_result::AnalysisResult)
     end
 end
 
-# An analysis request is "abandoned" once the document it targets is no longer
+# An analysis target is "abandoned" once its document is no longer
 # editor-managed: `file_cache` empty for an unsaved (`untitled:`/`buffer:`) URI,
-# or `notebook_cache` empty for a notebook entry. In either case the prior
-# analysis state was already evicted by `cleanup_analysis_state!`, so any
-# remaining work would only re-populate caches we just cleaned up.
-function is_abandoned_request(server::Server, request::AnalysisRequest)
+# or `notebook_cache` empty for a notebook entry. Any remaining work would only
+# re-populate caches that `didClose` has cleaned up.
+function is_abandoned_analysis_target(server::Server, uri::URI, entry::AnalysisEntry)
     state = server.state
-    uri = request.uri
     if isunsaveduri(uri)
         return get_file_info(state, uri) === nothing
     end
-    entry = request.entry
     if ((entry isa ScriptAnalysisEntry || entry isa ScriptInEnvAnalysisEntry) &&
         entry.isnotebook)
         return !is_notebook_uri(state, uri)
     end
     return false
 end
+
+is_abandoned_request(server::Server, request::AnalysisRequest) =
+    is_abandoned_analysis_target(server, request.uri, request.entry)
 
 """
     cleanup_analysis_state!(server::Server, uri::URI)
@@ -682,9 +688,9 @@ modules, so `cleanup_prev_methods` would delete the user's live methods.
 Keeping the cache also lets `workspace/diagnostic` keep reporting disk-based
 diagnostics after close.
 
-This only handles state already in the caches. Any in-flight or queued analysis
-for this entry is short-circuited separately by `is_abandoned_request` checks
-in `resolve_analysis_request`.
+This only handles state already known when `didClose` runs. Delayed progress
+responses are ignored, while any in-flight or queued analysis is short-circuited
+and cleaned up by `is_abandoned_request` checks in `resolve_analysis_request`.
 """
 function cleanup_analysis_state!(server::Server, uri::URI)
     manager = server.state.analysis_manager
@@ -913,6 +919,19 @@ function new_analysis_result(interp::LSInterpreter, result::JET.JETToplevelResul
     analysis_result = AnalysisResult(entry, uri2diagnostics, analyzer,
         analyzed_file_infos, actual2virtual, cache_world)
     return analysis_result, replace_analysis_result
+end
+
+function request_reanalysis_for_cached_entries!(server::Server)
+    entries = Dict{AnalysisEntry,URI}()
+    for (uri, analysis_info) in load(server.state.analysis_manager.cache)
+        analysis_info isa AnalysisResult || continue
+        get!(entries, analysis_info.entry, uri)
+    end
+    for (_, uri) in entries
+        request_analysis!(server, uri, #=invalidate=#true;
+            debounce = 0.0, notify_diagnostics = true)
+    end
+    return nothing
 end
 
 # Revise-based package analysis

--- a/src/code-action.jl
+++ b/src/code-action.jl
@@ -55,6 +55,7 @@ function handle_CodeActionRequest(
         delete_range_code_actions!(code_actions, uri, diagnostics)
         sort_imports_code_actions!(code_actions, uri, diagnostics)
         ambiguous_soft_scope_code_actions!(code_actions, uri, diagnostics)
+        missing_concretization_code_actions!(code_actions, server, diagnostics)
     end
     if wants_kindless_actions
         result = get_file_info(server.state, uri, cancel_flag)
@@ -343,4 +344,113 @@ function ambiguous_soft_scope_code_actions!(
                         newText = data.indent * "local $(data.name)\n")]))))
     end
     return code_actions
+end
+
+function missing_concretization_code_actions!(
+        code_actions::Vector{Union{CodeAction,Command}}, server::Server,
+        diagnostics::Vector{Diagnostic}
+    )
+    for diagnostic in diagnostics
+        diagnostic.code == TOPLEVEL_MISSING_CONCRETIZATION_CODE || continue
+        data = diagnostic.data
+        data isa MissingConcretizationData || continue
+        config_path = @something jetls_config_path_for_code_action(server) continue
+        path = @something concretization_pattern_path_for_code_action(server, data.assignment_file) continue
+        edit = @something jetls_config_workspace_edit(
+            server, config_path, data.pattern, path) continue
+        action = isfile(config_path) ? "Add" : "Create"
+        title = "$action `.JETLSConfig.toml` concretization pattern for `$(data.name)`"
+        push!(code_actions, CodeAction(;
+            title,
+            kind = CodeActionKind.QuickFix,
+            diagnostics = Diagnostic[diagnostic],
+            isPreferred = true,
+            edit))
+    end
+    return code_actions
+end
+
+function jetls_config_path_for_code_action(server::Server)
+    isdefined(server.state, :root_path) || return nothing
+    return joinpath(server.state.root_path, CONFIG_FILE)
+end
+
+function concretization_pattern_path_for_code_action(
+        server::Server, filename::AbstractString
+    )
+    path = @something relative_workspace_path_for_config(server, filename) return nothing
+    return escape_path_for_glob(path)
+end
+
+function jetls_config_workspace_edit(
+        server::Server, config_path::String, pattern::String, path::String
+    )
+    config_uri = filepath2uri(config_path)
+    if isfile(config_path)
+        text = read(config_path, String)
+        new_text = @something jetls_config_append_text(text, pattern, path) return nothing
+        position = _offset_to_xy(Vector{UInt8}(text), sizeof(text) + 1, server.state.encoding)
+        # TODO: This EOF position is based on disk content and may be stale when
+        # `.JETLSConfig.toml` has unsaved changes. Synchronize the config document
+        # and use its live contents and version for a versioned edit.
+        return WorkspaceEdit(;
+            changes = Dict{URI,Vector{TextEdit}}(
+                config_uri => TextEdit[TextEdit(;
+                    range = Range(; start=position, var"end"=position),
+                    newText = new_text)]))
+    end
+    supports_create_file_workspace_edit(server) || return nothing
+    text_edit = TextEdit(;
+        range = Range(;
+            start = Position(; line=0, character=0),
+            var"end" = Position(; line=0, character=0)),
+        newText = format_jetls_concretization_pattern(pattern, path))
+    create_file = CreateFile(; uri = config_uri)
+    text_document = OptionalVersionedTextDocumentIdentifier(;
+        uri = config_uri, version = null)
+    document_edit = TextDocumentEdit(;
+        textDocument = text_document,
+        edits = TextEdit[text_edit])
+    return WorkspaceEdit(;
+        documentChanges = Union{TextDocumentEdit, CreateFile, RenameFile, DeleteFile}[
+            create_file, document_edit])
+end
+
+function jetls_config_append_text(text::String, pattern::String, path::String)
+    parsed = TOML.tryparse(text)
+    parsed isa TOML.ParserError && return nothing
+    validated = try
+        validate_config_data(parsed)
+    catch
+        return nothing
+    end
+    full_analysis = get(validated, "full_analysis", Dict{String,Any}())
+    full_analysis isa Dict{String,Any} || return nothing
+    configured = get(full_analysis, "concretization_patterns", Any[])
+    configured isa Vector || return nothing
+    for pattern_config in configured
+        pattern_config isa Dict{String,Any} || return nothing
+        if (get(pattern_config, "pattern", nothing) == pattern &&
+            get(pattern_config, "path", nothing) == path)
+            return nothing
+        end
+    end
+    sep = isempty(text) ? "" : endswith(text, '\n') ? "\n" : "\n\n"
+    appended = sep * format_jetls_concretization_pattern(pattern, path)
+    TOML.tryparse(text * appended) isa TOML.ParserError && return nothing
+    return appended
+end
+
+function format_jetls_concretization_pattern(pattern::String, path::String)
+    io = IOBuffer()
+    println(io, "[[full_analysis.concretization_patterns]]")
+    TOML.print(io, Dict("pattern" => pattern))
+    TOML.print(io, Dict("path" => path))
+    return String(take!(io))
+end
+
+function supports_create_file_workspace_edit(server::Server)
+    supports(server, :workspace, :workspaceEdit, :documentChanges) || return false
+    operations = getcapability(server, :workspace, :workspaceEdit, :resourceOperations)
+    return operations !== nothing && ResourceOperationKind.Create in operations
 end

--- a/src/code-action.jl
+++ b/src/code-action.jl
@@ -388,16 +388,22 @@ function jetls_config_workspace_edit(
     config_uri = filepath2uri(config_path)
     if isfile(config_path)
         text = read(config_path, String)
-        new_text = @something jetls_config_append_text(text, pattern, path) return nothing
-        position = _offset_to_xy(Vector{UInt8}(text), sizeof(text) + 1, server.state.encoding)
-        # TODO: This EOF position is based on disk content and may be stale when
+        appended = jetls_config_append_text(text, pattern, path)
+        if appended === nothing
+            text_edit = @something jetls_config_inline_array_edit(
+                text, pattern, path, server.state.encoding) return nothing
+        else
+            position = _offset_to_xy(
+                Vector{UInt8}(text), sizeof(text) + 1, server.state.encoding)
+            text_edit = TextEdit(;
+                range = Range(; start=position, var"end"=position),
+                newText = appended)
+        end
+        # TODO: These positions are based on disk content and may be stale when
         # `.JETLSConfig.toml` has unsaved changes. Synchronize the config document
         # and use its live contents and version for a versioned edit.
         return WorkspaceEdit(;
-            changes = Dict{URI,Vector{TextEdit}}(
-                config_uri => TextEdit[TextEdit(;
-                    range = Range(; start=position, var"end"=position),
-                    newText = new_text)]))
+            changes = Dict{URI,Vector{TextEdit}}(config_uri => TextEdit[text_edit]))
     end
     supports_create_file_workspace_edit(server) || return nothing
     text_edit = TextEdit(;
@@ -417,6 +423,15 @@ function jetls_config_workspace_edit(
 end
 
 function jetls_config_append_text(text::String, pattern::String, path::String)
+    configured = @something parse_configured_concretization_patterns(text) return nothing
+    has_concretization_pattern(configured, pattern, path) && return nothing
+    sep = isempty(text) ? "" : endswith(text, '\n') ? "\n" : "\n\n"
+    appended = sep * format_jetls_concretization_pattern(pattern, path)
+    added_concretization_pattern(configured, text * appended, pattern, path) || return nothing
+    return appended
+end
+
+function parse_configured_concretization_patterns(text::String)
     parsed = TOML.tryparse(text)
     parsed isa TOML.ParserError && return nothing
     validated = try
@@ -428,17 +443,19 @@ function jetls_config_append_text(text::String, pattern::String, path::String)
     full_analysis isa Dict{String,Any} || return nothing
     configured = get(full_analysis, "concretization_patterns", Any[])
     configured isa Vector || return nothing
-    for pattern_config in configured
-        pattern_config isa Dict{String,Any} || return nothing
-        if (get(pattern_config, "pattern", nothing) == pattern &&
-            get(pattern_config, "path", nothing) == path)
-            return nothing
-        end
+    all(@nospecialize(pattern_config) -> pattern_config isa Dict{String,Any},
+        configured) || return nothing
+    return configured
+end
+
+function has_concretization_pattern(
+        configured::Vector, pattern::String, path::String
+    )
+    return any(configured) do @nospecialize pattern_config
+        pattern_config = pattern_config::Dict{String,Any}
+        return isequal(get(pattern_config, "pattern", nothing), pattern) &&
+            isequal(get(pattern_config, "path", nothing), path)
     end
-    sep = isempty(text) ? "" : endswith(text, '\n') ? "\n" : "\n\n"
-    appended = sep * format_jetls_concretization_pattern(pattern, path)
-    TOML.tryparse(text * appended) isa TOML.ParserError && return nothing
-    return appended
 end
 
 function format_jetls_concretization_pattern(pattern::String, path::String)
@@ -447,6 +464,42 @@ function format_jetls_concretization_pattern(pattern::String, path::String)
     TOML.print(io, Dict("pattern" => pattern))
     TOML.print(io, Dict("path" => path))
     return String(take!(io))
+end
+
+function added_concretization_pattern(
+        old_configured::Vector, updated_text::String, pattern::String, path::String
+    )
+    updated = @something parse_configured_concretization_patterns(updated_text) return false
+    return length(updated) == length(old_configured) + 1 &&
+        has_concretization_pattern(updated, pattern, path)
+end
+
+const CONCRETIZATION_PATTERNS_ARRAY_REGEX = Regex(
+    "(?:\"concretization_patterns\"|'concretization_patterns'|" *
+    "concretization_patterns)[ \\t]*=[ \\t]*\\[")
+
+function jetls_config_inline_array_edit(
+        text::String, pattern::String, path::String, encoding::PositionEncodingKind.Ty
+    )
+    configured = @something parse_configured_concretization_patterns(text) return nothing
+    has_concretization_pattern(configured, pattern, path) && return nothing
+    entry = format_toml_inline_table(Dict("pattern" => pattern, "path" => path))
+    bytes = Vector{UInt8}(text)
+    for m in eachmatch(CONCRETIZATION_PATTERNS_ARRAY_REGEX, text)
+        relative_open = findlast(==('['), m.match)::Int
+        start_offset = m.offset + relative_open
+        end_offset, new_text = toml_array_entry_insertion(
+            text, start_offset, entry, isempty(configured))
+        start_position = _offset_to_xy(bytes, start_offset, encoding)
+        end_position = _offset_to_xy(bytes, end_offset, encoding)
+        text_edit = TextEdit(;
+            range = Range(; start=start_position, var"end"=end_position),
+            newText = new_text)
+        updated = apply_text_change(text, text_edit.range, text_edit.newText, encoding)
+        added_concretization_pattern(configured, updated, pattern, path) || continue
+        return text_edit
+    end
+    return nothing
 end
 
 function supports_create_file_workspace_edit(server::Server)

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,5 +1,6 @@
-is_config_file(filepath::AbstractString) =
-    basename(filepath) == ".JETLSConfig.toml"
+const CONFIG_FILE = ".JETLSConfig.toml"
+
+is_config_file(filepath::AbstractString) = basename(filepath) == CONFIG_FILE
 
 @generated function merge_and_track(
         on_difference,
@@ -261,9 +262,10 @@ end
 # Drives `parse_config_from_dict`'s field-by-field hydration: turns the raw dict value `x`
 # into the field's declared type `T`. Handles the small type tree we actually use — Maybe,
 # nested `ConfigSection`, vectors of `ConfigSection`, the formatter union, and plain
-# `convert`-able leaves. `DiagnosticPattern` / `AnalysisOverride` need bespoke validation
-# and are inlined here for the same reason `Maybe{FormatterConfig}` is — the set of special
-# cases is small and closed, so a dispatch hook would be over-built.
+# `convert`-able leaves. `ConcretizationPattern` / `DiagnosticPattern` /
+# `AnalysisOverride` need bespoke validation and are inlined here for the same reason
+# `Maybe{FormatterConfig}` is — the set of special cases is small and closed, so a
+# dispatch hook would be over-built.
 function parse_config_dict_value(
         T::Type, @nospecialize(x), path::Vector{String} = String[]
     )
@@ -304,6 +306,7 @@ function parse_config_dict_value(
     if T <: ConfigSection
         x isa Dict{String,Any} ||
             parse_dict_error(path, "expected a table for $T, got $(typeof(x))")
+        T === ConcretizationPattern && return parse_concretization_pattern(x, path)
         T === DiagnosticPattern && return parse_diagnostic_pattern(x)
         T === AnalysisOverride && return parse_analysis_override(x)
         return parse_config_from_dict(T, x, path)
@@ -319,6 +322,44 @@ function parse_config_dict_value(
         e isa MethodError || rethrow(e)
         parse_dict_error(path, "expected $T, got $(typeof(x))")
     end
+end
+
+function parse_concretization_pattern(x::Dict{String,Any}, path::Vector{String})
+    valid_keys = ("pattern", "path")
+    for key in keys(x)
+        key in valid_keys || parse_dict_error(
+            path, "unknown field `$key`, expected `pattern` or `path`")
+    end
+    haskey(x, "pattern") || parse_dict_error(path, "missing required field `pattern`")
+    pattern_value = x["pattern"]
+    pattern_value isa String ||
+        parse_dict_error(String[path; "pattern"], "expected String, got $(typeof(pattern_value))")
+    pattern = parse_concretization_pattern_string(pattern_value, String[path; "pattern"])
+    path_glob = if haskey(x, "path")
+        path_value = x["path"]
+        path_value isa String ||
+            parse_dict_error(String[path; "path"], "expected String, got $(typeof(path_value))")
+        try
+            Glob.FilenameMatch(path_value, "dp")
+        catch e
+            parse_dict_error(String[path; "path"],
+                "invalid glob pattern `$path_value`: $(sprint(showerror, e))")
+        end
+    else
+        nothing
+    end
+    return ConcretizationPattern(pattern, path_glob, String(pattern_value))
+end
+
+function parse_concretization_pattern_string(s::String, path::Vector{String})
+    ret = Meta.parse(strip(s); raise=false)
+    ret === nothing &&
+        parse_dict_error(path, "expected a Julia expression pattern, got no expression")
+    if Meta.isexpr(ret, :error) || Meta.isexpr(ret, :incomplete)
+        err = ret.args[1]
+        parse_dict_error(path, "failed to parse Julia expression pattern `$s`: $err")
+    end
+    return ret
 end
 
 """
@@ -398,8 +439,9 @@ end
 mutable struct ConfigChangeTracker
     const changed_settings::Vector{ConfigChange}
     diagnostic_setting_changed::Bool
+    analysis_setting_changed::Bool
 end
-ConfigChangeTracker() = ConfigChangeTracker(ConfigChange[], false)
+ConfigChangeTracker() = ConfigChangeTracker(ConfigChange[], false, false)
 
 function (tracker::ConfigChangeTracker)(old_val, new_val, path::Tuple{Vararg{Symbol}})
     @nospecialize old_val new_val
@@ -408,6 +450,9 @@ function (tracker::ConfigChangeTracker)(old_val, new_val, path::Tuple{Vararg{Sym
         push!(tracker.changed_settings, ConfigChange(path_str, old_val, new_val))
         if !isempty(path) && first(path) === :diagnostic
             tracker.diagnostic_setting_changed = true
+        elseif (length(path) ≥ 2 && path[1] === :full_analysis &&
+                path[2] === :concretization_patterns)
+            tracker.analysis_setting_changed = true
         end
     end
 end

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -373,13 +373,27 @@ function jet_toplevel_error_report_to_diagnostic(
     message = JET.with_bufferring(:limit=>true) do io
         JET.print_report(io, report)
     end |> postprocessor
+    code = report isa JET.MissingConcretizationErrorReport ?
+        TOPLEVEL_MISSING_CONCRETIZATION_CODE : TOPLEVEL_ERROR_CODE
+    data = report isa JET.MissingConcretizationErrorReport ?
+        missing_concretization_data(report) : nothing
     return Diagnostic(;
         range = line_range(report.line),
         severity = DiagnosticSeverity.Error,
         message,
         source = DIAGNOSTIC_SOURCE_SAVE,
-        code = TOPLEVEL_ERROR_CODE,
-        codeDescription = diagnostic_code_description(TOPLEVEL_ERROR_CODE))
+        code,
+        codeDescription = diagnostic_code_description(code),
+        data)
+end
+
+# `nothing` when JET could not derive a pattern for the assignment: any pattern guessed
+# here would be one that never matches, so no quick fix is offered
+function missing_concretization_data(report::JET.MissingConcretizationErrorReport)
+    assignment = @something report.assignment return nothing
+    pattern = @something assignment.pattern return nothing
+    return MissingConcretizationData(
+        String(report.var.name), sprint(Base.show_unquoted, pattern), assignment.file)
 end
 
 # inference diagnostic

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -370,13 +370,17 @@ function jet_toplevel_error_report_to_diagnostic(
         @nospecialize(report::JET.ToplevelErrorReport), postprocessor::JET.PostProcessor
     )
     report isa JET.ParseErrorReport && return nothing # Syntax errors should be reported via `textDocument/diagnostic` or `workspace/diangostic`
-    message = JET.with_bufferring(:limit=>true) do io
-        JET.print_report(io, report)
-    end |> postprocessor
-    code = report isa JET.MissingConcretizationErrorReport ?
-        TOPLEVEL_MISSING_CONCRETIZATION_CODE : TOPLEVEL_ERROR_CODE
-    data = report isa JET.MissingConcretizationErrorReport ?
-        missing_concretization_data(report) : nothing
+    if report isa JET.MissingConcretizationErrorReport
+        data = missing_concretization_data(report)
+        message = missing_concretization_message(report, data, postprocessor)
+        code = TOPLEVEL_MISSING_CONCRETIZATION_CODE
+    else
+        data = nothing
+        message = JET.with_bufferring(:limit=>true) do io
+            JET.print_report(io, report)
+        end |> postprocessor
+        code = TOPLEVEL_ERROR_CODE
+    end
     return Diagnostic(;
         range = line_range(report.line),
         severity = DiagnosticSeverity.Error,
@@ -394,6 +398,40 @@ function missing_concretization_data(report::JET.MissingConcretizationErrorRepor
     pattern = @something assignment.pattern return nothing
     return MissingConcretizationData(
         String(report.var.name), sprint(Base.show_unquoted, pattern), assignment.file)
+end
+
+function missing_concretization_message(
+        report::JET.MissingConcretizationErrorReport,
+        data::Union{Nothing,MissingConcretizationData},
+        postprocessor::JET.PostProcessor
+    )
+    message = JET.with_bufferring(:limit=>true) do io
+        (; isconst, var, assignment) = report
+        (; mod, name) = var
+        println(io, "`$mod.$name` must have a concrete value for JETLS top-level analysis.")
+        if assignment === nothing
+            println(io, "JETLS could not identify the assignment that defines this binding.")
+        else
+            println(io, "JETLS did not evaluate the assignment at " *
+                "$(assignment.file):$(assignment.line) that defines this binding.")
+        end
+        if !isconst
+            println(io)
+            println(io, "Declaring `$name` as `const` may fix this when JETLS can " *
+                "infer the concrete value of its right-hand side without evaluating it.")
+        end
+        println(io)
+        if data === nothing
+            println(io, "Configure `full_analysis.concretization_patterns` in " *
+                "`.JETLSConfig.toml` manually to evaluate the relevant top-level statement.")
+            print(io, "JETLS could not derive a safe pattern for this assignment.")
+        else
+            println(io, "Configure `full_analysis.concretization_patterns` in " *
+                "`.JETLSConfig.toml` to evaluate this assignment.")
+            print(io, "The preferred quick fix can add the derived pattern `$(data.pattern)`.")
+        end
+    end
+    return postprocessor(message)
 end
 
 # inference diagnostic

--- a/src/did-change-watched-files.jl
+++ b/src/did-change-watched-files.jl
@@ -1,7 +1,6 @@
 const DID_CHANGE_WATCHED_FILES_REGISTRATION_ID = "jetls-did-change-watched-files"
 const DID_CHANGE_WATCHED_FILES_REGISTRATION_METHOD = "workspace/didChangeWatchedFiles"
 
-const CONFIG_FILE = ".JETLSConfig.toml"
 const PROFILE_TRIGGER_FILE = ".JETLSProfile"
 const SERVER_REVISE_TRIGGER_FILE = ".JETLS_REVISE"
 
@@ -71,6 +70,10 @@ function handle_config_file_change!(
     if tracker.diagnostic_setting_changed
         clear_per_file_diagnostics_cache!(server.state)
         notify_diagnostics!(server; ensure_cleared = true)
+        request_diagnostic_refresh!(server)
+    end
+    if tracker.analysis_setting_changed
+        request_reanalysis_for_cached_entries!(server)
         request_diagnostic_refresh!(server)
     end
 end

--- a/src/did-change-watched-files.jl
+++ b/src/did-change-watched-files.jl
@@ -73,7 +73,7 @@ function handle_config_file_change!(
         request_diagnostic_refresh!(server)
     end
     if tracker.analysis_setting_changed
-        request_reanalysis_for_cached_entries!(server)
+        request_reanalysis_for_tracked_entries!(server)
         request_diagnostic_refresh!(server)
     end
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -488,9 +488,18 @@ const Maybe{T} = Union{Nothing,T}
 
 function merge_key_value end
 
+struct ConcretizationPattern <: ConfigSection
+    pattern::Any
+    path::Maybe{Glob.FilenameMatch{String}}
+    __pattern_value__::String
+end
+@define_eq_overloads ConcretizationPattern
+merge_key_value(pattern::ConcretizationPattern) = (pattern.path, pattern.__pattern_value__)
+
 @kwdef struct FullAnalysisConfig <: ConfigSection
     debounce::Maybe{Float64} = nothing
     auto_instantiate::Maybe{Bool} = nothing
+    concretization_patterns::Maybe{Vector{ConcretizationPattern}} = nothing
 end
 @define_eq_overloads FullAnalysisConfig
 
@@ -544,6 +553,7 @@ const LOWERING_UNREACHABLE_CODE = "lowering/unreachable-code"
 const LOWERING_INACTIVE_CODE = "lowering/inactive-code"
 const LOWERING_AMBIGUOUS_SOFT_SCOPE_CODE = "lowering/ambiguous-soft-scope"
 const TOPLEVEL_ERROR_CODE = "toplevel/error"
+const TOPLEVEL_MISSING_CONCRETIZATION_CODE = "toplevel/missing-concretization"
 const TOPLEVEL_METHOD_OVERWRITE_CODE = "toplevel/method-overwrite"
 const TOPLEVEL_ABSTRACT_FIELD_CODE = "toplevel/abstract-field"
 const INFERENCE_UNDEF_GLOBAL_VAR_CODE = "inference/undef-global-var"
@@ -576,6 +586,7 @@ const ALL_DIAGNOSTIC_CODES = Set{String}(String[
     LOWERING_INACTIVE_CODE,
     LOWERING_AMBIGUOUS_SOFT_SCOPE_CODE,
     TOPLEVEL_ERROR_CODE,
+    TOPLEVEL_MISSING_CONCRETIZATION_CODE,
     TOPLEVEL_METHOD_OVERWRITE_CODE,
     TOPLEVEL_ABSTRACT_FIELD_CODE,
     INFERENCE_UNDEF_GLOBAL_VAR_CODE,
@@ -695,7 +706,8 @@ end
 
 const DEFAULT_CONFIG = JETLSConfig(;
     diagnostic = DiagnosticConfig(true, true, true, DiagnosticPattern[]),
-    full_analysis = FullAnalysisConfig(@static(JETLS_TEST_MODE ? 0.0 : 1.0), true),
+    full_analysis = FullAnalysisConfig(
+        @static(JETLS_TEST_MODE ? 0.0 : 1.0), true, ConcretizationPattern[]),
     testrunner = TestRunnerConfig(@static Sys.iswindows() ? "testrunner.bat" : "testrunner"),
     formatter = "Runic",
     completion = CompletionConfig(LaTeXEmojiConfig(missing)),

--- a/src/types.jl
+++ b/src/types.jl
@@ -343,6 +343,7 @@ signature_analysis_completion(job::AbstractSignatureAnalysisJob) =
     getfield(job, :completion)::Base.Event
 
 const AnalysisCache = LWContainer{Dict{URI,AnalysisInfo}, LWStats}
+const TrackedAnalysisEntries = CASContainer{Dict{AnalysisEntry,URI}, CASStats}
 const PendingAnalyses = CASContainer{Dict{AnalysisEntry,Union{Nothing,AnalysisRequest}}, CASStats}
 const CurrentGenerations = CASContainer{Dict{AnalysisEntry,Int}, CASStats}
 const AnalyzedGenerations = CASContainer{Dict{AnalysisEntry,Int}, CASStats}
@@ -357,6 +358,7 @@ struct AnalysisManager
     current_generations::CurrentGenerations
     analyzed_generations::AnalyzedGenerations
     debounced::DebouncedRequests
+    tracked_entries::TrackedAnalysisEntries
     instantiated_envs::InstantiatedEnvs
     worker_task::Base.RefValue{Task}
     signature_worker_tasks::Vector{Task}
@@ -369,6 +371,7 @@ struct AnalysisManager
             CurrentGenerations(),
             AnalyzedGenerations(),
             DebouncedRequests(),
+            TrackedAnalysisEntries(),
             InstantiatedEnvs(),
             Ref{Task}(), # initialized by start_analysis_worker!
             Task[], # initialized by start_signature_analysis_workers!

--- a/src/utils/path.jl
+++ b/src/utils/path.jl
@@ -82,6 +82,15 @@ end
 _paths_equal(a::AbstractString, b::AbstractString) =
     @static Sys.iswindows() ? lowercase(a) == lowercase(b) : a == b
 
+function escape_path_for_glob(path::AbstractString)
+    io = IOBuffer()
+    for c in glob_candidate_path(path, nothing)
+        c in ('\\', '*', '?', '[', ']') && write(io, '\\')
+        write(io, c)
+    end
+    return String(take!(io))
+end
+
 """
     fix_build_path(path::AbstractString) -> fixed_path::AbstractString
 

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -413,3 +413,10 @@ function collect_workspace_uris(server::Server)
     end
     return uris
 end
+
+function relative_workspace_path_for_config(server::Server, filename::AbstractString)
+    isdefined(server.state, :root_path) || return nothing
+    root_path = server.state.root_path
+    issubdir(filename, root_path) || return nothing
+    return glob_candidate_path(filename, root_path)
+end

--- a/src/utils/toml.jl
+++ b/src/utils/toml.jl
@@ -1,0 +1,51 @@
+"""
+    format_toml_inline_table(table::AbstractDict{String}) -> String
+
+Serialize `table` as a TOML inline table without an enclosing key assignment.
+"""
+function format_toml_inline_table(table::AbstractDict{String})
+    inline_tables = Base.IdSet{typeof(table)}()
+    push!(inline_tables, table)
+    io = IOBuffer()
+    TOML.print(io, Dict("value" => table); inline_tables)
+    text = chomp(String(take!(io)))
+    prefix = "value = "
+    @assert startswith(text, prefix)
+    return String(text[sizeof(prefix)+1:end])
+end
+
+"""
+    toml_array_entry_insertion(
+        text::String, content_start_offset::Int, entry::String,
+        isempty_array::Bool
+    ) -> Tuple{Int,String}
+
+Return the end byte offset and replacement text for inserting `entry` at the start of a
+TOML array. `content_start_offset` is the 1-based byte offset immediately after the
+opening `[`.
+"""
+function toml_array_entry_insertion(
+        text::String, content_start_offset::Int, entry::String, isempty_array::Bool
+    )
+    bytes = codeunits(text)
+    content_start_offset > length(bytes) && return content_start_offset, entry
+    first_byte = bytes[content_start_offset]
+    if first_byte != UInt8('\n') && first_byte != UInt8('\r')
+        return content_start_offset, entry * (isempty_array ? "" : ", ")
+    end
+    indent_start = content_start_offset + 1
+    if (first_byte == UInt8('\r') && indent_start ≤ length(bytes) &&
+            bytes[indent_start] == UInt8('\n'))
+        indent_start += 1
+    end
+    end_offset = indent_start
+    while (end_offset ≤ length(bytes) &&
+            (bytes[end_offset] == UInt8(' ') || bytes[end_offset] == UInt8('\t')))
+        end_offset += 1
+    end
+    linebreak = String(bytes[content_start_offset:indent_start-1])
+    indent = String(bytes[indent_start:end_offset-1])
+    prefix = linebreak * indent
+    separator = (isempty_array ? "" : ",") * linebreak * indent
+    return end_offset, prefix * entry * separator
+end

--- a/src/workspace-configuration.jl
+++ b/src/workspace-configuration.jl
@@ -120,6 +120,10 @@ function handle_lsp_config_change!(server::Server, tracker::ConfigChangeTracker,
         notify_diagnostics!(server; ensure_cleared = true)
         request_diagnostic_refresh!(server)
     end
+    if tracker.analysis_setting_changed
+        request_reanalysis_for_cached_entries!(server)
+        request_diagnostic_refresh!(server)
+    end
 end
 
 function handle_DidChangeConfigurationNotification(server::Server, msg::DidChangeConfigurationNotification)

--- a/src/workspace-configuration.jl
+++ b/src/workspace-configuration.jl
@@ -121,7 +121,7 @@ function handle_lsp_config_change!(server::Server, tracker::ConfigChangeTracker,
         request_diagnostic_refresh!(server)
     end
     if tracker.analysis_setting_changed
-        request_reanalysis_for_cached_entries!(server)
+        request_reanalysis_for_tracked_entries!(server)
         request_diagnostic_refresh!(server)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,7 @@ end
         @testset "path" include("utils/test_path.jl")
         @testset "markdown" include("utils/test_markdown.jl")
         @testset "string" include("utils/test_string.jl")
+        @testset "toml" include("utils/test_toml.jl")
         @testset "jl-syntax-macros" include("utils/test_jl_syntax_macros.jl")
         @testset "native-inference" include("utils/test_native_inference.jl")
     end

--- a/test/test_code_action.jl
+++ b/test/test_code_action.jl
@@ -5,6 +5,7 @@ using JETLS
 using JETLS: JL, JS
 using JETLS.LSP
 using JETLS.LSP.URIs2
+using JETLS.TOML
 
 include(normpath(pkgdir(JETLS), "test", "setup.jl"))
 include(normpath(pkgdir(JETLS), "test", "jsjl-utils.jl"))
@@ -510,6 +511,150 @@ end
         @test edit.newText == "    global x\n"
         @test edit.range.start == positions[1]
         @test edit.range.var"end" == positions[1]
+    end
+end
+
+function missing_concretization_diagnostic(assignment_file::String)
+    return Diagnostic(;
+        range = JETLS.line_range(1),
+        severity = DiagnosticSeverity.Error,
+        message = "`USE_PULSE` is not concretized",
+        source = JETLS.DIAGNOSTIC_SOURCE_SAVE,
+        code = JETLS.TOPLEVEL_MISSING_CONCRETIZATION_CODE,
+        data = MissingConcretizationData("USE_PULSE", "USE_PULSE = x_", assignment_file))
+end
+
+@testset HierarchicalTestSet "missing concretization code actions" begin
+    @testset "`jetls_config_append_text` appends a new pattern" begin
+        text = "foo = 1\n"
+        appended = JETLS.jetls_config_append_text(text, "USE_PULSE = x_", "issue464.jl")
+        parsed = TOML.parse(text * appended)
+        pattern_config = only(parsed["full_analysis"]["concretization_patterns"])
+        @test pattern_config["pattern"] == "USE_PULSE = x_"
+        @test pattern_config["path"] == "issue464.jl"
+    end
+
+    @testset "`format_jetls_concretization_pattern` escapes special characters" begin
+        pattern = "A\nB\t\u0001\\\"雪"
+        path = "src/A\nB\t\u0001\\\"雪.jl"
+        text = JETLS.format_jetls_concretization_pattern(pattern, path)
+        parsed = TOML.parse(text)
+        pattern_config = only(parsed["full_analysis"]["concretization_patterns"])
+        @test pattern_config["pattern"] == pattern
+        @test pattern_config["path"] == path
+    end
+
+    @testset "`jetls_config_append_text` skips already configured patterns" begin
+        text = """
+            [[full_analysis.concretization_patterns]]
+            pattern = "USE_PULSE = x_"
+            path = "issue464.jl"
+            """
+        @test JETLS.jetls_config_append_text(text, "USE_PULSE = x_", "issue464.jl") === nothing
+    end
+
+    @testset "existing config: append via `changes` fallback" begin
+        mktempdir() do dir
+            assignment_path = joinpath(dir, "config.jl")
+            config_path = joinpath(dir, ".JETLSConfig.toml")
+            write(assignment_path, "USE_PULSE = false\n")
+            write(config_path, """
+                [[full_analysis.concretization_patterns]]
+                pattern = "OLD = x_"
+                """)
+            rootUri = filepath2uri(dir)
+            withserver(; rootUri) do (; server)
+                code_actions = Union{CodeAction,Command}[]
+                JETLS.missing_concretization_code_actions!(
+                    code_actions, server,
+                    Diagnostic[missing_concretization_diagnostic(assignment_path)])
+                action = only(code_actions)
+                @test action.title ==
+                    "Add `.JETLSConfig.toml` concretization pattern for `USE_PULSE`"
+                edit = only(action.edit.changes[filepath2uri(config_path)])
+                @test edit.range.start == edit.range.var"end"
+                original = read(config_path, String)
+                updated = JETLS.apply_text_change(
+                    original, edit.range, edit.newText, server.state.encoding)
+                parsed = TOML.parse(updated)
+                patterns = parsed["full_analysis"]["concretization_patterns"]
+                @test [config["pattern"] for config in patterns] == ["OLD = x_", "USE_PULSE = x_"]
+                @test patterns[2]["path"] == "config.jl"
+
+                dirty = original * "# unsaved\n"
+                updated_dirty = JETLS.apply_text_change(
+                    dirty, edit.range, edit.newText, server.state.encoding)
+                @test occursin("# unsaved\n", updated_dirty)
+            end
+        end
+    end
+
+    @testset "missing config: `CreateFile` edit" begin
+        mktempdir() do dir
+            script_path = joinpath(dir, "issue464.jl")
+            write(script_path, "USE_PULSE = false\n")
+            rootUri = filepath2uri(dir)
+            capabilities = ClientCapabilities(;
+                workspace = WorkspaceClientCapabilities(;
+                    workspaceEdit = WorkspaceEditClientCapabilities(;
+                        documentChanges = true,
+                        resourceOperations = ResourceOperationKind.Ty[
+                            ResourceOperationKind.Create])))
+            withserver(; rootUri, capabilities) do (; server)
+                code_actions = Union{CodeAction,Command}[]
+                JETLS.missing_concretization_code_actions!(
+                    code_actions, server,
+                    Diagnostic[missing_concretization_diagnostic(script_path)])
+                action = only(code_actions)
+                @test action.title ==
+                    "Create `.JETLSConfig.toml` concretization pattern for `USE_PULSE`"
+                edit = action.edit
+                @test edit.documentChanges !== nothing
+                @test edit.documentChanges[1] isa CreateFile
+                @test edit.documentChanges[2] isa TextDocumentEdit
+                text_edit = only(edit.documentChanges[2].edits)
+                parsed = TOML.parse(text_edit.newText)
+                patterns = parsed["full_analysis"]["concretization_patterns"]
+                pattern_config = only(patterns)
+                @test pattern_config["pattern"] == "USE_PULSE = x_"
+                @test pattern_config["path"] == "issue464.jl"
+            end
+        end
+    end
+
+    @testset "missing config: no edit without `CreateFile` support" begin
+        mktempdir() do dir
+            config_path = joinpath(dir, ".JETLSConfig.toml")
+            rootUri = filepath2uri(dir)
+            capabilities = ClientCapabilities(;
+                workspace = WorkspaceClientCapabilities(;
+                    workspaceEdit = WorkspaceEditClientCapabilities(;
+                        documentChanges = true)))
+            withserver(; rootUri, capabilities) do (; server)
+                @test JETLS.jetls_config_workspace_edit(
+                    server, config_path, "USE_PULSE = x_", "issue464.jl") === nothing
+            end
+        end
+    end
+
+    @testset "external assignment: no code action" begin
+        mktempdir() do dir
+            workspace = joinpath(dir, "workspace")
+            mkpath(workspace)
+            assignment_path = joinpath(dir, "config.jl")
+            write(assignment_path, "USE_PULSE = false\n")
+            write(joinpath(workspace, ".JETLSConfig.toml"), "")
+            rootUri = filepath2uri(workspace)
+            withserver(; rootUri) do (; server)
+                @test isnothing(JETLS.concretization_pattern_path_for_code_action(
+                    server, assignment_path))
+                code_actions = Union{CodeAction,Command}[]
+                JETLS.missing_concretization_code_actions!(
+                    code_actions, server,
+                    Diagnostic[missing_concretization_diagnostic(assignment_path)])
+                @test isempty(code_actions)
+            end
+        end
     end
 end
 

--- a/test/test_code_action.jl
+++ b/test/test_code_action.jl
@@ -544,6 +544,49 @@ end
         @test pattern_config["path"] == path
     end
 
+    @testset "inline concretization pattern arrays are extended" begin
+        configs = String[
+            """
+            [full_analysis]
+            concretization_patterns = []
+            """,
+            """
+            [full_analysis]
+            concretization_patterns = [{ pattern = "OLD = x_" }]
+            """,
+            "note = '''concretization_patterns = []'''\n" *
+                "[full_analysis]\n" *
+                "concretization_patterns = [\n" *
+                "    { pattern = \"OLD = x_\", path = \"old.jl\" },\n" *
+                "]\n",
+            """
+            full_analysis = { concretization_patterns = [] }
+            """,
+            """
+            [full_analysis]
+            "concretization_patterns" = []
+            """,
+        ]
+        for original in configs
+            before = TOML.parse(original)
+            old_patterns = before["full_analysis"]["concretization_patterns"]
+            edit = JETLS.jetls_config_inline_array_edit(
+                original, "USE_PULSE = x_", "src/config.jl",
+                PositionEncodingKind.UTF16)::TextEdit
+            updated = JETLS.apply_text_change(
+                original, edit.range, edit.newText, PositionEncodingKind.UTF16)
+            parsed = TOML.parse(updated)
+            patterns = parsed["full_analysis"]["concretization_patterns"]
+            @test length(patterns) == length(old_patterns) + 1
+            @test any(patterns) do config
+                config["pattern"] == "USE_PULSE = x_" && config["path"] == "src/config.jl"
+            end
+            if haskey(before, "note")
+                @test parsed["note"] == before["note"]
+            end
+        end
+    end
+
     @testset "`jetls_config_append_text` skips already configured patterns" begin
         text = """
             [[full_analysis.concretization_patterns]]
@@ -585,6 +628,34 @@ end
                 updated_dirty = JETLS.apply_text_change(
                     dirty, edit.range, edit.newText, server.state.encoding)
                 @test occursin("# unsaved\n", updated_dirty)
+            end
+        end
+    end
+
+    @testset "existing config: edit inline array" begin
+        mktempdir() do dir
+            assignment_path = joinpath(dir, "config.jl")
+            config_path = joinpath(dir, ".JETLSConfig.toml")
+            original = """
+                [full_analysis]
+                concretization_patterns = []
+                """
+            write(assignment_path, "USE_PULSE = false\n")
+            write(config_path, original)
+            rootUri = filepath2uri(dir)
+            withserver(; rootUri) do (; server)
+                code_actions = Union{CodeAction,Command}[]
+                JETLS.missing_concretization_code_actions!(
+                    code_actions, server,
+                    Diagnostic[missing_concretization_diagnostic(assignment_path)])
+                action = only(code_actions)
+                edit = only(action.edit.changes[filepath2uri(config_path)])
+                updated = JETLS.apply_text_change(
+                    original, edit.range, edit.newText, server.state.encoding)
+                pattern_config = only(
+                    TOML.parse(updated)["full_analysis"]["concretization_patterns"])
+                @test pattern_config["pattern"] == "USE_PULSE = x_"
+                @test pattern_config["path"] == "config.jl"
             end
         end
     end

--- a/test/test_config.jl
+++ b/test/test_config.jl
@@ -5,7 +5,7 @@ using JETLS
 
 include("HierarchicalTestSet.jl")
 
-@testset "Configuration utilities" begin
+@testset HierarchicalTestSet "Configuration utilities" begin
     @testset "`get_default_config`" begin
         @test JETLS.get_default_config(:testrunner, :executable) ==
             (@static Sys.iswindows() ? "testrunner.bat" : "testrunner")
@@ -98,6 +98,28 @@ include("HierarchicalTestSet.jl")
                 @test patterns_by_path[test_path].severity == 0  # preserved
             end
         end
+
+        @testset "concretization pattern merge keys" begin
+            src_path = JETLS.Glob.FilenameMatch("src/**/*.jl", "")
+            test_path = JETLS.Glob.FilenameMatch("test/**/*.jl", "")
+            pattern_src = JETLS.ConcretizationPattern(:(USE_PULSE = x_), src_path, "USE_PULSE = x_")
+            pattern_test = JETLS.ConcretizationPattern(:(USE_PULSE = x_), test_path, "USE_PULSE = x_")
+            pattern_src_updated = JETLS.ConcretizationPattern(:(USE_PULSE = y_), src_path, "USE_PULSE = x_")
+
+            let base = JETLS.JETLSConfig(;
+                    full_analysis=JETLS.FullAnalysisConfig(;
+                        concretization_patterns=[pattern_src, pattern_test]))
+                overlay = JETLS.JETLSConfig(;
+                    full_analysis=JETLS.FullAnalysisConfig(;
+                        concretization_patterns=[pattern_src_updated]))
+                merged = JETLS.merge_settings(base, overlay)
+                patterns = JETLS.getobjpath(merged, :full_analysis, :concretization_patterns)
+                @test length(patterns) == 2
+                patterns_by_path = Dict(p.path => p for p in patterns)
+                @test patterns_by_path[src_path].pattern == :(USE_PULSE = y_)
+                @test patterns_by_path[test_path].pattern == :(USE_PULSE = x_)
+            end
+        end
     end
 
     @testset "`track_setting_changes`" begin
@@ -117,6 +139,16 @@ include("HierarchicalTestSet.jl")
                 (:full_analysis, :debounce),
                 (:testrunner, :executable),
             ])
+        end
+
+        @testset "concretization pattern update marks `analysis_setting_changed`" begin
+            pattern1 = JETLS.ConcretizationPattern(:(USE_PULSE = x_), nothing, "USE_PULSE = x_")
+            pattern2 = JETLS.ConcretizationPattern(:(USE_PULSE = y_), nothing, "USE_PULSE = x_")
+            config1 = JETLS.JETLSConfig(; full_analysis=JETLS.FullAnalysisConfig(; concretization_patterns=[pattern1]))
+            config2 = JETLS.JETLSConfig(; full_analysis=JETLS.FullAnalysisConfig(; concretization_patterns=[pattern2]))
+            tracker = JETLS.ConfigChangeTracker()
+            JETLS.track_setting_changes(tracker, config1, config2)
+            @test tracker.analysis_setting_changed
         end
 
         # Test that updating severity of an existing pattern is tracked
@@ -320,6 +352,67 @@ end
         @test err isa ErrorException
         @test occursin("Invalid value at `formatter`", err.msg)
         @test occursin("expected formatter table key `custom`", err.msg)
+    end
+end
+
+@testset HierarchicalTestSet "`parse_config_from_dict` concretization patterns" begin
+    @testset "patterns with and without `path`" begin
+        raw_config = Dict{String,Any}(
+            "full_analysis" => Dict{String,Any}(
+                "concretization_patterns" => Any[
+                    Dict{String,Any}("pattern" => "USE_PULSE = x_"),
+                    Dict{String,Any}(
+                        "pattern" => "SIMULATE = x_",
+                        "path" => "examples/**/*.jl")]))
+        config = JETLS.parse_config_from_dict(JETLS.JETLSConfig, raw_config)
+        patterns = config.full_analysis.concretization_patterns
+        @test length(patterns) == 2
+        @test patterns[1].pattern == :(USE_PULSE = x_)
+        @test patterns[1].path === nothing
+        @test patterns[2].pattern == :(SIMULATE = x_)
+        @test occursin(patterns[2].path, "examples/foo.jl")
+    end
+
+    @testset "non-table entry is rejected" begin
+        raw_config = Dict{String,Any}(
+            "full_analysis" => Dict{String,Any}(
+                "concretization_patterns" => Any["USE_PULSE = x_"]))
+        err = try
+            JETLS.parse_config_from_dict(JETLS.JETLSConfig, raw_config)
+            nothing
+        catch e; e; end
+        @test err isa ErrorException
+        @test occursin("expected a table for", err.msg)
+    end
+
+    @testset "incomplete pattern expression is rejected" begin
+        raw_config = Dict{String,Any}(
+            "full_analysis" => Dict{String,Any}(
+                "concretization_patterns" => Any[Dict{String,Any}(
+                    "pattern" => "USE_PULSE =",
+                    "path" => "examples/**/*.jl")]))
+        err = try
+            JETLS.parse_config_from_dict(JETLS.JETLSConfig, raw_config)
+            nothing
+        catch e; e; end
+        @test err isa ErrorException
+        @test occursin("full_analysis.concretization_patterns.pattern", err.msg)
+    end
+
+    @testset "empty or comment-only patterns are rejected" begin
+        for pattern in ("", "  \t\n", "# comment only")
+            raw_config = Dict{String,Any}(
+                "full_analysis" => Dict{String,Any}(
+                    "concretization_patterns" => Any[Dict{String,Any}(
+                        "pattern" => pattern)]))
+            err = try
+                JETLS.parse_config_from_dict(JETLS.JETLSConfig, raw_config)
+                nothing
+            catch e; e; end
+            @test err isa ErrorException
+            @test occursin("full_analysis.concretization_patterns.pattern", err.msg)
+            @test occursin("expected a Julia expression pattern", err.msg)
+        end
     end
 end
 

--- a/test/test_diagnostic.jl
+++ b/test/test_diagnostic.jl
@@ -77,6 +77,194 @@ end
     end
 end
 
+function get_open_diagnostics(
+        root_path::AbstractString, script_path::AbstractString, code::AbstractString;
+        settings = nothing
+    )
+    uri = filepath2uri(script_path)
+    rootUri = filepath2uri(root_path)
+    diagnostics = Diagnostic[]
+    withserver(; rootUri, settings) do (; writereadmsg)
+        (; raw_res) = writereadmsg(make_DidOpenTextDocumentNotification(uri, code))
+        @test raw_res isa PublishDiagnosticsNotification
+        append!(diagnostics, raw_res.params.diagnostics)
+    end
+    return diagnostics
+end
+
+const issue464_code = """
+USE_PULSE = false
+
+if USE_PULSE
+    SIMULATE = false
+else
+    SIMULATE = true
+end
+"""
+
+function get_included_diagnostics(
+        root_path::AbstractString, main_path::AbstractString,
+        included_path::AbstractString, settings
+    )
+    main_uri = filepath2uri(main_path)
+    included_uri = filepath2uri(included_path)
+    rootUri = filepath2uri(root_path)
+    diagnostics = Diagnostic[]
+    withserver(; rootUri, settings) do (; writereadmsg)
+        (; raw_res) = writereadmsg(
+            make_DidOpenTextDocumentNotification(main_uri, read(main_path, String));
+            read=2)
+        included_response = only(filter(raw_res) do response
+            return response isa PublishDiagnosticsNotification &&
+                response.params.uri == included_uri
+        end)
+        append!(diagnostics, included_response.params.diagnostics)
+    end
+    return diagnostics
+end
+
+function concretization_settings(path::Union{Nothing,String} = nothing)
+    pattern = Dict{String,Any}("pattern" => "USE_PULSE = x_")
+    path === nothing || (pattern["path"] = path)
+    return Dict{String,Any}(
+        "full_analysis" => Dict{String,Any}(
+            "concretization_patterns" => Any[pattern]))
+end
+
+@testset HierarchicalTestSet "missing concretization diagnostic" begin
+    @testset "`missing_concretization_data` preserves assignment syntax" begin
+        for (expression, expected) in (
+                (:(RandomType::DataType = rand((Bool, Int))), "RandomType::DataType = x_"),
+                (:(global RandomType = rand((Bool, Int))), "global RandomType = x_"),
+                (:(const RandomType = rand((Bool, Int))), "const RandomType = x_"),
+                (:(outer = RandomType = rand((Bool, Int))), "outer = (RandomType = x_)"),
+                # non-standard names need `var"..."` quoting to stay parseable
+                (Expr(:(=), Symbol("USE PULSE"), :(rand(Bool))), "var\"USE PULSE\" = x_"),
+            )
+            assignment = JETLS.JET.toplevel_assignment(expression, "config.jl", 1)
+            report = JETLS.JET.MissingConcretizationErrorReport(
+                false, GlobalRef(Main, :RandomType), assignment, "use.jl", 1)
+            data = JETLS.missing_concretization_data(report)
+            @test data.pattern == expected
+            # JET strips line numbers off configured patterns before matching
+            @test JETLS.JET.striplines(Meta.parse(data.pattern)) == assignment.pattern
+            @test data.assignment_file == "config.jl"
+        end
+        # no pattern could be derived: no `data`, hence no quick fix
+        let assignment = JETLS.JET.toplevel_assignment(
+                :(let; global RandomType = rand(Bool); end), "config.jl", 1)
+            @test assignment.pattern === nothing
+            report = JETLS.JET.MissingConcretizationErrorReport(
+                false, GlobalRef(Main, :RandomType), assignment, "use.jl", 1)
+            @test JETLS.missing_concretization_data(report) === nothing
+        end
+        let report = JETLS.JET.MissingConcretizationErrorReport(
+                false, GlobalRef(Main, :RandomType), nothing, "use.jl", 1)
+            @test JETLS.missing_concretization_data(report) === nothing
+        end
+    end
+
+    @testset "diagnostic reported for unconcretized global" begin
+        mktempdir() do dir
+            script_path = joinpath(dir, "issue464.jl")
+            write(script_path, issue464_code)
+            diagnostics = get_open_diagnostics(dir, script_path, issue464_code)
+            diag = only(filter(d -> d.code == JETLS.TOPLEVEL_MISSING_CONCRETIZATION_CODE, diagnostics))
+            @test diag.data isa MissingConcretizationData
+            @test diag.data.name == "USE_PULSE"
+            @test diag.data.pattern == "USE_PULSE = x_"
+            @test diag.data.assignment_file == script_path
+        end
+    end
+
+    # writing a pattern that covers the enclosing statement is left to the user, so no
+    # `data` is attached and no quick fix is offered; the message still locates it
+    @testset "no `data` when no pattern can be derived" begin
+        mktempdir() do dir
+            script_path = joinpath(dir, "nested.jl")
+            code = """
+                let
+                    global USE_PULSE = rand(Bool)
+                end
+
+                if USE_PULSE
+                    SIMULATE = false
+                else
+                    SIMULATE = true
+                end
+                """
+            write(script_path, code)
+            diagnostics = get_open_diagnostics(dir, script_path, code)
+            diag = only(filter(d -> d.code == JETLS.TOPLEVEL_MISSING_CONCRETIZATION_CODE, diagnostics))
+            @test diag.data === nothing
+            @test occursin("could not derive one from the statement holding that", diag.message)
+            # the `let` statement, while the diagnostic is anchored at the use site
+            @test occursin("the assignment at $script_path:1", diag.message)
+            @test diag.range.start.line == 4
+        end
+    end
+
+    @testset "suppressed by `.JETLSConfig.toml`" begin
+        mktempdir() do dir
+            script_path = joinpath(dir, "issue464.jl")
+            write(script_path, issue464_code)
+            write(joinpath(dir, ".JETLSConfig.toml"), """
+                [[full_analysis.concretization_patterns]]
+                pattern = "USE_PULSE = x_"
+                """)
+            diagnostics = get_open_diagnostics(dir, script_path, issue464_code)
+            @test !any(d -> d.code == JETLS.TOPLEVEL_MISSING_CONCRETIZATION_CODE, diagnostics)
+        end
+    end
+
+    @testset "suppressed by LSP settings" begin
+        mktempdir() do dir
+            script_path = joinpath(dir, "issue464.jl")
+            write(script_path, issue464_code)
+            settings = concretization_settings("issue464.jl")
+            diagnostics = get_open_diagnostics(dir, script_path, issue464_code; settings)
+            @test !any(d -> d.code == JETLS.TOPLEVEL_MISSING_CONCRETIZATION_CODE, diagnostics)
+        end
+    end
+
+    @testset "pattern `path` scoping with `include`" begin
+        mktempdir() do dir
+            main_path = joinpath(dir, "main.jl")
+            included_path = joinpath(dir, "config.jl")
+            write(main_path, "include(\"config.jl\")\n")
+            write(included_path, issue464_code)
+
+            @testset "path of the includer does not match" begin
+                diagnostics = get_included_diagnostics(dir, main_path, included_path, concretization_settings("main.jl"))
+                @test any(d -> d.code == JETLS.TOPLEVEL_MISSING_CONCRETIZATION_CODE, diagnostics)
+            end
+
+            @testset "path of the included file matches" begin
+                diagnostics = get_included_diagnostics(dir, main_path, included_path, concretization_settings("config.jl"))
+                @test !any(d -> d.code == JETLS.TOPLEVEL_MISSING_CONCRETIZATION_CODE, diagnostics)
+            end
+        end
+    end
+
+    @testset "configured patterns do not apply outside the workspace" begin
+        mktempdir() do dir
+            workspace = joinpath(dir, "workspace")
+            mkpath(workspace)
+            main_path = joinpath(workspace, "main.jl")
+            included_path = joinpath(dir, "config.jl")
+            write(main_path, "include($(repr(included_path)))\n")
+            write(included_path, issue464_code)
+            for settings in (
+                    concretization_settings(),
+                    concretization_settings(replace(included_path, '\\' => '/')),
+                )
+                diagnostics = get_included_diagnostics(workspace, main_path, included_path, settings)
+                @test any(d -> d.code == JETLS.TOPLEVEL_MISSING_CONCRETIZATION_CODE, diagnostics)
+            end
+        end
+    end
+end
+
 @testset "inference diagnostic (script analysis)" begin
     scriptcode = """
     struct MyStruct

--- a/test/test_diagnostic.jl
+++ b/test/test_diagnostic.jl
@@ -167,13 +167,14 @@ end
     @testset "diagnostic reported for unconcretized global" begin
         mktempdir() do dir
             script_path = joinpath(dir, "issue464.jl")
+            expected_path = uri2filename(filepath2uri(script_path))
             write(script_path, issue464_code)
             diagnostics = get_open_diagnostics(dir, script_path, issue464_code)
             diag = only(filter(d -> d.code == JETLS.TOPLEVEL_MISSING_CONCRETIZATION_CODE, diagnostics))
             @test diag.data isa MissingConcretizationData
             @test diag.data.name == "USE_PULSE"
             @test diag.data.pattern == "USE_PULSE = x_"
-            @test diag.data.assignment_file == script_path
+            @test diag.data.assignment_file == expected_path
         end
     end
 
@@ -182,6 +183,7 @@ end
     @testset "no `data` when no pattern can be derived" begin
         mktempdir() do dir
             script_path = joinpath(dir, "nested.jl")
+            expected_path = uri2filename(filepath2uri(script_path))
             code = """
                 let
                     global USE_PULSE = rand(Bool)
@@ -199,7 +201,7 @@ end
             @test diag.data === nothing
             @test occursin("could not derive one from the statement holding that", diag.message)
             # the `let` statement, while the diagnostic is anchored at the use site
-            @test occursin("the assignment at $script_path:1", diag.message)
+            @test occursin("the assignment at $expected_path:1", diag.message)
             @test diag.range.start.line == 4
         end
     end

--- a/test/test_diagnostic.jl
+++ b/test/test_diagnostic.jl
@@ -175,6 +175,12 @@ end
             @test diag.data.name == "USE_PULSE"
             @test diag.data.pattern == "USE_PULSE = x_"
             @test diag.data.assignment_file == expected_path
+            @test occursin("assignment at $expected_path:1", diag.message)
+            @test occursin("`full_analysis.concretization_patterns`", diag.message)
+            @test occursin("`.JETLSConfig.toml`", diag.message)
+            @test occursin("preferred quick fix", diag.message)
+            @test occursin("derived pattern `USE_PULSE = x_`", diag.message)
+            @test !occursin("report_file", diag.message)
         end
     end
 
@@ -199,9 +205,10 @@ end
             diagnostics = get_open_diagnostics(dir, script_path, code)
             diag = only(filter(d -> d.code == JETLS.TOPLEVEL_MISSING_CONCRETIZATION_CODE, diagnostics))
             @test diag.data === nothing
-            @test occursin("could not derive one from the statement holding that", diag.message)
+            @test occursin("`.JETLSConfig.toml` manually", diag.message)
+            @test occursin("could not derive a safe pattern", diag.message)
             # the `let` statement, while the diagnostic is anchored at the use site
-            @test occursin("the assignment at $expected_path:1", diag.message)
+            @test occursin("assignment at $expected_path:1", diag.message)
             @test diag.range.start.line == 4
         end
     end

--- a/test/test_did_change_watched_files.jl
+++ b/test/test_did_change_watched_files.jl
@@ -208,6 +208,28 @@ end
     end
 end
 
+@testset "config changes requeue initial analysis" begin
+    mktempdir() do tmpdir
+        script_path = joinpath(tmpdir, "script.jl")
+        script_uri = filepath2uri(script_path)
+        write(script_path, "x = 1\n")
+        rootUri = filepath2uri(tmpdir)
+
+        withserver(; rootUri, capabilities=CLIENT_CAPABILITIES) do (; server)
+            JETLS.stop_analysis_worker(server)
+            manager = server.state.analysis_manager
+            entry = JETLS.ScriptAnalysisEntry(script_uri)
+            JETLS.schedule_analysis!(server, script_uri, entry, #=invalidate=#false;
+                debounce=0.0, notify_diagnostics=false)
+
+            @test JETLS.get_analysis_info(manager, script_uri) === nothing
+            generation = JETLS.get_generation(manager, entry)
+            JETLS.request_reanalysis_for_tracked_entries!(server)
+            @test JETLS.get_generation(manager, entry) == generation + 1
+        end
+    end
+end
+
 @testset "DidChangeWatchedFilesNotification without config file" begin
     mktempdir() do tmpdir
         rootUri = filepath2uri(tmpdir)

--- a/test/test_did_change_watched_files.jl
+++ b/test/test_did_change_watched_files.jl
@@ -175,6 +175,39 @@ const TESTRUNNER_DEFAULT = JETLS.get_config(JETLS.ConfigManager(JETLS.ConfigMana
     end
 end
 
+@testset "concretization pattern changes trigger reanalysis" begin
+    mktempdir() do tmpdir
+        script_path = joinpath(tmpdir, "script.jl")
+        script_uri = filepath2uri(script_path)
+        write(script_path, "x = 1\n")
+        rootUri = filepath2uri(tmpdir)
+
+        withserver(; rootUri, capabilities=CLIENT_CAPABILITIES) do (; writereadmsg, server)
+            (; raw_res) = writereadmsg(
+                make_DidOpenTextDocumentNotification(script_uri, "x = 1\n"))
+            @test raw_res isa PublishDiagnosticsNotification
+
+            manager = server.state.analysis_manager
+            analysis_info = JETLS.get_analysis_info(manager, script_uri)
+            @test analysis_info isa JETLS.AnalysisResult
+            generation = JETLS.get_generation(manager, analysis_info.entry)
+
+            config_path = joinpath(tmpdir, ".JETLSConfig.toml")
+            write(config_path, """
+                [[full_analysis.concretization_patterns]]
+                pattern = "x = x_"
+                """)
+            notification = DidChangeWatchedFilesNotification(;
+                params = DidChangeWatchedFilesParams(;
+                    changes = [FileEvent(;
+                        uri=filepath2uri(config_path), type=FileChangeType.Created)]))
+            writereadmsg(notification; read=3)
+
+            @test JETLS.get_generation(manager, analysis_info.entry) == generation + 1
+        end
+    end
+end
+
 @testset "DidChangeWatchedFilesNotification without config file" begin
     mktempdir() do tmpdir
         rootUri = filepath2uri(tmpdir)

--- a/test/utils/test_path.jl
+++ b/test/utils/test_path.jl
@@ -17,8 +17,7 @@ using JETLS: JETLS
     @testset "built-in function paths" begin
         m = only(methods(sin,(Float64,)))
 
-        let file = m.file
-            filepath = JETLS.to_full_path(m.file)
+        let filepath = JETLS.to_full_path(m.file)
             @test isabspath(filepath)
             @test normpath(filepath) == filepath
             @test isfile(filepath)
@@ -26,8 +25,7 @@ using JETLS: JETLS
             # Check that fix_build_path is applied correctly
             @test !occursin("/usr/share/julia/", filepath)
         end
-        let (file, line) = Base.updated_methodloc(m)
-            filepath = JETLS.to_full_path(m.file)
+        let filepath = JETLS.to_full_path(m.file)
             @test isabspath(filepath)
             @test normpath(filepath) == filepath
             @test isfile(filepath)
@@ -196,6 +194,19 @@ end
         @test JETLS.glob_candidate_path(
             "C:\\Users\\Foo\\Project\\src\\file.jl",
             "c:/users/foo/project") == "src/file.jl"
+    end
+end
+
+@testset "glob path utilities" begin
+    let path = "examples/[case]?*.jl"
+        escaped = JETLS.escape_path_for_glob(path)
+        @test escaped == "examples/\\[case\\]\\?\\*.jl"
+        matcher = JETLS.Glob.FilenameMatch(escaped, "dp")
+        @test occursin(matcher, path)
+        @test !occursin(matcher, "examples/case1.jl")
+    end
+    let path = "src/config.jl"
+        @test JETLS.escape_path_for_glob(path) == path
     end
 end
 

--- a/test/utils/test_toml.jl
+++ b/test/utils/test_toml.jl
@@ -1,0 +1,51 @@
+module test_toml
+
+using Test
+using JETLS: JETLS, TOML
+
+function array_content_start(text::String)
+    open_bracket = findfirst(==('['), text)::Int
+    return nextind(text, open_bracket)
+end
+
+@testset "format_toml_inline_table" begin
+    table = Dict{String,Any}(
+        "pattern" => "A\nB\t\u0001\\\"雪",
+        "path" => "src/A\nB\t\u0001\\\"雪.jl",
+        "enabled" => true)
+    text = JETLS.format_toml_inline_table(table)
+    @test only(TOML.parse("entries = [$text]")["entries"]) == table
+end
+
+@testset "toml_array_entry_insertion" begin
+    entry = "{ value = 2 }"
+
+    let text = "entries = []", content_start = array_content_start(text)
+        @test JETLS.toml_array_entry_insertion(
+            text, content_start, entry, #=isempty_array=#true) ==
+            (content_start, entry)
+    end
+
+    let text = "entries = [{ value = 1 }]", content_start = array_content_start(text)
+        @test JETLS.toml_array_entry_insertion(
+            text, content_start, entry, #=isempty_array=#false) ==
+            (content_start, entry * ", ")
+    end
+
+    let text = "entries = [\n    ]", content_start = array_content_start(text)
+        close_bracket = findfirst(==(']'), text)::Int
+        @test JETLS.toml_array_entry_insertion(
+            text, content_start, entry, #=isempty_array=#true) ==
+            (close_bracket, "\n    $entry\n    ")
+    end
+
+    let text = "entries = [\r\n\t{ value = 1 },\r\n]",
+        content_start = array_content_start(text)
+        first_entry = findfirst(==('{'), text)::Int
+        @test JETLS.toml_array_entry_insertion(
+            text, content_start, entry, #=isempty_array=#false) ==
+            (first_entry, "\r\n\t$entry,\r\n\t")
+    end
+end
+
+end # module test_toml


### PR DESCRIPTION
## Summary

JETLS previously reported missing top-level concrete values through the generic `toplevel/error` diagnostic, with remediation guidance that referred to JET's direct API and could not be configured through JETLS.

This PR adds a dedicated `toplevel/missing-concretization` diagnostic and introduces `full_analysis.concretization_patterns` for `.JETLSConfig.toml` and LSP settings.

```toml
[[full_analysis.concretization_patterns]]
pattern = "USE_PULSE = x_"
path = "src/config.jl"
```

Each entry accepts a MacroTools expression pattern and an optional workspace-relative path glob. Configured patterns supplement JET's built-in patterns and apply only to files inside the workspace.

The new `toplevel/missing-concretization` diagnostic provides a preferred quick fix that creates or updates `.JETLSConfig.toml`. The generated pattern preserves the relevant assignment syntax and is scoped to the file containing the assignment, which may differ from the file containing the diagnostic.

Changes to analysis-related configuration automatically trigger reanalysis, including when the initial analysis is still queued or running.

Matching top-level expressions are evaluated in the JETLS analysis process and may have side effects, so patterns should be kept as specific as possible.

## Additional changes

- Added configuration schemas and client metadata for the new setting.
- Added documentation for configuring patterns and using the quick fix.
- Added focused coverage for configuration parsing, diagnostics, code actions, path matching, TOML editing utilities (offering a support for existing `.JETLSConfig.toml` files that represent `concretization_patterns` as inline arrays.), and configuration-triggered reanalysis.

----

Closes https://github.com/aviatesk/JETLS.jl/issues/464
