### PR TITLE
watched-files: Respect relative pattern support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed the TestRunner integration treating failed or errored tests as an unexpected TestRunner execution failure instead of reporting their results.
 
+- Fixed watched-file registration for clients that do not support relative glob patterns, while keeping handled file events scoped to the workspace root.
+
 ## 2026-08-05
 
 - Commit: [`6dacc52`](https://github.com/aviatesk/JETLS.jl/commit/6dacc52)

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,6 +1,5 @@
 const CONFIG_FILE = ".JETLSConfig.toml"
-
-is_config_file(filepath::AbstractString) = basename(filepath) == CONFIG_FILE
+const CONFIG_FILE_GLOB_PATTERN = "**/$CONFIG_FILE"
 
 @generated function merge_and_track(
         on_difference,

--- a/src/did-change-watched-files.jl
+++ b/src/did-change-watched-files.jl
@@ -4,32 +4,41 @@ const DID_CHANGE_WATCHED_FILES_REGISTRATION_METHOD = "workspace/didChangeWatched
 const PROFILE_TRIGGER_FILE = ".JETLSProfile"
 const SERVER_REVISE_TRIGGER_FILE = ".JETLS_REVISE"
 
+function watched_file_pattern(
+        root_uri::URI, pattern::String, fallback::String, relative_pattern_support::Bool
+    )
+    relative_pattern_support || return fallback
+    return RelativePattern(; baseUri = root_uri, pattern)
+end
+
 function did_change_watched_files_registration(server::Server)
     state = server.state
     isdefined(state, :root_path) || return nothing
     root_uri = filepath2uri(state.root_path)
+    relative_pattern_support = supports(
+        server, :workspace, :didChangeWatchedFiles, :relativePatternSupport)
     watchers = FileSystemWatcher[
         FileSystemWatcher(;
-            globPattern = RelativePattern(;
-                baseUri = root_uri,
-                pattern = CONFIG_FILE),
+            globPattern = watched_file_pattern(
+                root_uri, CONFIG_FILE, CONFIG_FILE_GLOB_PATTERN,
+                relative_pattern_support),
             kind = WatchKind.Create | WatchKind.Change | WatchKind.Delete),
         FileSystemWatcher(;
-            globPattern = RelativePattern(;
-                baseUri = root_uri,
-                pattern = PROFILE_TRIGGER_FILE),
+            globPattern = watched_file_pattern(
+                root_uri, PROFILE_TRIGGER_FILE, "**/$PROFILE_TRIGGER_FILE",
+                relative_pattern_support),
             kind = WatchKind.Create),
         FileSystemWatcher(;
-            globPattern = RelativePattern(;
-                baseUri = root_uri,
-                pattern = "**/*.jl"),
+            globPattern = watched_file_pattern(
+                root_uri, "**/*.jl", "**/*.jl",
+                relative_pattern_support),
             kind = WatchKind.Create | WatchKind.Change | WatchKind.Delete),
     ]
     @static if JETLS_DEV_MODE
         push!(watchers, FileSystemWatcher(;
-            globPattern = RelativePattern(;
-                baseUri = root_uri,
-                pattern = SERVER_REVISE_TRIGGER_FILE),
+            globPattern = watched_file_pattern(
+                root_uri, SERVER_REVISE_TRIGGER_FILE, "**/$SERVER_REVISE_TRIGGER_FILE",
+                relative_pattern_support),
             kind = WatchKind.Create))
     end
     Registration(;
@@ -138,8 +147,6 @@ function delete_file_config!(on_difference, manager::ConfigManager, filepath::Ab
     end
 end
 
-is_profile_trigger_file(path::AbstractString) = endswith(path, PROFILE_TRIGGER_FILE)
-is_server_revise_trigger_file(path::AbstractString) = endswith(path, SERVER_REVISE_TRIGGER_FILE)
 is_jl_file(path::AbstractString) = endswith(path, ".jl")
 
 function handle_server_revise_trigger!(server::Server, trigger_path::AbstractString)
@@ -153,13 +160,16 @@ end
 function handle_DidChangeWatchedFilesNotification(server::Server, msg::DidChangeWatchedFilesNotification)
     for change in msg.params.changes
         changed_path = @something uri2filepath(change.uri) continue
-        if is_config_file(changed_path)
+        state = server.state
+        if is_workspace_root_file(state, changed_path, CONFIG_FILE)
             handle_config_file_change!(server, changed_path, change.type)
-        elseif is_profile_trigger_file(changed_path) && change.type == FileChangeType.Created
+        elseif is_workspace_root_file(state, changed_path, PROFILE_TRIGGER_FILE) &&
+                change.type == FileChangeType.Created
             trigger_profile!(server, changed_path)
-        elseif is_server_revise_trigger_file(changed_path) && change.type != FileChangeType.Deleted
+        elseif is_workspace_root_file(state, changed_path, SERVER_REVISE_TRIGGER_FILE) &&
+                change.type != FileChangeType.Deleted
             handle_server_revise_trigger!(server, changed_path)
-        elseif is_jl_file(changed_path)
+        elseif is_workspace_file(state, changed_path) && is_jl_file(changed_path)
             handle_jl_file_change!(server, change)
         end
     end

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -224,6 +224,19 @@ end
 get_file_info(s::ServerState, t::TextDocumentIdentifier, cancel_flag::AbstractCancelFlag; kwargs...) =
     get_file_info(s, t.uri, cancel_flag; kwargs...)
 
+function is_workspace_root_file(
+        s::ServerState, filepath::AbstractString, filename::AbstractString
+    )
+    isdefined(s, :root_path) || return false
+    expected = joinpath(s.root_path, filename)
+    return _paths_equal(_normalize_path(filepath), _normalize_path(expected))
+end
+
+function is_workspace_file(s::ServerState, filepath::AbstractString)
+    isdefined(s, :root_path) || return false
+    return issubdir(filepath, s.root_path)
+end
+
 """
     may_have_file_info(s::ServerState, uri::URI) -> Bool
 

--- a/test/test_config.jl
+++ b/test/test_config.jl
@@ -181,14 +181,6 @@ include("HierarchicalTestSet.jl")
             end
         end
     end
-
-    @testset "`is_config_file`" begin
-        @test JETLS.is_config_file("/path/to/.JETLSConfig.toml")
-        @test JETLS.is_config_file(".JETLSConfig.toml")
-        @test !JETLS.is_config_file("/path/to/Non.JETLSConfig.toml")
-        @test !JETLS.is_config_file("config.toml")
-        @test !JETLS.is_config_file("/path/to/regular.txt")
-    end
 end
 
 @testset "`parse_config_from_dict` reports full key paths in `InvalidKeyError`" begin

--- a/test/test_did_change_watched_files.jl
+++ b/test/test_did_change_watched_files.jl
@@ -15,6 +15,51 @@ const CLIENT_CAPABILITIES = ClientCapabilities(;
 const DEBOUNCE_DEFAULT = JETLS.get_config(JETLS.ConfigManager(JETLS.ConfigManagerData()), :full_analysis, :debounce)
 const TESTRUNNER_DEFAULT = JETLS.get_config(JETLS.ConfigManager(JETLS.ConfigManagerData()), :testrunner, :executable)
 
+@testset "watched-file registration patterns" begin
+    mktempdir() do dir
+        root_uri = filepath2uri(dir)
+        for relative_pattern_support in (false, true)
+            capabilities = ClientCapabilities(;
+                workspace = WorkspaceClientCapabilities(;
+                    didChangeWatchedFiles = DidChangeWatchedFilesClientCapabilities(;
+                        dynamicRegistration = true,
+                        relativePatternSupport = relative_pattern_support)))
+            withserver(; capabilities, rootUri = root_uri) do (;
+                    register_capability_json_request
+                )
+                registration = only(
+                    reg for reg in register_capability_json_request.params.registrations
+                    if reg.method == "workspace/didChangeWatchedFiles")
+                options = registration.registerOptions::Dict{String,Any}
+                patterns = Any[watcher["globPattern"] for watcher in options["watchers"]]
+                expected = if relative_pattern_support
+                    [Dict{String,Any}(
+                        "baseUri" => string(root_uri),
+                        "pattern" => pattern)
+                        for pattern in (JETLS.CONFIG_FILE, JETLS.PROFILE_TRIGGER_FILE, "**/*.jl")
+                    ]
+                else
+                    [
+                        JETLS.CONFIG_FILE_GLOB_PATTERN,
+                        "**/$(JETLS.PROFILE_TRIGGER_FILE)",
+                        "**/*.jl"
+                    ]
+                end
+                @static if JETLS.JETLS_DEV_MODE
+                    revise_pattern = relative_pattern_support ?
+                        Dict{String,Any}(
+                            "baseUri" => string(root_uri),
+                            "pattern" => JETLS.SERVER_REVISE_TRIGGER_FILE
+                        ) :
+                        "**/$(JETLS.SERVER_REVISE_TRIGGER_FILE)"
+                    push!(expected, revise_pattern)
+                end
+                @test patterns == expected
+            end
+        end
+    end
+end
+
 # Test the full cycle of `DidChangeWatchedFilesNotification`:
 # 1. Initialize with `.JETLSConfig.toml` file.
 # 2. Change the keys that require reload
@@ -160,6 +205,20 @@ const TESTRUNNER_DEFAULT = JETLS.get_config(JETLS.ConfigManager(JETLS.ConfigMana
                     return false
                 end
             end
+
+            # nested config file change (should be ignored)
+            nested_dir = joinpath(tmpdir, "nested")
+            mkpath(nested_dir)
+            nested_config = joinpath(nested_dir, JETLS.CONFIG_FILE)
+            write(nested_config, "[testrunner]\nexecutable = \"nested\"\n")
+            let msg = DidChangeWatchedFilesNotification(;
+                    params = DidChangeWatchedFilesParams(;
+                        changes = [FileEvent(;
+                            uri = filepath2uri(nested_config),
+                            type = FileChangeType.Changed)]))
+                writereadmsg(msg; read=0)
+            end
+            @test JETLS.get_config(manager, :testrunner, :executable) == TESTRUNNER_RECREATE
 
             # non-config file change (should be ignored)
             other_file = joinpath(tmpdir, "other.txt")


### PR DESCRIPTION
JETLS unconditionally sent `RelativePattern` values in watched-file registrations. Clients can support dynamic registration without supporting relative patterns, causing JETLS to rely on unsupported registration options.

Check `workspace.didChangeWatchedFiles.relativePatternSupport` and use root-relative patterns when available, with portable string globs as the fallback. Since fallback globs can match a broader scope, validate config and trigger files against the workspace root and accept Julia file events only from within that root.

Tests cover both registration forms and ensure nested config events are ignored.