### PR TITLE
document-sync: Ignore unsupported text documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed crashes and incorrect synchronization state when language clients send text-document notifications for unsupported files, such as unrelated TOML files.
+
 - Hover and completion no longer append Base's auto-generated type summary for global bindings, matching how local bindings have always been rendered.
 
 - Fixed hover for script globals whose values full-analysis only tracks abstractly: hover no longer leaks the internal `JET.AbstractBindingState` placeholder and now shows the analyzed binding type (e.g. `release_commit :: String`) and any attached docstring.

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -81,7 +81,7 @@ function handle_DidOpenTextDocumentNotification(server::Server, msg::DidOpenText
     uri = textDocument.uri
     is_text_document_content_uri(uri) &&
         return mark_text_document_content_opened!(server, uri) # turn on the `opened` flag
-    @assert textDocument.languageId == "julia"
+    textDocument.languageId == "julia" || return nothing
     parsed_stream = ParseStream!(textDocument.text)
     cache_file_info!(server, uri, textDocument.version, parsed_stream)
     cache_saved_file_info!(server.state, uri, parsed_stream)
@@ -94,10 +94,11 @@ function handle_DidChangeTextDocumentNotification(server::Server, msg::DidChange
     uri = textDocument.uri
     # Read-only `jetls-*:` virtual documents never carry user edits to sync, so just ignore it.
     is_text_document_content_uri(uri) && return nothing
+    text = last(contentChanges).text
+    is_synchronized(server.state, uri) || return nothing
     for contentChange in contentChanges
         @assert contentChange.range === contentChange.rangeLength === nothing # since `change = TextDocumentSyncKind.Full`
     end
-    text = last(contentChanges).text
     cache_file_info!(server, uri, textDocument.version, text)
     # Unsaved buffers (untitled: scheme) never receive didSave, so trigger analysis
     # on every content change with a longer debounce to avoid excessive re-analysis.
@@ -107,13 +108,7 @@ end
 function handle_DidSaveTextDocumentNotification(server::Server, msg::DidSaveTextDocumentNotification)
     uri = msg.params.textDocument.uri
     cache = load(server.state.saved_file_cache)
-    if !haskey(cache, uri)
-        # Some language client implementations (in this case Zed) appear to be
-        # sending `textDocument/didSave` notifications for arbitrary text documents,
-        # so we add a save guard for such cases.
-        @static JETLS_DEV_MODE && @warn "Received textDocument/didSave for unopened or unsupported document" uri
-        return nothing
-    end
+    haskey(cache, uri) || return nothing
     text = msg.params.text
     if !(text isa String)
         @warn """
@@ -131,6 +126,7 @@ function handle_DidCloseTextDocumentNotification(server::Server, msg::DidCloseTe
     uri = msg.params.textDocument.uri
     is_text_document_content_uri(uri) &&
         return mark_text_document_content_closed!(server, uri) # turn off the `opened` flag
+    is_synchronized(server.state, uri) || return nothing
     store!(server.state.file_cache) do cache
         Base.delete(cache, uri), nothing
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,7 @@ end
     @testset "config" include("test_config.jl")
     @testset "URIs2" include("test_URIs2.jl")
     @testset "registration" include("test_registration.jl")
+    @testset "document synchronization" include("test_document_synchronization.jl")
     @testset "completions" include("test_completions.jl")
     @testset "signature help" include("test_signature_help.jl")
     @testset "declaration" include("test_declaration.jl")

--- a/test/test_document_synchronization.jl
+++ b/test/test_document_synchronization.jl
@@ -1,0 +1,44 @@
+module test_document_synchronization
+
+using Test
+using JETLS
+using JETLS.LSP
+using JETLS.LSP.URIs2: filepath2uri
+
+@testset "unsupported text documents are ignored" begin
+    mktempdir() do dir
+        server = JETLS.Server()
+        state = server.state
+        uri = filepath2uri(joinpath(dir, "Manifest.toml"))
+
+        open_notification = DidOpenTextDocumentNotification(;
+            params = DidOpenTextDocumentParams(;
+                textDocument = TextDocumentItem(;
+                    uri, languageId="toml", version=1, text="[deps]\n")))
+        @test JETLS.handle_DidOpenTextDocumentNotification(server, open_notification) === nothing
+        @test !JETLS.is_synchronized(state, uri)
+        @test !haskey(JETLS.load(state.saved_file_cache), uri)
+
+        change_notification = DidChangeTextDocumentNotification(;
+            params = DidChangeTextDocumentParams(;
+                textDocument = VersionedTextDocumentIdentifier(; uri, version=2),
+                contentChanges = TextDocumentContentChangeEvent[
+                    TextDocumentContentChangeEvent(; text="[compat]\n")]))
+        @test JETLS.handle_DidChangeTextDocumentNotification(server, change_notification) === nothing
+        @test !JETLS.is_synchronized(state, uri)
+
+        save_notification = DidSaveTextDocumentNotification(;
+            params = DidSaveTextDocumentParams(;
+                textDocument = TextDocumentIdentifier(; uri), text="[compat]\n"))
+        @test JETLS.handle_DidSaveTextDocumentNotification(server, save_notification) === nothing
+        @test !haskey(JETLS.load(state.saved_file_cache), uri)
+
+        close_notification = DidCloseTextDocumentNotification(;
+            params = DidCloseTextDocumentParams(;
+                textDocument = TextDocumentIdentifier(; uri)))
+        @test JETLS.handle_DidCloseTextDocumentNotification(server, close_notification) === nothing
+        @test !JETLS.is_synchronized(state, uri)
+    end
+end
+
+end # module test_document_synchronization


### PR DESCRIPTION
Clients without dynamic document synchronization receive a static `textDocumentSync` capability, which cannot carry a document selector. The client therefore decides which documents to send. This matters as JETLS begins synchronizing multiple languages, such as TOML config files, and for editor integrations that can express only a broad document scope: unrelated documents may reach the same handlers. Treating every notification as Julia source could trip the `languageId` assertion or pollute the file caches.

Ignore unsupported `didOpen` notifications and require a prior accepted open before handling subsequent change, save, and close notifications. Keep `.JETLSConfig.toml` and server-provided virtual documents on their dedicated synchronization paths.

Add lifecycle coverage for an unsupported TOML document and document the user-visible fix in the changelog.