### PR TITLE
jetls-client: Add server startup preflight and status bar reporting

### DIFF
--- a/jetls-client/CHANGELOG.md
+++ b/jetls-client/CHANGELOG.md
@@ -10,9 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
 - Diff: [`8cfd8fed7...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/8cfd8fed7...HEAD)
 
+### Added
+
+- Added a startup preflight. The status bar now shows when JETLS is being checked, precompiled, started, or restarted, briefly confirms when it is ready, and keeps startup and restart failures visible with a shortcut to the JETLS output.
+
 ### Fixed
 
 - Fixed duplicate watched-file notifications that could cause redundant configuration reloads and diagnostics refreshes.
+
 - Fixed overlapping JETLS restarts in VS Code by serializing rapid manual and configuration-triggered restart requests and waiting for the replacement server to finish initializing.
 
 ## v0.7.0

--- a/jetls-client/esbuild.js
+++ b/jetls-client/esbuild.js
@@ -5,7 +5,7 @@ const watch = process.argv.includes('--watch');
 
 async function main() {
     const ctx = await esbuild.context({
-        entryPoints: ['jetls-client.ts'],
+        entryPoints: ['src/jetls-client.ts'],
         bundle: true,
         format: 'cjs',
         minify: production,

--- a/jetls-client/src/CoalescingTaskRunner.ts
+++ b/jetls-client/src/CoalescingTaskRunner.ts
@@ -4,6 +4,10 @@ export class CoalescingTaskRunner {
 
   constructor(private readonly runOnce: () => Promise<void>) {}
 
+  get active(): Promise<void> | undefined {
+    return this.activeRun;
+  }
+
   run(): Promise<void> {
     this.runRequested = true;
     if (this.activeRun === undefined) {

--- a/jetls-client/src/constants.ts
+++ b/jetls-client/src/constants.ts
@@ -1,0 +1,41 @@
+export const JETLS_INSTALL_COMMAND =
+  'julia -e \'using Pkg; Pkg.Apps.add(; url="https://github.com/aviatesk/JETLS.jl", rev="release")\'';
+export const JETLS_INSTALL_GUIDE_URL =
+  "https://github.com/aviatesk/JETLS.jl/blob/master/jetls-client/README.md#getting-started";
+export const JETLS_CHANGELOG_URL =
+  "https://github.com/aviatesk/JETLS.jl/blob/master/jetls-client/CHANGELOG.md";
+export const JETLS_MIGRATION_GUIDE_URL = `${JETLS_CHANGELOG_URL}#v020`;
+
+/** Julia stderr substring that signals package precompilation has started. */
+export const PRECOMPILING_MARKER = "Precompiling packages";
+
+/**
+ * Budget for Julia precompilation: bounds the whole version preflight and
+ * re-arms the serve startup countdown when precompilation is detected.
+ */
+export const PRECOMPILATION_TIMEOUT_MS = 300000;
+
+/**
+ * How long to wait for the version preflight process to close after each
+ * termination attempt (`kill()`, SIGKILL escalation, or `taskkill`).
+ */
+export const PREFLIGHT_TERMINATION_TIMEOUT_MS = 5000;
+
+/**
+ * Cap on accumulated version preflight stdout, which is only ever surfaced
+ * as a single log line.
+ */
+export const PREFLIGHT_STDOUT_LIMIT = 64 * 1024;
+
+/**
+ * Budget for server startup without precompilation. For the socket and pipe
+ * channels this spans spawn until the transport connection is established;
+ * for stdio it bounds the whole `LanguageClient.start()` call.
+ */
+export const SERVER_START_TIMEOUT_MS = 60000;
+
+/**
+ * Grace period for `LanguageClient.stop()`. Also bounds how long
+ * `deactivate` waits for an in-flight startup/restart lifecycle.
+ */
+export const LANGUAGE_SERVER_STOP_TIMEOUT_MS = 10_000;

--- a/jetls-client/src/jetls-client.ts
+++ b/jetls-client/src/jetls-client.ts
@@ -15,12 +15,38 @@ import * as fs from "fs";
 import * as cp from "child_process";
 
 import { CoalescingTaskRunner } from "./CoalescingTaskRunner";
+import {
+  JETLS_CHANGELOG_URL,
+  JETLS_INSTALL_COMMAND,
+  JETLS_INSTALL_GUIDE_URL,
+  JETLS_MIGRATION_GUIDE_URL,
+  LANGUAGE_SERVER_STOP_TIMEOUT_MS,
+  PRECOMPILATION_TIMEOUT_MS,
+  PREFLIGHT_TERMINATION_TIMEOUT_MS,
+  SERVER_START_TIMEOUT_MS,
+} from "./constants";
+import {
+  createStderrWatcher,
+  ExecutableConfig,
+  JETLSCommands,
+  resolveJETLSCommands,
+  VersionPreflight,
+} from "./server-startup";
 
 let languageClient: LanguageClient;
 let outputChannel: LogOutputChannel;
 let statusBarItem: vscode.StatusBarItem;
+let statusBarHideTimer: NodeJS.Timeout | undefined;
+let deactivating = false;
 
-type ExecutableConfig = { path?: string; threads?: string } | string[];
+type ServerStartupStatus =
+  | "checking"
+  | "starting"
+  | "restarting"
+  | "precompiling"
+  | "ready"
+  | "failed"
+  | "restart-failed";
 
 interface ServerConfig {
   executable: ExecutableConfig;
@@ -30,71 +56,112 @@ interface ServerConfig {
 
 let currentServerConfig: ServerConfig | null = null;
 
-const JETLS_INSTALL_COMMAND =
-  'julia -e \'using Pkg; Pkg.Apps.add(; url="https://github.com/aviatesk/JETLS.jl", rev="release")\'';
-const JETLS_INSTALL_GUIDE_URL =
-  "https://github.com/aviatesk/JETLS.jl/blob/master/jetls-client/README.md#getting-started";
-const JETLS_CHANGELOG_URL =
-  "https://github.com/aviatesk/JETLS.jl/blob/master/jetls-client/CHANGELOG.md";
-const JETLS_MIGRATION_GUIDE_URL = `${JETLS_CHANGELOG_URL}#v020`;
-const LANGUAGE_SERVER_STOP_TIMEOUT_MS = 10_000;
+const versionPreflight = new VersionPreflight({
+  timeoutMs: PRECOMPILATION_TIMEOUT_MS,
+  terminationTimeoutMs: PREFLIGHT_TERMINATION_TIMEOUT_MS,
+  platform: process.platform,
+  appendLine: (message) => outputChannel.appendLine(message),
+  onPrecompiling: () => showServerStartupStatus("precompiling"),
+});
 
-interface ProcessManager {
-  process: cp.ChildProcess;
-  timeoutHandle: NodeJS.Timeout | null;
-  isPrecompiling: boolean;
-  timeoutDuration: number;
+function showServerStartupStatus(status: ServerStartupStatus): void {
+  if (deactivating) {
+    return;
+  }
+  if (statusBarHideTimer !== undefined) {
+    clearTimeout(statusBarHideTimer);
+    statusBarHideTimer = undefined;
+  }
+
+  statusBarItem.backgroundColor = undefined;
+  switch (status) {
+    case "checking":
+      statusBarItem.text = "$(sync~spin) Checking JETLS...";
+      statusBarItem.tooltip = "Checking the JETLS executable and version.";
+      break;
+    case "starting":
+      statusBarItem.text = "$(sync~spin) Starting JETLS...";
+      statusBarItem.tooltip = "Starting the JETLS language server.";
+      break;
+    case "restarting":
+      statusBarItem.text = "$(sync~spin) Restarting JETLS...";
+      statusBarItem.tooltip = "Restarting the JETLS language server.";
+      break;
+    case "precompiling":
+      statusBarItem.text = "$(sync~spin) Precompiling JETLS...";
+      statusBarItem.tooltip =
+        "Precompiling JETLS. The first startup may take longer.";
+      break;
+    case "ready":
+      statusBarItem.text = "$(check) JETLS ready";
+      statusBarItem.tooltip = "JETLS started successfully.";
+      statusBarHideTimer = setTimeout(() => {
+        statusBarItem.hide();
+        statusBarHideTimer = undefined;
+      }, 3000);
+      break;
+    case "failed":
+      statusBarItem.text = "$(error) JETLS failed to start";
+      statusBarItem.tooltip =
+        "JETLS failed to start. Click to open the JETLS output.";
+      statusBarItem.backgroundColor = new vscode.ThemeColor(
+        "statusBarItem.errorBackground",
+      );
+      break;
+    case "restart-failed":
+      statusBarItem.text = "$(error) JETLS restart failed";
+      statusBarItem.tooltip =
+        "JETLS could not be stopped for restart. Click to open the JETLS output.";
+      statusBarItem.backgroundColor = new vscode.ThemeColor(
+        "statusBarItem.errorBackground",
+      );
+      break;
+  }
+  statusBarItem.show();
 }
 
-// Helper to create timeout handler with precompilation detection
+interface ProcessManager {
+  timeoutHandle: NodeJS.Timeout | null;
+}
+
 function setupProcessMonitoring(
   juliaProcess: cp.ChildProcess,
-  onTimeout: (isPrecompiling: boolean) => void,
-  options: { initialTimeout?: number } = {},
+  onTimeout: () => void,
 ): ProcessManager {
   const manager: ProcessManager = {
-    process: juliaProcess,
     timeoutHandle: null,
-    isPrecompiling: false,
-    timeoutDuration: options.initialTimeout || 60000, // Default 60 seconds
+  };
+  const armTimeout = (timeoutMs: number): void => {
+    manager.timeoutHandle = setTimeout(() => {
+      manager.timeoutHandle = null;
+      onTimeout();
+    }, timeoutMs);
   };
 
-  // Monitor stderr for precompilation messages
-  juliaProcess.stderr?.on("data", (data: Buffer) =>
-    data
-      .toString()
-      .trimEnd()
-      .split("\n")
-      .forEach((s) => {
-        outputChannel.appendLine(`[JETLS-stderr] ${s}`);
-
-        // Check for precompilation messages
-        if (s.includes("Precompiling packages") && !manager.isPrecompiling) {
-          manager.isPrecompiling = true;
-          manager.timeoutDuration = 300000; // Extend to 300 seconds
-          outputChannel.appendLine(
-            `[jetls-client] Detected precompilation, extending timeout to 300 seconds`,
-          );
-
-          // Reset the timeout with new duration
-          if (manager.timeoutHandle) {
-            clearTimeout(manager.timeoutHandle);
-          }
-
-          manager.timeoutHandle = setTimeout(
-            () => onTimeout(true),
-            manager.timeoutDuration,
-          );
+  juliaProcess.stderr?.on(
+    "data",
+    createStderrWatcher({
+      logPrefix: "[JETLS-stderr]",
+      appendLine: (message) => outputChannel.appendLine(message),
+      onPrecompiling: () => {
+        if (manager.timeoutHandle !== null) {
+          clearTimeout(manager.timeoutHandle);
+          armTimeout(PRECOMPILATION_TIMEOUT_MS);
+          showServerStartupStatus("precompiling");
         }
-      }),
+      },
+    }),
   );
 
-  manager.timeoutHandle = setTimeout(
-    () => onTimeout(manager.isPrecompiling),
-    manager.timeoutDuration,
-  );
-
+  armTimeout(SERVER_START_TIMEOUT_MS);
   return manager;
+}
+
+function stopProcessMonitoring(manager: ProcessManager): void {
+  if (manager.timeoutHandle !== null) {
+    clearTimeout(manager.timeoutHandle);
+    manager.timeoutHandle = null;
+  }
 }
 
 // Helper to handle spawn errors with user-friendly messages
@@ -142,14 +209,11 @@ function createTimeoutHandler(
   reject: (error: Error) => void,
   options: {
     timeoutMessage: string;
-    precompilingMessage: string;
     cleanup?: () => void;
   },
-): (isPrecompiling: boolean) => void {
-  return (isPrecompiling: boolean) => {
-    const message = isPrecompiling
-      ? options.precompilingMessage
-      : options.timeoutMessage;
+): () => void {
+  return () => {
+    const message = options.timeoutMessage;
     outputChannel.appendLine(`[jetls-client] ${message}`);
     juliaProcess.kill();
     if (options.cleanup) {
@@ -157,6 +221,31 @@ function createTimeoutHandler(
     }
     reject(new Error(message));
   };
+}
+
+// The stdio channel has no process-level startup monitoring (the language
+// client library owns the spawned process), so bound `start()` itself and
+// force-dispose the client on expiry.
+function startWithTimeout(
+  client: LanguageClient,
+  timeoutMs: number,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeoutHandle = setTimeout(() => {
+      void client.dispose().catch(() => undefined);
+      reject(new Error("Timeout waiting for JETLS to start"));
+    }, timeoutMs);
+    client.start().then(
+      () => {
+        clearTimeout(timeoutHandle);
+        resolve();
+      },
+      (err) => {
+        clearTimeout(timeoutHandle);
+        reject(err);
+      },
+    );
+  });
 }
 
 function getServerConfig(): ServerConfig {
@@ -189,22 +278,27 @@ function hasServerConfigChanged(
 }
 
 async function startLanguageServer() {
+  if (deactivating) {
+    return;
+  }
+  showServerStartupStatus("checking");
+
   const serverConfig = getServerConfig();
   currentServerConfig = serverConfig;
 
-  let baseCommand: string;
-  let baseArgs: string[];
-
-  if (Array.isArray(serverConfig.executable)) {
-    const [cmd, ...args] = serverConfig.executable;
-    baseCommand = cmd;
-    baseArgs = args;
-  } else {
-    const defaultExecutable = "jetls";
-    baseCommand = serverConfig.executable.path || defaultExecutable;
-    const threads = serverConfig.executable.threads || "auto";
-    baseArgs = [`--threads=${threads}`, "--", "serve"];
+  let resolvedCommands: JETLSCommands;
+  try {
+    resolvedCommands = resolveJETLSCommands(serverConfig.executable);
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    if (!deactivating) {
+      showServerStartupStatus("failed");
+      outputChannel.appendLine(`[jetls-client] ${error.message}`);
+      vscode.window.showErrorMessage(error.message);
+    }
+    throw error;
   }
+  const { command: baseCommand, versionArgs, serveArgs } = resolvedCommands;
 
   let commChannel = serverConfig.communicationChannel;
   if (commChannel === "auto") {
@@ -240,18 +334,34 @@ async function startLanguageServer() {
   // On Windows, batch files must be spawned with shell: true
   const spawnOptions = process.platform === "win32" ? { shell: true } : {};
 
+  try {
+    await versionPreflight.run(baseCommand, versionArgs, spawnOptions);
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    if (!deactivating) {
+      showServerStartupStatus("failed");
+      handleSpawnError(error, baseCommand);
+    }
+    throw error;
+  }
+
+  if (deactivating) {
+    return;
+  }
+  showServerStartupStatus("starting");
+
   let serverOptions: ServerOptions;
 
   if (commChannel === "stdio") {
     serverOptions = {
       run: {
         command: baseCommand,
-        args: [...baseArgs, "--stdio"],
+        args: [...serveArgs, "--stdio"],
         options: spawnOptions,
       },
       debug: {
         command: baseCommand,
-        args: [...baseArgs, "--stdio"],
+        args: [...serveArgs, "--stdio"],
         options: spawnOptions,
       },
     };
@@ -266,7 +376,7 @@ async function startLanguageServer() {
 
         const jetlsProcess = cp.spawn(
           baseCommand,
-          [...baseArgs, "--socket", port.toString()],
+          [...serveArgs, "--socket", port.toString()],
           spawnOptions,
         );
 
@@ -274,18 +384,13 @@ async function startLanguageServer() {
 
         const timeoutHandler = createTimeoutHandler(jetlsProcess, reject, {
           timeoutMessage: "Timeout waiting for JETLS to provide port number",
-          precompilingMessage:
-            "Timeout waiting for JETLS to provide port number (during precompilation)",
         });
 
-        const manager = setupProcessMonitoring(
-          jetlsProcess,
-          (isPrecompiling) => {
-            if (!actualPort) {
-              timeoutHandler(isPrecompiling);
-            }
-          },
-        );
+        const manager = setupProcessMonitoring(jetlsProcess, () => {
+          if (!actualPort) {
+            timeoutHandler();
+          }
+        });
 
         // Capture stdout to get the actual port number
         jetlsProcess.stdout?.on("data", (data: Buffer) => {
@@ -304,11 +409,7 @@ async function startLanguageServer() {
                   `[jetls-client] JETLS listening on port: ${actualPort}`,
                 );
 
-                // Clear timeout since we got the port
-                if (manager.timeoutHandle) {
-                  clearTimeout(manager.timeoutHandle);
-                  manager.timeoutHandle = null;
-                }
+                stopProcessMonitoring(manager);
 
                 // Connect to the server
                 const socket = net.createConnection(
@@ -335,9 +436,7 @@ async function startLanguageServer() {
 
         jetlsProcess.on("error", (err) => {
           handleSpawnError(err, baseCommand);
-          if (manager.timeoutHandle) {
-            clearTimeout(manager.timeoutHandle);
-          }
+          stopProcessMonitoring(manager);
           reject(err);
         });
 
@@ -345,9 +444,7 @@ async function startLanguageServer() {
           outputChannel.appendLine(
             `[jetls-client] JETLS process exited (code: ${code}, signal: ${signal})`,
           );
-          if (manager.timeoutHandle) {
-            clearTimeout(manager.timeoutHandle);
-          }
+          stopProcessMonitoring(manager);
           if (!actualPort) {
             reject(new Error("JETLS exited without providing a port number"));
           }
@@ -388,7 +485,7 @@ async function startLanguageServer() {
           outputChannel.appendLine(`[jetls-client] Starting JETLS...`);
           const jetlsProcess = cp.spawn(
             baseCommand,
-            [...baseArgs, "--pipe-connect", socketPath],
+            [...serveArgs, "--pipe-connect", socketPath],
             spawnOptions,
           );
 
@@ -397,8 +494,6 @@ async function startLanguageServer() {
             jetlsProcess,
             createTimeoutHandler(jetlsProcess, reject, {
               timeoutMessage: "Timeout waiting for JETLS to connect",
-              precompilingMessage:
-                "Timeout waiting for JETLS to connect (during precompilation)",
               cleanup: () => server.close(),
             }),
           );
@@ -413,34 +508,31 @@ async function startLanguageServer() {
 
           jetlsProcess.on("error", (err) => {
             handleSpawnError(err, baseCommand);
-            if (manager.timeoutHandle) {
-              clearTimeout(manager.timeoutHandle);
-            }
+            stopProcessMonitoring(manager);
             server.close();
             reject(err);
           });
+
+          let connected = false;
 
           jetlsProcess.on("exit", (code, signal) => {
             outputChannel.appendLine(
               `[jetls-client] JETLS process exited (code: ${code}, signal: ${signal})`,
             );
-            if (manager.timeoutHandle) {
-              clearTimeout(manager.timeoutHandle);
-            }
+            stopProcessMonitoring(manager);
             server.close();
             if (process.platform !== "win32" && fs.existsSync(socketPath)) {
               fs.unlinkSync(socketPath);
+            }
+            if (!connected) {
+              reject(new Error("JETLS exited before connecting to the pipe"));
             }
           });
 
           server.once("connection", (socket: net.Socket) => {
             outputChannel.appendLine(`[jetls-client] JETLS connected!`);
-
-            // Clear timeout since connection succeeded
-            if (manager.timeoutHandle) {
-              clearTimeout(manager.timeoutHandle);
-              manager.timeoutHandle = null;
-            }
+            connected = true;
+            stopProcessMonitoring(manager);
 
             server.close(); // Stop accepting new connections
             resolve({ reader: socket, writer: socket });
@@ -534,22 +626,24 @@ async function startLanguageServer() {
     clientOptions,
   );
 
-  statusBarItem.text = "$(sync~spin) Loading JETLS ...";
-  statusBarItem.tooltip =
-    "Loading JETLS and attempting to establish communication between client and server.";
-  statusBarItem.show();
-
   try {
-    await languageClient.start();
+    if (commChannel === "stdio") {
+      await startWithTimeout(languageClient, SERVER_START_TIMEOUT_MS);
+    } else {
+      await languageClient.start();
+    }
   } catch (err) {
-    statusBarItem.hide();
     const error = err instanceof Error ? err : new Error(String(err));
-    handleSpawnError(error, baseCommand);
+    if (!deactivating) {
+      showServerStartupStatus("failed");
+      handleSpawnError(error, baseCommand);
+    }
     throw error;
   }
 
-  statusBarItem.hide();
-
+  if (deactivating) {
+    return;
+  }
   const serverInfo = languageClient.initializeResult?.serverInfo;
   if (serverInfo) {
     outputChannel.appendLine(
@@ -562,9 +656,7 @@ async function startLanguageServer() {
   // Register handler for workspace/configuration requests after client starts
   languageClient.onRequest(
     "workspace/configuration",
-    (params: {
-      items: { scopeUri?: string; section?: string | null }[];
-    }) => {
+    (params: { items: { scopeUri?: string; section?: string | null }[] }) => {
       const items = params.items || [];
       const results = items.map((item) => {
         const section = "jetls-client.settings";
@@ -576,13 +668,22 @@ async function startLanguageServer() {
       return results;
     },
   );
+
+  showServerStartupStatus("ready");
 }
 
 async function restartLanguageServer() {
-  if (languageClient) {
+  if (deactivating) {
+    return;
+  }
+  // A client that never reached the `Running` state (e.g. `StartFailed`)
+  // cannot be stopped: `stop()` would throw and permanently block restarts.
+  if (languageClient?.needsStop()) {
+    showServerStartupStatus("restarting");
     try {
       await languageClient.stop(LANGUAGE_SERVER_STOP_TIMEOUT_MS);
     } catch (err) {
+      showServerStartupStatus("restart-failed");
       const message = err instanceof Error ? err.message : String(err);
       outputChannel.appendLine(
         `[jetls-client] Failed to stop language client: ${message}.`,
@@ -594,6 +695,15 @@ async function restartLanguageServer() {
 }
 
 const restartRunner = new CoalescingTaskRunner(restartLanguageServer);
+
+function requestLanguageServerRestart(): void {
+  void restartRunner.run().catch((err) => {
+    const message = err instanceof Error ? err.message : String(err);
+    outputChannel.appendLine(
+      `[jetls-client] Failed to restart language server: ${message}.`,
+    );
+  });
+}
 
 async function checkForUpdates(context: ExtensionContext): Promise<void> {
   const currentVersion = vscode.extensions.getExtension("aviatesk.jetls-client")
@@ -680,10 +790,16 @@ async function checkForUpdates(context: ExtensionContext): Promise<void> {
 }
 
 export function activate(context: ExtensionContext) {
+  deactivating = false;
   statusBarItem = vscode.window.createStatusBarItem(
     vscode.StatusBarAlignment.Left,
     100,
   );
+  statusBarItem.name = "JETLS server startup status";
+  statusBarItem.command = {
+    command: "jetls-client.showOutput",
+    title: "Show JETLS output",
+  };
   context.subscriptions.push(statusBarItem);
 
   context.subscriptions.push(
@@ -698,33 +814,69 @@ export function activate(context: ExtensionContext) {
           vscode.window.showInformationMessage(
             "JETLS configuration changed. Restarting language server...",
           );
-          void restartRunner.run().catch((err) => {
-            const message = err instanceof Error ? err.message : String(err);
-            outputChannel.appendLine(
-              `[jetls-client] Failed to restart language server: ${message}.`,
-            );
-          });
+          requestLanguageServerRestart();
         }
       }
     }),
   );
   context.subscriptions.push(
-    vscode.commands.registerCommand(
-      "jetls-client.restartLanguageServer",
-      () => restartRunner.run(),
+    vscode.commands.registerCommand("jetls-client.restartLanguageServer", () =>
+      requestLanguageServerRestart(),
     ),
   );
 
   outputChannel = vscode.window.createOutputChannel("JETLS", { log: true });
+  context.subscriptions.push(
+    vscode.commands.registerCommand("jetls-client.showOutput", () =>
+      outputChannel.show(),
+    ),
+  );
 
   checkForUpdates(context);
 
-  startLanguageServer();
+  requestLanguageServerRestart();
+}
+
+function awaitWithTimeout(
+  promise: Promise<void> | undefined,
+  timeoutMs: number,
+): Promise<void> {
+  if (promise === undefined) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    const timeoutHandle = setTimeout(resolve, timeoutMs);
+    void promise.catch(() => undefined).then(() => {
+      clearTimeout(timeoutHandle);
+      resolve();
+    });
+  });
 }
 
 export async function deactivate() {
-  if (languageClient) {
-    await languageClient.stop(LANGUAGE_SERVER_STOP_TIMEOUT_MS);
+  deactivating = true;
+  if (statusBarHideTimer !== undefined) {
+    clearTimeout(statusBarHideTimer);
+    statusBarHideTimer = undefined;
+  }
+  try {
+    await versionPreflight.terminate();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    outputChannel?.appendLine(
+      `[jetls-client] Failed to terminate JETLS version check: ${message}`,
+    );
+  }
+  await awaitWithTimeout(restartRunner.active, LANGUAGE_SERVER_STOP_TIMEOUT_MS);
+  if (languageClient?.needsStop()) {
+    try {
+      await languageClient.stop(LANGUAGE_SERVER_STOP_TIMEOUT_MS);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      outputChannel?.appendLine(
+        `[jetls-client] Failed to stop language client: ${message}.`,
+      );
+    }
   }
   if (outputChannel) {
     outputChannel.dispose();

--- a/jetls-client/src/server-startup.ts
+++ b/jetls-client/src/server-startup.ts
@@ -1,0 +1,328 @@
+import * as cp from "child_process";
+
+import { PRECOMPILING_MARKER, PREFLIGHT_STDOUT_LIMIT } from "./constants";
+
+export type ExecutableConfig =
+  | { path?: string; threads?: string }
+  | string[];
+
+export interface JETLSCommands {
+  command: string;
+  versionArgs: string[];
+  serveArgs: string[];
+}
+
+export function resolveJETLSCommands(
+  executable: ExecutableConfig,
+): JETLSCommands {
+  if (Array.isArray(executable)) {
+    const [command, ...args] = executable;
+    // Without exactly one `serve`, the server would print the help text and
+    // exit 0, which the preflight cannot distinguish from a working setup.
+    if (args.filter((argument) => argument === "serve").length !== 1) {
+      throw new Error(
+        "Invalid JETLS executable configuration: expected exactly one " +
+          `\`serve\` subcommand, got ${JSON.stringify(executable)}.`,
+      );
+    }
+    return {
+      command,
+      versionArgs: args.map((argument) =>
+        argument === "serve" ? "version" : argument,
+      ),
+      serveArgs: args,
+    };
+  }
+
+  const command = executable.path || "jetls";
+  const threads = executable.threads || "auto";
+  const juliaArgs = [`--threads=${threads}`, "--"];
+  return {
+    command,
+    versionArgs: [...juliaArgs, "version"],
+    serveArgs: [...juliaArgs, "serve"],
+  };
+}
+
+export interface StderrWatcherOptions {
+  logPrefix: string;
+  appendLine: (message: string) => void;
+  onPrecompiling: () => void;
+}
+
+export function createStderrWatcher(
+  options: StderrWatcherOptions,
+): (data: Buffer) => void {
+  let carry = "";
+  let precompilationDetected = false;
+  return (data: Buffer) => {
+    const text = data.toString();
+    text
+      .trimEnd()
+      .split("\n")
+      .forEach((line) => options.appendLine(`${options.logPrefix} ${line}`));
+    if (precompilationDetected) {
+      return;
+    }
+    const searchText = carry + text;
+    if (searchText.includes(PRECOMPILING_MARKER)) {
+      precompilationDetected = true;
+      options.onPrecompiling();
+    } else {
+      // Keep just enough tail to detect a marker split across chunks.
+      carry = searchText.slice(-(PRECOMPILING_MARKER.length - 1));
+    }
+  };
+}
+
+interface ActivePreflightProcess {
+  process: cp.ChildProcess;
+  closed: boolean;
+  closedPromise: Promise<void>;
+  terminationPromise: Promise<void> | undefined;
+}
+
+type SpawnProcess = (
+  command: string,
+  args: readonly string[],
+  options: cp.SpawnOptions,
+) => cp.ChildProcess;
+
+export interface VersionPreflightOptions {
+  timeoutMs: number;
+  terminationTimeoutMs: number;
+  platform: NodeJS.Platform;
+  spawnProcess?: SpawnProcess;
+  appendLine: (message: string) => void;
+  onPrecompiling: () => void;
+}
+
+export class VersionPreflight {
+  private activeProcess: ActivePreflightProcess | undefined;
+  private readonly spawnProcess: SpawnProcess;
+
+  constructor(private readonly options: VersionPreflightOptions) {
+    this.spawnProcess = options.spawnProcess ?? cp.spawn;
+  }
+
+  private waitForClose(
+    preflight: ActivePreflightProcess,
+  ): Promise<boolean> {
+    if (preflight.closed) {
+      return Promise.resolve(true);
+    }
+    return new Promise((resolve) => {
+      const timeoutHandle = setTimeout(
+        () => resolve(false),
+        this.options.terminationTimeoutMs,
+      );
+      void preflight.closedPromise.then(() => {
+        clearTimeout(timeoutHandle);
+        resolve(true);
+      });
+    });
+  }
+
+  private async terminateProcessImpl(
+    preflight: ActivePreflightProcess,
+  ): Promise<void> {
+    if (preflight.closed) {
+      return;
+    }
+
+    let terminationError: Error | undefined;
+    const pid = preflight.process.pid;
+    if (this.options.platform === "win32" && pid !== undefined) {
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const taskkill = this.spawnProcess(
+            "taskkill",
+            ["/PID", pid.toString(), "/T", "/F"],
+            { stdio: "ignore", windowsHide: true },
+          );
+          let settled = false;
+          const finish = (error?: Error): void => {
+            if (settled) {
+              return;
+            }
+            settled = true;
+            clearTimeout(timeoutHandle);
+            if (error === undefined) {
+              resolve();
+            } else {
+              reject(error);
+            }
+          };
+          taskkill.once("error", finish);
+          taskkill.once("close", (code) => {
+            if (code === 0) {
+              finish();
+            } else {
+              finish(new Error(`taskkill exited with code ${code}.`));
+            }
+          });
+          const timeoutHandle = setTimeout(() => {
+            taskkill.kill();
+            finish(new Error("taskkill timed out."));
+          }, this.options.terminationTimeoutMs);
+        });
+      } catch (err) {
+        terminationError = err instanceof Error ? err : new Error(String(err));
+        preflight.process.kill();
+      }
+    } else {
+      preflight.process.kill();
+    }
+
+    if (await this.waitForClose(preflight)) {
+      return;
+    }
+    if (this.options.platform !== "win32") {
+      preflight.process.kill("SIGKILL");
+      if (await this.waitForClose(preflight)) {
+        return;
+      }
+    }
+
+    throw (
+      terminationError ??
+      new Error("JETLS version check did not exit after termination.")
+    );
+  }
+
+  private terminateProcess(
+    preflight: ActivePreflightProcess,
+  ): Promise<void> {
+    if (preflight.terminationPromise === undefined) {
+      preflight.terminationPromise = this.terminateProcessImpl(preflight).catch(
+        (err) => {
+          // Drop the failed attempt so termination can be retried and a fresh
+          // preflight is not blocked by a process we already gave up on.
+          preflight.terminationPromise = undefined;
+          if (this.activeProcess === preflight) {
+            this.activeProcess = undefined;
+          }
+          throw err;
+        },
+      );
+    }
+    return preflight.terminationPromise;
+  }
+
+  terminate(): Promise<void> {
+    const preflight = this.activeProcess;
+    return preflight === undefined
+      ? Promise.resolve()
+      : this.terminateProcess(preflight);
+  }
+
+  async run(
+    command: string,
+    args: string[],
+    spawnOptions: cp.SpawnOptions,
+  ): Promise<void> {
+    if (this.activeProcess !== undefined) {
+      throw new Error("A previous JETLS version check is still running.");
+    }
+    this.options.appendLine(
+      `[jetls-client] JETLS version check: ${JSON.stringify([command, ...args])}`,
+    );
+
+    await new Promise<void>((resolve, reject) => {
+      const versionProcess = this.spawnProcess(command, args, spawnOptions);
+      let resolveClosed!: () => void;
+      const preflight: ActivePreflightProcess = {
+        process: versionProcess,
+        closed: false,
+        closedPromise: new Promise((resolve) => {
+          resolveClosed = resolve;
+        }),
+        terminationPromise: undefined,
+      };
+      this.activeProcess = preflight;
+
+      let stdout = "";
+      let settled = false;
+      let timedOut = false;
+      let processError: Error | undefined;
+
+      const finish = (error?: Error): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeoutHandle);
+        if (error === undefined) {
+          resolve();
+        } else {
+          reject(error);
+        }
+      };
+
+      versionProcess.stdout?.on("data", (data: Buffer) => {
+        if (!settled && stdout.length < PREFLIGHT_STDOUT_LIMIT) {
+          stdout += data.toString();
+        }
+      });
+      const watchStderr = createStderrWatcher({
+        logPrefix: "[JETLS-version-stderr]",
+        appendLine: this.options.appendLine,
+        onPrecompiling: this.options.onPrecompiling,
+      });
+      versionProcess.stderr?.on("data", (data: Buffer) => {
+        if (settled) {
+          return;
+        }
+        watchStderr(data);
+      });
+      versionProcess.once("error", (err) => {
+        processError = err;
+      });
+      versionProcess.once("close", (code, signal) => {
+        preflight.closed = true;
+        resolveClosed();
+        if (this.activeProcess === preflight) {
+          this.activeProcess = undefined;
+        }
+        if (timedOut || settled) {
+          return;
+        }
+        const output = stdout.trim();
+        if (output) {
+          this.options.appendLine(
+            `[jetls-client] JETLS version check stdout:\n${output}`,
+          );
+        }
+        if (processError !== undefined) {
+          finish(processError);
+        } else if (code === 0) {
+          finish();
+        } else if (signal !== null) {
+          finish(
+            new Error(`JETLS version check exited with signal ${signal}.`),
+          );
+        } else {
+          finish(new Error(`JETLS version check exited with code ${code}.`));
+        }
+      });
+
+      const timeoutHandle = setTimeout(() => {
+        timedOut = true;
+        const timeoutError = new Error(
+          `JETLS version check timed out after ${this.options.timeoutMs / 1000} seconds.`,
+        );
+        this.options.appendLine(`[jetls-client] ${timeoutError.message}`);
+        void this.terminateProcess(preflight).then(
+          () => finish(timeoutError),
+          (err) => {
+            const terminationError =
+              err instanceof Error ? err : new Error(String(err));
+            finish(
+              new Error(`${timeoutError.message} ${terminationError.message}`),
+            );
+          },
+        );
+      }, this.options.timeoutMs);
+    });
+  }
+}

--- a/jetls-client/test/coalescing-task-runner.test.ts
+++ b/jetls-client/test/coalescing-task-runner.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { CoalescingTaskRunner } from "../CoalescingTaskRunner";
+import { CoalescingTaskRunner } from "../src/CoalescingTaskRunner";
 
 function deferred(): {
   promise: Promise<void>;
@@ -70,6 +70,18 @@ test("runs a pending task after the active task fails", async () => {
   await Promise.all([activeRun, pendingRun]);
 
   assert.equal(runCount, 2);
+});
+
+test("exposes the active run until it settles", async () => {
+  const release = deferred();
+  const runner = new CoalescingTaskRunner(() => release.promise);
+
+  assert.equal(runner.active, undefined);
+  const run = runner.run();
+  assert.equal(runner.active, run);
+  release.resolve();
+  await run;
+  assert.equal(runner.active, undefined);
 });
 
 test("recovers after a failed task", async () => {

--- a/jetls-client/test/server-startup.test.ts
+++ b/jetls-client/test/server-startup.test.ts
@@ -1,0 +1,322 @@
+import * as assert from "node:assert/strict";
+import type * as cp from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { test } from "node:test";
+
+import {
+  createStderrWatcher,
+  resolveJETLSCommands,
+  VersionPreflight,
+  VersionPreflightOptions,
+} from "../src/server-startup";
+
+class FakeChildProcess extends EventEmitter {
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly killCalls: (NodeJS.Signals | number | undefined)[] = [];
+  pid: number | undefined = 1234;
+  onKill: ((signal?: NodeJS.Signals | number) => void) | undefined;
+
+  kill(signal?: NodeJS.Signals | number): boolean {
+    this.killCalls.push(signal);
+    this.onKill?.(signal);
+    return true;
+  }
+
+  close(code: number | null, signal: NodeJS.Signals | null): void {
+    this.stdout.end();
+    this.stderr.end();
+    this.emit("close", code, signal);
+  }
+
+  asChildProcess(): cp.ChildProcess {
+    return this as unknown as cp.ChildProcess;
+  }
+}
+
+interface SpawnCall {
+  command: string;
+  args: readonly string[];
+  options: cp.SpawnOptions;
+}
+
+function createPreflight(
+  children: FakeChildProcess[],
+  options: Partial<VersionPreflightOptions> = {},
+): {
+  preflight: VersionPreflight;
+  spawnCalls: SpawnCall[];
+  logs: string[];
+  precompilationCount: () => number;
+} {
+  const spawnCalls: SpawnCall[] = [];
+  const logs: string[] = [];
+  let nextChild = 0;
+  let precompilationCount = 0;
+  const preflight = new VersionPreflight({
+    timeoutMs: 1000,
+    terminationTimeoutMs: 20,
+    platform: "darwin",
+    spawnProcess: (command, args, spawnOptions) => {
+      spawnCalls.push({ command, args, options: spawnOptions });
+      const child = children[nextChild++];
+      assert.ok(child, `Unexpected spawn: ${command}`);
+      return child.asChildProcess();
+    },
+    appendLine: (message) => logs.push(message),
+    onPrecompiling: () => {
+      precompilationCount += 1;
+    },
+    ...options,
+  });
+  return {
+    preflight,
+    spawnCalls,
+    logs,
+    precompilationCount: () => precompilationCount,
+  };
+}
+
+test("resolves installed and development commands", () => {
+  assert.deepEqual(resolveJETLSCommands({}), {
+    command: "jetls",
+    versionArgs: ["--threads=auto", "--", "version"],
+    serveArgs: ["--threads=auto", "--", "serve"],
+  });
+  assert.deepEqual(
+    resolveJETLSCommands({ path: "/opt/julia/bin/jetls", threads: "4" }),
+    {
+      command: "/opt/julia/bin/jetls",
+      versionArgs: ["--threads=4", "--", "version"],
+      serveArgs: ["--threads=4", "--", "serve"],
+    },
+  );
+
+  const executable = [
+    "julia",
+    "--startup-file=no",
+    "--project=/checkout",
+    "-m",
+    "JETLS",
+    "serve",
+  ];
+  assert.deepEqual(resolveJETLSCommands(executable), {
+    command: "julia",
+    versionArgs: [
+      "--startup-file=no",
+      "--project=/checkout",
+      "-m",
+      "JETLS",
+      "version",
+    ],
+    serveArgs: [
+      "--startup-file=no",
+      "--project=/checkout",
+      "-m",
+      "JETLS",
+      "serve",
+    ],
+  });
+  assert.deepEqual(executable, [
+    "julia",
+    "--startup-file=no",
+    "--project=/checkout",
+    "-m",
+    "JETLS",
+    "serve",
+  ]);
+
+  assert.throws(
+    () => resolveJETLSCommands(["julia", "-m", "JETLS"]),
+    /expected exactly one `serve` subcommand/,
+  );
+  assert.throws(
+    () => resolveJETLSCommands(["jetls", "serve", "serve"]),
+    /expected exactly one `serve` subcommand/,
+  );
+});
+
+test("runs a successful version preflight", async () => {
+  const child = new FakeChildProcess();
+  const { preflight, spawnCalls, logs } = createPreflight([child]);
+
+  const run = preflight.run("jetls", ["--", "version"], { shell: true });
+  child.stdout.write("JETLS version 1.0\n");
+  child.close(0, null);
+  await run;
+
+  assert.deepEqual(spawnCalls, [
+    {
+      command: "jetls",
+      args: ["--", "version"],
+      options: { shell: true },
+    },
+  ]);
+  assert.ok(
+    logs.includes(
+      "[jetls-client] JETLS version check stdout:\nJETLS version 1.0",
+    ),
+  );
+});
+
+test("preserves spawn errors", async () => {
+  const child = new FakeChildProcess();
+  const { preflight } = createPreflight([child]);
+  const expectedError = Object.assign(new Error("spawn failed"), {
+    code: "ENOENT",
+  });
+
+  const run = preflight.run("missing-jetls", ["version"], {});
+  child.emit("error", expectedError);
+  child.close(-2, null);
+
+  await assert.rejects(run, (error) => error === expectedError);
+});
+
+test("reports nonzero and signal exits", async () => {
+  const failedChild = new FakeChildProcess();
+  const { preflight: failedPreflight } = createPreflight([failedChild]);
+  const failedRun = failedPreflight.run("jetls", ["version"], {});
+  failedChild.close(2, null);
+  await assert.rejects(failedRun, /JETLS version check exited with code 2\./);
+
+  const signaledChild = new FakeChildProcess();
+  const { preflight: signaledPreflight } = createPreflight([signaledChild]);
+  const signaledRun = signaledPreflight.run("jetls", ["version"], {});
+  signaledChild.close(null, "SIGTERM");
+  await assert.rejects(
+    signaledRun,
+    /JETLS version check exited with signal SIGTERM\./,
+  );
+});
+
+test("detects split precompilation output once", async () => {
+  const child = new FakeChildProcess();
+  const { preflight, precompilationCount } = createPreflight([child]);
+
+  const run = preflight.run("jetls", ["version"], {});
+  child.stderr.write("Precompiling pack");
+  child.stderr.write("ages\nPrecompiling packages\n");
+  child.close(0, null);
+  await run;
+
+  assert.equal(precompilationCount(), 1);
+});
+
+test("stderr watcher logs lines and detects a split marker once", () => {
+  const logs: string[] = [];
+  let precompilingCount = 0;
+  const watch = createStderrWatcher({
+    logPrefix: "[test-stderr]",
+    appendLine: (message) => logs.push(message),
+    onPrecompiling: () => {
+      precompilingCount += 1;
+    },
+  });
+
+  watch(Buffer.from("Info: loading\nPrecompiling pack"));
+  watch(Buffer.from("ages\n"));
+  watch(Buffer.from("Precompiling packages\n"));
+
+  assert.equal(precompilingCount, 1);
+  assert.deepEqual(logs.slice(0, 2), [
+    "[test-stderr] Info: loading",
+    "[test-stderr] Precompiling pack",
+  ]);
+});
+
+test("terminates a timed-out preflight before rejecting", async () => {
+  const child = new FakeChildProcess();
+  child.onKill = () => queueMicrotask(() => child.close(null, "SIGTERM"));
+  const { preflight } = createPreflight([child], {
+    timeoutMs: 10,
+  });
+
+  await assert.rejects(
+    preflight.run("jetls", ["version"], {}),
+    /JETLS version check timed out after 0\.01 seconds\./,
+  );
+  assert.deepEqual(child.killCalls, [undefined]);
+});
+
+test("shares termination and escalates a stubborn POSIX process", async () => {
+  const child = new FakeChildProcess();
+  child.onKill = (signal) => {
+    if (signal === "SIGKILL") {
+      queueMicrotask(() => child.close(null, "SIGKILL"));
+    }
+  };
+  const { preflight } = createPreflight([child], {
+    terminationTimeoutMs: 5,
+  });
+
+  const run = preflight.run("jetls", ["version"], {});
+  const firstTermination = preflight.terminate();
+  const secondTermination = preflight.terminate();
+  assert.equal(firstTermination, secondTermination);
+  await firstTermination;
+  await assert.rejects(run, /JETLS version check exited with signal SIGKILL\./);
+  assert.deepEqual(child.killCalls, [undefined, "SIGKILL"]);
+});
+
+test("recovers after a failed termination", async () => {
+  const stubbornChild = new FakeChildProcess();
+  const replacementChild = new FakeChildProcess();
+  const { preflight } = createPreflight([stubbornChild, replacementChild], {
+    terminationTimeoutMs: 5,
+  });
+
+  const run = preflight.run("jetls", ["version"], {});
+  await assert.rejects(preflight.terminate(), /did not exit after termination/);
+  assert.deepEqual(stubbornChild.killCalls, [undefined, "SIGKILL"]);
+
+  const rerun = preflight.run("jetls", ["version"], {});
+  replacementChild.stdout.write("JETLS version 1.0\n");
+  replacementChild.close(0, null);
+  await rerun;
+
+  stubbornChild.close(null, "SIGTERM");
+  await assert.rejects(run, /JETLS version check exited with signal SIGTERM\./);
+});
+
+test("uses taskkill to terminate a Windows preflight", async () => {
+  const versionChild = new FakeChildProcess();
+  versionChild.pid = 4321;
+  const taskkillChild = new FakeChildProcess();
+  const { preflight, spawnCalls } = createPreflight(
+    [versionChild, taskkillChild],
+    { platform: "win32" },
+  );
+
+  const run = preflight.run("jetls.bat", ["version"], { shell: true });
+  const termination = preflight.terminate();
+  assert.deepEqual(spawnCalls[1], {
+    command: "taskkill",
+    args: ["/PID", "4321", "/T", "/F"],
+    options: { stdio: "ignore", windowsHide: true },
+  });
+  taskkillChild.close(0, null);
+  versionChild.close(null, "SIGTERM");
+  await termination;
+  await assert.rejects(run, /JETLS version check exited with signal SIGTERM\./);
+  assert.deepEqual(versionChild.killCalls, []);
+});
+
+test("falls back to kill() when taskkill fails", async () => {
+  const versionChild = new FakeChildProcess();
+  versionChild.pid = 4321;
+  versionChild.onKill = () =>
+    queueMicrotask(() => versionChild.close(null, "SIGTERM"));
+  const taskkillChild = new FakeChildProcess();
+  const { preflight } = createPreflight([versionChild, taskkillChild], {
+    platform: "win32",
+  });
+
+  const run = preflight.run("jetls.bat", ["version"], { shell: true });
+  const termination = preflight.terminate();
+  taskkillChild.close(1, null);
+  await termination;
+  assert.deepEqual(versionChild.killCalls, [undefined]);
+  await assert.rejects(run, /JETLS version check exited with signal SIGTERM\./);
+});


### PR DESCRIPTION
Previously the extension spawned `jetls serve` directly and reported little while it started: a missing or broken executable, a long first-run precompilation, and a server that died before connecting all looked the same — a silent spinner, or nothing at all, often recoverable only by reloading the window.

Startup now begins with a version preflight that runs `jetls version` before the server is launched. It catches missing and broken executables with actionable messages, absorbs first-run precompilation under a dedicated 300-second budget, and surfaces progress in the status bar, which tracks the whole sequence (checking, precompiling, starting, restarting, ready, failed) and opens the JETLS output channel on click when something goes wrong. For the array form of `jetls-client.executable`, the configured argv must contain exactly one `serve` subcommand, which the preflight swaps for `version`; misconfigurations fail fast with an explicit error.

The failure paths are hardened so that no error requires a window reload: restarts skip `stop()` for clients that never reached the `Running` state, a preflight whose process cannot be terminated resets its state (with a `taskkill` → `kill()` fallback on Windows), pipe startup rejects when the server exits before connecting, stdio startup is bounded by the same startup timeout as the other channels, and `deactivate` awaits the in-flight restart lifecycle with a bound instead of indefinitely. Serve-side precompilation detection re-arms the startup timeout with the precompilation budget.

TypeScript sources now live under `src/`, with shared tunables documented in `src/constants.ts`. Unit tests cover the preflight lifecycle (success, spawn errors, exit codes, split precompilation output, timeout termination, recovery after failed termination, and the Windows `taskkill` path) and the coalescing runner's active-run accessor.