### PR TITLE
server: Stop `get_file_info` polling for rejected documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed crashes and incorrect synchronization state when language clients send text-document notifications for unsupported files, such as unrelated TOML files.
 
+- Fixed delays when clients send `textDocument/*` requests for unsupported files. Such requests now return promptly once JETLS determines that the document is not supported for synchronization.
+
 - Hover and completion no longer append Base's auto-generated type summary for global bindings, matching how local bindings have always been rendered.
 
 - Fixed hover for script globals whose values full-analysis only tracks abstractly: hover no longer leaks the internal `JET.AbstractBindingState` placeholder and now shows the analyzed binding type (e.g. `release_commit :: String`) and any attached docstring.

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -76,12 +76,33 @@ function cache_saved_file_info!(state::ServerState, uri::URI, parsed_stream::JS.
     end
 end
 
+is_rejected_text_document(state::ServerState, uri::URI) =
+    haskey(load(state.rejected_text_documents), uri)
+
+function mark_text_document_rejected!(state::ServerState, uri::URI)
+    store!(state.rejected_text_documents) do documents
+        Base.PersistentDict(documents, uri => nothing), nothing
+    end
+    return nothing
+end
+
+function delete_rejected_text_document!(state::ServerState, uri::URI)
+    return store!(state.rejected_text_documents) do documents
+        haskey(documents, uri) || return documents, false
+        return Base.delete(documents, uri), true
+    end
+end
+
 function handle_DidOpenTextDocumentNotification(server::Server, msg::DidOpenTextDocumentNotification)
     textDocument = msg.params.textDocument
     uri = textDocument.uri
     is_text_document_content_uri(uri) &&
         return mark_text_document_content_opened!(server, uri) # turn on the `opened` flag
-    textDocument.languageId == "julia" || return nothing
+    if textDocument.languageId != "julia"
+        mark_text_document_rejected!(server.state, uri)
+        return nothing
+    end
+    delete_rejected_text_document!(server.state, uri)
     parsed_stream = ParseStream!(textDocument.text)
     cache_file_info!(server, uri, textDocument.version, parsed_stream)
     cache_saved_file_info!(server.state, uri, parsed_stream)
@@ -126,6 +147,7 @@ function handle_DidCloseTextDocumentNotification(server::Server, msg::DidCloseTe
     uri = msg.params.textDocument.uri
     is_text_document_content_uri(uri) &&
         return mark_text_document_content_closed!(server, uri) # turn off the `opened` flag
+    delete_rejected_text_document!(server.state, uri) && return nothing
     is_synchronized(server.state, uri) || return nothing
     store!(server.state.file_cache) do cache
         Base.delete(cache, uri), nothing

--- a/src/types.jl
+++ b/src/types.jl
@@ -847,6 +847,7 @@ end
 # Type aliases for document-synchronization caches using `SWContainer` (sequential-only updates)
 const FileCache = SWContainer{Base.PersistentDict{URI,FileInfo}, SWStats}
 const SavedFileCache = SWContainer{Base.PersistentDict{URI,SavedFileInfo}, SWStats}
+const RejectedTextDocuments = SWContainer{Base.PersistentDict{URI,Nothing}, SWStats}
 const NotebookCache = SWContainer{Base.PersistentDict{URI,NotebookInfo}, SWStats}
 const CellToNotebookMap = SWContainer{Base.PersistentDict{URI,URI}, SWStats} # cell URI -> notebook URI
 
@@ -917,6 +918,8 @@ end
 mutable struct ServerState
     const file_cache::FileCache # syntactic analysis cache (synced with `textDocument/didChange`)
     const saved_file_cache::SavedFileCache # syntactic analysis cache (synced with `textDocument/didSave`)
+    # Prevent requests for documents rejected by `didOpen` from waiting for a `FileInfo`.
+    const rejected_text_documents::RejectedTextDocuments
     const notebook_cache::NotebookCache # notebook document cache (synced with `notebookDocument/did*`), mapping notebook URIs to their notebook info
     const cell_to_notebook::CellToNotebookMap # maps cell URIs to their notebook URI
     # Cache for files not synced via document-synchronization (unsynced files).
@@ -958,6 +961,7 @@ mutable struct ServerState
         return new(
             #=file_cache=# FileCache(),
             #=saved_file_cache=# SavedFileCache(),
+            #=rejected_text_documents=# RejectedTextDocuments(),
             #=notebook_cache=# NotebookCache(),
             #=cell_to_notebook=# CellToNotebookMap(),
             #=unsynced_file_cache=# UnsyncedFileCache(),

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -200,6 +200,7 @@ function get_file_info(
     start = time()
     request_id = objectid(cancel_flag) # Each request uses a unique `cancel_flag`, so this objectid can be used as a request-unique ID
     while true
+        may_have_file_info(s, uri) || return nothing
         is_cancelled(cancel_flag) && return request_cancelled_error(;
             data = cancelled_error_data)
         cache = get(load(s.file_cache), uri, nothing)
@@ -228,11 +229,12 @@ get_file_info(s::ServerState, t::TextDocumentIdentifier, cancel_flag::AbstractCa
 
 Return `true` if `uri` could ever be backed by a `FileInfo`, i.e. it is a saved (`file:`)
 or unsaved (`untitled:`/`buffer:`) document, or an already-registered notebook cell.
-Any other URI (e.g. server-provided `jetls:` virtual documents, or requests from clients
-that ignore the registered document selectors) can never receive a `FileInfo`, so the
-polling [`get_file_info`](@ref) returns early instead of blocking until its timeout.
+Text documents explicitly rejected by `textDocument/didOpen` and any other URI that cannot
+receive a `FileInfo` return `false`, so polling [`get_file_info`](@ref) exits without
+waiting for its timeout.
 """
 function may_have_file_info(s::ServerState, uri::URI)
+    is_rejected_text_document(s, uri) && return false
     uri.scheme == "file" && return true
     isunsaveduri(uri) && return true
     return get_notebook_uri_for_cell(s, uri) !== nothing

--- a/test/test_document_synchronization.jl
+++ b/test/test_document_synchronization.jl
@@ -18,6 +18,8 @@ using JETLS.LSP.URIs2: filepath2uri
         @test JETLS.handle_DidOpenTextDocumentNotification(server, open_notification) === nothing
         @test !JETLS.is_synchronized(state, uri)
         @test !haskey(JETLS.load(state.saved_file_cache), uri)
+        @test JETLS.is_rejected_text_document(state, uri)
+        @test !JETLS.may_have_file_info(state, uri)
 
         change_notification = DidChangeTextDocumentNotification(;
             params = DidChangeTextDocumentParams(;
@@ -33,11 +35,29 @@ using JETLS.LSP.URIs2: filepath2uri
         @test JETLS.handle_DidSaveTextDocumentNotification(server, save_notification) === nothing
         @test !haskey(JETLS.load(state.saved_file_cache), uri)
 
+        delayed_uri = filepath2uri(joinpath(dir, "Project.toml"))
+        waiter = Threads.@spawn JETLS.get_file_info(
+            state, delayed_uri, JETLS.CancelFlag(false); timeout=5.0)
+        @test timedwait(() -> istaskstarted(waiter), 1.0) == :ok
+        sleep(0.1)
+        @test !istaskdone(waiter)
+        delayed_open = DidOpenTextDocumentNotification(;
+            params = DidOpenTextDocumentParams(;
+                textDocument = TextDocumentItem(;
+                    uri = delayed_uri,
+                    languageId = "toml",
+                    version = 1,
+                    text = "[deps]\n")))
+        JETLS.handle_DidOpenTextDocumentNotification(server, delayed_open)
+        @test timedwait(() -> istaskdone(waiter), 1.0) == :ok
+        @test istaskdone(waiter) && fetch(waiter) === nothing
+
         close_notification = DidCloseTextDocumentNotification(;
             params = DidCloseTextDocumentParams(;
                 textDocument = TextDocumentIdentifier(; uri)))
         @test JETLS.handle_DidCloseTextDocumentNotification(server, close_notification) === nothing
         @test !JETLS.is_synchronized(state, uri)
+        @test !JETLS.is_rejected_text_document(state, uri)
     end
 end
 


### PR DESCRIPTION
Clients without dynamic registration for a text-document feature receive static provider capabilities that cannot carry JETLS's document selector. Depending on the client integration's scope, requests for unrelated `file:` documents, such as TOML files synchronized alongside Julia, can therefore reach JETLS.

Those URIs passed `may_have_file_info` because it only considered the URI scheme. Even after `didOpen` rejected a non-Julia document, request handlers could poll for up to ten seconds for a `FileInfo` that would never be created.

Track documents explicitly rejected by `didOpen`. `get_file_info` checks this state before and during polling, so an in-flight request also stops once the sequential document handler rejects its URI. The state is cleared on close or when the URI is accepted as Julia later.

Tests cover rejection lifecycle and a request already polling when the rejection is recorded. The CHANGELOG documents the avoided request delay separately from the unsupported-notification fix.