### PR TITLE
full-analysis: Cancel outstanding work during shutdown

### DIFF
--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -249,6 +249,7 @@ function runserver(
             elseif msg isa ShutdownRequest
                 shutdown_requested = true
                 send(server, ShutdownResponse(; id = msg.id, result = null))
+                begin_analysis_shutdown!(server)
             elseif msg isa ExitNotification
                 exit_code = !shutdown_requested
                 break
@@ -292,8 +293,8 @@ function runserver(
     finally
         # The client may close the transport after `exit`; reject output before worker cleanup.
         close(server.endpoint)
-        stop_analysis_worker(server)
-        stop_signature_analysis_workers(server)
+        begin_analysis_shutdown!(server)
+        wait_analysis_workers(server)
         put!(seq_queue, nothing); put!(con_queue, nothing);
         close(seq_queue); close(con_queue);
         waitall((seq_task, con_task))

--- a/src/analysis/Interpreter.jl
+++ b/src/analysis/Interpreter.jl
@@ -134,11 +134,14 @@ struct InterpreterSignatureAnalysisJob <: JETLS.AbstractSignatureAnalysisJob
     n_sigs::Int
     completion::Base.Event
 end
+JETLS.signature_analysis_execution_impl(job::InterpreterSignatureAnalysisJob) =
+    job.interp.execution
 
 function (job::InterpreterSignatureAnalysisJob)(server::Server)
     (; interp, res, progress, index, entrypoint, cancellable_token, n_sigs) = job
     try
-        if cancellable_token !== nothing && is_cancelled(cancellable_token.cancel_flag)
+        if (JETLS.is_analysis_cancelled(interp.execution) ||
+            cancellable_token !== nothing && is_cancelled(cancellable_token.cancel_flag))
             return
         end
         (; tt) = res.signature_infos[index]

--- a/src/analysis/Interpreter.jl
+++ b/src/analysis/Interpreter.jl
@@ -194,15 +194,11 @@ function compute_percentage(count, total, max=100)
 end
 
 function cache_intermediate_analysis_result!(interp::LSInterpreter)
-    result = JET.JETToplevelResult(interp.analyzer, interp.state.res, "LSInterpreter (intermediate result)", ())
+    result = JET.JETToplevelResult(interp.analyzer, interp.state.res,
+        "LSInterpreter (intermediate result)", ())
     intermediate_result, _ = JETLS.new_analysis_result(interp, result; intermediate=true)
-    JETLS.update_analysis_cache!(interp.server.state, intermediate_result)
-    # Module contexts are complete at this point, which is all pull diagnostics need,
-    # so refresh them now rather than after signature analysis.
-    JETLS.request_diagnostic_refresh!(interp.server)
-    JETLS.request_codelens_refresh!(interp.server)
-    interp.execution.context_refreshed = true
-    nothing
+    return JETLS.cache_intermediate_analysis_result!(
+        interp.server, interp.execution, intermediate_result)
 end
 
 function JET.analyze_from_definitions!(interp::LSInterpreter, config::JET.ToplevelConfig)
@@ -213,9 +209,12 @@ function JET.analyze_from_definitions!(interp::LSInterpreter, config::JET.Toplev
         notify(activation_done)
     end
 
+    JETLS.is_analysis_cancelled(interp.execution) && return
+
     # Cache intermediate analysis results after file analysis completes
     # This makes module context information available immediately for LS features
-    cache_intermediate_analysis_result!(interp)
+    cache_intermediate_analysis_result!(interp) || return
+    JETLS.is_analysis_cancelled(interp.execution) && return
 
     res = JET.InterpretationState(interp).res
     reset_report_target_modules!(interp.analyzer, res.analyzed_files)
@@ -276,6 +275,7 @@ function JET.analyze_from_definitions!(interp::LSInterpreter, config::JET.Toplev
     end
 
     JETLS.run_signature_analysis_jobs!(interp.server, jobs)
+    JETLS.is_analysis_cancelled(interp.execution) && return
 
     append!(res.inference_error_reports, progress.reports)
 end
@@ -283,6 +283,7 @@ end
 function JET.virtual_process!(interp::LSInterpreter,
                               x::Union{AbstractString,JS.SyntaxNode},
                               overrideex::Union{Nothing,Expr})
+    JETLS.is_analysis_cancelled(interp.execution) && return nothing
     cancellable_token = interp.execution.request.cancellable_token
     if cancellable_token !== nothing
         filename = JET.InterpretationState(interp).filename

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -308,7 +308,10 @@ function signature_analysis_worker(server::Server)
         was_sticky = task.sticky
         task.sticky = true
         try
-            @tryinvokelatest job(server)
+            execution = signature_analysis_execution(job)
+            if execution === nothing || !is_analysis_cancelled(execution)
+                @tryinvokelatest job(server)
+            end
         finally
             task.sticky = was_sticky
             notify(signature_analysis_completion(job))
@@ -320,9 +323,31 @@ end
 function run_signature_analysis_jobs!(
         server::Server, jobs::Vector{<:AbstractSignatureAnalysisJob}
     )
-    queue = server.state.analysis_manager.signature_queue
-    foreach(job -> put!(queue, job), jobs)
-    foreach(job -> wait(signature_analysis_completion(job)), jobs)
+    isempty(jobs) && return nothing
+    manager = server.state.analysis_manager
+    execution = signature_analysis_execution(first(jobs))
+    @assert all(job -> signature_analysis_execution(job) === execution, jobs)
+
+    accepted = if execution === nothing
+        foreach(job -> put!(manager.signature_queue, job), jobs)
+        true
+    else
+        @lock manager.lifecycle_lock begin
+            if manager.stopping[] || is_analysis_cancelled(execution)
+                cancel!(execution.shutdown_cancel_flag)
+                false
+            else
+                foreach(job -> put!(manager.signature_queue, job), jobs)
+                true
+            end
+        end
+    end
+
+    if accepted
+        foreach(job -> wait(signature_analysis_completion(job)), jobs)
+    else
+        foreach(job -> notify(signature_analysis_completion(job)), jobs)
+    end
     return nothing
 end
 
@@ -1322,6 +1347,7 @@ mutable struct ReviseAnalysisProgress
 end
 
 struct ReviseSignatureAnalysisJob <: AbstractSignatureAnalysisJob
+    execution::AnalysisExecution
     workitem::SigWorkItem
     analyzer::LSAnalyzer
     progress::ReviseAnalysisProgress
@@ -1330,12 +1356,15 @@ struct ReviseSignatureAnalysisJob <: AbstractSignatureAnalysisJob
     n_sigs::Int
     completion::Base.Event
 end
+signature_analysis_execution_impl(job::ReviseSignatureAnalysisJob) = job.execution
 
 function (job::ReviseSignatureAnalysisJob)(server::Server)
-    (; workitem, analyzer, progress, inf_world, cancellable_token, n_sigs) = job
+    (; execution, workitem, analyzer, progress, inf_world,
+        cancellable_token, n_sigs) = job
     siginfo = workitem.siginfo
     try
-        if cancellable_token !== nothing && is_cancelled(cancellable_token.cancel_flag)
+        if (is_analysis_cancelled(execution) ||
+            cancellable_token !== nothing && is_cancelled(cancellable_token.cancel_flag))
             return
         end
         ext = Revise.get_extended_data(siginfo, :JETLS)
@@ -1572,7 +1601,8 @@ function analyze_package_with_revise(
     jobs = ReviseSignatureAnalysisJob[]
     for workitem in workitems
         push!(jobs, ReviseSignatureAnalysisJob(
-            workitem, analyzer, progress, inf_world, cancellable_token, n_sigs, Base.Event()))
+            execution, workitem, analyzer, progress, inf_world,
+            cancellable_token, n_sigs, Base.Event()))
     end
     run_signature_analysis_jobs!(server, jobs)
 

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -227,6 +227,12 @@ function begin_analysis_shutdown!(server::Server)
             Tuple{Timer,Base.Event}[]
         else
             manager.stopping[] = true
+            active_execution = manager.active_analysis[]
+            if active_execution !== nothing
+                cancel!(active_execution.shutdown_cancel_flag)
+                rollback_intermediate_analysis_result_locked!(
+                    server.state, active_execution)
+            end
             store!(manager.debounced) do debounced
                 return empty(debounced), collect(values(debounced))
             end
@@ -241,6 +247,36 @@ end
 
 is_analysis_stopping(manager::AnalysisManager) =
     @lock manager.lifecycle_lock manager.stopping[]
+
+is_analysis_cancelled(execution::AnalysisExecution) =
+    is_cancelled(execution.shutdown_cancel_flag)
+
+function begin_analysis_execution!(
+        manager::AnalysisManager, request::AnalysisRequest,
+        prev_result::Union{Nothing,AnalysisResult},
+    )
+    return @lock manager.lifecycle_lock begin
+        if manager.stopping[]
+            nothing
+        else
+            @assert manager.active_analysis[] === nothing
+            execution = AnalysisExecution(request, prev_result, CancelFlag(false))
+            manager.active_analysis[] = execution
+            execution
+        end
+    end
+end
+
+function finish_analysis_execution!(
+        manager::AnalysisManager, execution::AnalysisExecution
+    )
+    @lock manager.lifecycle_lock begin
+        if manager.active_analysis[] === execution
+            manager.active_analysis[] = nothing
+        end
+    end
+    return nothing
+end
 
 function start_signature_analysis_workers!(server::Server)
     manager = server.state.analysis_manager
@@ -614,41 +650,80 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
         @goto next_request
     end
 
-    execution = AnalysisExecution(request, current_analysis_result(manager, request))
-    prev_result = execution.prev_result
-
-    if has_any_parse_errors(server, execution)
+    prev_result = current_analysis_result(manager, request)
+    if has_any_parse_errors(server, prev_result)
         @static JETLS_DEV_MODE && @info "Requested analysis unit has parse errors" entry=progress_title(request.entry) uri=request.uri generation=get_generation(manager,request.entry)
         @goto next_request
     end
 
-    cancellable_token = request.cancellable_token
-    if cancellable_token !== nothing
-        begin_full_analysis_progress(server, cancellable_token, request.entry, prev_result === nothing)
+    maybe_execution = begin_analysis_execution!(manager, request, prev_result)
+    if maybe_execution === nothing
+        @static JETLS_DEV_MODE && @info "Cancelled analysis before execution during shutdown" entry=progress_title(request.entry) uri=request.uri generation=request.generation
+        @goto next_request
     end
+    execution = maybe_execution::AnalysisExecution
+    progress_started = false
 
+    try
+        cancellable_token = request.cancellable_token
+        if cancellable_token !== nothing
+            begin_full_analysis_progress(
+                server, cancellable_token, request.entry, prev_result === nothing)
+            progress_started = true
+        end
+        execute_active_analysis!(server, execution)
+    finally
+        try
+            try
+                if progress_started
+                    end_full_analysis_progress(
+                        server, request.cancellable_token::CancellableToken)
+                end
+            finally
+                finish_analysis_execution!(manager, execution)
+            end
+        finally
+            finish_analysis_request!(manager, request)
+        end
+    end
+    return nothing
+
+    @label next_request
+
+    finish_analysis_request!(manager, request)
+end
+
+function execute_active_analysis!(server::Server, execution::AnalysisExecution)
+    request = execution.request
+    prev_result = execution.prev_result
+    manager = server.state.analysis_manager
     s = time()
     @static JETLS_DEV_MODE && @info "Executing analysis for:" entry=progress_title(request.entry) uri=request.uri generation=get_generation(manager,request.entry)
-    local cleanup::Bool = local failed::Bool = false
-    analysis_result = try
-        result, cleanup = execute_analysis(server, execution)
-        result
+    outcome = try
+        execute_analysis(server, execution)
     catch err
         @error "Error in `execute_analysis` for " request
         Base.display_error(stderr, err, catch_backtrace())
-        failed = true
+        # Keep any published intermediate result on plain failures so LS features
+        # retain the fresh module context; roll it back only when this analysis
+        # was cancelled by server shutdown.
+        if is_analysis_cancelled(execution)
+            rollback_intermediate_analysis_result!(server.state, execution)
+        end
+        return nothing
     finally
-        if cancellable_token !== nothing
-            end_full_analysis_progress(server, cancellable_token)
-        end
-        if cleanup && prev_result !== nothing
-            cleanup_prev_methods(prev_result)
-        end
         clear_pkg_registry_cache!()
-        failed && @goto next_request
     end
-    @assert !(analysis_result isa Bool)
 
+    if outcome isa CancelledAnalysis
+        @static JETLS_DEV_MODE && @info "Cancelled active analysis during shutdown" entry=progress_title(request.entry) uri=request.uri generation=request.generation
+        rollback_intermediate_analysis_result!(server.state, execution)
+        return nothing
+    end
+
+    completed = outcome::CompletedAnalysis
+    analysis_result = completed.result
+    cleanup_prev_result = completed.cleanup_prev_result
     tm = round(time() - s, digits=2)
     @static JETLS_DEV_MODE && @info "Analysis completed in $tm seconds:" entry=progress_title(request.entry) uri=request.uri generation=get_generation(manager,request.entry)
 
@@ -661,21 +736,26 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
         @static JETLS_DEV_MODE && @info "Discarding analysis result for closed editor-managed document" entry=progress_title(request.entry) uri=request.uri
         cleanup_prev_methods(analysis_result)
         cleanup_analysis_entry_state!(manager, request.entry)
-        @goto next_request
+        return nothing
     end
 
-    update_analysis_cache!(server.state, analysis_result)
-    mark_analyzed_generation!(manager, request)
+    if !commit_analysis_result!(server, execution, analysis_result)
+        @static JETLS_DEV_MODE && @info "Discarded completed analysis during shutdown" entry=progress_title(request.entry) uri=request.uri generation=request.generation
+        rollback_intermediate_analysis_result!(server.state, execution)
+        return nothing
+    end
+
+    execution.intermediate_result[] = nothing
+    if cleanup_prev_result && prev_result !== nothing
+        cleanup_prev_methods(prev_result)
+    end
     request.notify_diagnostics && notify_diagnostics!(server)
     # Top-level errors can skip signature analysis and its intermediate context refresh.
     if !execution.context_refreshed
         request_diagnostic_refresh!(server)
         request_codelens_refresh!(server)
     end
-
-    @label next_request
-
-    finish_analysis_request!(manager, request)
+    return nothing
 end
 
 function finish_analysis_request!(manager::AnalysisManager, request::AnalysisRequest)
@@ -731,8 +811,10 @@ function is_generation_analyzed(manager::AnalysisManager, request::AnalysisReque
     return analyzed_generation == request.generation
 end
 
-function has_any_parse_errors(server::Server, execution::AnalysisExecution)
-    prev_result = @something execution.prev_result return false
+function has_any_parse_errors(
+        server::Server, prev_result::Union{Nothing,AnalysisResult}
+    )
+    prev_result === nothing && return false
     return any(analyzed_file_uris(prev_result)) do uri::URI
         (; parsed_stream) = @something (isunsaveduri(uri) ?
             get_file_info(server.state, uri) :
@@ -891,6 +973,67 @@ function pop_analysis_info!(manager::AnalysisManager, uri::URI)
     end
 end
 
+function cache_intermediate_analysis_result!(
+        server::Server, execution::AnalysisExecution, analysis_result::AnalysisResult
+    )
+    manager = server.state.analysis_manager
+    return @lock manager.lifecycle_lock begin
+        if (manager.stopping[] || is_analysis_cancelled(execution) ||
+            manager.active_analysis[] !== execution)
+            false
+        else
+            execution.intermediate_result[] = analysis_result
+            update_analysis_cache!(server.state, analysis_result)
+            # Refresh the complete module contexts before signature analysis, under the
+            # lifecycle lock so shutdown cannot roll them back before these requests.
+            request_diagnostic_refresh!(server)
+            request_codelens_refresh!(server)
+            execution.context_refreshed = true
+            true
+        end
+    end
+end
+
+function rollback_intermediate_analysis_result!(
+        state::ServerState, execution::AnalysisExecution
+    )
+    manager = state.analysis_manager
+    @lock manager.lifecycle_lock begin
+        rollback_intermediate_analysis_result_locked!(state, execution)
+    end
+    return nothing
+end
+
+function rollback_intermediate_analysis_result_locked!(
+        state::ServerState, execution::AnalysisExecution
+    )
+    intermediate_result = execution.intermediate_result[]
+    intermediate_result === nothing && return nothing
+    prev_result = execution.prev_result
+    prev_uris = prev_result === nothing ? () : analyzed_file_uris(prev_result)
+    reverted_uris = store!(state.analysis_manager.cache) do cache
+        new_cache = copy(cache)
+        reverted = URI[]
+        for uri in analyzed_file_uris(intermediate_result)
+            get(cache, uri, nothing) === intermediate_result || continue
+            if prev_result !== nothing && uri in prev_uris
+                new_cache[uri] = prev_result
+            else
+                delete!(new_cache, uri)
+            end
+            push!(reverted, uri)
+        end
+        return new_cache, reverted
+    end
+    execution.intermediate_result[] = nothing
+    for uri in reverted_uris
+        clear_inferred_context_cache!(state, uri)
+        invalidate_binding_occurrences_cache!(state, uri)
+        invalidate_per_file_diagnostics_cache!(state, uri)
+    end
+    return nothing
+end
+
 function update_analysis_cache!(state::ServerState, analysis_result::AnalysisResult)
     manager = state.analysis_manager
     analyzed_uris = analyzed_file_uris(analysis_result)
@@ -937,10 +1080,32 @@ function mark_analyzed_generation!(manager::AnalysisManager, request::AnalysisRe
     end
 end
 
-function execute_analysis(server::Server, execution::AnalysisExecution)
-    request = execution.request
-    entry = request.entry
+function commit_analysis_result!(
+        server::Server, execution::AnalysisExecution, analysis_result::AnalysisResult
+    )
+    manager = server.state.analysis_manager
+    return @lock manager.lifecycle_lock begin
+        if (manager.stopping[] || is_analysis_cancelled(execution) ||
+            manager.active_analysis[] !== execution)
+            false
+        else
+            update_analysis_cache!(server.state, analysis_result)
+            mark_analyzed_generation!(manager, execution.request)
+            manager.active_analysis[] = nothing
+            true
+        end
+    end
+end
 
+function execute_analysis(server::Server, execution::AnalysisExecution)
+    is_analysis_cancelled(execution) && return CancelledAnalysis()
+    outcome = execute_analysis_impl(server, execution, execution.request.entry)
+    return is_analysis_cancelled(execution) ? CancelledAnalysis() : outcome
+end
+
+function execute_analysis_impl(
+        server::Server, execution::AnalysisExecution, @nospecialize(entry::AnalysisEntry)
+    )
     if entry isa NewAnalysisEntry
         env_path = entry.env_path
         result = if env_path === nothing
@@ -950,7 +1115,7 @@ function execute_analysis(server::Server, execution::AnalysisExecution)
                 analyze_package_with_revise(server, execution, entry.pkgid, activation_done)
             end::AnalysisResult
         end
-        return result, false
+        return CompletedAnalysis(result, false)
     end
 
     interp, result = if entry isa ScriptAnalysisEntry
@@ -973,7 +1138,7 @@ function execute_analysis(server::Server, execution::AnalysisExecution)
 
     # TODO Request fallback analysis in cases this script was not analyzed by the analysis entry
     # request.uri ∉ analyzed_file_uris(ret)
-    return ret, analysis_result_replaced
+    return CompletedAnalysis(ret, analysis_result_replaced)
 end
 
 function begin_full_analysis_progress(
@@ -1364,10 +1529,8 @@ function analyze_package_with_revise(
     let uri2diagnostics = intermediate_analysis_diagnostics(execution, analyzed_file_infos)
         intermediate_result = AnalysisResult(request.entry, uri2diagnostics, analyzer,
             analyzed_file_infos, pkgmod => pkgmod, world)
-        update_analysis_cache!(server.state, intermediate_result)
-        request_diagnostic_refresh!(server)
-        request_codelens_refresh!(server)
-        execution.context_refreshed = true
+        cache_intermediate_analysis_result!(server, execution, intermediate_result) ||
+            return intermediate_result
     end
 
     # Detect method overwrites
@@ -1393,10 +1556,11 @@ function analyze_package_with_revise(
     progress = ReviseAnalysisProgress(n_sigs)
     inf_world = CC.get_inference_world(analyzer)
     cancellable_token = request.cancellable_token
+    if (is_analysis_cancelled(execution) ||
+        cancellable_token !== nothing && is_cancelled(cancellable_token.cancel_flag))
+        @goto completed
+    end
     if cancellable_token !== nothing
-        if is_cancelled(cancellable_token.cancel_flag)
-            @goto completed
-        end
         send_progress(server, cancellable_token.token,
             WorkDoneProgressReport(;
                 cancellable = true,

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -226,6 +226,9 @@ function begin_analysis_shutdown!(server::Server)
     return nothing
 end
 
+is_analysis_stopping(manager::AnalysisManager) =
+    @lock manager.lifecycle_lock manager.stopping[]
+
 function start_signature_analysis_workers!(server::Server)
     manager = server.state.analysis_manager
     worker_tasks = manager.signature_worker_tasks
@@ -549,6 +552,11 @@ end
 
 function resolve_analysis_request(server::Server, request::AnalysisRequest)
     manager = server.state.analysis_manager
+
+    if is_analysis_stopping(manager)
+        @static JETLS_DEV_MODE && @info "Skipped queued analysis request during shutdown" entry=progress_title(request.entry) uri=request.uri generation=request.generation
+        @goto next_request
+    end
 
     if is_superseded_request(manager, request)
         @static JETLS_DEV_MODE && @info "Skipped superseded analysis request" entry=progress_title(request.entry) uri=request.uri generation=request.generation

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -334,6 +334,32 @@ function stop_analysis_worker(server::Server)
     return nothing
 end
 
+function wait_analysis_workers(server::Server)
+    begin_analysis_shutdown!(server)
+    manager = server.state.analysis_manager
+
+    worker_task = manager.worker_task
+    if isassigned(worker_task)
+        task = worker_task[]
+        istaskdone(task) || put!(manager.queue, nothing)
+        wait(task)
+    end
+
+    # Low-level callers may have stopped the worker before queueing test work.
+    while isready(manager.queue)
+        request = take!(manager.queue)
+        request === nothing || finish_analysis_request!(manager, request)
+    end
+
+    # Active full analysis may still be waiting for signature-analysis jobs.
+    worker_tasks = manager.signature_worker_tasks
+    for task in worker_tasks
+        istaskdone(task) || put!(manager.signature_queue, nothing)
+    end
+    foreach(wait, worker_tasks)
+    return nothing
+end
+
 # Analysis worker pipeline
 # ========================
 
@@ -649,6 +675,10 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
 
     @label next_request
 
+    finish_analysis_request!(manager, request)
+end
+
+function finish_analysis_request!(manager::AnalysisManager, request::AnalysisRequest)
     notify(request.completion)
 
     # Check for pending request and re-queue if exist
@@ -677,6 +707,7 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
     end
     cancelled_pending_request === nothing ||
         notify(cancelled_pending_request.completion)
+    return nothing
 end
 
 function increment_generation!(manager::AnalysisManager, @nospecialize entry::AnalysisEntry)

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -220,6 +220,12 @@ end
 # Analysis workers
 # ================
 
+function begin_analysis_shutdown!(server::Server)
+    manager = server.state.analysis_manager
+    @lock manager.lifecycle_lock manager.stopping[] = true
+    return nothing
+end
+
 function start_signature_analysis_workers!(server::Server)
     manager = server.state.analysis_manager
     worker_tasks = manager.signature_worker_tasks
@@ -413,44 +419,65 @@ function schedule_analysis!(
         debounce::Float64 = get_config(server, :full_analysis, :debounce),
     )
     manager = server.state.analysis_manager
+    local cancelled_request::Union{Nothing,AnalysisRequest} = nothing
+    local cancelled_duplicate::Bool = false
 
-    store!(manager.tracked_entries) do entries
-        get(entries, entry, nothing) == uri && return entries, nothing
-        new_entries = copy(entries)
-        new_entries[entry] = uri
-        return new_entries, nothing
-    end
-
-    generation = invalidate ? increment_generation!(manager, entry) : get_generation(manager, entry)
-
-    request = AnalysisRequest(
-        entry, uri, generation, cancellable_token, notify_diagnostics, completion)
-
-    if invalidate && debounce > 0
-        store!(manager.debounced) do debounced
-            if haskey(debounced, request.entry)
-                # Cancel existing timer if any
-                debounce_timer, debounce_completion = debounced[request.entry]
-                close(debounce_timer)
-                @static JETLS_DEV_MODE && @info "Cancelled analysis debounce timer:" entry=progress_title(request.entry) uri generation
-                notify(debounce_completion)
+    accepted = @lock manager.lifecycle_lock begin
+        if manager.stopping[]
+            false
+        else
+            store!(manager.tracked_entries) do entries
+                get(entries, entry, nothing) == uri && return entries, nothing
+                new_entries = copy(entries)
+                new_entries[entry] = uri
+                return new_entries, nothing
             end
-            local new_debounced = copy(debounced)
-            timer = Timer(debounce) do _
-                store!(manager.debounced) do debounced′
-                    local new_debounced′ = copy(debounced′)
-                    delete!(new_debounced′, request.entry)
-                    return new_debounced′, nothing
+
+            generation = invalidate ?
+                increment_generation!(manager, entry) : get_generation(manager, entry)
+            request = AnalysisRequest(
+                entry, uri, generation, cancellable_token, notify_diagnostics, completion)
+
+            if invalidate && debounce > 0
+                store!(manager.debounced) do debounced
+                    if haskey(debounced, request.entry)
+                        # Cancel existing timer if any
+                        debounce_timer, debounce_completion = debounced[request.entry]
+                        close(debounce_timer)
+                        @static JETLS_DEV_MODE && @info "Cancelled analysis debounce timer:" entry=progress_title(request.entry) uri generation
+                        notify(debounce_completion)
+                    end
+                    local new_debounced = copy(debounced)
+                    timer = Timer(debounce) do _
+                        store!(manager.debounced) do debounced′
+                            local new_debounced′ = copy(debounced′)
+                            delete!(new_debounced′, request.entry)
+                            return new_debounced′, nothing
+                        end
+                        queue_request!(server, request)
+                    end
+                    new_debounced[request.entry] = timer, request.completion
+                    return new_debounced, nothing
                 end
-                queue_request!(server, request)
+            else
+                invalidate && cancel_debounced_request!(manager, request)
+                cancelled_request, cancelled_duplicate =
+                    _queue_request_locked!(manager, request)
             end
-            new_debounced[request.entry] = timer, request.completion
-            return new_debounced, nothing
+            true
         end
-    else
-        invalidate && cancel_debounced_request!(manager, request)
-        queue_request!(server, request)
     end
+
+    if !accepted
+        @static JETLS_DEV_MODE && @info "Rejected analysis scheduling during shutdown" entry=progress_title(entry) uri
+        notify(completion)
+    elseif cancelled_request !== nothing
+        if cancelled_duplicate
+            @static JETLS_DEV_MODE && @info "Cancelled duplicated pending analysis request:" entry=progress_title(cancelled_request.entry) uri=cancelled_request.uri generation=cancelled_request.generation
+        end
+        notify(cancelled_request.completion)
+    end
+    return nothing
 end
 
 function cancel_debounced_request!(manager::AnalysisManager, request::AnalysisRequest)
@@ -466,12 +493,20 @@ function cancel_debounced_request!(manager::AnalysisManager, request::AnalysisRe
     end
 end
 
-function queue_request!(server::Server, request::AnalysisRequest)
-    manager = server.state.analysis_manager
+# Admission gate for the full-analysis queue. The caller must hold
+# `manager.lifecycle_lock` so that the stopping check and the queue registration are
+# atomic with the shutdown transition. Returns `(cancelled_request, is_duplicate)`:
+# the caller must notify `cancelled_request.completion` outside the lock, and
+# `is_duplicate` tells whether it was cancelled as a duplicated pending request
+# (as opposed to being rejected by shutdown or supersession; used only for logging).
+function _queue_request_locked!(manager::AnalysisManager, request::AnalysisRequest)
+    if manager.stopping[]
+        @static JETLS_DEV_MODE && @info "Rejected analysis request during shutdown" entry=progress_title(request.entry) uri=request.uri generation=request.generation
+        return request, false
+    end
     if is_superseded_request(manager, request)
         @static JETLS_DEV_MODE && @info "Skipped superseded analysis request before queueing" entry=progress_title(request.entry) uri=request.uri generation=request.generation
-        notify(request.completion)
-        return nothing
+        return request, false
     end
     # Check if already analyzing and handle pending requests.
     # This check must happen here (after debounce) rather than in request_analysis!,
@@ -494,11 +529,21 @@ function queue_request!(server::Server, request::AnalysisRequest)
             return new_analyses, (true, nothing)
         end
     end
+    should_queue && put!(manager.queue, request)
+    return cancelled_request, cancelled_request !== nothing
+end
+
+function queue_request!(server::Server, request::AnalysisRequest)
+    manager = server.state.analysis_manager
+    cancelled_request, cancelled_duplicate = @lock manager.lifecycle_lock begin
+        _queue_request_locked!(manager, request)
+    end
     if cancelled_request !== nothing
-        @static JETLS_DEV_MODE && @info "Cancelled duplicated pending analysis request:" entry=progress_title(cancelled_request.entry) uri=cancelled_request.uri generation=cancelled_request.generation
+        if cancelled_duplicate
+            @static JETLS_DEV_MODE && @info "Cancelled duplicated pending analysis request:" entry=progress_title(cancelled_request.entry) uri=cancelled_request.uri generation=cancelled_request.generation
+        end
         notify(cancelled_request.completion)
     end
-    should_queue && put!(manager.queue, request)
     return nothing
 end
 
@@ -586,21 +631,31 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
     notify(request.completion)
 
     # Check for pending request and re-queue if exist
-    pending_request = store!(manager.pending_analyses) do analyses
-        if haskey(analyses, request.entry)
-            new_analyses = copy(analyses)
-            pending = pop!(new_analyses, request.entry)
-            if pending !== nothing
-                # Re-mark as analyzing before queueing the pending request
-                new_analyses[request.entry] = nothing
+    cancelled_pending_request = @lock manager.lifecycle_lock begin
+        stopping = manager.stopping[]
+        pending_request = store!(manager.pending_analyses) do analyses
+            if haskey(analyses, request.entry)
+                new_analyses = copy(analyses)
+                pending = pop!(new_analyses, request.entry)
+                if pending !== nothing && !stopping
+                    # Re-mark as analyzing before queueing the pending request
+                    new_analyses[request.entry] = nothing
+                end
+                return new_analyses, pending
             end
-            return new_analyses, pending
+            return analyses, nothing
         end
-        return analyses, nothing
+        if pending_request === nothing
+            nothing
+        elseif stopping
+            pending_request
+        else
+            put!(manager.queue, pending_request)
+            nothing
+        end
     end
-    if pending_request !== nothing
-        put!(manager.queue, pending_request)
-    end
+    cancelled_pending_request === nothing ||
+        notify(cancelled_pending_request.completion)
 end
 
 function increment_generation!(manager::AnalysisManager, @nospecialize entry::AnalysisEntry)

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -222,7 +222,20 @@ end
 
 function begin_analysis_shutdown!(server::Server)
     manager = server.state.analysis_manager
-    @lock manager.lifecycle_lock manager.stopping[] = true
+    debounced_requests = @lock manager.lifecycle_lock begin
+        if manager.stopping[]
+            Tuple{Timer,Base.Event}[]
+        else
+            manager.stopping[] = true
+            store!(manager.debounced) do debounced
+                return empty(debounced), collect(values(debounced))
+            end
+        end
+    end
+    for (timer, completion) in debounced_requests
+        close(timer)
+        notify(completion)
+    end
     return nothing
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -371,6 +371,10 @@ struct CancelledAnalysis <: AnalysisOutcome end
 abstract type AbstractSignatureAnalysisJob end
 signature_analysis_completion(job::AbstractSignatureAnalysisJob) =
     getfield(job, :completion)::Base.Event
+function signature_analysis_execution_impl end
+signature_analysis_execution(job::AbstractSignatureAnalysisJob) =
+    signature_analysis_execution_impl(job)::Union{Nothing,AnalysisExecution}
+signature_analysis_execution_impl(::AbstractSignatureAnalysisJob) = nothing
 
 const AnalysisCache = LWContainer{Dict{URI,AnalysisInfo}, LWStats}
 const TrackedAnalysisEntries = CASContainer{Dict{AnalysisEntry,URI}, CASStats}

--- a/src/types.jl
+++ b/src/types.jl
@@ -338,14 +338,35 @@ baseline result that this analysis run replaces. It is intentionally fixed for
 the whole run: it is not a live view of the latest analysis cache. This keeps
 intermediate and final results consistent even if the run itself updates the
 cache before completion.
+
+`shutdown_cancel_flag` is owned by the server lifecycle and is independent of
+client-request cancellation. `intermediate_result` records any cache value published
+before signature analysis so shutdown can restore `prev_result` when cancellation begins.
 """
 mutable struct AnalysisExecution
     const request::AnalysisRequest
     const prev_result::Union{Nothing,AnalysisResult}
+    const shutdown_cancel_flag::CancelFlag
+    const intermediate_result::Base.RefValue{Union{Nothing,AnalysisResult}}
     context_refreshed::Bool
-    AnalysisExecution(request::AnalysisRequest, prev_result::Union{Nothing,AnalysisResult}) =
-        new(request, prev_result, false)
+    function AnalysisExecution(
+            request::AnalysisRequest,
+            prev_result::Union{Nothing,AnalysisResult},
+            shutdown_cancel_flag::CancelFlag = CancelFlag(false),
+        )
+        return new(request, prev_result, shutdown_cancel_flag,
+            Ref{Union{Nothing,AnalysisResult}}(nothing), false)
+    end
 end
+
+abstract type AnalysisOutcome end
+
+struct CompletedAnalysis <: AnalysisOutcome
+    result::AnalysisResult
+    cleanup_prev_result::Bool
+end
+
+struct CancelledAnalysis <: AnalysisOutcome end
 
 abstract type AbstractSignatureAnalysisJob end
 signature_analysis_completion(job::AbstractSignatureAnalysisJob) =
@@ -378,6 +399,7 @@ const InstantiationPrompts = LWContainer{Dict{String,InstantiationPrompt}, LWSta
 struct AnalysisManager
     lifecycle_lock::ReentrantLock
     stopping::Base.RefValue{Bool}
+    active_analysis::Base.RefValue{Union{Nothing,AnalysisExecution}}
     cache::AnalysisCache
     pending_analyses::PendingAnalyses
     queue::Channel{Union{Nothing,AnalysisRequest}}
@@ -394,6 +416,7 @@ struct AnalysisManager
         return new(
             ReentrantLock(),
             Ref(false),
+            Ref{Union{Nothing,AnalysisExecution}}(nothing),
             AnalysisCache(),
             PendingAnalyses(),
             Channel{Union{Nothing,AnalysisRequest}}(Inf),

--- a/src/types.jl
+++ b/src/types.jl
@@ -376,6 +376,8 @@ end
 const InstantiationPrompts = LWContainer{Dict{String,InstantiationPrompt}, LWStats}
 
 struct AnalysisManager
+    lifecycle_lock::ReentrantLock
+    stopping::Base.RefValue{Bool}
     cache::AnalysisCache
     pending_analyses::PendingAnalyses
     queue::Channel{Union{Nothing,AnalysisRequest}}
@@ -390,6 +392,8 @@ struct AnalysisManager
     signature_worker_tasks::Vector{Task}
     function AnalysisManager()
         return new(
+            ReentrantLock(),
+            Ref(false),
             AnalysisCache(),
             PendingAnalyses(),
             Channel{Union{Nothing,AnalysisRequest}}(Inf),

--- a/test/analysis/test_full_analysis.jl
+++ b/test/analysis/test_full_analysis.jl
@@ -6,12 +6,41 @@ using JETLS.URIs2: URI, filepath2uri
 
 struct ShutdownTestEntry <: JETLS.AnalysisEntry end
 
+struct ActiveShutdownTestEntry <: JETLS.AnalysisEntry
+    uri::URI
+    started::Base.Event
+    release::Base.Event
+end
+
 struct ShutdownSignatureJob <: JETLS.AbstractSignatureAnalysisJob
     completion::Base.Event
 end
 
 JETLS.progress_title_impl(::ShutdownTestEntry) = "shutdown test"
+JETLS.progress_title_impl(::ActiveShutdownTestEntry) = "active shutdown test"
 (::ShutdownSignatureJob)(::JETLS.Server) = nothing
+
+function active_shutdown_analysis_result(entry::ActiveShutdownTestEntry)
+    return JETLS.AnalysisResult(
+        entry,
+        JETLS.URI2Diagnostics(entry.uri => JETLS.LSP.Diagnostic[]),
+        JETLS.LSAnalyzer(entry),
+        Dict(entry.uri => JETLS.JET.AnalyzedFileInfo()),
+        Main => Main,
+        Base.get_world_counter())
+end
+
+function JETLS.execute_analysis_impl(
+        server::JETLS.Server, execution::JETLS.AnalysisExecution,
+        entry::ActiveShutdownTestEntry,
+    )
+    analysis_result = active_shutdown_analysis_result(entry)
+    @assert JETLS.cache_intermediate_analysis_result!(
+        server, execution, analysis_result)
+    notify(entry.started)
+    wait(entry.release)
+    return JETLS.CompletedAnalysis(analysis_result, false)
+end
 # Tripwire: `is_abandoned_analysis_target` is only reached when `resolve_analysis_request`
 # executes the analysis body, so any queued request that is not skipped during shutdown
 # fails the test with this error.
@@ -387,10 +416,14 @@ end
                 response = ResponseMessage(; id = analysis_progress_request.id, result = null)
                 writemsg(response; check = false)
                 analysis_messages = Any[]
-                while true
+                diagnostics_published = analysis_finished = false
+                while !diagnostics_published || !analysis_finished
                     (; raw_msg) = readmsg(; check = false)
                     push!(analysis_messages, raw_msg)
-                    raw_msg isa PublishDiagnosticsNotification && break
+                    diagnostics_published |= raw_msg isa PublishDiagnosticsNotification
+                    analysis_finished |= raw_msg isa ProgressNotification &&
+                        raw_msg.params.token == analysis_progress_request.params.token &&
+                        raw_msg.params.value isa WorkDoneProgressEnd
                 end
                 readmsg(; read=0)
                 @test any(analysis_messages) do msg
@@ -603,6 +636,69 @@ end
     @test timedwait(() -> istaskdone(completion_waiter), 1.0) == :ok
     @test !haskey(JETLS.load(manager.pending_analyses), entry)
     @test !isready(manager.queue)
+end
+
+@testset "shutdown cancels active analysis" begin
+    recorder = JETLS.ServerMessageRecorder()
+    endpoint = JETLS.LSP.Endpoint(IOBuffer(), IOBuffer())
+    server = JETLS.Server(endpoint; callback=recorder)
+    manager = server.state.analysis_manager
+    capabilities = JETLS.LSP.ClientCapabilities(;
+        workspace = JETLS.LSP.WorkspaceClientCapabilities(;
+            diagnostics = JETLS.LSP.DiagnosticWorkspaceClientCapabilities(;
+                refreshSupport = true),
+            codeLens = JETLS.LSP.CodeLensWorkspaceClientCapabilities(;
+                refreshSupport = true)))
+    server.state.init_params = JETLS.LSP.InitializeParams(;
+        processId = nothing, rootUri = nothing, capabilities)
+
+    script_uri = filepath2uri(joinpath(@__DIR__, "shutdown-active.jl"))
+    entry = ActiveShutdownTestEntry(script_uri, Base.Event(), Base.Event())
+    previous_result = active_shutdown_analysis_result(entry)
+    JETLS.update_analysis_cache!(server.state, previous_result)
+    previous_request = JETLS.AnalysisRequest(
+        entry, script_uri, #=generation=#0, nothing, false)
+    JETLS.mark_analyzed_generation!(manager, previous_request)
+
+    completion = Base.Event()
+    completion_waiter = Threads.@spawn wait(completion)
+    request = JETLS.AnalysisRequest(
+        entry, script_uri, #=generation=#1, nothing, true, completion)
+
+    JETLS.queue_request!(server, request)
+    JETLS.start_analysis_worker!(server)
+    wait(entry.started)
+    intermediate_result = JETLS.get_analysis_info(manager, script_uri)
+    @test intermediate_result isa JETLS.AnalysisResult
+    @test intermediate_result !== previous_result
+
+    active_execution = manager.active_analysis[]
+    @test active_execution isa JETLS.AnalysisExecution
+    @test active_execution.context_refreshed
+    @test active_execution.intermediate_result[] === intermediate_result
+    @test take!(recorder.sent_queue) isa JETLS.LSP.WorkspaceDiagnosticRefreshRequest
+    @test take!(recorder.sent_queue) isa JETLS.LSP.CodeLensRefreshRequest
+    @test isempty(recorder.sent_queue)
+
+    JETLS.begin_analysis_shutdown!(server)
+    @test JETLS.is_analysis_cancelled(active_execution)
+    @test JETLS.get_analysis_info(manager, script_uri) === previous_result
+    @test active_execution.intermediate_result[] === nothing
+    @test !JETLS.cache_intermediate_analysis_result!(
+        server, active_execution, intermediate_result)
+    @test isempty(recorder.sent_queue)
+
+    notify(entry.release)
+    JETLS.wait_analysis_workers(server)
+
+    @test timedwait(() -> istaskdone(completion_waiter), 1.0) == :ok
+    @test JETLS.get_analysis_info(manager, script_uri) === previous_result
+    @test JETLS.load(manager.analyzed_generations)[entry] == 0
+    @test !haskey(JETLS.load(manager.pending_analyses), entry)
+    @test manager.active_analysis[] === nothing
+    @test isempty(recorder.sent_queue)
+    close(endpoint)
+    wait(endpoint.read_task)
 end
 
 @testset "shutdown joins full analysis before signature workers" begin

--- a/test/analysis/test_full_analysis.jl
+++ b/test/analysis/test_full_analysis.jl
@@ -2,7 +2,16 @@ module test_full_analysis
 
 using Test
 using JETLS: JETLS
-using JETLS.URIs2: filepath2uri
+using JETLS.URIs2: URI, filepath2uri
+
+struct ShutdownTestEntry <: JETLS.AnalysisEntry end
+
+JETLS.progress_title_impl(::ShutdownTestEntry) = "shutdown test"
+# Tripwire: `is_abandoned_analysis_target` is only reached when `resolve_analysis_request`
+# executes the analysis body, so any queued request that is not skipped during shutdown
+# fails the test with this error.
+JETLS.is_abandoned_analysis_target(::JETLS.Server, ::URI, ::ShutdownTestEntry) =
+    error("queued analysis executed during shutdown")
 
 include(normpath(pkgdir(JETLS), "test", "setup.jl"))
 
@@ -522,6 +531,28 @@ end
 
     @test timedwait(() -> istaskdone(active_waiter), 1.0) == :ok
     @test timedwait(() -> istaskdone(pending_waiter), 1.0) == :ok
+    @test !haskey(JETLS.load(manager.pending_analyses), entry)
+    @test !isready(manager.queue)
+end
+
+@testset "shutdown skips queued analysis" begin
+    server = JETLS.Server()
+    manager = server.state.analysis_manager
+    script_uri = filepath2uri(joinpath(@__DIR__, "shutdown-queued.jl"))
+    entry = ShutdownTestEntry()
+    completion = Base.Event()
+    completion_waiter = Threads.@spawn wait(completion)
+    request = JETLS.AnalysisRequest(
+        entry, script_uri, #=generation=#0, nothing, false, completion)
+
+    JETLS.queue_request!(server, request)
+    @test JETLS.load(manager.pending_analyses)[entry] === nothing
+
+    JETLS.begin_analysis_shutdown!(server)
+    JETLS.start_analysis_worker!(server)
+    JETLS.stop_analysis_worker(server)
+
+    @test timedwait(() -> istaskdone(completion_waiter), 1.0) == :ok
     @test !haskey(JETLS.load(manager.pending_analyses), entry)
     @test !isready(manager.queue)
 end

--- a/test/analysis/test_full_analysis.jl
+++ b/test/analysis/test_full_analysis.jl
@@ -12,15 +12,44 @@ struct ActiveShutdownTestEntry <: JETLS.AnalysisEntry
     release::Base.Event
 end
 
+struct QueuedSignatureShutdownTestEntry <: JETLS.AnalysisEntry
+    uri::URI
+    first_started::Base.Event
+    release_first::Base.Event
+    first_ran::Base.RefValue{Bool}
+    queued_ran::Base.RefValue{Bool}
+end
+
 struct ShutdownSignatureJob <: JETLS.AbstractSignatureAnalysisJob
+    completion::Base.Event
+end
+
+struct CancellableShutdownSignatureJob <: JETLS.AbstractSignatureAnalysisJob
+    execution::JETLS.AnalysisExecution
+    started::Union{Nothing,Base.Event}
+    release::Union{Nothing,Base.Event}
+    ran::Base.RefValue{Bool}
     completion::Base.Event
 end
 
 JETLS.progress_title_impl(::ShutdownTestEntry) = "shutdown test"
 JETLS.progress_title_impl(::ActiveShutdownTestEntry) = "active shutdown test"
+JETLS.progress_title_impl(::QueuedSignatureShutdownTestEntry) =
+    "queued signature shutdown test"
 (::ShutdownSignatureJob)(::JETLS.Server) = nothing
+JETLS.signature_analysis_execution_impl(job::CancellableShutdownSignatureJob) =
+    job.execution
+function (job::CancellableShutdownSignatureJob)(::JETLS.Server)
+    job.ran[] = true
+    job.started === nothing || notify(job.started)
+    job.release === nothing || wait(job.release)
+    return nothing
+end
 
-function active_shutdown_analysis_result(entry::ActiveShutdownTestEntry)
+const ShutdownAnalysisTestEntry =
+    Union{ActiveShutdownTestEntry,QueuedSignatureShutdownTestEntry}
+
+function active_shutdown_analysis_result(entry::ShutdownAnalysisTestEntry)
     return JETLS.AnalysisResult(
         entry,
         JETLS.URI2Diagnostics(entry.uri => JETLS.LSP.Diagnostic[]),
@@ -40,6 +69,21 @@ function JETLS.execute_analysis_impl(
     notify(entry.started)
     wait(entry.release)
     return JETLS.CompletedAnalysis(analysis_result, false)
+end
+
+function JETLS.execute_analysis_impl(
+        server::JETLS.Server, execution::JETLS.AnalysisExecution,
+        entry::QueuedSignatureShutdownTestEntry,
+    )
+    jobs = [
+        CancellableShutdownSignatureJob(
+            execution, entry.first_started, entry.release_first,
+            entry.first_ran, Base.Event()),
+        CancellableShutdownSignatureJob(
+            execution, nothing, nothing, entry.queued_ran, Base.Event()),
+    ]
+    JETLS.run_signature_analysis_jobs!(server, jobs)
+    return JETLS.CompletedAnalysis(active_shutdown_analysis_result(entry), false)
 end
 # Tripwire: `is_abandoned_analysis_target` is only reached when `resolve_analysis_request`
 # executes the analysis body, so any queued request that is not skipped during shutdown
@@ -699,6 +743,65 @@ end
     @test isempty(recorder.sent_queue)
     close(endpoint)
     wait(endpoint.read_task)
+end
+
+@testset "shutdown rejects signature job admission" begin
+    server = JETLS.Server()
+    manager = server.state.analysis_manager
+    script_uri = filepath2uri(joinpath(@__DIR__, "shutdown-signature-admission.jl"))
+    request = JETLS.AnalysisRequest(
+        JETLS.ScriptAnalysisEntry(script_uri), script_uri,
+        #=generation=#0, nothing, false)
+    maybe_execution = JETLS.begin_analysis_execution!(manager, request, nothing)
+    @test maybe_execution isa JETLS.AnalysisExecution
+    execution = maybe_execution::JETLS.AnalysisExecution
+    ran = Ref(false)
+    job = CancellableShutdownSignatureJob(
+        execution, nothing, nothing, ran, Base.Event())
+    completion_waiter = Threads.@spawn wait(job.completion)
+
+    JETLS.begin_analysis_shutdown!(server)
+    JETLS.run_signature_analysis_jobs!(server, [job])
+
+    @test JETLS.is_analysis_cancelled(execution)
+    @test !ran[]
+    @test timedwait(() -> istaskdone(completion_waiter), 1.0) == :ok
+    @test !isready(manager.signature_queue)
+    JETLS.finish_analysis_execution!(manager, execution)
+end
+
+@testset "shutdown skips queued signature jobs" begin
+    server = JETLS.Server()
+    manager = server.state.analysis_manager
+    signature_task = Threads.@spawn :default JETLS.signature_analysis_worker(server)
+    push!(manager.signature_worker_tasks, signature_task)
+
+    script_uri = filepath2uri(joinpath(@__DIR__, "shutdown-signatures.jl"))
+    entry = QueuedSignatureShutdownTestEntry(
+        script_uri, Base.Event(), Base.Event(), Ref(false), Ref(false))
+    completion = Base.Event()
+    completion_waiter = Threads.@spawn wait(completion)
+    request = JETLS.AnalysisRequest(
+        entry, script_uri, #=generation=#0, nothing, false, completion)
+
+    JETLS.queue_request!(server, request)
+    JETLS.start_analysis_worker!(server)
+    wait(entry.first_started)
+    @test entry.first_ran[]
+    @test !entry.queued_ran[]
+
+    JETLS.begin_analysis_shutdown!(server)
+    notify(entry.release_first)
+    JETLS.wait_analysis_workers(server)
+
+    @test timedwait(() -> istaskdone(completion_waiter), 1.0) == :ok
+    @test !entry.queued_ran[]
+    @test JETLS.get_analysis_info(manager, script_uri) === nothing
+    @test !haskey(JETLS.load(manager.analyzed_generations), entry)
+    @test !haskey(JETLS.load(manager.pending_analyses), entry)
+    @test manager.active_analysis[] === nothing
+    @test istaskdone(signature_task)
+    @test !isready(manager.signature_queue)
 end
 
 @testset "shutdown joins full analysis before signature workers" begin

--- a/test/analysis/test_full_analysis.jl
+++ b/test/analysis/test_full_analysis.jl
@@ -6,7 +6,12 @@ using JETLS.URIs2: URI, filepath2uri
 
 struct ShutdownTestEntry <: JETLS.AnalysisEntry end
 
+struct ShutdownSignatureJob <: JETLS.AbstractSignatureAnalysisJob
+    completion::Base.Event
+end
+
 JETLS.progress_title_impl(::ShutdownTestEntry) = "shutdown test"
+(::ShutdownSignatureJob)(::JETLS.Server) = nothing
 # Tripwire: `is_abandoned_analysis_target` is only reached when `resolve_analysis_request`
 # executes the analysis body, so any queued request that is not skipped during shutdown
 # fails the test with this error.
@@ -508,6 +513,27 @@ end
     @test isnothing(JETLS.begin_analysis_shutdown!(server))
 end
 
+@testset "shutdown waits without started workers" begin
+    server = JETLS.Server()
+    manager = server.state.analysis_manager
+    script_uri = filepath2uri(joinpath(@__DIR__, "shutdown-without-worker.jl"))
+    entry = ShutdownTestEntry()
+    completion = Base.Event()
+    completion_waiter = Threads.@spawn wait(completion)
+    request = JETLS.AnalysisRequest(
+        entry, script_uri, #=generation=#0, nothing, false, completion)
+
+    JETLS.queue_request!(server, request)
+    @test isnothing(JETLS.wait_analysis_workers(server))
+
+    @test timedwait(() -> istaskdone(completion_waiter), 1.0) == :ok
+    @test !haskey(JETLS.load(manager.pending_analyses), entry)
+    @test !isready(manager.queue)
+    @test !isassigned(manager.worker_task)
+    @test isempty(manager.signature_worker_tasks)
+    @test isnothing(JETLS.wait_analysis_workers(server))
+end
+
 @testset "shutdown rejects late queue admission" begin
     server = JETLS.Server()
     manager = server.state.analysis_manager
@@ -572,11 +598,73 @@ end
 
     JETLS.begin_analysis_shutdown!(server)
     JETLS.start_analysis_worker!(server)
-    JETLS.stop_analysis_worker(server)
+    JETLS.wait_analysis_workers(server)
 
     @test timedwait(() -> istaskdone(completion_waiter), 1.0) == :ok
     @test !haskey(JETLS.load(manager.pending_analyses), entry)
     @test !isready(manager.queue)
+end
+
+@testset "shutdown joins full analysis before signature workers" begin
+    server = JETLS.Server()
+    manager = server.state.analysis_manager
+    release_full_analysis = Base.Event()
+    signature_job = ShutdownSignatureJob(Base.Event())
+
+    signature_task = Threads.@spawn :default JETLS.signature_analysis_worker(server)
+    push!(manager.signature_worker_tasks, signature_task)
+    manager.worker_task[] = Threads.@spawn :default begin
+        wait(release_full_analysis)
+        JETLS.run_signature_analysis_jobs!(server, [signature_job])
+    end
+
+    shutdown_task = Threads.@spawn JETLS.wait_analysis_workers(server)
+    @test timedwait(() -> isready(manager.queue), 1.0) == :ok
+    @test !istaskdone(signature_task)
+
+    notify(release_full_analysis)
+    @test timedwait(() -> istaskdone(shutdown_task), 1.0) == :ok
+    @test fetch(shutdown_task) === nothing
+    @test istaskdone(manager.worker_task[])
+    @test istaskdone(signature_task)
+    @test !isready(manager.queue)
+    @test !isready(manager.signature_queue)
+end
+
+@testset "runserver starts analysis shutdown" begin
+    input_pipe = Pipe()
+    output_pipe = Pipe()
+    Base.link_pipe!(input_pipe; reader_supports_async=true, writer_supports_async=true)
+    Base.link_pipe!(output_pipe; reader_supports_async=true, writer_supports_async=true)
+    recorder = JETLS.ServerMessageRecorder()
+    endpoint = JETLS.LSP.Endpoint(input_pipe.out, output_pipe.in)
+    server = JETLS.Server(endpoint; callback=recorder)
+    server_task = Threads.@spawn :interactive JETLS.runserver(server)
+
+    try
+        JETLS.LSP.writelsp(input_pipe.in, JETLS.LSP.ShutdownRequest(; id=1))
+        @test take!(recorder.received_queue) isa JETLS.LSP.ShutdownRequest
+        @test take!(recorder.sent_queue) isa JETLS.LSP.ShutdownResponse
+        @test timedwait(
+            () -> JETLS.is_analysis_stopping(server.state.analysis_manager), 1.0) == :ok
+
+        JETLS.LSP.writelsp(input_pipe.in, JETLS.LSP.ExitNotification())
+        @test take!(recorder.received_queue) isa JETLS.LSP.ExitNotification
+        @test fetch(server_task) == 0
+    finally
+        close(input_pipe.in)
+        wait(endpoint.read_task)
+        close(input_pipe.out)
+        close(output_pipe.in)
+        close(output_pipe.out)
+    end
+end
+
+@testset "transport EOF starts analysis shutdown" begin
+    server = JETLS.Server()
+    @test JETLS.runserver(server) == 1
+    @test JETLS.is_analysis_stopping(server.state.analysis_manager)
+    wait(server.endpoint.read_task)
 end
 
 end # module test_full_analysis

--- a/test/analysis/test_full_analysis.jl
+++ b/test/analysis/test_full_analysis.jl
@@ -457,4 +457,73 @@ end
     end
 end
 
+@testset "shutdown rejects scheduling" begin
+    server = JETLS.Server()
+    manager = server.state.analysis_manager
+    script_uri = filepath2uri(joinpath(@__DIR__, "shutdown-scheduling.jl"))
+    entry = JETLS.ScriptAnalysisEntry(script_uri)
+    completion = Base.Event()
+    completion_waiter = Threads.@spawn wait(completion)
+
+    JETLS.begin_analysis_shutdown!(server)
+    JETLS.schedule_analysis!(server, script_uri, entry, #=invalidate=#true;
+        completion, debounce=60.0, notify_diagnostics=false)
+
+    @test timedwait(() -> istaskdone(completion_waiter), 1.0) == :ok
+    @test isempty(JETLS.load(manager.tracked_entries))
+    @test isempty(JETLS.load(manager.current_generations))
+    @test isempty(JETLS.load(manager.debounced))
+    @test isempty(JETLS.load(manager.pending_analyses))
+    @test !isready(manager.queue)
+end
+
+@testset "shutdown rejects late queue admission" begin
+    server = JETLS.Server()
+    manager = server.state.analysis_manager
+    script_uri = filepath2uri(joinpath(@__DIR__, "shutdown-queueing.jl"))
+    entry = JETLS.ScriptAnalysisEntry(script_uri)
+
+    JETLS.schedule_analysis!(server, script_uri, entry, #=invalidate=#false;
+        debounce=0.0, notify_diagnostics=false)
+    take!(manager.queue)
+    @test JETLS.load(manager.pending_analyses)[entry] === nothing
+
+    completion = Base.Event()
+    completion_waiter = Threads.@spawn wait(completion)
+    late_request = JETLS.AnalysisRequest(
+        entry, script_uri, #=generation=#0, nothing, false, completion)
+    JETLS.begin_analysis_shutdown!(server)
+    JETLS.queue_request!(server, late_request)
+
+    @test timedwait(() -> istaskdone(completion_waiter), 1.0) == :ok
+    @test JETLS.load(manager.pending_analyses)[entry] === nothing
+    @test !isready(manager.queue)
+end
+
+@testset "shutdown cancels pending requeue" begin
+    server = JETLS.Server()
+    manager = server.state.analysis_manager
+    script_uri = filepath2uri(joinpath(@__DIR__, "shutdown-pending.jl"))
+    entry = JETLS.ScriptAnalysisEntry(script_uri)
+
+    JETLS.schedule_analysis!(server, script_uri, entry, #=invalidate=#false;
+        debounce=0.0, notify_diagnostics=false)
+    active_request = take!(manager.queue)::JETLS.AnalysisRequest
+    active_waiter = Threads.@spawn wait(active_request.completion)
+
+    pending_completion = Base.Event()
+    pending_waiter = Threads.@spawn wait(pending_completion)
+    JETLS.schedule_analysis!(server, script_uri, entry, #=invalidate=#true;
+        completion=pending_completion, debounce=0.0, notify_diagnostics=false)
+    @test JETLS.load(manager.pending_analyses)[entry] isa JETLS.AnalysisRequest
+
+    JETLS.begin_analysis_shutdown!(server)
+    JETLS.resolve_analysis_request(server, active_request)
+
+    @test timedwait(() -> istaskdone(active_waiter), 1.0) == :ok
+    @test timedwait(() -> istaskdone(pending_waiter), 1.0) == :ok
+    @test !haskey(JETLS.load(manager.pending_analyses), entry)
+    @test !isready(manager.queue)
+end
+
 end # module test_full_analysis

--- a/test/analysis/test_full_analysis.jl
+++ b/test/analysis/test_full_analysis.jl
@@ -486,6 +486,28 @@ end
     @test !isready(manager.queue)
 end
 
+@testset "shutdown cancels debounced analysis" begin
+    server = JETLS.Server()
+    manager = server.state.analysis_manager
+    script_uri = filepath2uri(joinpath(@__DIR__, "shutdown-debounced.jl"))
+    entry = JETLS.ScriptAnalysisEntry(script_uri)
+    completion = Base.Event()
+    completion_waiter = Threads.@spawn wait(completion)
+
+    JETLS.schedule_analysis!(server, script_uri, entry, #=invalidate=#true;
+        completion, debounce=60.0, notify_diagnostics=false)
+    timer, _ = JETLS.load(manager.debounced)[entry]
+    @test isopen(timer)
+
+    JETLS.begin_analysis_shutdown!(server)
+
+    @test timedwait(() -> istaskdone(completion_waiter), 1.0) == :ok
+    @test !isopen(timer)
+    @test isempty(JETLS.load(manager.debounced))
+    @test !isready(manager.queue)
+    @test isnothing(JETLS.begin_analysis_shutdown!(server))
+end
+
 @testset "shutdown rejects late queue admission" begin
     server = JETLS.Server()
     manager = server.state.analysis_manager


### PR DESCRIPTION
## Summary

Prevent outstanding analysis work from unnecessarily delaying server shutdown.

Before this change, the analysis worker could continue processing its backlog after shutdown had started. An active full analysis could also continue through later phases, enqueue signature-analysis jobs, and publish results that were no longer needed. Since `runserver` waits for these workers, this could substantially delay process exit.

This PR introduces an explicit analysis shutdown lifecycle that:

- Rejects new analysis requests once shutdown begins.
- Cancels debounced requests and notifies their completion waiters.
- Skips queued full-analysis requests through the normal worker cleanup path.
- Cooperatively cancels the active full analysis.
- Rejects or skips queued signature-analysis jobs.
- Prevents cancelled analyses from publishing caches, diagnostics,
  generations, or refresh notifications.
- Joins the full-analysis worker before stopping signature workers.

Already-running compiler and inference work is allowed to finish naturally.
The implementation does not use `InterruptException`, return from `runserver` with live workers, or otherwise force task termination.

## Implementation

`AnalysisManager` now has a lifecycle lock and stopping state. Analysis admission, pending requeueing, active execution tracking, and shutdown use the same lock so that shutdown has a well-defined boundary.

Queued requests retain ownership of their existing cleanup path. This ensures that completion events are notified and pending markers are removed without introducing a separate shutdown drain.

Active analyses use an explicit shutdown cancellation flag and return either a completed or cancelled outcome. Shutdown-cancelled analyses restore the previous intermediate result and do not publish derived state. Plain analysis failures continue to retain the fresh intermediate module context.

Signature jobs are associated with their enclosing analysis execution.
Admission is serialized with shutdown, and queued jobs are skipped when their execution has been cancelled. Jobs that have already started still finish naturally.

The server begins analysis shutdown after sending `ShutdownResponse`, then joins the full-analysis worker before stopping and joining signature workers. This preserves the dependency where full analysis may wait for signature job completion.

## Measurements

A source-based LSP harness compared three revisions using an old-style package analysis and a synthetic queued backlog. These runs include Julia JIT overhead.

Shutdown near the beginning of an active analysis:

| Revision | Shutdown to exit |
|---|---:|
| Before this series | 12.08 s |
| Queued-work handling only | 10.37–10.45 s |
| This PR | 1.92–1.99 s |

Shutdown with one active analysis and two queued analyses:

| Revision | Shutdown to exit | Analyses executed |
|---|---:|---:|
| Before this series | 9.80–10.01 s | 3 |
| Queued-work handling only | 2.60 s | 1 |
| This PR | 1.49 s | 1 |

The first scenario demonstrates active-analysis cancellation. The second demonstrates that shutdown no longer processes the queued backlog.

These are representative measurements with one or two runs per configuration, not latency guarantees. Remaining latency depends on reaching a cooperative cancellation checkpoint after already-running compiler or JIT work.
