### PR TITLE
jetls-client: Seriealize language server restarts

### DIFF
--- a/.github/workflows/jetls-client.yml
+++ b/.github/workflows/jetls-client.yml
@@ -29,10 +29,16 @@ jobs:
           node-version: "lts/*"
       - name: Install dependencies
         working-directory: jetls-client
-        run: npm install
+        run: npm ci
       - name: Run checks
         working-directory: jetls-client
         run: npm run check
+      - name: Run tests
+        working-directory: jetls-client
+        run: npm test
+      - name: Build production bundle
+        working-directory: jetls-client
+        run: npm run build
 
   check_package_json:
     name: Check package.json is up to date

--- a/jetls-client/CHANGELOG.md
+++ b/jetls-client/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed duplicate watched-file notifications that could cause redundant configuration reloads and diagnostics refreshes.
+- Fixed overlapping JETLS restarts in VS Code by serializing rapid manual and configuration-triggered restart requests and waiting for the replacement server to finish initializing.
 
 ## v0.7.0
 

--- a/jetls-client/CoalescingTaskRunner.ts
+++ b/jetls-client/CoalescingTaskRunner.ts
@@ -1,0 +1,25 @@
+export class CoalescingTaskRunner {
+  private activeRun: Promise<void> | undefined;
+  private runRequested = false;
+
+  constructor(private readonly runOnce: () => Promise<void>) {}
+
+  run(): Promise<void> {
+    this.runRequested = true;
+    if (this.activeRun === undefined) {
+      this.activeRun = Promise.resolve().then(() => this.runRequestedTasks());
+    }
+    return this.activeRun;
+  }
+
+  private async runRequestedTasks(): Promise<void> {
+    try {
+      while (this.runRequested) {
+        this.runRequested = false;
+        await this.runOnce();
+      }
+    } finally {
+      this.activeRun = undefined;
+    }
+  }
+}

--- a/jetls-client/jetls-client.ts
+++ b/jetls-client/jetls-client.ts
@@ -14,6 +14,8 @@ import * as path from "path";
 import * as fs from "fs";
 import * as cp from "child_process";
 
+import { CoalescingTaskRunner } from "./CoalescingTaskRunner";
+
 let languageClient: LanguageClient;
 let outputChannel: LogOutputChannel;
 let statusBarItem: vscode.StatusBarItem;
@@ -536,42 +538,43 @@ async function startLanguageServer() {
     "Loading JETLS and attempting to establish communication between client and server.";
   statusBarItem.show();
 
-  languageClient
-    .start()
-    .then(() => {
-      statusBarItem.hide();
+  try {
+    await languageClient.start();
+  } catch (err) {
+    statusBarItem.hide();
+    const error = err instanceof Error ? err : new Error(String(err));
+    handleSpawnError(error, baseCommand);
+    throw error;
+  }
 
-      const serverInfo = languageClient.initializeResult?.serverInfo;
-      if (serverInfo) {
-        outputChannel.appendLine(
-          `[jetls-client] JETLS is ready! (${serverInfo.name} [version: ${serverInfo.version ?? "unknown"}])`,
-        );
-      } else {
-        outputChannel.appendLine("[jetls-client] JETLS is ready!");
-      }
+  statusBarItem.hide();
 
-      // Register handler for workspace/configuration requests after client starts
-      languageClient.onRequest(
-        "workspace/configuration",
-        (params: {
-          items: { scopeUri?: string; section?: string | null }[];
-        }) => {
-          const items = params.items || [];
-          const results = items.map((item) => {
-            const section = "jetls-client.settings";
-            const scope = item.scopeUri
-              ? vscode.Uri.parse(item.scopeUri)
-              : undefined;
-            return vscode.workspace.getConfiguration(section, scope);
-          });
-          return results;
-        },
-      );
-    })
-    .catch((err) => {
-      statusBarItem.hide();
-      handleSpawnError(err, baseCommand);
-    });
+  const serverInfo = languageClient.initializeResult?.serverInfo;
+  if (serverInfo) {
+    outputChannel.appendLine(
+      `[jetls-client] JETLS is ready! (${serverInfo.name} [version: ${serverInfo.version ?? "unknown"}])`,
+    );
+  } else {
+    outputChannel.appendLine("[jetls-client] JETLS is ready!");
+  }
+
+  // Register handler for workspace/configuration requests after client starts
+  languageClient.onRequest(
+    "workspace/configuration",
+    (params: {
+      items: { scopeUri?: string; section?: string | null }[];
+    }) => {
+      const items = params.items || [];
+      const results = items.map((item) => {
+        const section = "jetls-client.settings";
+        const scope = item.scopeUri
+          ? vscode.Uri.parse(item.scopeUri)
+          : undefined;
+        return vscode.workspace.getConfiguration(section, scope);
+      });
+      return results;
+    },
+  );
 }
 
 async function restartLanguageServer() {
@@ -587,6 +590,8 @@ async function restartLanguageServer() {
   }
   await startLanguageServer();
 }
+
+const restartRunner = new CoalescingTaskRunner(restartLanguageServer);
 
 async function checkForUpdates(context: ExtensionContext): Promise<void> {
   const currentVersion = vscode.extensions.getExtension("aviatesk.jetls-client")
@@ -691,7 +696,12 @@ export function activate(context: ExtensionContext) {
           vscode.window.showInformationMessage(
             "JETLS configuration changed. Restarting language server...",
           );
-          restartLanguageServer();
+          void restartRunner.run().catch((err) => {
+            const message = err instanceof Error ? err.message : String(err);
+            outputChannel.appendLine(
+              `[jetls-client] Failed to restart language server: ${message}.`,
+            );
+          });
         }
       }
     }),
@@ -699,9 +709,7 @@ export function activate(context: ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       "jetls-client.restartLanguageServer",
-      () => {
-        restartLanguageServer();
-      },
+      () => restartRunner.run(),
     ),
   );
 

--- a/jetls-client/package.json
+++ b/jetls-client/package.json
@@ -430,8 +430,9 @@
     "check:tsc": "tsc --noEmit",
     "check:lint": "eslint",
     "check:package-schema": "node check-package-schema.mjs",
+    "test": "node test-runner.mjs",
     "clean": "rm -rf out *.vsix",
-    "vscode:prepublish": "npm run check && npm run build"
+    "vscode:prepublish": "npm run check && npm test && npm run build"
   },
   "dependencies": {
     "vscode-languageclient": "^10.1.0"

--- a/jetls-client/test-runner.mjs
+++ b/jetls-client/test-runner.mjs
@@ -1,0 +1,61 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { build } from "esbuild";
+
+const rootDirectory = path.dirname(fileURLToPath(import.meta.url));
+const testDirectory = path.join(rootDirectory, "test");
+
+async function runNodeTests(testFiles) {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["--test", ...testFiles], {
+      cwd: rootDirectory,
+      stdio: "inherit",
+    });
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (signal !== null) {
+        reject(new Error(`Node test process exited with signal ${signal}.`));
+      } else {
+        resolve(code ?? 1);
+      }
+    });
+  });
+}
+
+const testNames = (await readdir(testDirectory))
+  .filter((name) => name.endsWith(".test.ts"))
+  .sort();
+if (testNames.length === 0) {
+  throw new Error(`No TypeScript tests found in ${testDirectory}.`);
+}
+
+const outputDirectory = await mkdtemp(
+  path.join(tmpdir(), "jetls-client-tests-"),
+);
+try {
+  await build({
+    entryPoints: testNames.map((name) => path.join(testDirectory, name)),
+    outdir: outputDirectory,
+    bundle: true,
+    platform: "node",
+    format: "cjs",
+    target: "node20",
+    outExtension: { ".js": ".cjs" },
+    sourcemap: "inline",
+    logLevel: "silent",
+  });
+  const compiledTests = testNames.map((name) =>
+    path.join(outputDirectory, name.replace(/\.ts$/, ".cjs")),
+  );
+  const exitCode = await runNodeTests(compiledTests);
+  if (exitCode !== 0) {
+    process.exitCode = exitCode;
+  }
+} finally {
+  await rm(outputDirectory, { recursive: true, force: true });
+}

--- a/jetls-client/test/coalescing-task-runner.test.ts
+++ b/jetls-client/test/coalescing-task-runner.test.ts
@@ -1,0 +1,66 @@
+import * as assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { CoalescingTaskRunner } from "../CoalescingTaskRunner";
+
+function deferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+test("runs a task once", async () => {
+  let runCount = 0;
+  const runner = new CoalescingTaskRunner(async () => {
+    runCount += 1;
+  });
+
+  await runner.run();
+
+  assert.equal(runCount, 1);
+});
+
+test("coalesces requests while serializing task runs", async () => {
+  const events: string[] = [];
+  const releaseFirstRun = deferred();
+  const firstRunStarted = deferred();
+  let runCount = 0;
+  const runner = new CoalescingTaskRunner(async () => {
+    runCount += 1;
+    events.push(`start ${runCount}`);
+    if (runCount === 1) {
+      firstRunStarted.resolve();
+      await releaseFirstRun.promise;
+    }
+    events.push(`end ${runCount}`);
+  });
+
+  const activeRun = runner.run();
+  await firstRunStarted.promise;
+  const requestedRuns = [runner.run(), runner.run(), runner.run()];
+  releaseFirstRun.resolve();
+  await Promise.all([activeRun, ...requestedRuns]);
+
+  assert.deepEqual(events, ["start 1", "end 1", "start 2", "end 2"]);
+});
+
+test("recovers after a failed task", async () => {
+  const expectedError = new Error("task failed");
+  let runCount = 0;
+  const runner = new CoalescingTaskRunner(async () => {
+    runCount += 1;
+    if (runCount === 1) {
+      throw expectedError;
+    }
+  });
+
+  await assert.rejects(runner.run(), expectedError);
+  await runner.run();
+
+  assert.equal(runCount, 2);
+});

--- a/jetls-client/test/smoke.test.ts
+++ b/jetls-client/test/smoke.test.ts
@@ -1,0 +1,7 @@
+import * as assert from "node:assert/strict";
+import { test } from "node:test";
+
+test("bundles and runs TypeScript tests", () => {
+  const result = { value: 42 } satisfies { value: number };
+  assert.equal(result.value, 42);
+});

--- a/jetls-client/test/smoke.test.ts
+++ b/jetls-client/test/smoke.test.ts
@@ -1,7 +1,0 @@
-import * as assert from "node:assert/strict";
-import { test } from "node:test";
-
-test("bundles and runs TypeScript tests", () => {
-  const result = { value: 42 } satisfies { value: number };
-  assert.equal(result.value, 42);
-});


### PR DESCRIPTION
JETLS restart requests could overlap because `startLanguageServer()` returned before `LanguageClient.start()` completed and manual or configuration-triggered restarts invoked the lifecycle independently.

Make startup `await` language-client initialization and route restart requests through `CoalescingTaskRunner`. Requests received during an active restart now schedule at most one serialized follow-up restart.