### PR TITLE
inlay-hint: Fix matrix literal type annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed type inlay hints for matrix and multidimensional array literals, which now show the constructed array type without annotations for internal row dimensions. (Closed https://github.com/aviatesk/JETLS.jl/issues/841)
+
 - Fixed the TestRunner integration treating failed or errored tests as an unexpected TestRunner execution failure instead of reporting their results.
 
 - Fixed watched-file registration for clients that do not support relative glob patterns, while keeping handled file events scoped to the workspace root.

--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -1542,7 +1542,13 @@ end
 # collapses onto the very expression it wraps, and letting the wrapper claim the range
 # would drop the query into `tmerge_at_range`, merging loop/closure scaffolding types
 # into the user-visible result.
-const DISPATCH_SURFACE_KINDS = JS.KSet"macrocall call dotcall tuple ' do juxtapose typed_comprehension for while function macro = comparison && || if ?"
+const CALL_RESULT_SURFACE_KINDS = JS.KSet"""
+    call dotcall tuple ' do juxtapose vect vcat hcat ncat typed_vcat typed_hcat typed_ncat
+    """
+const DISPATCH_SURFACE_KINDS = JS.KSet"""
+    function do macro call dotcall macrocall tuple ' juxtapose = comparison && || if ? for while
+    vect vcat hcat ncat typed_vcat typed_hcat typed_ncat typed_comprehension row
+    """
 
 function collect_provenance_indexes(inferred_tree::SyntaxTree, annotations::TreeAnnotations)
     surface_kind_index = Dict{UnitRange{Int},JS.Kind}()
@@ -1819,8 +1825,10 @@ nodes appropriately; see the source of each helper for the rationale behind its 
 | surface kind                                           | strategy                     |
 |:-------------------------------------------------------|:-----------------------------|
 | `K"call"` / `K"dotcall"` / `K"tuple"` / `K"'"` / `K"do"` | `type_for_call`              |
+| array literal kinds                                     | `type_for_call`              |
 | `K"macrocall"`                                         | `type_for_macroexpansion`    |
 | `K"typed_comprehension"`                               | `type_for_array_construct`   |
+| `K"row"`                                               | always `nothing`             |
 | `K"function"` / `K"macro"`                             | `type_for_funcdef`           |
 | `K"comparison"` / `K"&&"` / `K"||"` / `K"if"` / `K"?"` | `type_for_branching`         |
 | `K"for"` / `K"while"`                                  | always `Core.Const(nothing)` |
@@ -1836,12 +1844,15 @@ function get_type_for_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
     surface_kind = surface_kind_at_range(ctx, rng)
     if surface_kind === JS.K"macrocall"
         return type_for_macroexpansion(ctx, rng)
-    elseif surface_kind in JS.KSet"call dotcall tuple ' do juxtapose"
+    elseif surface_kind in CALL_RESULT_SURFACE_KINDS
         # `juxtapose`: parse-tree provenance retains the parser kind for `2x`,
         # which desugars to a `K"call"` in the inferred tree.
         return type_for_call(ctx, rng)
     elseif surface_kind === JS.K"typed_comprehension"
         return type_for_typed_comprehension(ctx, rng)
+    elseif surface_kind === JS.K"row"
+        # Matrix rows carry synthetic `hvcat` dimension arguments, not values.
+        return nothing
     elseif surface_kind in JS.KSet"for while"
         return Core.Const(nothing)
     elseif surface_kind in JS.KSet"function macro"
@@ -1887,6 +1898,8 @@ end
 # - NamedTuple literal `(; a=1, b=2)`: lowered as four calls — names tuple,
 #   `NamedTuple{…}` type apply, values tuple, final constructor — and the
 #   constructor (which produces the NamedTuple value) is emitted last.
+# - Matrix / n-dimensional literals: the dimension tuple is constructed before
+#   the final `hvcat` / `hvncat` call, so the array-producing call wins.
 # - Positional `f(args)` and `(1, 2, 3)`: a single K"call" at the range,
 #   so "last" is just that single entry.
 function type_for_call(ctx::InferredTreeContext, rng::UnitRange{<:Integer})

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -1170,9 +1170,8 @@ end
         end
     end
 
-    # `[xs...]` / `T[xs...]` should surface the constructed `Vector{T}` type,
-    # not widen to a union with the synthetic `Base.vect` / `Base.getindex`
-    # callees that lowering plants at the literal's byte range.
+    # Array literals should surface the constructed array type, not widen to a
+    # union with synthetic callees or dimension tuples at the literal's byte range.
     @testset "array literal leaf scaffolding doesn't pollute tmerge range" begin
         let code = "[1, 2, 3]"
             _, ctx = type_annotate(code)
@@ -1183,6 +1182,18 @@ end
             _, ctx = type_annotate(code)
             @test widenconst(get_type_for_range(ctx, range_of(code, "Any[1, 2, 3]"))) ===
                 Vector{Any}
+        end
+        let code = "[1 2; 3 4]"
+            _, ctx = type_annotate(code)
+            @test widenconst(get_type_for_range(ctx, range_of(code, code))) === Matrix{Int}
+        end
+        let code = "Int[1 2; 3 4]"
+            _, ctx = type_annotate(code)
+            @test widenconst(get_type_for_range(ctx, range_of(code, code))) === Matrix{Int}
+        end
+        let code = "[1 2;;; 3 4]"
+            _, ctx = type_annotate(code)
+            @test widenconst(get_type_for_range(ctx, range_of(code, code))) === Array{Int,3}
         end
     end
 

--- a/test/test_inlay_hint.jl
+++ b/test/test_inlay_hint.jl
@@ -465,6 +465,25 @@ end
         @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
     end
 
+    @testset "matrix literals" begin
+        let code = "X = [1 2; 3 4]\n"
+            expected = "X = [1 2; 3 4]::Matrix{$Int}\n"
+            @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
+        end
+        let code = """
+            function matrix_from_vars(x::Int, y::Int)
+                [x y; y x]
+            end
+            """
+            expected = """
+            function matrix_from_vars(x::Int, y::Int)::Matrix{$Int}
+                [x::$Int y::$Int; y::$Int x::$Int]::Matrix{$Int}
+            end
+            """
+            @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
+        end
+    end
+
     @testset "range filtering" begin
         code = "let x = [1, 2, 3]\n" *
             "    sum(x)\n" *


### PR DESCRIPTION
Matrix literals such as `[1 2; 3 4]` exposed synthetic row dimensions as inline type hints and merged those values into the literal result. The resulting `Union` obscured the actual matrix type and could degrade downstream inference.

Route array literal surface forms through call-result selection and suppress synthetic matrix row ranges. This preserves the final `hvcat` or `hvncat` result for matrix and multidimensional literals.

Add focused type-annotation and inlay-hint coverage for regular, typed, and multidimensional literals.

Fixes aviatesk/JETLS.jl#841