### PR TITLE
jetls-client: Send `didChangeConfiguration` only for JETLS settings

### DIFF
--- a/jetls-client/CHANGELOG.md
+++ b/jetls-client/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed overlapping JETLS restarts in VS Code by serializing rapid manual and configuration-triggered restart requests and waiting for the replacement server to finish initializing.
 
+- Fixed unnecessary configuration syncs: the server is now notified only when `jetls-client.settings` actually changes, instead of on every VS Code configuration change.
+
 ## v0.7.0
 
 - Commit: [`8cfd8fed7`](https://github.com/aviatesk/JETLS.jl/commit/8cfd8fed7)

--- a/jetls-client/src/constants.ts
+++ b/jetls-client/src/constants.ts
@@ -6,6 +6,13 @@ export const JETLS_CHANGELOG_URL =
   "https://github.com/aviatesk/JETLS.jl/blob/master/jetls-client/CHANGELOG.md";
 export const JETLS_MIGRATION_GUIDE_URL = `${JETLS_CHANGELOG_URL}#v020`;
 
+/**
+ * VS Code configuration section served to the server as its workspace
+ * configuration (`workspace/configuration`), and therefore the only section
+ * whose changes need announcing via `workspace/didChangeConfiguration`.
+ */
+export const JETLS_CLIENT_SETTINGS_SECTION = "jetls-client.settings";
+
 /** Julia stderr substring that signals package precompilation has started. */
 export const PRECOMPILING_MARKER = "Precompiling packages";
 

--- a/jetls-client/src/jetls-client.ts
+++ b/jetls-client/src/jetls-client.ts
@@ -9,6 +9,7 @@ import {
   requestLanguageServerRestart,
   restartOnServerConfigChange,
   shutdownServerLifecycle,
+  syncConfigurationChange,
 } from "./server-lifecycle";
 import { StartupStatusBar } from "./status-bar";
 import { checkForUpdates } from "./update-check";
@@ -25,6 +26,7 @@ export function activate(context: ExtensionContext) {
       if (affectsServerConfig(event)) {
         restartOnServerConfigChange();
       }
+      syncConfigurationChange(event);
     }),
   );
   context.subscriptions.push(

--- a/jetls-client/src/server-lifecycle.ts
+++ b/jetls-client/src/server-lifecycle.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { LogOutputChannel } from "vscode";
 
 import {
+  DidChangeConfigurationNotification,
   LanguageClient,
   LanguageClientOptions,
   ServerOptions,
@@ -10,6 +11,7 @@ import {
 
 import { CoalescingTaskRunner } from "./coalescing-task-runner";
 import {
+  JETLS_CLIENT_SETTINGS_SECTION,
   JETLS_INSTALL_COMMAND,
   JETLS_INSTALL_GUIDE_URL,
   LANGUAGE_SERVER_STOP_TIMEOUT_MS,
@@ -40,6 +42,49 @@ let statusBar: StartupStatusBar;
 let deactivating = false;
 let currentServerConfig: ServerConfig | null = null;
 let cancelServerStartup: (() => void) | undefined;
+
+/**
+ * Sends `workspace/didChangeConfiguration` when a configuration change
+ * affects `jetls-client.settings`, prompting the server to re-pull it via
+ * `workspace/configuration`. The extension owns this send: the language
+ * client's configuration sync feature cannot see which settings changed
+ * (the server registers without a section filter, so it would send on every
+ * configuration change) and is therefore suppressed in the middleware below.
+ * The send is skipped while a restart is queued or shutdown is underway;
+ * the replacement server pulls fresh configuration on initialize anyway.
+ *
+ * TODO (managed installation): once the extension manages the server binary
+ * and a paired server version is guaranteed, declare
+ * `configuration_section: JETLS_CLIENT_SETTINGS_SECTION` in the
+ * `initializationOptions` instead. The server then registers the
+ * notification with that section filter and the library's configuration
+ * sync feature takes over, so this function and the middleware suppression
+ * below can be deleted. Declaring it today would make older servers reject
+ * the whole `initializationOptions` as containing an unknown key.
+ */
+export function syncConfigurationChange(
+  event: vscode.ConfigurationChangeEvent,
+): void {
+  if (deactivating || restartRunner.pending) {
+    return;
+  }
+  if (!event.affectsConfiguration(JETLS_CLIENT_SETTINGS_SECTION)) {
+    return;
+  }
+  if (!languageClient?.isRunning()) {
+    return;
+  }
+  void languageClient
+    .sendNotification(DidChangeConfigurationNotification.type, {
+      settings: null,
+    })
+    .catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      outputChannel.appendLine(
+        `[jetls-client] Failed to send workspace/didChangeConfiguration: ${message}.`,
+      );
+    });
+}
 
 export function activateServerLifecycle(
   channel: LogOutputChannel,
@@ -277,6 +322,12 @@ async function startLanguageServer() {
       },
     ],
     middleware: {
+      workspace: {
+        // Suppress the configuration sync feature's own sends entirely:
+        // `syncConfigurationChange` owns the notification and only sends it
+        // when `jetls-client.settings` actually changed.
+        didChangeConfiguration: () => Promise.resolve(),
+      },
       // `editor.action.showReferences` is a built-in VSCode command that
       // requires actual `vscode.Uri`/`vscode.Position`/`vscode.Location`
       // instances, but server-sent command arguments arrive as plain JSON.
@@ -392,7 +443,7 @@ async function startLanguageServer() {
     (params: { items: { scopeUri?: string; section?: string | null }[] }) => {
       const items = params.items || [];
       const results = items.map((item) => {
-        const section = "jetls-client.settings";
+        const section = JETLS_CLIENT_SETTINGS_SECTION;
         const scope = item.scopeUri
           ? vscode.Uri.parse(item.scopeUri)
           : undefined;


### PR DESCRIPTION
The server currently registers `workspace/didChangeConfiguration` without a section filter, which vscode-languageclient's configuration sync feature interprets as "notify on every configuration change": any settings change, JETLS related or not, triggered the notification and the `jetls-client.settings` re-pull it signals. The send could also race the teardown of a configuration-triggered restart, failing with a spurious "Sending notification workspace/didChangeConfiguration failed: Starting server failed" error log.

This change suppresses the sync feature's own sends through the `didChangeConfiguration` middleware and moves the notification into the extension's configuration listener, which, unlike the middleware, has access to the change event. `syncConfigurationChange` sends the notification (with the same `settings: null` payload the feature used) only when the change affects `jetls-client.settings`, no restart is queued, shutdown is not underway, and the client is running.

A TODO documents the eventual replacement: once managed installation guarantees a paired server version, the extension should declare the `configuration_section` initialization option (aviatesk/JETLS.jl#859) instead and let the server-side section filter take over; declaring it today would make older servers reject the whole `initializationOptions` as containing an unknown key. The `jetls-client.settings` literal is also extracted into the shared `JETLS_CLIENT_SETTINGS_SECTION` constant.