### PR TITLE
type-annotation: Fix typed vector splat results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed type inlay hints for typed vector literals with splatted values, which now show the constructed vector type instead of an unrelated union containing tuple types.
+
 - Fixed type inlay hints for matrix and multidimensional array literals, which now show the constructed array type without annotations for internal row dimensions. (Closed https://github.com/aviatesk/JETLS.jl/issues/841)
 
 - Fixed the TestRunner integration treating failed or errored tests as an unexpected TestRunner execution failure instead of reporting their results.

--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -1543,10 +1543,12 @@ end
 # would drop the query into `tmerge_at_range`, merging loop/closure scaffolding types
 # into the user-visible result.
 const CALL_RESULT_SURFACE_KINDS = JS.KSet"""
-    call dotcall tuple ' do juxtapose vect vcat hcat ncat typed_vcat typed_hcat typed_ncat
+    call dotcall ref tuple ' do juxtapose
+    vect vcat hcat ncat typed_vcat typed_hcat typed_ncat
     """
 const DISPATCH_SURFACE_KINDS = JS.KSet"""
-    function do macro call dotcall macrocall tuple ' juxtapose = comparison && || if ? for while
+    function do macro call dotcall macrocall ref tuple ' juxtapose =
+    comparison && || if ? for while
     vect vcat hcat ncat typed_vcat typed_hcat typed_ncat typed_comprehension row
     """
 
@@ -1822,17 +1824,16 @@ a naive `tmerge` of all matches would pull in synthetic helper types that the us
 wrote. The dispatch picks a per-kind strategy that filters or summarizes the lowered
 nodes appropriately; see the source of each helper for the rationale behind its choice:
 
-| surface kind                                           | strategy                     |
-|:-------------------------------------------------------|:-----------------------------|
-| `K"call"` / `K"dotcall"` / `K"tuple"` / `K"'"` / `K"do"` | `type_for_call`              |
-| array literal kinds                                     | `type_for_call`              |
-| `K"macrocall"`                                         | `type_for_macroexpansion`    |
-| `K"typed_comprehension"`                               | `type_for_array_construct`   |
-| `K"row"`                                               | always `nothing`             |
-| `K"function"` / `K"macro"`                             | `type_for_funcdef`           |
-| `K"comparison"` / `K"&&"` / `K"||"` / `K"if"` / `K"?"` | `type_for_branching`         |
-| `K"for"` / `K"while"`                                  | always `Core.Const(nothing)` |
-| everything else                                        | `tmerge_at_range`            |
+| surface kind                                                                              | strategy                     |
+|:-----------------------------------------------------------------------------------------:|:----------------------------:|
+| `K"call"` / `K"dotcall"` / `K"ref"` / `K"tuple"` / `K"'"` / `K"do"` / array literal kinds | `type_for_call`              |
+| `K"macrocall"`                                                                            | `type_for_macroexpansion`    |
+| `K"typed_comprehension"`                                                                  | `type_for_array_construct`   |
+| `K"row"`                                                                                  | always `nothing`             |
+| `K"function"` / `K"macro"`                                                                | `type_for_funcdef`           |
+| `K"comparison"` / `K"&&"` / `K"||"` / `K"if"` / `K"?"`                                    | `type_for_branching`         |
+| `K"for"` / `K"while"`                                                                     | always `Core.Const(nothing)` |
+| everything else                                                                           | `tmerge_at_range`            |
 """
 function get_type_for_range(ctx::InferredTreeContext, rng::UnitRange{<:Integer})
     binding_typ = get(ctx.oc_argument_binding_types, rng, nothing)

--- a/test/analysis/test_TypeAnnotation.jl
+++ b/test/analysis/test_TypeAnnotation.jl
@@ -1183,6 +1183,10 @@ end
             @test widenconst(get_type_for_range(ctx, range_of(code, "Any[1, 2, 3]"))) ===
                 Vector{Any}
         end
+        let code = "Int[(1, 2)...]"
+            _, ctx = type_annotate(code)
+            @test widenconst(get_type_for_range(ctx, range_of(code, code))) === Vector{Int}
+        end
         let code = "[1 2; 3 4]"
             _, ctx = type_annotate(code)
             @test widenconst(get_type_for_range(ctx, range_of(code, code))) === Matrix{Int}

--- a/test/test_inlay_hint.jl
+++ b/test/test_inlay_hint.jl
@@ -465,6 +465,13 @@ end
         @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
     end
 
+    @testset "typed vector literals" begin
+        let code = "X = Int[(1, 2)...]\n"
+            expected = "X = Int[(1, 2)::Tuple{$Int, $Int}...]::Vector{$Int}\n"
+            @test apply_inlay_hints(code, get_type_inlay_hints(code)) == expected
+        end
+    end
+
     @testset "matrix literals" begin
         let code = "X = [1 2; 3 4]\n"
             expected = "X = [1 2; 3 4]::Matrix{$Int}\n"


### PR DESCRIPTION
Typed vector literals with splatted values, such as `Int[(1, 2)...]`, merged synthetic type-construction tuples into the literal result. Type inlay hints consequently displayed an unrelated `Union` instead of `Vector{Int}`.

Route `K"ref"` surfaces through call-result selection so indexing and typed vector literals use the final lowered call result. Add direct type-annotation and inlay-hint regression coverage.