### PR TITLE
analysis: Add `reuse_native_inference` initialization option

### DIFF
--- a/.JETLSConfig.toml
+++ b/.JETLSConfig.toml
@@ -66,6 +66,9 @@ match_type = "regex"
 severity = "off"
 path = "src/testrunner/testrunner-types.jl"
 
+[initialization_options]
+reuse_native_inference = true
+
 [[initialization_options.analysis_overrides]]
 module_name = "JETLS"
 path = "src/**/*.jl"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 >
 > Note: Path glob patterns use `/` as the separator on all platforms, including Windows; backslashes are not supported as separators.
 
+### Added
+
+- Added the experimental `reuse_native_inference` [initialization option](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options) (disabled by default): when enabled, calls to methods defined outside the modules being analyzed reuse results from Julia's native inference cache instead of being analyzed recursively:
+  ```toml
+  # .JETLSConfig.toml example
+  [initialization_options]
+  reuse_native_inference = true
+  ```
+  This can substantially speed up full analysis of packages with large dependencies, provided those dependencies are precompiled, since the analysis then reuses the inference results cached in their precompiled images. Packages whose analysis time is dominated by their own code see little change. Note that analysis results may change slightly with this option, which can change the diagnostics that are reported.
+
 ## 2026-08-05
 
 - Commit: [`6dacc52`](https://github.com/aviatesk/JETLS.jl/commit/6dacc52)

--- a/docs/src/launching.md
+++ b/docs/src/launching.md
@@ -211,3 +211,32 @@ Configure initialization options in Zed's `settings.json`:
   }
 }
 ```
+
+### [Options reference](@id init-options/reference)
+
+#### [`reuse_native_inference`](@id init-options/reuse_native_inference)
+
+- **Type**: boolean
+- **Default**: `false`
+
+When enabled, calls to methods defined outside the modules being analyzed reuse
+results from Julia's native inference cache instead of being analyzed
+recursively.
+
+This may substantially speed up full analysis of packages with large
+dependencies. The reused results come from the dependencies' precompiled
+images, so the speedup requires those dependencies to be precompiled, and grows
+with how much of their code precompilation covers. Packages whose analysis time
+is dominated by their own code see little change, while those that spend much of
+it in dependencies can become several times faster.
+
+```toml
+[initialization_options]
+reuse_native_inference = true
+```
+
+Analysis results may change slightly when this option is enabled, since the
+reused results come from Julia's compiler rather than the JETLS analyzer, and
+that can change the diagnostics that are reported. Diagnostics for the modules
+being analyzed are unaffected in practice, but this remains an experimental
+option that may be removed or changed in future releases.

--- a/jetls-client/package.json
+++ b/jetls-client/package.json
@@ -136,6 +136,11 @@
               },
               "markdownDescription": "Override full analysis behavior for specific file patterns. Primarily used as a temporary workaround to disable analysis for files affected by memory leak issues. Each override specifies a glob pattern, optionally a module name, and can opt back into full analysis. Note: This is an experimental feature that may be removed or changed in future versions.",
               "type": "array"
+            },
+            "reuse_native_inference": {
+              "default": false,
+              "markdownDescription": "Reuse results from Julia's native inference cache for calls to methods defined outside the modules being analyzed, instead of analyzing them recursively. This can substantially speed up analysis of packages with large dependency surfaces, but analysis results may change slightly, which can change the diagnostics that are reported. See [`reuse_native_inference`](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options/reuse_native_inference). Note: This is an experimental feature that may be removed or changed in future versions.",
+              "type": "boolean"
             }
           },
           "order": 4,

--- a/schemas/config-toml.schema.json
+++ b/schemas/config-toml.schema.json
@@ -221,6 +221,11 @@
             "type": "object"
           },
           "type": "array"
+        },
+        "reuse_native_inference": {
+          "default": false,
+          "description": "Reuse results from Julia's native inference cache for calls to methods defined outside the modules being analyzed, instead of analyzing them recursively. This can substantially speed up analysis of packages with large dependency surfaces, but analysis results may change slightly, which can change the diagnostics that are reported. See [`reuse_native_inference`](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options/reuse_native_inference). Note: This is an experimental feature that may be removed or changed in future versions.",
+          "type": "boolean"
         }
       },
       "required": [],

--- a/schemas/description.toml
+++ b/schemas/description.toml
@@ -34,6 +34,7 @@ executable_range = "Path to custom formatter executable for range formatting. Sh
 
 [InitOptions]
 analysis_overrides = "Override full analysis behavior for specific file patterns. Primarily used as a temporary workaround to disable analysis for files affected by memory leak issues. Each override specifies a glob pattern, optionally a module name, and can opt back into full analysis. Note: This is an experimental feature that may be removed or changed in future versions."
+reuse_native_inference = "Reuse results from Julia's native inference cache for calls to methods defined outside the modules being analyzed, instead of analyzing them recursively. This can substantially speed up analysis of packages with large dependency surfaces, but analysis results may change slightly, which can change the diagnostics that are reported. See [`reuse_native_inference`](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options/reuse_native_inference). Note: This is an experimental feature that may be removed or changed in future versions."
 
 [AnalysisOverride]
 path = "Glob pattern to match files for which analysis should be overridden (e.g., `src/**/*.jl`, `test/**/*.jl`). Patterns are matched against file paths relative to the workspace root. Use `/` as the path separator on all platforms, including Windows; backslashes are not interpreted as path separators. Supports globstar (`**`) for matching directories recursively."

--- a/schemas/init-options.schema.json
+++ b/schemas/init-options.schema.json
@@ -1,5 +1,8 @@
 {
   "$defs": {
+    "Core.Bool": {
+      "type": "boolean"
+    },
     "Core.String": {
       "type": "string"
     },
@@ -35,6 +38,11 @@
             "type": "object"
           },
           "type": "array"
+        },
+        "reuse_native_inference": {
+          "$ref": "#/$defs/Core.Bool",
+          "default": false,
+          "description": "Reuse results from Julia's native inference cache for calls to methods defined outside the modules being analyzed, instead of analyzing them recursively. This can substantially speed up analysis of packages with large dependency surfaces, but analysis results may change slightly, which can change the diagnostics that are reported. See [`reuse_native_inference`](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options/reuse_native_inference). Note: This is an experimental feature that may be removed or changed in future versions."
         }
       },
       "type": "object"

--- a/src/analysis/Analyzer.jl
+++ b/src/analysis/Analyzer.jl
@@ -113,6 +113,15 @@ struct LSAnalyzer <: ToplevelAbstractAnalyzer
     """
     report_target_modules::Union{Nothing,Set{Module}}
 
+    """
+        `LSAnalyzer.reuse_native_inference::Bool`
+
+    When enabled, calls to methods defined outside `report_target_modules` reuse results
+    from Julia's native inference cache instead of being analyzed recursively.
+    See [`is_native_boundary`](@ref).
+    """
+    reuse_native_inference::Bool
+
     invariable_analysis_hash::UInt
 
     """
@@ -123,11 +132,12 @@ struct LSAnalyzer <: ToplevelAbstractAnalyzer
     """
     function LSAnalyzer(
             state::AnalyzerState, analysis_token::AnalysisToken,
-            report_target_modules::Union{Nothing,Set{Module}},
+            report_target_modules::Union{Nothing,Set{Module}}, reuse_native_inference::Bool,
             invariable_analysis_hash::UInt
         )
         method_table = CC.CachedMethodTable(CC.OverlayMethodTable(state.world, jetls_method_table))
-        return new(state, analysis_token, method_table, report_target_modules, invariable_analysis_hash)
+        return new(state, analysis_token, method_table, report_target_modules,
+            reuse_native_inference, invariable_analysis_hash)
     end
 end
 
@@ -136,7 +146,8 @@ const global_mode_hash = rand(UInt)
 const lagacy_mode_hash = rand(UInt)
 
 """
-    LSAnalyzer(entry::AnalysisEntry, state::AnalyzerState; report_target_modules=missing)
+    LSAnalyzer(entry::AnalysisEntry, state::AnalyzerState;
+               report_target_modules=missing, reuse_native_inference=false)
         -> analyzer::LSAnalyzer
 
 Internal utility constructor for [`analyzer::LSAnalyzer`](@ref), which initializes
@@ -151,7 +162,8 @@ All new analysis entries should construct `LSAnalyzer` through this method.
 """
 function LSAnalyzer(
         @nospecialize(entry::AnalysisEntry), state::AnalyzerState;
-        report_target_modules = missing
+        report_target_modules = missing,
+        reuse_native_inference::Bool = false
     )
     # N.B. Separate the cache by the identity of `report_target_modules`.
     if report_target_modules === missing
@@ -171,10 +183,15 @@ function LSAnalyzer(
             report_target_modules_hash = hash(mod, report_target_modules_hash)
         end
     end
-    invariable_analysis_hash = JET.compute_hash(entry, report_target_modules_hash)
+    # N.B. `reuse_native_inference` participates in the cache key: reports are cached within
+    # `CodeInstance`s, and the boundary suppresses those of out-of-target callees, so
+    # results must never be shared across the two settings.
+    invariable_analysis_hash =
+        JET.compute_hash(entry, report_target_modules_hash, reuse_native_inference)
     analysis_cache_key = JET.compute_hash(state.inf_params, invariable_analysis_hash)
     analysis_token = @lock LS_ANALYZER_CACHE_LOCK get!(AnalysisToken, LS_ANALYZER_CACHE, analysis_cache_key)
-    return LSAnalyzer(state, analysis_token, report_target_modules, invariable_analysis_hash)
+    return LSAnalyzer(state, analysis_token, report_target_modules, reuse_native_inference,
+        invariable_analysis_hash)
 end
 
 # AbstractInterpreter API
@@ -200,7 +217,8 @@ function JETInterface.AbstractAnalyzer(analyzer::LSAnalyzer, state::AnalyzerStat
     analysis_cache_key = JET.compute_hash(state.inf_params, analyzer.invariable_analysis_hash)
     report_target_modules = analyzer.report_target_modules
     analysis_token = @lock LS_ANALYZER_CACHE_LOCK get!(AnalysisToken, LS_ANALYZER_CACHE, analysis_cache_key)
-    return LSAnalyzer(state, analysis_token, report_target_modules, analyzer.invariable_analysis_hash)
+    return LSAnalyzer(state, analysis_token, report_target_modules,
+        analyzer.reuse_native_inference, analyzer.invariable_analysis_hash)
 end
 JETInterface.AnalysisToken(analyzer::LSAnalyzer) = analyzer.analysis_token
 
@@ -327,6 +345,50 @@ function CC.concrete_eval_call(
     return res.rt === Union{} ? nothing : res
 end
 end # @static if VERSION ≥ v"1.12.2"
+
+# Native-interpreter boundary (experimental)
+# ==========================================
+
+"""
+    is_native_boundary(analyzer::LSAnalyzer, method::Method) -> Bool
+
+Whether inference of a call to `method` may be served from Julia's native inference cache
+instead of being analyzed, i.e. whether `analyzer.reuse_native_inference` is enabled and
+`method` sits outside `analyzer.report_target_modules`. Reports are never collected beyond
+that boundary, so it only applies to methods whose reports would be filtered out by
+`report_target_modules` anyway.
+"""
+function is_native_boundary(analyzer::LSAnalyzer, method::Method)
+    analyzer.reuse_native_inference || return false
+    report_target_modules = analyzer.report_target_modules
+    isnothing(report_target_modules) && return false
+    return method.module ∉ report_target_modules
+end
+
+function CC.typeinf_edge(analyzer::LSAnalyzer,
+        method::Method, @nospecialize(atype), sparams::Core.SimpleVector,
+        caller::CC.InferenceState, edgecycle::Bool, edgelimited::Bool
+    )
+    if is_native_boundary(analyzer, method)
+        world = CC.get_inference_world(analyzer)
+        mi = CC.specialize_method(method, atype, sparams)
+        ci = CC.get(CC.WorldView(CC.InternalCodeCache(nothing), world), mi, nothing)
+        if ci isa Core.CodeInstance
+            rt = CC.cached_return_type(ci)
+            # `rt === Union{}` means this callee definitely errors. Let the analyzer infer
+            # it so that reports created on the callee frame (builtin errors, which surface
+            # at their in-scope call site via `collect_callee_reports!`) are not silenced.
+            if rt !== Union{}
+                effects = CC.decode_effects(ci.ipo_purity_bits)
+                return CC.Future(CC.MethodCallResult(
+                    rt, ci.exctype, effects, ci, edgecycle, edgelimited))
+            end
+        end
+    end
+    return @invoke CC.typeinf_edge(analyzer::ToplevelAbstractAnalyzer,
+        method::Method, atype::Any, sparams::Core.SimpleVector,
+        caller::CC.InferenceState, edgecycle::Bool, edgelimited::Bool)
+end
 
 # Analysis injections
 # ===================
@@ -1164,6 +1226,7 @@ end
 function LSAnalyzer(
         @nospecialize(entry::AnalysisEntry), world::UInt = Base.get_world_counter();
         report_target_modules = missing,
+        reuse_native_inference::Bool = false,
         jetconfigs...
     )
     inf_params = CC.InferenceParams(;
@@ -1175,10 +1238,11 @@ function LSAnalyzer(
         # make the situation worse.
         assume_bindings_static = true)
     state = AnalyzerState(world; inf_params, jetconfigs...)
-    return LSAnalyzer(entry, state; report_target_modules)
+    return LSAnalyzer(entry, state; report_target_modules, reuse_native_inference)
 end
 
-const LS_ANALYZER_CONFIGURATIONS = Set{Symbol}((:report_target_modules,))
+const LS_ANALYZER_CONFIGURATIONS =
+    Set{Symbol}((:report_target_modules, :reuse_native_inference))
 
 let valid_keys = JET.GENERAL_CONFIGURATIONS ∪ LS_ANALYZER_CONFIGURATIONS
     @eval JETInterface.valid_configurations(::LSAnalyzer) = $valid_keys

--- a/src/analysis/Interpreter.jl
+++ b/src/analysis/Interpreter.jl
@@ -6,7 +6,7 @@ using JuliaSyntax: JuliaSyntax as JS
 using Compiler: Compiler as CC
 using JET: JET, JuliaInterpreter
 using ..JETLS: AnalysisExecution, JETLS, JETLS_DEV_MODE, Server,
-    get_source_text, is_cancelled, send_progress, yield_to_endpoint
+    get_init_option, get_source_text, is_cancelled, send_progress, yield_to_endpoint
 using ..JETLS.URIs2
 using ..JETLS.LSP
 using ..JETLS.Analyzer
@@ -52,8 +52,10 @@ function LSInterpreter(
         activation_done::Union{Nothing,Base.Event} = nothing
     )
     request = execution.request
-    return LSInterpreter(
-        server, execution, LSAnalyzer(request.entry), Counter(), activation_done)
+    reuse_native_inference =
+        get_init_option(server.state.init_options, :reuse_native_inference)
+    analyzer = LSAnalyzer(request.entry; reuse_native_inference)
+    return LSInterpreter(server, execution, analyzer, Counter(), activation_done)
 end
 
 # `JET.ConcreteInterpreter` interface

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -1165,7 +1165,10 @@ function analyze_package_with_revise(
     end
 
     analyzer = let analyzer # avoid captured boxes
-        analyzer = LSAnalyzer(request.entry; report_target_modules) # TODO Revisit (submodules)
+        reuse_native_inference =
+            get_init_option(server.state.init_options, :reuse_native_inference)
+        # TODO Revisit (submodules)
+        analyzer = LSAnalyzer(request.entry; report_target_modules, reuse_native_inference)
         newstate = JET.AnalyzerState(JET.AnalyzerState(analyzer); world)
         JET.AbstractAnalyzer(analyzer, newstate)
     end

--- a/src/types.jl
+++ b/src/types.jl
@@ -629,15 +629,20 @@ merge_key_value(analysis_override::AnalysisOverride) = analysis_override.path
 # These are set once during the initialize request and remain constant.
 @kwdef struct InitOptions <: ConfigSection
     analysis_overrides::Maybe{Vector{AnalysisOverride}} = nothing
+    reuse_native_inference::Maybe{Bool} = nothing
 end
 @define_eq_overloads InitOptions
 function Base.show(io::IO, init_options::InitOptions)
     print(io, "InitOptions(;")
     analysis_overrides = init_options.analysis_overrides
     analysis_overrides === nothing || print(io, " analysis_overrides=", analysis_overrides)
+    reuse_native_inference = init_options.reuse_native_inference
+    reuse_native_inference === nothing ||
+        print(io, " reuse_native_inference=", reuse_native_inference)
     print(io, ")")
 end
-const DEFAULT_INIT_OPTIONS = InitOptions(; analysis_overrides=AnalysisOverride[])
+const DEFAULT_INIT_OPTIONS = InitOptions(;
+    analysis_overrides=AnalysisOverride[], reuse_native_inference=false)
 
 @kwdef struct LaTeXEmojiConfig <: ConfigSection
     strip_prefix::Maybe{Union{Missing,Bool}} = nothing # missing is used as sentinel for default setting value

--- a/test/analysis/test_Analyzer.jl
+++ b/test/analysis/test_Analyzer.jl
@@ -858,4 +858,48 @@ end
     end
 end
 
+module NativeBoundaryModule
+    # these error on the callee frame, and are surfaced at their in-scope call site
+    typeassert_error(x::Int) = x::String
+    getfield_error(x::Pair{Int,Int}) = getfield(x, :nonexistent)
+    # `precompile` puts these specializations into the native inference cache, which is
+    # what makes the regression test below exercise the boundary's cache-hit path
+    precompile(typeassert_error, (Int,))
+    precompile(getfield_error, (Pair{Int,Int},))
+end
+
+call_boundary_typeassert(x::Int) = NativeBoundaryModule.typeassert_error(x)
+call_boundary_getfield(pair::Pair{Int,Int}) = NativeBoundaryModule.getfield_error(pair)
+
+@testset HierarchicalTestSet "reuse_native_inference" begin
+    @testset "analysis cache separation" begin
+        # reports are cached within `CodeInstance`s and the boundary suppresses those of
+        # out-of-target callees, so the two settings must never share analysis results
+        enabled = JETLS.LSAnalyzer(;
+            report_target_modules=(@__MODULE__,), reuse_native_inference=true)
+        disabled = JETLS.LSAnalyzer(;
+            report_target_modules=(@__MODULE__,), reuse_native_inference=false)
+        @test JET.AnalysisToken(enabled) !== JET.AnalysisToken(disabled)
+    end
+
+    @testset "out-of-target callee errors are still reported" begin
+        # Serving an out-of-target callee from the native inference cache would silence
+        # reports created on that callee frame, so definitely erroring callees
+        # (`rt === Union{}`) must keep taking the analyzer path.
+        for reuse_native_inference in (false, true)
+            let result = analyze_call(call_boundary_typeassert, (Int,);
+                    report_target_modules=(@__MODULE__,), reuse_native_inference)
+                r = only(get_reports(result))
+                @test r isa TypeAssertErrorReport
+                @test r.expected === String && r.actual === Int
+            end
+            let result = analyze_call(call_boundary_getfield, (Pair{Int,Int},);
+                    report_target_modules=(@__MODULE__,), reuse_native_inference)
+                r = only(get_reports(result))
+                @test r isa FieldErrorReport && r.field === :nonexistent
+            end
+        end
+    end
+end
+
 end # module test_LSAnalyzer


### PR DESCRIPTION
Full analysis spends a large share of its time abstractly interpreting code outside the modules it reports on, even though reports from those frames are filtered out by `report_target_modules` anyway. For a package whose analysis is dominated by its dependencies this is close to pure overhead: analyzing JETLS itself takes 41s, of which only ~15s is attributable to its own sources.

This commit adds `reuse_native_inference`, a static initialization option that is disabled by default. When enabled, a call to a method defined outside `report_target_modules` is served from Julia's native inference cache instead of being analyzed recursively, so results already cached in the dependencies' precompiled images are reused. Analyzing JETLS itself drops from 41s to 15s; packages that spend much of their analysis in dependencies gain up to ~20%, while those dominated by their own code are unchanged.

The implementation hooks `CC.typeinf_edge` for `LSAnalyzer`, which sits below the recursion limiting of `abstract_call_method`, so the widened signature and the `edgecycle`/`edgelimited` flags computed there are preserved and propagated into the returned `MethodCallResult`. `LSAnalyzer.reuse_native_inference` participates in `invariable_analysis_hash`, since reports are cached within `CodeInstance`s and results must never be shared across the two settings.

A cached result is only reused when its return type is not `Union{}`. A callee that definitely errors keeps taking the analyzer path so that reports created on its frame, which surface at their in-scope call site through `collect_callee_reports!`, are not silenced; without this guard, a `TypeError` or `FieldError` inside a directly called out-of-target method goes unreported once that method's specialization is in the native cache.

Reusing results inferred by the native interpreter in does come with caveats.
The return types, exception types and effects that propagate back are generally not the ones `LSAnalyzer` would derive, which can change the diagnostics that are reported. A cache hit also supplies the result for the entire callee subtree, so nothing inside it is analyzed: when code in the analyzed modules is reached only through a dependency, e.g. via a callback the dependency invokes, or an overload it calls on a type that flows into it, the reports that used to be produced there simply disappear. The `rt !== Union{}` guard is clearly incomplete too, since a frame that should report a diagnostic often still has a non-empty return type, because the error is confined to one branch.

Given these limitations, the option is published as experimental and opt-in for the time being.