### PR TITLE
docs: Document the `analysis_overrides` workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > [!warning]
 > JETLS currently has a known memory leak issue where memory usage grows with each re-analysis (https://github.com/aviatesk/JETLS.jl/issues/357).
-> As a temporary workaround, you can disable full-analysis for specific files using the `analysis_overrides` [initialization option](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options):
+> As a temporary workaround, you can disable full-analysis for specific files using the [`analysis_overrides` initialization option](https://aviatesk.github.io/JETLS.jl/release/launching/#init-options/analysis_overrides):
 > ```jsonc
 > // VSCode settings.json example
 > {

--- a/docs/src/launching.md
+++ b/docs/src/launching.md
@@ -160,7 +160,6 @@ at your project root:
 ```toml
 [[initialization_options.analysis_overrides]]
 path = "test/fixtures/**"
-full_analysis = false
 ```
 
 This method is client-agnostic and can be easily committed to version control.
@@ -183,8 +182,7 @@ Configure initialization options in VSCode's `settings.json`:
   "jetls-client.initializationOptions": {
     "analysis_overrides": [
       {
-        "path": "test/fixtures/**",
-        "full_analysis": false
+        "path": "test/fixtures/**"
       }
     ]
   }
@@ -202,8 +200,7 @@ Configure initialization options in Zed's `settings.json`:
       "initialization_options": {
         "analysis_overrides": [
           {
-            "path": "test/fixtures/**",
-            "full_analysis": false
+            "path": "test/fixtures/**"
           }
         ]
       }
@@ -213,6 +210,50 @@ Configure initialization options in Zed's `settings.json`:
 ```
 
 ### [Options reference](@id init-options/reference)
+
+- [`analysis_overrides`](@ref init-options/analysis_overrides)
+- [`reuse_native_inference`](@ref init-options/reuse_native_inference)
+
+#### [`analysis_overrides`](@id init-options/analysis_overrides)
+
+- **Type**: array of tables
+- **Default**: `[]`
+
+Excludes the matched files from full analysis. This is primarily a workaround
+for the [known memory leak](https://github.com/aviatesk/JETLS.jl/issues/357),
+where memory usage grows with each re-analysis: excluding the files that
+trigger the heaviest analysis keeps the server usable until the leak is fixed.
+
+Each entry requires a `path` field: a glob pattern selecting the files to
+exclude. Patterns are matched against file paths relative to the workspace
+root, and `**` matches directories recursively. Use `/` as the separator on all
+platforms, including Windows; backslashes are not interpreted as separators.
+
+```toml
+# exclude test fixtures entirely
+[[initialization_options.analysis_overrides]]
+path = "test/fixtures/**"
+```
+
+Save-time diagnostics produced by full analysis, including
+[`toplevel` diagnostics](@ref diagnostic/reference/toplevel) and
+[`inference` diagnostics](@ref diagnostic/reference/inference), are unavailable
+for the matched files.
+
+Features that do not require full analysis keep working. These include
+completion, hover, inlay hints, and
+[`syntax` diagnostics](@ref diagnostic/reference/syntax). Context-independent
+[`lowering` diagnostics](@ref diagnostic/reference/lowering) also remain
+available, while context-dependent diagnostics such as
+`lowering/macro-expansion-error` and `lowering/undef-global-var` are
+unavailable.
+Hover and type inlay hints infer the current top-level form on demand, but their
+results may be incomplete because full analysis does not establish a module
+context for the matched files.
+
+!!! warning
+    `analysis_overrides` is provided as a temporary workaround and may be
+    removed or changed at any time.
 
 #### [`reuse_native_inference`](@id init-options/reuse_native_inference)
 


### PR DESCRIPTION
`analysis_overrides` is the temporary workaround for memory growth during re-analysis, but its supported configuration and effect on language-server features were not covered by the initialization options reference.

Document the path-based glob format and editor examples, link the CHANGELOG announcement directly to the new reference, and distinguish save-time full-analysis diagnostics from features that remain available without full analysis.

Keep the experimental Revise-based override behavior out of the public documentation.