### PR TITLE
initialize: Warn about unsupported workspace setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - JETLS servers started without a workspace root (i.e., when an LSP `InitializeRequest` specifies neither `workspaceFolders` nor `rootUri`) now analyze opened Julia files as standalone scripts instead of discovering nearby project environments. This avoids automatic environment setup and package-wide analysis in rootless LSP sessions.
 
+- JETLS now displays a warning when workspace analysis and folder-local configuration are unavailable because a server was started without a workspace folder, with an unsupported root URI scheme, or with multiple workspace folders. For multi-root workspaces, configure the editor to start one server per top-level folder.
+
 - `inference/*` diagnostic related information now labels inference frames as `origin`, `via`, or `entry`, making it clearer where the error originated and which analysis entry reported it.
 
 - `inference/type-error/*` now groups diagnostics for the subset of runtime `TypeError` cases that JETLS can infer, including non-`Bool` conditions and statically failing type assertions. Users can ignore or reconfigure this family together with a regex code match such as `inference/type-error/.*`.

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -24,7 +24,7 @@ using Preferences: Preferences
 const JETLS_DEV_MODE = Preferences.@load_preference("JETLS_DEV_MODE", false)
 const JETLS_TEST_MODE = Preferences.@load_preference("JETLS_TEST_MODE", false)
 const JETLS_DEBUG_LOWERING = Preferences.@load_preference("JETLS_DEBUG_LOWERING", false)
-function show_setup_info(msg)
+function show_setup_info(msg::AbstractString)
     @info msg Sys.BINDIR pkgdir(JETLS) Threads.nthreads() JETLS_VERSION JETLS_DEV_MODE JETLS_TEST_MODE JETLS_DEBUG_LOWERING
 end
 

--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -24,9 +24,16 @@ function handle_InitializeRequest(
         state.workspaceFolders = URI[]
         if rootUri !== nothing
             push!(state.workspaceFolders, rootUri)
-        else
-            @warn "No workspaceFolders or rootUri in InitializeRequest - some functionality will be limited"
         end
+    end
+    if isempty(state.workspaceFolders)
+        @warn "No workspace folder in InitializeRequest - some functionality will be limited"
+        show_warning_message(server,
+            """
+            JETLS started without a workspace folder.
+            Workspace analysis and folder-local configuration are unavailable.
+            Open a folder to enable full functionality.
+            """)
     end
 
     # Update root information
@@ -43,9 +50,20 @@ function handle_InitializeRequest(
             end
         else
             @warn "Root URI scheme not supported for workspace analysis" root_uri
+            show_warning_message(server,
+                """
+                JETLS cannot perform workspace analysis for the root URI scheme `$(root_uri.scheme):`.
+                Some language features will be limited.
+                """)
         end
     else
         @warn "Multiple workspaceFolders are not supported - using limited functionality" state.workspaceFolders
+        show_warning_message(server,
+            """
+            JETLS does not support multiple workspace folders in a single server.
+            Workspace analysis and folder-local configuration are unavailable.
+            Configure your editor to start one JETLS server per workspace folder.
+            """)
         # leave Refs undefined
     end
 
@@ -541,6 +559,15 @@ function handle_InitializedNotification(server::Server)
 
     register(server, registrations)
 
-    @static JETLS_DEV_MODE && show_setup_info("Initialized JETLS with the following setup:")
-    @static JETLS_DEV_MODE && @info "JETLS initialization options" init_options=state.init_options
+    @static JETLS_DEV_MODE && show_initialization_info(server, "Initialized JETLS with the following setup:")
+end
+
+function show_initialization_info(server::Server, msg::AbstractString)
+    state = server.state
+    (; init_options, workspaceFolders) = state
+    root_path = isdefined(state, :root_path) ? state.root_path : nothing
+    root_env_path = isdefined(state, :root_env_path) ? state.root_env_path : nothing
+    Base.CoreLogging.with_logger(Base.CoreLogging.ConsoleLogger(stderr; show_limited=false)) do
+        @info msg Sys.BINDIR pkgdir(JETLS) Threads.nthreads() JETLS_VERSION JETLS_DEV_MODE JETLS_TEST_MODE JETLS_DEBUG_LOWERING init_options workspaceFolders root_path root_env_path
+    end
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -27,8 +27,32 @@ module __demo__ end
             # `ClientCapabilities` dominates time-to-first-response and is otherwise
             # compiled lazily on the first request, which on slow machines can exceed
             # strict client initialize timeouts (e.g. Helix's 20s default). See #784.
+            workspace_uri = string(filepath2uri(dirname(filename)))
             init_json = """
-                {"jsonrpc":"2.0","id":0,"method":"initialize","params":{"processId":null,"rootUri":null,"capabilities":{"textDocument":{"completion":{"dynamicRegistration":true},"hover":{"dynamicRegistration":true}},"general":{"positionEncodings":["utf-8"]}}}}
+                {
+                    "jsonrpc": "2.0",
+                    "id": 0,
+                    "method": "initialize",
+                    "params": {
+                        "processId": null,
+                        "rootUri": null,
+                        "workspaceFolders": [
+                            {
+                                "uri": "$workspace_uri",
+                                "name": "precompile"
+                            }
+                        ],
+                        "capabilities": {
+                            "textDocument": {
+                                "completion": {"dynamicRegistration": true},
+                                "hover": {"dynamicRegistration": true}
+                            },
+                            "general": {
+                                "positionEncodings": ["utf-8"]
+                            }
+                        }
+                    }
+                }
                 """
             init_msg = LSP.to_lsp_object(init_json)
             # Capture the response via the recorder (populated synchronously by `send`)
@@ -37,9 +61,15 @@ module __demo__ end
             Base.CoreLogging.with_logger(Base.CoreLogging.NullLogger()) do
                 recorder = ServerMessageRecorder()
                 init_server = Server(; callback=recorder)
-                handle_InitializeRequest(init_server, init_msg)
-                LSP.to_lsp_json(take!(recorder.sent_queue))
-                close(init_server.endpoint)
+                try
+                    handle_InitializeRequest(init_server, init_msg)
+                    response = take!(recorder.sent_queue)::InitializeResponse
+                    LSP.to_lsp_json(response)
+                finally
+                    stop_analysis_worker(init_server)
+                    stop_signature_analysis_workers(init_server)
+                    close(init_server.endpoint)
+                end
             end
 
             server = Server()

--- a/test/app/test_jetls_serve.jl
+++ b/test/app/test_jetls_serve.jl
@@ -75,6 +75,18 @@ function read_lsp_message(io)
     return String(read(io, var"Content-Length"))
 end
 
+function read_lsp_response(io, id::Int)
+    preceding_messages = String[]
+    id_marker = "\"id\":$id"
+    while true
+        message = read_lsp_message(io)
+        if occursin(id_marker, message)
+            return (; response=message, preceding_messages)
+        end
+        push!(preceding_messages, message)
+    end
+end
+
 const DEFAULT_TIMEOUT = 10
 const STARTUP_TIMEOUT = 60
 
@@ -99,7 +111,7 @@ end
 end
 
 # test a very simple, normal server lifecycle
-withserverprocess() do proc
+withserverprocess() do proc; mktempdir() do root_dir
     # Send initialization request
     initialize_msg = """{
         "jsonrpc": "2.0",
@@ -107,15 +119,17 @@ withserverprocess() do proc
         "method": "initialize",
         "params": {
             "processId": $(getpid()),
-            "rootUri": null,
             "capabilities": {},
-            "workspaceFolders": []
+            "workspaceFolders": [{
+                "uri": "$(JETLS.LSP.URIs2.filepath2uri(root_dir))",
+                "name": "test-workspace"
+            }]
         }
     }"""
     write_lsp_message(proc, initialize_msg)
-    initialization_response = @something read_lsp_message(proc) begin
-        error("No response received from server (may have terminated)")
-    end
+    initialization = read_lsp_response(proc, 1)
+    @test isempty(initialization.preceding_messages)
+    initialization_response = initialization.response
     @test occursin("\"id\":1", initialization_response)
     @test occursin("\"result\"", initialization_response)
     # @info "Server responded to initialize request successfully"
@@ -128,9 +142,9 @@ withserverprocess() do proc
         "params": null
     }"""
     write_lsp_message(proc, shutdown_msg)
-    shutdown_response = @something read_lsp_message(proc) begin
-        error("No response received from server (may have terminated)")
-    end
+    shutdown = read_lsp_response(proc, 2)
+    @test isempty(shutdown.preceding_messages)
+    shutdown_response = shutdown.response
     @test occursin("\"id\":2", shutdown_response)
     @test occursin("\"result\":null", shutdown_response)
     # @info "Server responded to shutdown request"
@@ -148,10 +162,10 @@ withserverprocess() do proc
         return true
     end
     @test process_exited(proc) && proc.exitcode == 0
-end
+end; end
 
 # test a very simple, abnormal server lifecycle
-withserverprocess() do proc
+withserverprocess() do proc; mktempdir() do root_dir
     # Send initialization request
     initialize_msg = """{
         "jsonrpc": "2.0",
@@ -159,15 +173,17 @@ withserverprocess() do proc
         "method": "initialize",
         "params": {
             "processId": $(getpid()),
-            "rootUri": null,
             "capabilities": {},
-            "workspaceFolders": []
+            "workspaceFolders": [{
+                "uri": "$(JETLS.LSP.URIs2.filepath2uri(root_dir))",
+                "name": "test-workspace"
+            }]
         }
     }"""
     write_lsp_message(proc, initialize_msg)
-    initialization_response = @something read_lsp_message(proc) begin
-        error("No response received from server (may have terminated)")
-    end
+    initialization = read_lsp_response(proc, 1)
+    @test isempty(initialization.preceding_messages)
+    initialization_response = initialization.response
     @test occursin("\"id\":1", initialization_response)
     @test occursin("\"result\"", initialization_response)
     # @info "Server responded to initialize request successfully"
@@ -185,6 +201,6 @@ withserverprocess() do proc
         return true
     end
     @test process_exited(proc) && proc.exitcode == 1
-end
+end; end
 
 end # module test_jetls_serve

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,7 @@ end
     @testset "types" include("test_types.jl")
     @testset "config" include("test_config.jl")
     @testset "URIs2" include("test_URIs2.jl")
+    @testset "initialize" include("test_initialize.jl")
     @testset "registration" include("test_registration.jl")
     @testset "document synchronization" include("test_document_synchronization.jl")
     @testset "completions" include("test_completions.jl")

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -170,26 +170,37 @@ function withserver(
         return (; raw_msg, json_msg)
     end
 
+    function read_initialize_response(id::Int)
+        while true
+            raw_res = take_with_timeout!(sent_queue)
+            json_res = LSP.readlsp(out)
+            if raw_res isa InitializeResponse
+                @assert raw_res.id == id
+                return (; raw_res, json_res)
+            end
+            raw_res isa ShowMessageNotification ||
+                error("Unexpected message before InitializeResponse: $(typeof(raw_res))")
+        end
+    end
+
     local initialize_response, initialize_json_response
     local register_capability_request, register_capability_json_request
     initialize_completed = false
     try
         let id = id_counter[] += 1
-            (; raw_msg, raw_res, json_res) = writereadmsg(
-                InitializeRequest(;
-                    id,
-                    params=InitializeParams(;
-                        processId=getpid(),
-                        capabilities,
-                        rootUri,
-                        workspaceFolders));
-                check = false)
+            LSP.writelsp(in, InitializeRequest(;
+                id,
+                params = InitializeParams(;
+                    processId = getpid(),
+                    capabilities,
+                    rootUri,
+                    workspaceFolders)))
+            raw_msg = take_with_timeout!(received_queue)::InitializeRequest
             initialize_completed = true
+            (; raw_res, json_res) = read_initialize_response(id)
             assert_empty_queues()
-            raw_msg = raw_msg::InitializeRequest
             @assert raw_msg.params.workspaceFolders == workspaceFolders
-            initialize_response = raw_res::InitializeResponse
-            @assert initialize_response.id == id
+            initialize_response = raw_res
             initialize_json_response = json_res::Dict{Symbol,Any}
 
             (; raw_msg, raw_res, json_res) = writereadmsg(InitializedNotification())

--- a/test/test_initialize.jl
+++ b/test/test_initialize.jl
@@ -1,0 +1,80 @@
+module test_initialize
+
+include("setup.jl")
+
+function initialize_messages(;
+        root_uri::Union{Nothing,URI} = nothing,
+        workspace_folders::Union{Nothing,Vector{WorkspaceFolder}} = nothing
+    )
+    recorder = JETLS.ServerMessageRecorder()
+    server = Server(; callback=recorder)
+    request = InitializeRequest(;
+        id = 1,
+        params = InitializeParams(;
+            processId = getpid(),
+            capabilities = ClientCapabilities(),
+            rootUri = root_uri,
+            workspaceFolders = workspace_folders))
+    try
+        JETLS.handle_InitializeRequest(server, request; client_process_id = Int(getpid()))
+        messages = Any[]
+        while isready(recorder.sent_queue)
+            push!(messages, take!(recorder.sent_queue))
+        end
+        return messages
+    finally
+        JETLS.stop_analysis_worker(server)
+        JETLS.stop_signature_analysis_workers(server)
+        close(server.endpoint)
+    end
+end
+
+function test_initialize_warning(messages::Vector{Any}, expected::AbstractString)
+    @test length(messages) == 2
+    warning = first(messages)
+    if warning isa ShowMessageNotification
+        @test warning.params.type == MessageType.Warning
+        @test occursin(expected, warning.params.message)
+    else
+        @test warning isa ShowMessageNotification
+    end
+    @test last(messages) isa InitializeResponse
+    return nothing
+end
+
+@testset "workspace initialization warnings" begin
+    let messages = @test_logs(
+            (:warn, r"No workspace folder"),
+            match_mode = :any,
+            initialize_messages())
+        test_initialize_warning(messages, "started without a workspace folder")
+    end
+
+    let workspace_folders = WorkspaceFolder[]
+        messages = @test_logs(
+            (:warn, r"No workspace folder"),
+            match_mode = :any,
+            initialize_messages(; workspace_folders))
+        test_initialize_warning(messages, "started without a workspace folder")
+    end
+
+    let root_uri = URI("https://example.com/workspace")
+        messages = @test_logs(
+            (:warn, r"Root URI scheme not supported"),
+            match_mode = :any,
+            initialize_messages(; root_uri))
+        test_initialize_warning(messages, "root URI scheme `https:`")
+    end
+
+    let workspace_folders = [
+            WorkspaceFolder(; uri=URI("file:///workspace-a"), name="workspace-a"),
+            WorkspaceFolder(; uri=URI("file:///workspace-b"), name="workspace-b")]
+        messages = @test_logs(
+            (:warn, r"Multiple workspaceFolders are not supported"),
+            match_mode = :any,
+            initialize_messages(; workspace_folders))
+        test_initialize_warning(messages, "one JETLS server per workspace folder")
+    end
+end
+
+end # module test_initialize


### PR DESCRIPTION
JETLS previously only logged when initialization could not establish a single supported workspace root. Users could therefore miss that workspace analysis and folder-local configuration were unavailable.

Send `window/showMessage` warnings for rootless sessions, unsupported URI schemes, and multiple workspace folders. Treat an empty `workspaceFolders` array as rootless and direct multi-root clients to start one server per folder. This warning notifies users about startup patterns unsupported by JETLS, while `jetls-client` specific multi-project support (for aviatesk/jetls-vscode#3) should be developed separately on jetls-client side.

Add focused initialization coverage. Keep the initialization precompile workload on the supported single-workspace path so it still targets `InitializeResponse`, and clean up the workers started by the handler.