### PR TITLE
server: Reject output during shutdown

### DIFF
--- a/LSP/src/communication.jl
+++ b/LSP/src/communication.jl
@@ -47,6 +47,7 @@ mutable struct Endpoint
         out_msg_queue = Channel{Any}(Inf)
 
         local endpoint_ref = Ref{Endpoint}()
+        is_endpoint_open() = !isassigned(endpoint_ref) || isopen(endpoint_ref[])
 
         read_task = Threads.@spawn :interactive begin
             while true
@@ -56,7 +57,7 @@ mutable struct Endpoint
                     err_handler(#=isread=#true, err, catch_backtrace())
                     continue
                 end break # terminate this task loop when the stream is closed
-                (!isassigned(endpoint_ref) || isopen(endpoint_ref[])) || break
+                is_endpoint_open() || break
                 put!(in_msg_queue, msg)
                 GC.safepoint()
             end
@@ -69,11 +70,15 @@ mutable struct Endpoint
 
         write_task = Threads.@spawn :interactive for msg in out_msg_queue
             msg === nothing && break # terminate this task loop when taking this special token
+            # The peer may close the transport after `exit`; discard queued output during shutdown.
+            is_endpoint_open() || break
             if isopen(out)
                 try
                     writelsp(out, msg)
                 catch err
-                    err_handler(#=isread=#false, err, catch_backtrace())
+                    if is_endpoint_open()
+                        err_handler(#=isread=#false, err, catch_backtrace())
+                    end
                     continue
                 end
             else
@@ -144,10 +149,11 @@ end
 to_lsp_json(@nospecialize msg) = JSON3.write(msg)
 
 function Base.close(endpoint::Endpoint)
+    isopen(endpoint) || return endpoint
+    @atomic :release endpoint.isopen = false
     put!(endpoint.out_msg_queue, nothing) # send a special token to terminate the write task
     close(endpoint.out_msg_queue)
     wait(endpoint.write_task)
-    @atomic :release endpoint.isopen = false
     close(endpoint.in_msg_queue)
     # TODO we would also like to fetch the read task here, but it may be blocked on
     # `readlsp(in)`. Unclear how to unblock it without closing the socket.
@@ -168,21 +174,25 @@ function Base.iterate(endpoint::Endpoint, _=nothing)
 end
 
 """
-    send(endpoint::Endpoint, msg)
+    send(endpoint::Endpoint, msg) -> sent::Bool
 
 Send a message through the endpoint's output queue.
 
 The message will be asynchronously written to the output stream by the endpoint's write task.
-This function is non-blocking and returns immediately after queueing the message.
+This function is non-blocking and returns `true` after queueing the message, or
+`false` if the endpoint is closed.
 
 # Arguments
 - `endpoint::Endpoint`: The endpoint to send the message through
 - `msg`: The message to send (typically an LSP message structure)
-
-# Throws
-- `ErrorException`: If the endpoint is closed
 """
-function send(endpoint::Endpoint, @nospecialize(msg::Any))
-    put!(endpoint.out_msg_queue, msg)
-    nothing
+function send(endpoint::Endpoint, @nospecialize(msg::Any))::Bool
+    isopen(endpoint) || return false
+    try
+        put!(endpoint.out_msg_queue, msg)
+    catch err
+        err isa InvalidStateException && !isopen(endpoint) || rethrow()
+        return false
+    end
+    return true
 end

--- a/LSP/test/runtests.jl
+++ b/LSP/test/runtests.jl
@@ -4,6 +4,20 @@ using LSP: test_roundtrip, to_lsp_json
 using REPL: REPL
 using Test
 
+struct BlockingFailingWriteIO <: IO
+    write_started::Base.Event
+    resume_write::Base.Event
+end
+
+Base.isopen(::BlockingFailingWriteIO) = true
+Base.flush(::BlockingFailingWriteIO) = nothing
+
+function Base.unsafe_write(io::BlockingFailingWriteIO, ::Ptr{UInt8}, ::UInt)
+    notify(io.write_started)
+    wait(io.resume_write)
+    throw(EOFError())
+end
+
 @testset "LSP" begin
     # De/serializing complex LSP objects
     uri = filename2uri(@__FILE__)
@@ -246,5 +260,29 @@ using Test
                        string(REPL.fielddoc(Position, :line)))
         @test occursin("Character offset on a line",
                        string(REPL.fielddoc(Position, :character)))
+    end
+
+    @testset "closed endpoint" begin
+        endpoint = LSP.Endpoint(Returns(nothing), IOBuffer(), IOBuffer())
+        close(endpoint)
+        wait(endpoint.read_task)
+        @test !isopen(endpoint)
+        @test !LSP.send(endpoint, ExitNotification())
+    end
+
+    # A write may fail after shutdown starts; do not report that expected error.
+    @testset "write error during close" begin
+        output = BlockingFailingWriteIO(Base.Event(), Base.Event())
+        errors = Channel{Any}(Inf)
+        endpoint = LSP.Endpoint((args...) -> put!(errors, args), IOBuffer(), output)
+        @test LSP.send(endpoint, ExitNotification())
+        wait(output.write_started)
+
+        close_task = Threads.@spawn close(endpoint)
+        @test timedwait(() -> !isopen(endpoint), 1.0) == :ok
+
+        notify(output.resume_write)
+        wait(close_task); wait(endpoint.read_task)
+        @test isempty(errors)
     end
 end

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -289,12 +289,13 @@ function runserver(
         @error "Message handling loop failed"
         Base.display_error(stderr, err, catch_backtrace())
     finally
+        # The client may close the transport after `exit`; reject output before worker cleanup.
+        close(server.endpoint)
         stop_analysis_worker(server)
         stop_signature_analysis_workers(server)
         put!(seq_queue, nothing); put!(con_queue, nothing);
         close(seq_queue); close(con_queue);
         waitall((seq_task, con_task))
-        close(server.endpoint)
     end
     @static JETLS_DEV_MODE && @info "Exited JETLS server loop"
     return exit_code

--- a/src/utils/server.jl
+++ b/src/utils/server.jl
@@ -17,7 +17,7 @@ This function is used by each handler that processes messages sent from the clie
 as well as for sending requests and notifications from the server to the client.
 """
 function send(server::Server, @nospecialize msg)
-    LSP.Communication.send(server.endpoint, msg)
+    LSP.Communication.send(server.endpoint, msg) || return nothing
     server.callback !== nothing && server.callback(:sent, msg)
     # Mark request as handled when sending a response
     if isdefined(msg, :id) && isdefined(msg, :result) && isdefined(msg, :error) # i.e. msg isa ResponseMessage


### PR DESCRIPTION
JETLS could close its endpoint while detached request handlers were still finishing. Late responses then reached the endpoint writer after the client had already closed the transport, producing shutdown-time write errors.

Mark the endpoint closed before worker cleanup and discard queued output once shutdown begins. Make `send` report whether it accepted a message so server-level sends can skip callbacks and completion bookkeeping when output is rejected.

A write that was already in progress may still fail after the endpoint closes. Suppress its expected error once shutdown has begun, and cover the close/write overlap with a controlled output stream test.