### PR TITLE
app: Speed up version command startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - JETLS now displays a warning when workspace analysis and folder-local configuration are unavailable because a server was started without a workspace folder, with an unsupported root URI scheme, or with multiple workspace folders. For multi-root workspaces, configure the editor to start one server per top-level folder.
 
+- The `jetls version` command now starts faster when precompile workloads are disabled.
+
 ## 2026-08-07
 
 - Commit: [`29f138d`](https://github.com/aviatesk/JETLS.jl/commit/29f138d)

--- a/src/app/app.jl
+++ b/src/app/app.jl
@@ -30,6 +30,11 @@ function (@main)(args::Vector{String})::Cint
         println(stdout, "JETLS version $JETLS_VERSION on Julia $VERSION")
         return 0
     end
+    # Keep `jetls --version` fast when `precompile_workload` is disabled.
+    return @invokelatest run_command(args)
+end
+
+function run_command(args::Vector{String})
     if !isempty(args)
         first_arg = args[1]
         if first_arg == "check"

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -95,7 +95,7 @@ module __demo__ end
             collect_type_inlay_hints!(inlay_hints, st0, ctx, fi, uri, range, postprocessor)
             isempty(inlay_hints) && @warn "textDocument/inlayHint is broken"
 
-            precompile(main, (Vector{String},))
+            precompile(run_command, (Vector{String},))
         end
     end
 end


### PR DESCRIPTION
The `version` command compiled the full CLI dispatch when precompile workloads were disabled, making a metadata-only invocation pay for the `check`, `schema`, and `serve` command paths.

Keep the version fast path in `main` and invoke the remaining command dispatch through `@invokelatest`. Precompile `run_command` so regular installations still warm the heavier CLI path.