### PR TITLE
ci: Clean up closed documentation previews

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -18,6 +18,9 @@ on:
 
 jobs:
   build:
+    concurrency:
+      group: gh-pages-deployment
+      cancel-in-progress: false
     # These permissions are needed to:
     # - Deploy the documentation: https://documenter.juliadocs.org/stable/man/hosting/#Permissions
     # - Delete old caches: https://github.com/julia-actions/cache#usage

--- a/.github/workflows/doc-preview-cleanup.yml
+++ b/.github/workflows/doc-preview-cleanup.yml
@@ -1,0 +1,47 @@
+name: Documentation preview cleanup
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    concurrency:
+      group: gh-pages-deployment
+      cancel-in-progress: false
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: gh-pages
+          fetch-depth: 1
+      - name: Remove preview and squash history
+        env:
+          PREVIEW_DIR: previews/PR${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ ! -d "$PREVIEW_DIR" ]; then
+            echo "No preview found at $PREVIEW_DIR"
+            exit 0
+          fi
+
+          git config user.name "Documenter.jl"
+          git config user.email "documenter@juliadocs.github.io"
+
+          expected_head=$(git rev-parse HEAD)
+          git rm -rf "$PREVIEW_DIR"
+          tree=$(git write-tree)
+          # `commit-tree` without `-p` creates a root commit.
+          commit=$(
+            printf '%s\n\n%s\n%s\n' \
+              "docs: Remove preview for PR $PR_NUMBER" \
+              "Remove the closed pull request preview and reset the generated" \
+              "documentation history." |
+              git commit-tree "$tree"
+          )
+          git push \
+            --force-with-lease="refs/heads/gh-pages:$expected_head" \
+            origin "$commit:refs/heads/gh-pages"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,9 @@ jobs:
   docs:
     name: Documentation
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch'
+    concurrency:
+      group: gh-pages-deployment
+      cancel-in-progress: false
     permissions:
       actions: write
       contents: write


### PR DESCRIPTION
Closed pull request previews remained in `gh-pages`, causing the published site and generated branch history to grow indefinitely.

Add a cleanup workflow that deletes the closed pull request preview and replaces `gh-pages` with a root commit containing the updated tree. Serialize documentation writers with a shared concurrency group and use `--force-with-lease` to avoid overwriting concurrent updates.