### PR TITLE
testrunner: Accept failed test results from exit code 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Text and notebook document synchronization now use dynamic registration when supported, allowing regular text synchronization to be scoped to supported Julia buffers and server-provided virtual documents. Static fallbacks remain available for other clients.
 
+### Fixed
+
+- Fixed the TestRunner integration treating failed or errored tests as an unexpected TestRunner execution failure instead of reporting their results.
+
 ## 2026-08-05
 
 - Commit: [`6dacc52`](https://github.com/aviatesk/JETLS.jl/commit/6dacc52)

--- a/src/testrunner/testrunner.jl
+++ b/src/testrunner/testrunner.jl
@@ -562,10 +562,17 @@ function read_testrunner_result(
     testrunnerproc = open(pipeline(cmd; stdin = IOBuffer(source)); read = true)
     (; output, process_success, cancelled) =
         read_testrunner_output(testrunnerproc, cancellable_token)
-    if cancelled
-        return "Test execution cancelled by user"
-    elseif !process_success
-        log_testrunner_failure(cmd, testrunnerproc, output, :process)
+    cancelled && return "Test execution cancelled by user"
+
+    result = try
+        LSP.JSON3.read(output, TestRunnerResult)
+    catch err
+        if process_success
+            parse_error = sprint(Base.showerror, err, catch_backtrace())
+            log_testrunner_failure(cmd, testrunnerproc, output, :invalid_output; parse_error)
+        else
+            log_testrunner_failure(cmd, testrunnerproc, output, :process)
+        end
         show_error_message(server, """
         An unexpected error occurred while executing TestRunner.jl:
         See the server log for details.
@@ -573,17 +580,19 @@ function read_testrunner_result(
         return "Test execution failed"
     end
 
-    try
-        return LSP.JSON3.read(output, TestRunnerResult)
-    catch err
-        parse_error = sprint(Base.showerror, err, catch_backtrace())
-        log_testrunner_failure(cmd, testrunnerproc, output, :invalid_output; parse_error)
+    expected_test_failure =
+        testrunnerproc.termsignal == 0 &&
+        testrunnerproc.exitcode == 1 &&
+        (!iszero(result.stats.n_failed) || !iszero(result.stats.n_errored))
+    if !process_success && !expected_test_failure
+        log_testrunner_failure(cmd, testrunnerproc, output, :process)
         show_error_message(server, """
         An unexpected error occurred while executing TestRunner.jl:
         See the server log for details.
         """)
         return "Test execution failed"
     end
+    return result
 end
 
 function _testrunner_run_testset(

--- a/test/test_testrunner.jl
+++ b/test/test_testrunner.jl
@@ -115,9 +115,39 @@ end
             @test result.logs == expected.logs
         end
 
+        @testset "test failure result with exit 1" begin
+            server = JETLS.Server()
+            expected = mock_testrunner_result(; n_passed = 1, n_failed = 1)
+            source = String(LSP.JSON3.write(expected))
+            cmd = Cmd(["/bin/sh", "-c", "cat; exit 1"])
+            result = JETLS.read_testrunner_result(server, cmd, source)
+            result = result::JETLS.TestRunnerResult
+            @test result.stats.n_passed == expected.stats.n_passed
+            @test result.stats.n_failed == expected.stats.n_failed
+        end
+
+        @testset "non-test exit 1 remains a process failure" begin
+            server = JETLS.Server()
+            source = String(LSP.JSON3.write(mock_testrunner_result()))
+            cmd = Cmd(["/bin/sh", "-c", "cat; exit 1"])
+            logger = Test.TestLogger()
+            result = with_logger(logger) do
+                JETLS.read_testrunner_result(server, cmd, source)
+            end
+            @test result == "Test execution failed"
+            log = only(logger.logs)
+            @test log.message == "TestRunner execution failed"
+            details = log.kwargs[:details]
+            @test details.exitcode == 1
+            @test details.termsignal == 0
+            @test details.stdout_bytes == ncodeunits(source)
+            @test details.reason === :process
+            @test isnothing(details.parse_error)
+        end
+
         @testset "process failure logs metadata" begin
             server = JETLS.Server()
-            cmd = Cmd(["/bin/sh", "-c", "printf 'testrunner failed\\n'; exit 1"])
+            cmd = Cmd(["/bin/sh", "-c", "cat; printf 'testrunner failed\\n'; exit 1"])
             logger = Test.TestLogger()
             result = with_logger(logger) do
                 JETLS.read_testrunner_result(server, cmd, "")


### PR DESCRIPTION
TestRunner writes a valid JSON result but exits with status 1 when tests contain failures or errors. JETLS treated every nonzero exit as a subprocess failure before parsing stdout, so clients showed an unexpected execution error and discarded diagnostics and logs.

Parse stdout before classifying the process status. Accept exit 1 only when the process was not signaled and the parsed statistics contain a failure or error. Malformed output and inconsistent nonzero exits remain execution failures.

Tests cover expected failed-test results, malformed output, unexpected nonzero exits, and cancellation.