### PR TITLE
initialize: Normalize standalone script workspace roots

### DIFF
--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -43,6 +43,9 @@ function handle_InitializeRequest(
         root_uri = only(state.workspaceFolders)
         root_path = uri2filepath(root_uri)
         if root_path !== nothing
+            # Some clients (for example, Zed) send an opened standalone script path as
+            # `workspaceFolders`, so normalize it to a folder here.
+            isfile(root_path) && (root_path = dirname(root_path))
             state.root_path = root_path
             env_path = find_env_path(root_path)
             if env_path !== nothing

--- a/test/test_initialize.jl
+++ b/test/test_initialize.jl
@@ -2,7 +2,7 @@ module test_initialize
 
 include("setup.jl")
 
-function initialize_messages(;
+function initialize_result(;
         root_uri::Union{Nothing,URI} = nothing,
         workspace_folders::Union{Nothing,Vector{WorkspaceFolder}} = nothing
     )
@@ -21,7 +21,8 @@ function initialize_messages(;
         while isready(recorder.sent_queue)
             push!(messages, take!(recorder.sent_queue))
         end
-        return messages
+        root_path = isdefined(server.state, :root_path) ? server.state.root_path : nothing
+        return (; messages, root_path)
     finally
         JETLS.stop_analysis_worker(server)
         JETLS.stop_signature_analysis_workers(server)
@@ -43,37 +44,55 @@ function test_initialize_warning(messages::Vector{Any}, expected::AbstractString
 end
 
 @testset "workspace initialization warnings" begin
-    let messages = @test_logs(
+    let result = @test_logs(
             (:warn, r"No workspace folder"),
             match_mode = :any,
-            initialize_messages())
-        test_initialize_warning(messages, "started without a workspace folder")
+            initialize_result())
+        test_initialize_warning(result.messages, "started without a workspace folder")
     end
 
     let workspace_folders = WorkspaceFolder[]
-        messages = @test_logs(
+        result = @test_logs(
             (:warn, r"No workspace folder"),
             match_mode = :any,
-            initialize_messages(; workspace_folders))
-        test_initialize_warning(messages, "started without a workspace folder")
+            initialize_result(; workspace_folders))
+        test_initialize_warning(result.messages, "started without a workspace folder")
     end
 
     let root_uri = URI("https://example.com/workspace")
-        messages = @test_logs(
+        result = @test_logs(
             (:warn, r"Root URI scheme not supported"),
             match_mode = :any,
-            initialize_messages(; root_uri))
-        test_initialize_warning(messages, "root URI scheme `https:`")
+            initialize_result(; root_uri))
+        test_initialize_warning(result.messages, "root URI scheme `https:`")
     end
 
     let workspace_folders = [
             WorkspaceFolder(; uri=URI("file:///workspace-a"), name="workspace-a"),
             WorkspaceFolder(; uri=URI("file:///workspace-b"), name="workspace-b")]
-        messages = @test_logs(
+        result = @test_logs(
             (:warn, r"Multiple workspaceFolders are not supported"),
             match_mode = :any,
-            initialize_messages(; workspace_folders))
-        test_initialize_warning(messages, "one JETLS server per workspace folder")
+            initialize_result(; workspace_folders))
+        test_initialize_warning(result.messages, "one JETLS server per workspace folder")
+    end
+end
+
+@testset "workspace root normalization" begin
+    mktempdir() do dir
+        normalized_dir = uri2filepath(filepath2uri(dir))::String
+        let script_path = joinpath(dir, "script.jl")
+            write(script_path, "")
+            workspace_folders = [WorkspaceFolder(; uri = filepath2uri(script_path), name = "script.jl")]
+            result = initialize_result(; workspace_folders)
+            @test result.root_path == normalized_dir
+        end
+
+        let workspace_path = joinpath(dir, "missing-workspace")
+            workspace_folders = [WorkspaceFolder(; uri = filepath2uri(workspace_path), name = "missing-workspace")]
+            result = initialize_result(; workspace_folders)
+            @test result.root_path == joinpath(normalized_dir, "missing-workspace")
+        end
     end
 end
 


### PR DESCRIPTION
Some clients, including Zed, report an opened standalone script as a workspace folder. JETLS then stores the file path in `root_path`, so workspace-boundary checks reject the script and folder-local configuration lookup treats the file as a directory.

Normalize existing file paths to their parent directory during initialization. Keep paths that are not confirmed files unchanged. This prevents a missing or inaccessible workspace directory from being widened to its parent.