### PR TITLE
document-sync: Dynamically register document synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   ```
   This can substantially speed up full analysis of packages with large dependencies, provided those dependencies are precompiled, since the analysis then reuses the inference results cached in their precompiled images. Packages whose analysis time is dominated by their own code see little change. Note that analysis results may change slightly with this option, which can change the diagnostics that are reported.
 
+### Changed
+
+- Text and notebook document synchronization now use dynamic registration when supported, allowing regular text synchronization to be scoped to supported Julia buffers and server-provided virtual documents. Static fallbacks remain available for other clients.
+
 ## 2026-08-05
 
 - Commit: [`6dacc52`](https://github.com/aviatesk/JETLS.jl/commit/6dacc52)

--- a/jetls-client/jetls-client.ts
+++ b/jetls-client/jetls-client.ts
@@ -454,6 +454,9 @@ async function startLanguageServer() {
 
 
   const clientOptions: LanguageClientOptions = {
+    // Keep this selector as a static-registration fallback while jetls-client can
+    // connect to independently installed JETLS versions. Once the extension manages
+    // the `jetls` binary, rely only on server-side dynamic registration and remove it.
     documentSelector: [
       {
         scheme: "file",

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -1,3 +1,68 @@
+# TODO: Full analysis for `file:` documents is retriggered by `didSave`. Clients
+# without `textDocument.synchronization.didSave` only update the live cache on
+# `didChange`, leaving analysis stale after edits. Add a change-based fallback.
+
+const DID_OPEN_TEXT_DOCUMENT_REGISTRATION_ID = "jetls-did-open-text-document"
+const DID_OPEN_TEXT_DOCUMENT_REGISTRATION_METHOD = "textDocument/didOpen"
+const DID_CHANGE_TEXT_DOCUMENT_REGISTRATION_ID = "jetls-did-change-text-document"
+const DID_CHANGE_TEXT_DOCUMENT_REGISTRATION_METHOD = "textDocument/didChange"
+const DID_SAVE_TEXT_DOCUMENT_REGISTRATION_ID = "jetls-did-save-text-document"
+const DID_SAVE_TEXT_DOCUMENT_REGISTRATION_METHOD = "textDocument/didSave"
+const DID_CLOSE_TEXT_DOCUMENT_REGISTRATION_ID = "jetls-did-close-text-document"
+const DID_CLOSE_TEXT_DOCUMENT_REGISTRATION_METHOD = "textDocument/didClose"
+
+const JULIA_TEXT_DOCUMENT_SYNC_SELECTOR = DocumentFilter[
+    TextDocumentFilterLanguage(; language = "julia", scheme = "file"),
+    [TextDocumentFilterLanguage(; language = "julia", scheme) for scheme in UNSAVED_DOCUMENT_SCHEMES]...,
+]
+
+function text_document_sync_options(server::Server)
+    return TextDocumentSyncOptions(;
+        openClose = true,
+        change = TextDocumentSyncKind.Full,
+        save = supports(server, :textDocument, :synchronization, :didSave) ?
+            SaveOptions(; includeText = true) : nothing)
+end
+
+function text_document_sync_registrations(server::Server)
+    open_close_selector = copy(JULIA_TEXT_DOCUMENT_SYNC_SELECTOR)
+    if supports_text_document_content(server)
+        append!(open_close_selector,
+            TextDocumentFilterScheme[
+                TextDocumentFilterScheme(; scheme) for scheme in TEXT_DOCUMENT_CONTENT_SCHEMES])
+    end
+
+    registrations = Registration[
+        Registration(;
+            id = DID_OPEN_TEXT_DOCUMENT_REGISTRATION_ID,
+            method = DID_OPEN_TEXT_DOCUMENT_REGISTRATION_METHOD,
+            registerOptions = TextDocumentRegistrationOptions(;
+                documentSelector = open_close_selector)),
+        Registration(;
+            id = DID_CHANGE_TEXT_DOCUMENT_REGISTRATION_ID,
+            method = DID_CHANGE_TEXT_DOCUMENT_REGISTRATION_METHOD,
+            registerOptions = TextDocumentChangeRegistrationOptions(;
+                documentSelector = JULIA_TEXT_DOCUMENT_SYNC_SELECTOR,
+                syncKind = TextDocumentSyncKind.Full)),
+        Registration(;
+            id = DID_CLOSE_TEXT_DOCUMENT_REGISTRATION_ID,
+            method = DID_CLOSE_TEXT_DOCUMENT_REGISTRATION_METHOD,
+            registerOptions = TextDocumentRegistrationOptions(;
+                documentSelector = open_close_selector)),
+    ]
+    if supports(server, :textDocument, :synchronization, :didSave)
+        push!(
+            registrations, Registration(;
+                id = DID_SAVE_TEXT_DOCUMENT_REGISTRATION_ID,
+                method = DID_SAVE_TEXT_DOCUMENT_REGISTRATION_METHOD,
+                registerOptions = TextDocumentSaveRegistrationOptions(;
+                    documentSelector = DocumentFilter[
+                        TextDocumentFilterLanguage(; language = "julia", scheme = "file")],
+                    includeText = true)))
+    end
+    return registrations
+end
+
 function ParseStream!(s::Union{AbstractString,Vector{UInt8}})
     stream = JS.ParseStream(s)
     JS.parse!(stream; rule=:all)

--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -5,10 +5,8 @@ server capabilities and server information that should occur during initializati
 
 For server capabilities, it's preferable to register those that support dynamic/static
 registration in the `handle_InitializedNotification` handler using `RegisterCapabilityRequest`.
-On the other hand, basic server capabilities such as `textDocumentSync` must be registered here,
-and features that don't extend and support `StaticRegistrationOptions` like "completion"
-need to be registered in this handler in a case when the client does not support
-dynamic registration.
+When the client does not support dynamic registration, the corresponding static capability
+is returned from this handler instead.
 """
 function handle_InitializeRequest(
         server::Server, msg::InitializeRequest;
@@ -251,22 +249,23 @@ function handle_InitializeRequest(
     end
     state.encoding = positionEncoding
 
+    if supports(server, :textDocument, :synchronization, :dynamicRegistration)
+        textDocumentSync = nothing
+    else
+        textDocumentSync = text_document_sync_options(server)
+    end
+
+    if supports(server, :notebookDocument, :synchronization, :dynamicRegistration)
+        notebookDocumentSync = nothing
+    else
+        notebookDocumentSync = notebook_document_sync_options()
+    end
+
     result = InitializeResult(;
         capabilities = ServerCapabilities(;
             positionEncoding,
-            textDocumentSync = TextDocumentSyncOptions(;
-                openClose = true,
-                change = TextDocumentSyncKind.Full,
-                save = SaveOptions(;
-                    includeText = true)),
-            notebookDocumentSync = NotebookDocumentSyncOptions(;
-                notebookSelector = NotebookDocumentSyncOptionsNotebookSelectorItem[
-                    NotebookDocumentSyncOptionsNotebookSelectorItem(;
-                        notebook = "jupyter-notebook",
-                        cells = NotebookDocumentSyncOptionsNotebookSelectorCellsItem[
-                            NotebookDocumentSyncOptionsNotebookSelectorCellsItem(;
-                                language = "julia")])],
-                save = true),
+            textDocumentSync,
+            notebookDocumentSync,
             completionProvider,
             signatureHelpProvider,
             declarationProvider,
@@ -351,6 +350,16 @@ function handle_InitializedNotification(server::Server)
     load_lsp_config!(server, nothing, "[LSP] initialize"; on_init=true)
 
     registrations = Registration[]
+
+    if supports(server, :textDocument, :synchronization, :dynamicRegistration)
+        append!(registrations, text_document_sync_registrations(server))
+        @static JETLS_DEV_MODE && @info "Dynamically registering text document synchronization"
+    end
+
+    if supports(server, :notebookDocument, :synchronization, :dynamicRegistration)
+        push!(registrations, notebook_document_sync_registration())
+        @static JETLS_DEV_MODE && @info "Dynamically registering notebook synchronization"
+    end
 
     if supports(server, :textDocument, :completion, :dynamicRegistration)
         push!(registrations, completion_registration())

--- a/src/notebook.jl
+++ b/src/notebook.jl
@@ -1,6 +1,31 @@
 # Document synchronization
 # ========================
 
+const NOTEBOOK_DOCUMENT_SYNC_REGISTRATION_ID = "jetls-notebook-document-sync"
+const NOTEBOOK_DOCUMENT_SYNC_REGISTRATION_METHOD = "notebookDocument/sync"
+
+notebook_document_sync_selector() =
+    NotebookDocumentSyncOptionsNotebookSelectorItem[
+        NotebookDocumentSyncOptionsNotebookSelectorItem(;
+            notebook = "jupyter-notebook",
+            cells = NotebookDocumentSyncOptionsNotebookSelectorCellsItem[
+                NotebookDocumentSyncOptionsNotebookSelectorCellsItem(; language = "julia")])]
+
+function notebook_document_sync_options()
+    return NotebookDocumentSyncOptions(;
+        notebookSelector = notebook_document_sync_selector(),
+        save = true)
+end
+
+function notebook_document_sync_registration()
+    return Registration(;
+        id = NOTEBOOK_DOCUMENT_SYNC_REGISTRATION_ID,
+        method = NOTEBOOK_DOCUMENT_SYNC_REGISTRATION_METHOD,
+        registerOptions = NotebookDocumentSyncRegistrationOptions(;
+            notebookSelector = notebook_document_sync_selector(),
+            save = true))
+end
+
 get_notebook_info(state::ServerState, uri::URI, default=nothing) =
     get(load(state.notebook_cache), uri, default)
 

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -186,8 +186,9 @@ function withserver(f;
     end
 
     # do the server initialization
+    local initialize_response, initialize_json_response, register_capability_request, register_capability_json_request
     let id = id_counter[] += 1
-        (; raw_msg, raw_res) = writereadmsg(
+        (; raw_msg, raw_res, json_res) = writereadmsg(
             InitializeRequest(;
                 id,
                 params=InitializeParams(;
@@ -197,10 +198,14 @@ function withserver(f;
                     workspaceFolders)))
         @test raw_msg isa InitializeRequest && raw_msg.params.workspaceFolders == workspaceFolders
         @test raw_res isa InitializeResponse && raw_res.id == id
+        initialize_response = raw_res
+        initialize_json_response = json_res
 
-        (; raw_msg, raw_res) = writereadmsg(InitializedNotification())
+        (; raw_msg, raw_res, json_res) = writereadmsg(InitializedNotification())
         @test raw_msg isa InitializedNotification
         @test raw_res isa RegisterCapabilityRequest && raw_res.id isa String
+        register_capability_request = raw_res
+        register_capability_json_request = json_res
 
         # apply initial settings if provided
         # read=1: ShowMessageNotification for config change
@@ -210,7 +215,16 @@ function withserver(f;
         end
     end
 
-    argnt = (; server, writemsg, readmsg, writereadmsg, id_counter)
+    argnt = (;
+        server,
+        writemsg,
+        readmsg,
+        writereadmsg,
+        id_counter,
+        initialize_response,
+        initialize_json_response,
+        register_capability_request,
+        register_capability_json_request)
     try
         # do the main callback
         return f(argnt)

--- a/test/test_document_synchronization.jl
+++ b/test/test_document_synchronization.jl
@@ -1,9 +1,157 @@
 module test_document_synchronization
 
+include("setup.jl")
+
 using Test
 using JETLS
 using JETLS.LSP
 using JETLS.LSP.URIs2: filepath2uri
+
+function registration_for_method(request::RegisterCapabilityRequest, method::String)
+    return only(registration for registration in request.params.registrations
+        if registration.method == method)
+end
+
+@testset "dynamic document synchronization registration" begin
+    capabilities = ClientCapabilities(;
+        textDocument = TextDocumentClientCapabilities(;
+            synchronization = TextDocumentSyncClientCapabilities(;
+                dynamicRegistration = true,
+                didSave = true)),
+        notebookDocument = NotebookDocumentClientCapabilities(;
+            synchronization = NotebookDocumentSyncClientCapabilities(;
+                dynamicRegistration = true)))
+    withserver(; capabilities) do (;
+            initialize_response,
+            register_capability_request
+        )
+        server_capabilities = initialize_response.result.capabilities
+        @test isnothing(server_capabilities.textDocumentSync)
+        @test isnothing(server_capabilities.notebookDocumentSync)
+
+        open_registration = registration_for_method(
+            register_capability_request, "textDocument/didOpen")
+        @test open_registration.id == "jetls-did-open-text-document"
+        open_options = open_registration.registerOptions
+        @test open_options isa TextDocumentRegistrationOptions
+        open_filters = [
+            (filter.language, filter.scheme, filter.pattern)
+            for filter in open_options.documentSelector
+        ]
+        @test open_filters == [
+            ("julia", "file", nothing),
+            ("julia", "untitled", nothing),
+            ("julia", "buffer", nothing),
+        ]
+
+        change_registration = registration_for_method(
+            register_capability_request, "textDocument/didChange")
+        @test change_registration.id == "jetls-did-change-text-document"
+        change_options = change_registration.registerOptions
+        @test change_options isa TextDocumentChangeRegistrationOptions
+        @test change_options.syncKind == TextDocumentSyncKind.Full
+        change_filters = [
+            (filter.language, filter.scheme, filter.pattern)
+            for filter in change_options.documentSelector
+        ]
+        @test change_filters == open_filters
+
+        save_registration = registration_for_method(
+            register_capability_request, "textDocument/didSave")
+        @test save_registration.id == "jetls-did-save-text-document"
+        save_options = save_registration.registerOptions
+        @test save_options isa TextDocumentSaveRegistrationOptions
+        @test save_options.includeText === true
+        save_filters = [
+            (filter.language, filter.scheme, filter.pattern)
+            for filter in save_options.documentSelector
+        ]
+        @test save_filters == [("julia", "file", nothing)]
+
+        close_registration = registration_for_method(
+            register_capability_request, "textDocument/didClose")
+        @test close_registration.id == "jetls-did-close-text-document"
+        close_options = close_registration.registerOptions
+        @test close_options isa TextDocumentRegistrationOptions
+        close_filters = [
+            (filter.language, filter.scheme, filter.pattern)
+            for filter in close_options.documentSelector
+        ]
+        @test close_filters == open_filters
+
+        notebook_registration = registration_for_method(
+            register_capability_request, "notebookDocument/sync")
+        @test notebook_registration.id == "jetls-notebook-document-sync"
+        notebook_options = notebook_registration.registerOptions
+        @test notebook_options isa NotebookDocumentSyncRegistrationOptions
+        @test notebook_options.save === true
+        @test length(notebook_options.notebookSelector) == 1
+        notebook_selector = only(notebook_options.notebookSelector)
+        @test notebook_selector.notebook == "jupyter-notebook"
+        @test length(notebook_selector.cells) == 1
+        @test only(notebook_selector.cells).language == "julia"
+    end
+end
+
+@testset "static document synchronization fallback" begin
+    capabilities = ClientCapabilities(;
+        textDocument = TextDocumentClientCapabilities(;
+            synchronization = TextDocumentSyncClientCapabilities(;
+                dynamicRegistration = false,
+                didSave = false)),
+        notebookDocument = NotebookDocumentClientCapabilities(;
+            synchronization = NotebookDocumentSyncClientCapabilities(;
+                dynamicRegistration = false)))
+    withserver(; capabilities) do (;
+            initialize_response,
+            register_capability_request
+        )
+        server_capabilities = initialize_response.result.capabilities
+        text_options = server_capabilities.textDocumentSync
+        @test text_options isa TextDocumentSyncOptions
+        @test text_options.openClose === true
+        @test text_options.change == TextDocumentSyncKind.Full
+        @test isnothing(text_options.save)
+
+        notebook_options = server_capabilities.notebookDocumentSync
+        @test notebook_options isa NotebookDocumentSyncOptions
+        @test notebook_options.save === true
+        @test length(notebook_options.notebookSelector) == 1
+        notebook_selector = only(notebook_options.notebookSelector)
+        @test notebook_selector.notebook == "jupyter-notebook"
+        @test length(notebook_selector.cells) == 1
+        @test only(notebook_selector.cells).language == "julia"
+
+        methods = Set(reg.method for reg in register_capability_request.params.registrations)
+        @test isempty(intersect(methods, Set((
+            "textDocument/didOpen",
+            "textDocument/didChange",
+            "textDocument/didSave",
+            "textDocument/didClose",
+            "notebookDocument/sync",
+        ))))
+    end
+end
+
+@testset "dynamic synchronization without didSave" begin
+    capabilities = ClientCapabilities(;
+        textDocument = TextDocumentClientCapabilities(;
+            synchronization = TextDocumentSyncClientCapabilities(;
+                dynamicRegistration = true,
+                didSave = false)))
+    withserver(; capabilities) do (;
+            initialize_response,
+            register_capability_request
+        )
+        @test isnothing(initialize_response.result.capabilities.textDocumentSync)
+
+        methods = Set(reg.method for reg in register_capability_request.params.registrations)
+        @test "textDocument/didOpen" in methods
+        @test "textDocument/didChange" in methods
+        @test "textDocument/didClose" in methods
+        @test "textDocument/didSave" ∉ methods
+    end
+end
 
 @testset "unsupported text documents are ignored" begin
     mktempdir() do dir

--- a/test/test_registration.jl
+++ b/test/test_registration.jl
@@ -19,8 +19,8 @@ let capabilities = ClientCapabilities(;
 
         # test dynamic unregistration
         unregister(server, Unregistration(;
-            id=JETLS.COMPLETION_REGISTRATION_ID,
-            method=JETLS.COMPLETION_REGISTRATION_METHOD))
+            id = JETLS.COMPLETION_REGISTRATION_ID,
+            method = JETLS.COMPLETION_REGISTRATION_METHOD))
         (; raw_msg) = readmsg()
         @test raw_msg isa UnregisterCapabilityRequest
         @test reg ∉ load(state.currently_registered)

--- a/test/test_testrunner.jl
+++ b/test/test_testrunner.jl
@@ -220,26 +220,6 @@ end
     end
 end
 
-@testset "jetls document synchronization (track open/close, no Julia analysis)" begin
-    # Spec-conformant clients may sync `jetls:` virtual documents. The Julia-only
-    # sync path must not run for them (no crash on the non-`julia` languageId, no
-    # `FileInfo` pollution); instead open/close is tracked to drive content refreshes.
-    server = JETLS.Server()
-    juri = URI(; scheme=JETLS.TESTRUNNER_LOGS_SCHEME, path="/testrunner/logs", query="source=x&index=1&name=ts")
-    JETLS.update_text_document_content!(server, juri, "logs\n")
-
-    open_msg = DidOpenTextDocumentNotification(; params = DidOpenTextDocumentParams(;
-        textDocument = TextDocumentItem(; uri=juri, languageId="log", version=1, text="logs\n")))
-    @test JETLS.handle_DidOpenTextDocumentNotification(server, open_msg) === nothing
-    @test JETLS.get_file_info(server.state, juri) === nothing
-    @test JETLS.load(server.state.text_document_content_cache)[juri].opened
-
-    close_msg = DidCloseTextDocumentNotification(; params = DidCloseTextDocumentParams(;
-        textDocument = TextDocumentIdentifier(; uri=juri)))
-    @test JETLS.handle_DidCloseTextDocumentNotification(server, close_msg) === nothing
-    @test !JETLS.load(server.state.text_document_content_cache)[juri].opened
-end
-
 @testset "testrunner_code_lenses" begin
     let server = JETLS.Server()
         test_code = """

--- a/test/test_text_document_content.jl
+++ b/test/test_text_document_content.jl
@@ -1,9 +1,120 @@
 module test_text_document_content
 
+include("setup.jl")
+
 using Test
 using JETLS
 using JETLS.LSP
 using JETLS.LSP.URIs2
+
+function registration_for_method(request::RegisterCapabilityRequest, method::String)
+    return only(registration for registration in request.params.registrations
+        if registration.method == method)
+end
+
+@testset "virtual document synchronization registration" begin
+    capabilities = ClientCapabilities(;
+        workspace = WorkspaceClientCapabilities(;
+            textDocumentContent = TextDocumentContentClientCapabilities(;
+                dynamicRegistration = true)),
+        textDocument = TextDocumentClientCapabilities(;
+            synchronization = TextDocumentSyncClientCapabilities(;
+                dynamicRegistration = true,
+                didSave = true)))
+    withserver(; capabilities) do (; register_capability_request)
+        virtual_schemes = [
+            "jetls-testrunner-logs",
+            "jetls-macro-expansion",
+            "jetls-type-annotation",
+        ]
+
+        content_registration = registration_for_method(
+            register_capability_request, "workspace/textDocumentContent")
+        @test content_registration.id == "jetls-text-document-content"
+        content_options = content_registration.registerOptions
+        @test content_options isa TextDocumentContentRegistrationOptions
+        @test content_options.schemes == virtual_schemes
+
+        for method in ("textDocument/didOpen", "textDocument/didClose")
+            registration = registration_for_method(register_capability_request, method)
+            options = registration.registerOptions
+            registered_schemes = Set(filter.scheme for filter in options.documentSelector
+                if isnothing(filter.language))
+            @test registered_schemes == Set(virtual_schemes)
+        end
+
+        for method in ("textDocument/didChange", "textDocument/didSave")
+            registration = registration_for_method(register_capability_request, method)
+            options = registration.registerOptions
+            registered_schemes = Set(filter.scheme for filter in options.documentSelector)
+            @test isempty(intersect(registered_schemes, Set(virtual_schemes)))
+        end
+    end
+end
+
+@testset "static virtual document content registration" begin
+    capabilities = ClientCapabilities(;
+        workspace = WorkspaceClientCapabilities(;
+            textDocumentContent = TextDocumentContentClientCapabilities(;
+                dynamicRegistration = false)),
+        textDocument = TextDocumentClientCapabilities(;
+            synchronization = TextDocumentSyncClientCapabilities(;
+                dynamicRegistration = true,
+                didSave = true)))
+    withserver(; capabilities) do (;
+            initialize_response,
+            register_capability_request
+        )
+        virtual_schemes = [
+            "jetls-testrunner-logs",
+            "jetls-macro-expansion",
+            "jetls-type-annotation",
+        ]
+
+        server_capabilities = initialize_response.result.capabilities
+        @test isnothing(server_capabilities.textDocumentSync)
+        workspace_options = server_capabilities.workspace
+        @test workspace_options isa WorkspaceOptions
+        content_options = workspace_options.textDocumentContent
+        @test content_options isa TextDocumentContentOptions
+        @test content_options.schemes == virtual_schemes
+
+        methods = Set(reg.method for reg in register_capability_request.params.registrations)
+        @test "workspace/textDocumentContent" ∉ methods
+        for method in ("textDocument/didOpen", "textDocument/didClose")
+            registration = registration_for_method(register_capability_request, method)
+            options = registration.registerOptions
+            registered_schemes = Set(filter.scheme for filter in options.documentSelector
+                if isnothing(filter.language))
+            @test registered_schemes == Set(virtual_schemes)
+        end
+    end
+end
+
+@testset "virtual document open and close handling" begin
+    # Virtual documents use the text synchronization protocol only to track whether
+    # they are open. They must not enter the Julia analysis path or its file cache.
+    server = JETLS.Server()
+    uri = URI(;
+        scheme = JETLS.TESTRUNNER_LOGS_SCHEME,
+        path = "/testrunner/logs",
+        query = "source=x&index=1&name=ts")
+    JETLS.update_text_document_content!(server, uri, "logs\n")
+
+    open_msg = DidOpenTextDocumentNotification(;
+        params = DidOpenTextDocumentParams(;
+            textDocument = TextDocumentItem(;
+                uri, languageId = "log", version = 1, text = "logs\n")))
+    @test JETLS.handle_DidOpenTextDocumentNotification(server, open_msg) === nothing
+    @test JETLS.get_file_info(server.state, uri) === nothing
+    @test JETLS.load(server.state.text_document_content_cache)[uri].opened
+
+    close_msg = DidCloseTextDocumentNotification(;
+        params = DidCloseTextDocumentParams(;
+            textDocument = TextDocumentIdentifier(; uri)))
+    @test JETLS.handle_DidCloseTextDocumentNotification(server, close_msg) === nothing
+    @test !JETLS.load(server.state.text_document_content_cache)[uri].opened
+end
 
 @testset "parse_text_document_content_query" begin
     # a URI with no query yields no parameters


### PR DESCRIPTION
JETLS always advertised static text and notebook synchronization even when clients supported dynamic registration. Static text document synchronization also could not express the scope expected by the server.

Use the text and notebook synchronization client capabilities to omit static options and register synchronization after initialization. Regular text synchronization is scoped to Julia files and unsaved buffers, while notebook cells remain under `notebookDocument/sync`. Read-only virtual documents receive only open and close notifications.

Retain static fallbacks for clients without dynamic registration. Save notifications and `includeText` are requested only when the client advertises `didSave` support. The VS Code client keeps its `documentSelector` fallback while it can connect to independently installed `jetls` binaries; remove it once the extension manages the server binary and can require dynamic registration.

Tests cover dynamic and static registration fallbacks, `didSave` capability handling, exact text and notebook selectors, and virtual document open/close behavior.