### PR TITLE
Sync `.JETLSConfig.toml` for versioned edits

### DIFF
--- a/jetls-client/jetls-client.ts
+++ b/jetls-client/jetls-client.ts
@@ -185,7 +185,6 @@ function hasServerConfigChanged(
   );
 }
 
-
 async function startLanguageServer() {
   const serverConfig = getServerConfig();
   currentServerConfig = serverConfig;
@@ -451,7 +450,6 @@ async function startLanguageServer() {
   const initializationOptions = vscode.workspace
     .getConfiguration("jetls-client")
     .get("initializationOptions", {});
-
 
   const clientOptions: LanguageClientOptions = {
     // Keep this selector as a static-registration fallback while jetls-client can

--- a/src/code-action.jl
+++ b/src/code-action.jl
@@ -358,7 +358,9 @@ function missing_concretization_code_actions!(
         path = @something concretization_pattern_path_for_code_action(server, data.assignment_file) continue
         edit = @something jetls_config_workspace_edit(
             server, config_path, data.pattern, path) continue
-        action = isfile(config_path) ? "Add" : "Create"
+        creates_config = edit.documentChanges !== nothing &&
+            any(change -> change isa CreateFile, edit.documentChanges)
+        action = creates_config ? "Create" : "Add"
         title = "$action `.JETLSConfig.toml` concretization pattern for `$(data.name)`"
         push!(code_actions, CodeAction(;
             title,
@@ -386,12 +388,23 @@ function jetls_config_workspace_edit(
         server::Server, config_path::String, pattern::String, path::String
     )
     config_uri = filepath2uri(config_path)
-    if isfile(config_path)
-        text = read(config_path, String)
-        appended = jetls_config_append_text(text, pattern, path)
+    config_document = get_config_document(server.state, config_uri)
+    # The live buffer may hold unsaved changes or outlive a file deleted on disk
+    if config_document !== nothing || isfile(config_path)
+        if config_document === nothing
+            text = read(config_path, String)
+            version = null
+            configured = @something parse_configured_concretization_patterns(text) return nothing
+        else
+            text = config_document.text
+            version = config_document.version
+            config_data = @something config_document.config_data return nothing
+            configured = @something configured_concretization_patterns(config_data) return nothing
+        end
+        appended = jetls_config_append_text(text, configured, pattern, path)
         if appended === nothing
             text_edit = @something jetls_config_inline_array_edit(
-                text, pattern, path, server.state.encoding) return nothing
+                text, configured, pattern, path, server.state.encoding) return nothing
         else
             position = _offset_to_xy(
                 Vector{UInt8}(text), sizeof(text) + 1, server.state.encoding)
@@ -399,9 +412,16 @@ function jetls_config_workspace_edit(
                 range = Range(; start=position, var"end"=position),
                 newText = appended)
         end
-        # TODO: These positions are based on disk content and may be stale when
-        # `.JETLSConfig.toml` has unsaved changes. Synchronize the config document
-        # and use its live contents and version for a versioned edit.
+        if supports(server, :workspace, :workspaceEdit, :documentChanges)
+            text_document = OptionalVersionedTextDocumentIdentifier(;
+                uri = config_uri, version)
+            document_edit = TextDocumentEdit(;
+                textDocument = text_document,
+                edits = TextEdit[text_edit])
+            document_changes =
+                Union{TextDocumentEdit, CreateFile, RenameFile, DeleteFile}[document_edit]
+            return WorkspaceEdit(; documentChanges = document_changes)
+        end
         return WorkspaceEdit(;
             changes = Dict{URI,Vector{TextEdit}}(config_uri => TextEdit[text_edit]))
     end
@@ -424,6 +444,12 @@ end
 
 function jetls_config_append_text(text::String, pattern::String, path::String)
     configured = @something parse_configured_concretization_patterns(text) return nothing
+    return jetls_config_append_text(text, configured, pattern, path)
+end
+
+function jetls_config_append_text(
+        text::String, configured::Vector, pattern::String, path::String
+    )
     has_concretization_pattern(configured, pattern, path) && return nothing
     sep = isempty(text) ? "" : endswith(text, '\n') ? "\n" : "\n\n"
     appended = sep * format_jetls_concretization_pattern(pattern, path)
@@ -432,14 +458,12 @@ function jetls_config_append_text(text::String, pattern::String, path::String)
 end
 
 function parse_configured_concretization_patterns(text::String)
-    parsed = TOML.tryparse(text)
-    parsed isa TOML.ParserError && return nothing
-    validated = try
-        validate_config_data(parsed)
-    catch
-        return nothing
-    end
-    full_analysis = get(validated, "full_analysis", Dict{String,Any}())
+    config_data = @something tryparse_config_data(text) return nothing
+    return configured_concretization_patterns(config_data)
+end
+
+function configured_concretization_patterns(config_data::Dict{String,Any})
+    full_analysis = get(config_data, "full_analysis", Dict{String,Any}())
     full_analysis isa Dict{String,Any} || return nothing
     configured = get(full_analysis, "concretization_patterns", Any[])
     configured isa Vector || return nothing
@@ -482,6 +506,13 @@ function jetls_config_inline_array_edit(
         text::String, pattern::String, path::String, encoding::PositionEncodingKind.Ty
     )
     configured = @something parse_configured_concretization_patterns(text) return nothing
+    return jetls_config_inline_array_edit(text, configured, pattern, path, encoding)
+end
+
+function jetls_config_inline_array_edit(
+        text::String, configured::Vector, pattern::String, path::String,
+        encoding::PositionEncodingKind.Ty
+    )
     has_concretization_pattern(configured, pattern, path) && return nothing
     entry = format_toml_inline_table(Dict("pattern" => pattern, "path" => path))
     bytes = Vector{UInt8}(text)

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,6 +1,42 @@
 const CONFIG_FILE = ".JETLSConfig.toml"
 const CONFIG_FILE_GLOB_PATTERN = "**/$CONFIG_FILE"
 
+function is_config_document_uri(state::ServerState, uri::URI)
+    filepath = @something uri2filepath(uri) return false
+    return is_workspace_root_file(state, filepath, CONFIG_FILE)
+end
+
+get_config_document(state::ServerState, uri::URI) =
+    get(load(state.config_document_cache), uri, nothing)
+
+function tryparse_config_data(text::String)
+    config_data = TOML.tryparse(text)
+    config_data isa TOML.ParserError && return nothing
+    try
+        return validate_config_data(config_data)
+    catch err
+        err isa InvalidConfigDataError || rethrow(err)
+        return nothing
+    end
+end
+
+function cache_config_document!(
+        state::ServerState, uri::URI, version::Int, text::String
+    )
+    info = ConfigDocumentInfo(version, text, tryparse_config_data(text))
+    store!(state.config_document_cache) do cache
+        Base.PersistentDict(cache, uri => info), nothing
+    end
+    return info
+end
+
+function delete_config_document!(state::ServerState, uri::URI)
+    store!(state.config_document_cache) do cache
+        Base.delete(cache, uri), nothing
+    end
+    return nothing
+end
+
 @generated function merge_and_track(
         on_difference,
         old_config::T,

--- a/src/did-change-watched-files.jl
+++ b/src/did-change-watched-files.jl
@@ -87,6 +87,19 @@ function handle_config_file_change!(
     end
 end
 
+# TODO: We may eventually want to separate live config validation from saved config
+# application. Synchronized `.JETLSConfig.toml` buffers could be validated on
+# `textDocument/didChange`, with source-ranged issues exposed through pull diagnostics,
+# while this watched-file path remains the trigger for applying saved settings. Proper
+# ranges for JETLS-specific semantic errors would require a provenance-preserving TOML
+# parser or source map. However, schema-aware external tools such as Tombi can already
+# provide most live validation using `config-toml.schema.json`, so it is unclear whether
+# JETLS should own that machinery.
+#
+# In any case, do not reuse live `ConfigDocumentInfo.config_data` here: it may contain
+# unsaved changes, and config-change invalidation must only run after saved settings are
+# applied.
+
 """
 Loads the file-based configuration from the specified path into the server's config manager.
 

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -16,6 +16,19 @@ const JULIA_TEXT_DOCUMENT_SYNC_SELECTOR = DocumentFilter[
     [TextDocumentFilterLanguage(; language = "julia", scheme) for scheme in UNSAVED_DOCUMENT_SCHEMES]...,
 ]
 
+function config_document_sync_filter(server::Server)
+    state = server.state
+    isdefined(state, :root_path) || return nothing
+    pattern = if supports(server, :textDocument, :filters, :relativePatternSupport)
+        RelativePattern(;
+            baseUri = filepath2uri(state.root_path),
+            pattern = CONFIG_FILE)
+    else
+        CONFIG_FILE_GLOB_PATTERN
+    end
+    return TextDocumentFilterPattern(; scheme = "file", pattern)
+end
+
 function text_document_sync_options(server::Server)
     return TextDocumentSyncOptions(;
         openClose = true,
@@ -25,7 +38,11 @@ function text_document_sync_options(server::Server)
 end
 
 function text_document_sync_registrations(server::Server)
-    open_close_selector = copy(JULIA_TEXT_DOCUMENT_SYNC_SELECTOR)
+    sync_selector = copy(JULIA_TEXT_DOCUMENT_SYNC_SELECTOR)
+    config_filter = config_document_sync_filter(server)
+    config_filter === nothing || push!(sync_selector, config_filter)
+
+    open_close_selector = copy(sync_selector)
     if supports_text_document_content(server)
         append!(open_close_selector,
             TextDocumentFilterScheme[
@@ -42,7 +59,7 @@ function text_document_sync_registrations(server::Server)
             id = DID_CHANGE_TEXT_DOCUMENT_REGISTRATION_ID,
             method = DID_CHANGE_TEXT_DOCUMENT_REGISTRATION_METHOD,
             registerOptions = TextDocumentChangeRegistrationOptions(;
-                documentSelector = JULIA_TEXT_DOCUMENT_SYNC_SELECTOR,
+                documentSelector = sync_selector,
                 syncKind = TextDocumentSyncKind.Full)),
         Registration(;
             id = DID_CLOSE_TEXT_DOCUMENT_REGISTRATION_ID,
@@ -163,6 +180,10 @@ function handle_DidOpenTextDocumentNotification(server::Server, msg::DidOpenText
     uri = textDocument.uri
     is_text_document_content_uri(uri) &&
         return mark_text_document_content_opened!(server, uri) # turn on the `opened` flag
+    if is_config_document_uri(server.state, uri)
+        cache_config_document!(server.state, uri, textDocument.version, textDocument.text)
+        return nothing
+    end
     if textDocument.languageId != "julia"
         mark_text_document_rejected!(server.state, uri)
         return nothing
@@ -181,6 +202,10 @@ function handle_DidChangeTextDocumentNotification(server::Server, msg::DidChange
     # Read-only `jetls-*:` virtual documents never carry user edits to sync, so just ignore it.
     is_text_document_content_uri(uri) && return nothing
     text = last(contentChanges).text
+    if is_config_document_uri(server.state, uri)
+        cache_config_document!(server.state, uri, textDocument.version, text)
+        return nothing
+    end
     is_synchronized(server.state, uri) || return nothing
     for contentChange in contentChanges
         @assert contentChange.range === contentChange.rangeLength === nothing # since `change = TextDocumentSyncKind.Full`
@@ -193,6 +218,7 @@ end
 
 function handle_DidSaveTextDocumentNotification(server::Server, msg::DidSaveTextDocumentNotification)
     uri = msg.params.textDocument.uri
+    is_config_document_uri(server.state, uri) && return nothing
     cache = load(server.state.saved_file_cache)
     haskey(cache, uri) || return nothing
     text = msg.params.text
@@ -212,6 +238,10 @@ function handle_DidCloseTextDocumentNotification(server::Server, msg::DidCloseTe
     uri = msg.params.textDocument.uri
     is_text_document_content_uri(uri) &&
         return mark_text_document_content_closed!(server, uri) # turn off the `opened` flag
+    if is_config_document_uri(server.state, uri)
+        delete_config_document!(server.state, uri)
+        return nothing
+    end
     delete_rejected_text_document!(server.state, uri) && return nothing
     is_synchronized(server.state, uri) || return nothing
     store!(server.state.file_cache) do cache

--- a/src/types.jl
+++ b/src/types.jl
@@ -181,6 +181,12 @@ struct SavedFileInfo
     end
 end
 
+struct ConfigDocumentInfo
+    version::Int
+    text::String
+    config_data::Union{Nothing,Dict{String,Any}}
+end
+
 # Notebook document synchronization
 # =================================
 
@@ -868,6 +874,7 @@ end
 const FileCache = SWContainer{Base.PersistentDict{URI,FileInfo}, SWStats}
 const SavedFileCache = SWContainer{Base.PersistentDict{URI,SavedFileInfo}, SWStats}
 const RejectedTextDocuments = SWContainer{Base.PersistentDict{URI,Nothing}, SWStats}
+const ConfigDocumentCache = SWContainer{Base.PersistentDict{URI,ConfigDocumentInfo}, SWStats}
 const NotebookCache = SWContainer{Base.PersistentDict{URI,NotebookInfo}, SWStats}
 const CellToNotebookMap = SWContainer{Base.PersistentDict{URI,URI}, SWStats} # cell URI -> notebook URI
 
@@ -940,6 +947,7 @@ mutable struct ServerState
     const saved_file_cache::SavedFileCache # syntactic analysis cache (synced with `textDocument/didSave`)
     # Prevent requests for documents rejected by `didOpen` from waiting for a `FileInfo`.
     const rejected_text_documents::RejectedTextDocuments
+    const config_document_cache::ConfigDocumentCache
     const notebook_cache::NotebookCache # notebook document cache (synced with `notebookDocument/did*`), mapping notebook URIs to their notebook info
     const cell_to_notebook::CellToNotebookMap # maps cell URIs to their notebook URI
     # Cache for files not synced via document-synchronization (unsynced files).
@@ -982,6 +990,7 @@ mutable struct ServerState
             #=file_cache=# FileCache(),
             #=saved_file_cache=# SavedFileCache(),
             #=rejected_text_documents=# RejectedTextDocuments(),
+            #=config_document_cache=# ConfigDocumentCache(),
             #=notebook_cache=# NotebookCache(),
             #=cell_to_notebook=# CellToNotebookMap(),
             #=unsynced_file_cache=# UnsyncedFileCache(),

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -248,6 +248,7 @@ waiting for its timeout.
 """
 function may_have_file_info(s::ServerState, uri::URI)
     is_rejected_text_document(s, uri) && return false
+    is_config_document_uri(s, uri) && return false
     uri.scheme == "file" && return true
     isunsaveduri(uri) && return true
     return get_notebook_uri_for_cell(s, uri) !== nothing

--- a/test/test_code_action.jl
+++ b/test/test_code_action.jl
@@ -660,6 +660,68 @@ end
         end
     end
 
+    @testset "existing config: versioned edit for the synced document" begin
+        mktempdir() do dir
+            config_path = joinpath(dir, ".JETLSConfig.toml")
+            config_uri = filepath2uri(config_path)
+            original = """
+                [[full_analysis.concretization_patterns]]
+                pattern = "OLD = x_"
+                """
+            write(config_path, original)
+            rootUri = filepath2uri(dir)
+            capabilities = ClientCapabilities(;
+                workspace = WorkspaceClientCapabilities(;
+                    workspaceEdit = WorkspaceEditClientCapabilities(;
+                        documentChanges = true)))
+            withserver(; rootUri, capabilities) do (; server)
+                JETLS.handle_DidOpenTextDocumentNotification(server,
+                    make_DidOpenTextDocumentNotification(config_uri, original; languageId = "toml", version = 1))
+                config_document = JETLS.get_config_document(server.state, config_uri)
+                @test config_document.version == 1
+                @test config_document.config_data == TOML.parse(original)
+
+                live = original * "# unsaved\n"
+                JETLS.handle_DidChangeTextDocumentNotification(server,
+                    make_DidChangeTextDocumentNotification(config_uri, live, 2))
+                config_document = JETLS.get_config_document(server.state, config_uri)
+                @test config_document.version == 2
+                @test config_document.text == live
+                @test config_document.config_data == TOML.parse(live)
+
+                edit = JETLS.jetls_config_workspace_edit(server, config_path, "USE_PULSE = x_", "issue464.jl")
+                @test edit.changes === nothing
+                document_edit = only(edit.documentChanges)::TextDocumentEdit
+                @test document_edit.textDocument.uri == config_uri
+                @test document_edit.textDocument.version == 2
+                text_edit = only(document_edit.edits)
+                updated = JETLS.apply_text_change(live, text_edit.range, text_edit.newText, server.state.encoding)
+                @test startswith(updated, live)
+                patterns = TOML.parse(updated)["full_analysis"]["concretization_patterns"]
+                @test [config["pattern"] for config in patterns] == ["OLD = x_", "USE_PULSE = x_"]
+
+                # The live document remains the edit target even after the file is
+                # deleted on disk.
+                rm(config_path)
+                edit = JETLS.jetls_config_workspace_edit(server, config_path, "USE_PULSE = x_", "issue464.jl")
+                document_edit = only(edit.documentChanges)::TextDocumentEdit
+                @test document_edit.textDocument.version == 2
+
+                invalid = "[full_analysis"
+                JETLS.handle_DidChangeTextDocumentNotification(server,
+                    make_DidChangeTextDocumentNotification(config_uri, invalid, 3))
+                config_document = JETLS.get_config_document(server.state, config_uri)
+                @test config_document.version == 3
+                @test config_document.config_data === nothing
+                @test JETLS.jetls_config_workspace_edit(server, config_path, "USE_PULSE = x_", "issue464.jl") === nothing
+
+                JETLS.handle_DidCloseTextDocumentNotification(server,
+                    make_DidCloseTextDocumentNotification(config_uri))
+                @test JETLS.get_config_document(server.state, config_uri) === nothing
+            end
+        end
+    end
+
     @testset "missing config: `CreateFile` edit" begin
         mktempdir() do dir
             script_path = joinpath(dir, "issue464.jl")

--- a/test/test_config.jl
+++ b/test/test_config.jl
@@ -1,7 +1,7 @@
 module test_config
 
 using Test
-using JETLS
+using JETLS: JETLS
 
 include("HierarchicalTestSet.jl")
 
@@ -179,6 +179,17 @@ include("HierarchicalTestSet.jl")
             @test any(changes) do (_, _, path)
                 path == (:diagnostic, :patterns)
             end
+        end
+    end
+
+    @testset "`is_config_document_uri`" begin
+        mktempdir() do dir
+            state = JETLS.Server().state
+            state.root_path = dir
+            @test JETLS.is_config_document_uri(state, JETLS.filepath2uri(joinpath(dir, JETLS.CONFIG_FILE)))
+            @test JETLS.is_config_document_uri(state, JETLS.filepath2uri(joinpath(dir, "nested", "..", JETLS.CONFIG_FILE)))
+            @test !JETLS.is_config_document_uri(state, JETLS.filepath2uri(joinpath(dir, "nested", JETLS.CONFIG_FILE)))
+            @test !JETLS.is_config_document_uri(state, JETLS.filepath2uri(joinpath(dir, "config.toml")))
         end
     end
 end

--- a/test/test_document_synchronization.jl
+++ b/test/test_document_synchronization.jl
@@ -12,6 +12,24 @@ function registration_for_method(request::RegisterCapabilityRequest, method::Str
         if registration.method == method)
 end
 
+function test_config_document_sync_registration(
+        request::RegisterCapabilityRequest, config_filter::Dict{String,Any}
+    )
+    for method in (
+            "textDocument/didOpen",
+            "textDocument/didChange",
+            "textDocument/didClose"
+        )
+        reg = registration_for_method(request, method)
+        options = reg.registerOptions::Dict{String,Any}
+        @test config_filter in options["documentSelector"]
+    end
+
+    save_registration = registration_for_method(request, "textDocument/didSave")
+    save_options = save_registration.registerOptions::Dict{String,Any}
+    @test config_filter ∉ save_options["documentSelector"]
+end
+
 @testset "dynamic document synchronization registration" begin
     capabilities = ClientCapabilities(;
         textDocument = TextDocumentClientCapabilities(;
@@ -153,10 +171,53 @@ end
     end
 end
 
+@testset "workspace config document synchronization registration" begin
+    mktempdir() do dir
+        root_uri = filepath2uri(dir)
+
+        let capabilities = ClientCapabilities(;
+                textDocument = TextDocumentClientCapabilities(;
+                    filters = TextDocumentFilterClientCapabilities(;
+                        relativePatternSupport = true),
+                    synchronization = TextDocumentSyncClientCapabilities(;
+                        dynamicRegistration = true,
+                        didSave = true)))
+            withserver(; capabilities, rootUri = root_uri) do (;
+                    register_capability_json_request
+                )
+                config_filter = Dict{String,Any}(
+                    "scheme" => "file",
+                    "pattern" => Dict{String,Any}(
+                        "baseUri" => string(root_uri),
+                        "pattern" => JETLS.CONFIG_FILE))
+                test_config_document_sync_registration(
+                    register_capability_json_request, config_filter)
+            end
+        end
+
+        let capabilities = ClientCapabilities(;
+                textDocument = TextDocumentClientCapabilities(;
+                    synchronization = TextDocumentSyncClientCapabilities(;
+                        dynamicRegistration = true,
+                        didSave = true)))
+            withserver(; capabilities, rootUri = root_uri) do (;
+                    register_capability_json_request
+                )
+                config_filter = Dict{String,Any}(
+                    "scheme" => "file",
+                    "pattern" => JETLS.CONFIG_FILE_GLOB_PATTERN)
+                test_config_document_sync_registration(
+                    register_capability_json_request, config_filter)
+            end
+        end
+    end
+end
+
 @testset "unsupported text documents are ignored" begin
     mktempdir() do dir
         server = JETLS.Server()
         state = server.state
+        state.root_path = dir
         uri = filepath2uri(joinpath(dir, "Manifest.toml"))
 
         open_notification = DidOpenTextDocumentNotification(;
@@ -168,6 +229,15 @@ end
         @test !haskey(JETLS.load(state.saved_file_cache), uri)
         @test JETLS.is_rejected_text_document(state, uri)
         @test !JETLS.may_have_file_info(state, uri)
+
+        config_uri = filepath2uri(joinpath(dir, JETLS.CONFIG_FILE))
+        @test !JETLS.may_have_file_info(state, config_uri)
+
+        nested_config_uri = filepath2uri(joinpath(dir, "nested", JETLS.CONFIG_FILE))
+        nested_open = make_DidOpenTextDocumentNotification(nested_config_uri, ""; languageId = "toml")
+        JETLS.handle_DidOpenTextDocumentNotification(server, nested_open)
+        @test JETLS.get_config_document(state, nested_config_uri) === nothing
+        @test JETLS.is_rejected_text_document(state, nested_config_uri)
 
         change_notification = DidChangeTextDocumentNotification(;
             params = DidChangeTextDocumentParams(;


### PR DESCRIPTION
The missing-concretization quick fix previously computed edits from on-disk config text. Unsaved editor changes could make the target position stale, allowing an unversioned edit to modify content it was not computed against.

When clients support dynamic document synchronization, JETLS adds the workspace-root `.JETLSConfig.toml` to the server-owned selector for open, change, and close notifications. The server stores each live buffer as a `ConfigDocumentInfo` snapshot containing its version, text, and validated raw config data. Code actions reuse that snapshot while still reparsing and validating each candidate edit.

`jetls_config_workspace_edit` prefers the live buffer even when the file has been deleted on disk. It returns a versioned `TextDocumentEdit` when the client supports `documentChanges`, with the existing `changes` fallback otherwise. Invalid live TOML suppresses the action until the next synchronized update.

Saved config application remains driven by watched-file notifications, so unsaved buffer contents never affect analysis settings. Tests cover snapshot updates, invalid TOML, versioned edits, deleted-on-disk buffers, cache cleanup, and file creation.