### PR TITLE
path: Centralize platform-aware path equality

### DIFF
--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -1124,7 +1124,7 @@ function _get_lines_in_ex(lines::Pair{Int,Int}, filepath::AbstractString, @nospe
         end
     elseif ex isa LineNumberNode
         file = ex.file
-        if file isa Symbol && filepath == String(file)
+        if file isa Symbol && paths_equal(filepath, String(file))
             return min(ex.line,first(lines)) => max(ex.line,last(lines))
         end
     end
@@ -1136,7 +1136,7 @@ function get_lines_in_src(filepath::AbstractString, src::Core.CodeInfo)
     for pc in 1:length(src.code)
         lins = Base.IRShow.buildLineInfoNode(src.debuginfo, nothing, pc)
         for lin in lins
-            if filepath == String(lin.file)
+            if paths_equal(filepath, String(lin.file))
                 lines = min(lin.line,first(lines)) => max(lin.line,last(lines))
             end
         end

--- a/src/did-change-watched-files.jl
+++ b/src/did-change-watched-files.jl
@@ -110,7 +110,8 @@ send error message while leaving current configuration unchanged.
 function load_file_config!(on_difference, server::Server, filepath::AbstractString;
                            reload::Bool = false)
     store!(server.state.config_manager) do old_data::ConfigManagerData
-        if reload && old_data.file_config_path != filepath
+        old_path = old_data.file_config_path
+        if reload && (old_path === nothing || !paths_equal(old_path, filepath))
             show_warning_message(server, "Loading unregistered configuration file: $filepath")
         end
 
@@ -150,7 +151,9 @@ unmatched_key_in_config_file_msg(filepath::AbstractString, path::Vector{String})
 
 function delete_file_config!(on_difference, manager::ConfigManager, filepath::AbstractString)
     store!(manager) do old_data::ConfigManagerData
-        old_data.file_config_path == filepath || return old_data, nothing
+        old_path = old_data.file_config_path
+        old_path === nothing && return old_data, nothing
+        paths_equal(old_path, filepath) || return old_data, nothing
         new_data = ConfigManagerData(old_data;
             file_config=EMPTY_CONFIG,
             file_config_path=nothing

--- a/src/utils/path.jl
+++ b/src/utils/path.jl
@@ -27,6 +27,20 @@ function traverse_dir(f, dir::AbstractString)
 end
 
 """
+    paths_equal(path1::AbstractString, path2::AbstractString) -> Bool
+
+Return whether two paths are lexically equal. Both paths must be absolute or both relative;
+mixed paths return `false`. Comparisons are case-insensitive on Windows. This function does
+not access the file system or resolve symbolic links.
+"""
+function paths_equal(path1::AbstractString, path2::AbstractString)
+    path1 = _normalize_path(path1)
+    path2 = _normalize_path(path2)
+    isabspath(path1) == isabspath(path2) || return false
+    return _paths_equal(path1, path2)
+end
+
+"""
     issubdir(dir1::AbstractString, dir2::AbstractString) -> Bool
 
 Return whether `dir1` is lexically equal to or contained within `dir2`. Both paths must

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -229,7 +229,7 @@ function is_workspace_root_file(
     )
     isdefined(s, :root_path) || return false
     expected = joinpath(s.root_path, filename)
-    return _paths_equal(_normalize_path(filepath), _normalize_path(expected))
+    return paths_equal(filepath, expected)
 end
 
 function is_workspace_file(s::ServerState, filepath::AbstractString)

--- a/test/test_diagnostic.jl
+++ b/test/test_diagnostic.jl
@@ -174,7 +174,7 @@ end
             @test diag.data isa MissingConcretizationData
             @test diag.data.name == "USE_PULSE"
             @test diag.data.pattern == "USE_PULSE = x_"
-            @test diag.data.assignment_file == expected_path
+            @test JETLS.paths_equal(diag.data.assignment_file, script_path)
             @test occursin("assignment at $expected_path:1", diag.message)
             @test occursin("`full_analysis.concretization_patterns`", diag.message)
             @test occursin("`.JETLSConfig.toml`", diag.message)

--- a/test/test_initialize.jl
+++ b/test/test_initialize.jl
@@ -80,18 +80,17 @@ end
 
 @testset "workspace root normalization" begin
     mktempdir() do dir
-        normalized_dir = uri2filepath(filepath2uri(dir))::String
         let script_path = joinpath(dir, "script.jl")
             write(script_path, "")
             workspace_folders = [WorkspaceFolder(; uri = filepath2uri(script_path), name = "script.jl")]
             result = initialize_result(; workspace_folders)
-            @test result.root_path == normalized_dir
+            @test JETLS.paths_equal(result.root_path, dir)
         end
 
         let workspace_path = joinpath(dir, "missing-workspace")
             workspace_folders = [WorkspaceFolder(; uri = filepath2uri(workspace_path), name = "missing-workspace")]
             result = initialize_result(; workspace_folders)
-            @test result.root_path == joinpath(normalized_dir, "missing-workspace")
+            @test JETLS.paths_equal(result.root_path, workspace_path)
         end
     end
 end

--- a/test/utils/test_path.jl
+++ b/test/utils/test_path.jl
@@ -10,7 +10,7 @@ using JETLS: JETLS
         @test isabspath(test_file)
         result = JETLS.to_full_path(test_file)
         @test isabspath(result)
-        @test result == test_file
+        @test JETLS.paths_equal(result, test_file)
     end
 
     # Test with Base function paths
@@ -51,9 +51,9 @@ end
         # Test finding Project.toml from various depths
         # find_env_path expects a file path, uses dirname to get the directory
         test_file = joinpath(sub_dir, "test.jl")
-        @test JETLS.find_env_path(test_file) == proj_file
-        @test JETLS.find_env_path(joinpath(src_dir, "file.jl")) == proj_file
-        @test JETLS.find_env_path(joinpath(proj_dir, "file.jl")) == proj_file
+        @test JETLS.paths_equal(JETLS.find_env_path(test_file)::String, proj_file)
+        @test JETLS.paths_equal(JETLS.find_env_path(joinpath(src_dir, "file.jl"))::String, proj_file)
+        @test JETLS.paths_equal(JETLS.find_env_path(joinpath(proj_dir, "file.jl"))::String, proj_file)
 
         # Test when no Project.toml exists above
         no_proj_dir = joinpath(temp_root, "no_project", "deep", "path")
@@ -73,8 +73,6 @@ end
         touch(source_file)
         touch(project_file)
         uri = JETLS.filepath2uri(source_file)
-        normalized_project_file =
-            JETLS.uri2filepath(JETLS.filepath2uri(project_file))::String
 
         let state = JETLS.ServerState()
             @test JETLS.find_analysis_env_path(state, uri) === nothing
@@ -82,7 +80,8 @@ end
 
         let state = JETLS.ServerState()
             state.root_path = project_dir
-            @test JETLS.find_analysis_env_path(state, uri) == normalized_project_file
+            result = JETLS.find_analysis_env_path(state, uri)::String
+            @test JETLS.paths_equal(result, project_file)
         end
 
         let state = JETLS.ServerState()
@@ -101,7 +100,8 @@ end
 
         let state = JETLS.ServerState(; cli_mode=true)
             state.root_path = workspace_dir
-            @test JETLS.find_analysis_env_path(state, uri) == normalized_project_file
+            result = JETLS.find_analysis_env_path(state, uri)::String
+            @test JETLS.paths_equal(result, project_file)
         end
     end
 end
@@ -118,13 +118,25 @@ end
         touch(joinpath(dir1, "middle.txt"))
 
         # Search for files going up the tree
-        @test JETLS.search_up_file(dir2, "middle.txt") == joinpath(dir1, "middle.txt")
-        @test JETLS.search_up_file(dir2, "root.txt") == joinpath(temp_root, "root.txt")
+        @test JETLS.paths_equal(JETLS.search_up_file(dir2, "middle.txt")::String, joinpath(dir1, "middle.txt"))
+        @test JETLS.paths_equal(JETLS.search_up_file(dir2, "root.txt")::String, joinpath(temp_root, "root.txt"))
         @test isnothing(JETLS.search_up_file(dir2, "nonexistent.txt"))
 
         # Test with file in the same directory
         touch(joinpath(dir2, "same.txt"))
-        @test JETLS.search_up_file(joinpath(dir2, "dummy.jl"), "same.txt") == joinpath(dir2, "same.txt")
+        @test JETLS.paths_equal(JETLS.search_up_file(joinpath(dir2, "dummy.jl"), "same.txt")::String, joinpath(dir2, "same.txt"))
+    end
+end
+
+@testset "paths_equal" begin
+    @test JETLS.paths_equal("project", "project")
+    @test JETLS.paths_equal("project", joinpath("project", "src", ".."))
+    @test !JETLS.paths_equal("project", "project-other")
+    @test !JETLS.paths_equal(abspath("project"), "project")
+    @static if Sys.iswindows()
+        @test JETLS.paths_equal("C:\\Users\\Foo", "c:/users/foo/")
+    else
+        @test !JETLS.paths_equal("/home/user/Project", "/home/user/project")
     end
 end
 


### PR DESCRIPTION
Filesystem paths reconstructed from LSP URIs can differ from local paths in drive-letter casing, separators, and lexical spelling. Raw string equality made Windows behavior and tests sensitive to these representation differences.

Add `paths_equal` for lexical, platform-aware comparison without accessing the filesystem or resolving symlinks. Use it for workspace, config, source-location, and test path comparisons while preserving exact equality where URI or output representation is the contract.