### PR TITLE
jetls-client: Store managed installations in immutable generations

### DIFF
--- a/jetls-client/CHANGELOG.md
+++ b/jetls-client/CHANGELOG.md
@@ -17,11 +17,11 @@ and this project uses [calendar versioning](https://calver.org/) (`YYYY.M.D`, th
   When the pinned version cannot be installed or verified, startup fails with an error notification.
   Set `jetls-client.executable.env.JULIA_APPS_JULIA_CMD` to select another Julia executable, or specify `jetls-client.executable.path` or a full command array to bypass managed installation.
 
-- Added status bar updates and live process output for managed installation checks, downloads, repairs, startup, and failures.
+- Added status bar updates and live process output for managed installation checks, downloads, startup, and failures.
   Failure notifications offer to retry and to show the JETLS output with the full details; configuration problems additionally offer to open the executable setting.
 
 - Added the `JETLS Client: Reinstall Server` command for recovering from a broken managed installation.
-  The command asks for confirmation before deleting the managed storage, since recreating it may require network access.
+  The command asks for confirmation and installs a fresh copy, since reinstalling may require network access.
 
 ### Removed
 

--- a/jetls-client/README.md
+++ b/jetls-client/README.md
@@ -50,7 +50,9 @@ extension update requires a newer version.
 
 The extension stores JETLS separately from packages in your regular Julia
 depot. Different Julia installations and Julia minor versions use separate
-managed copies. You do not need to configure or maintain this storage.
+managed copies, and copies for a Julia you stopped using are removed
+automatically after a while. You do not need to configure or maintain this
+storage.
 
 The first installation and each managed update require network access.
 Once installed, the cached server can start while offline. The status bar shows
@@ -64,8 +66,8 @@ failed status bar item opens the same output.
 
 To recover from a broken managed installation, run
 `JETLS Client: Reinstall Server` from the Command Palette.
-The command asks for confirmation before deleting the managed storage;
-recreating the installation requires network access.
+The command asks for confirmation and installs a fresh copy, which
+requires network access; superseded copies are cleaned up automatically.
 
 ## Launching configuration (advanced)
 

--- a/jetls-client/src/constants.ts
+++ b/jetls-client/src/constants.ts
@@ -48,12 +48,7 @@ export const TIMEOUTS = {
   /**
    * Budget for installing the pinned JETLS release, the only managed step
    * that legitimately runs long: it downloads and fully precompiles the
-   * JETLS dependency tree. Also reused as the depot-lock wait budget.
+   * JETLS dependency tree. Also reused as the install-lock wait budget.
    */
   install: 15 * 60 * 1000,
-  /**
-   * Budget for `Pkg.gc` maintenance of the managed depot after an
-   * installation, which fails fast when it hangs.
-   */
-  gc: 2 * 60 * 1000,
 } as const;

--- a/jetls-client/src/managed-installation.ts
+++ b/jetls-client/src/managed-installation.ts
@@ -1,9 +1,9 @@
 import { spawn } from "node:child_process";
-import { createHash } from "node:crypto";
-import { homedir, uptime } from "node:os";
+import { createHash, randomBytes } from "node:crypto";
+import { homedir } from "node:os";
 import {
-  cp,
   mkdir,
+  readdir,
   readFile,
   rename,
   rm,
@@ -31,7 +31,10 @@ export const JETLS_REPOSITORY = "https://github.com/aviatesk/JETLS.jl";
 // structured data; the values are inlined into the bundle at build time.
 export const JETLS_REVISION: string = JETLS_VERSION.revision;
 const MANAGED_DEPOTS_DIR = "jetls-depots";
+const CURRENT_POINTER_FILE = "current";
+const INSTALL_LOCK_DIR = "install.lock";
 const INSTALL_STAMP_FILE = "install-stamp.json";
+const LAST_USED_FILE = "last-used";
 const JULIA_VERSION_LOWER_BOUND: string = JETLS_VERSION.julia.lower;
 const JULIA_VERSION_UPPER_MINOR: string = JETLS_VERSION.julia.upperMinor;
 
@@ -44,10 +47,25 @@ const JULIA_VERSION_SCRIPT = "print(stdout, VERSION)";
 // packages. The generated launcher shim itself stays unused: the server
 // is launched as `julia -m JETLS` directly.
 const INSTALL_SCRIPT = `using Pkg; Pkg.Apps.add(; url="${JETLS_REPOSITORY}", rev="${JETLS_REVISION}")`;
-const GC_SCRIPT = "using Pkg, Dates; Pkg.gc(; collect_delay=Dates.Day(0))";
 const JULIA_BASE_ARGS = ["--startup-file=no", "--history-file=no"] as const;
 const LOCK_RETRY_DELAY = 100;
-const INCOMPLETE_LOCK_GRACE_PERIOD = 30 * 1000;
+// A lock older than the whole installation budget belongs to a dead
+// host; a margin absorbs clock skew between hosts.
+const LOCK_STALE_AGE = TIMEOUTS.install + 60 * 1000;
+// An unpublished generation may hold an installation still in progress
+// (including one whose process outlived its host), so it is only removed
+// well past any plausible installation lifetime.
+const UNPUBLISHED_GENERATION_GRACE = 24 * 60 * 60 * 1000;
+// A published but unreferenced generation may still be running a server
+// in another window; it is removed only after it has gone unused long
+// enough that no live window plausibly resolved it.
+const GENERATION_RETENTION = 7 * 24 * 60 * 60 * 1000;
+// A whole runtime container goes stale when the user switches Julia
+// (another executable, or another minor version): no start resolves it
+// anymore, so nothing inside it can be in use. The retention is long
+// because reclaiming a runtime the user switches back to costs a full
+// reinstall.
+const RUNTIME_RETENTION = 30 * 24 * 60 * 60 * 1000;
 
 export interface ProcessResult {
   status: number | null;
@@ -67,8 +85,6 @@ export interface ProcessRunnerOptions {
   timeoutMs: number;
   onStdout?: (chunk: string) => void;
   onStderr?: (chunk: string) => void;
-  /** Reports the spawned process id as soon as it is known. */
-  onPid?: (pid: number) => void;
 }
 
 export type ProcessRunner = (
@@ -85,6 +101,11 @@ export interface ManagedInstallationOptions {
   progress?: (message: string) => void;
   processRunner?: ProcessRunner;
   platform?: NodeJS.Platform;
+  /**
+   * Installs a fresh generation even when the current one is verified,
+   * for recovering from corruption the verification cannot see.
+   */
+  forceInstall?: boolean;
 }
 
 export interface ManagedJETLSInstallation {
@@ -100,23 +121,13 @@ export interface JuliaVersion {
 }
 
 /** The processing stage a managed-installation failure originated from. */
-type ManagedStage =
-  | "julia-resolution"
-  | "julia-version"
-  | "lock"
-  | "install"
-  | "repair"
-  | "verify"
-  | "gc"
-  | "uninstall";
+type ManagedStage = "julia-resolution" | "julia-version" | "install" | "verify";
 
 interface RuntimeContext {
-  depotPath: string;
+  containerPath: string;
   juliaPath: string;
   juliaVersion: string;
 }
-
-type InstallationOperation = "Installing" | "Repairing";
 
 interface ProcessOutputObserver {
   onStdout: (chunk: string) => void;
@@ -128,10 +139,6 @@ class ManagedStepError extends Error {
   readonly processMayBeAlive: boolean;
   /** Overrides the stage-derived retryability default when set. */
   readonly retryable?: boolean;
-  /** Overrides the first-line summary default when set. */
-  readonly summary?: string;
-  /** Overrides the stage-derived recovery guidance when set. */
-  readonly recovery?: string;
 
   constructor(
     message: string,
@@ -139,8 +146,6 @@ class ManagedStepError extends Error {
     options: {
       processMayBeAlive?: boolean;
       retryable?: boolean;
-      summary?: string;
-      recovery?: string;
       cause?: unknown;
     } = {},
   ) {
@@ -149,41 +154,31 @@ class ManagedStepError extends Error {
     this.stage = stage;
     this.processMayBeAlive = options.processMayBeAlive === true;
     this.retryable = options.retryable;
-    this.summary = options.summary;
-    this.recovery = options.recovery;
   }
-}
-
-function stepProcessMayBeAlive(error: unknown): boolean {
-  return error instanceof ManagedStepError && error.processMayBeAlive;
 }
 
 /**
  * Terminal managed-installation failure carrying the facts the UI needs
  * to pick guidance without parsing the message: a one-line `summary` for
- * notifications and the status bar tooltip, whether a retry with the same
- * configuration can help (`retryable`), and whether a surviving process
- * may still be mutating the depot (`processMayBeAlive`). The message
- * carries the human-readable details for the output channel.
+ * notifications and the status bar tooltip, and whether a retry with the
+ * same configuration can help (`retryable`). The message carries the
+ * human-readable details for the output channel.
  */
 export class ManagedJETLSError extends Error {
   readonly summary: string;
   readonly retryable: boolean;
-  readonly processMayBeAlive: boolean;
 
   constructor(
     message: string,
     details: {
       summary: string;
       retryable: boolean;
-      processMayBeAlive: boolean;
     },
   ) {
     super(message);
     this.name = "ManagedJETLSError";
     this.summary = details.summary;
     this.retryable = details.retryable;
-    this.processMayBeAlive = details.processMayBeAlive;
   }
 }
 
@@ -346,11 +341,27 @@ export function juliaMinorVersion(version: string): string {
   return `${parsed.major}.${parsed.minor}`;
 }
 
+// The key spells out the Julia minor version and hashes the executable
+// path: different installations of the same Julia version are different
+// builds, whose precompile caches must not share a depot, and the path
+// itself cannot be embedded in a directory name safely. The patch
+// version stays out deliberately: package resolution is stable within a
+// minor, so a patch update only costs a re-verification of the current
+// generation (the install stamp tracks the exact version) instead of a
+// full reinstall into a fresh container.
 export function runtimeKey(juliaPath: string, juliaVersion: string): string {
-  const runtime = `${juliaPath}\n${juliaMinorVersion(juliaVersion)}`;
-  return createHash("sha256").update(runtime).digest("hex").slice(0, 16);
+  const pathHash = createHash("sha256")
+    .update(juliaPath)
+    .digest("hex")
+    .slice(0, 8);
+  return `v${juliaMinorVersion(juliaVersion)}-${pathHash}`;
 }
 
+/**
+ * The per-runtime container. Each installation lives in its own
+ * immutable generation depot directly inside the container, and the
+ * `current` pointer file names the generation launches resolve.
+ */
 export function managedDepotPath(
   storagePath: string,
   juliaPath: string,
@@ -363,20 +374,68 @@ export function managedDepotPath(
   );
 }
 
+export function currentPointerPath(containerPath: string): string {
+  return path.join(containerPath, CURRENT_POINTER_FILE);
+}
+
+// The generation directory is never renamed once the installation ran:
+// precompile caches record absolute source paths, so publication happens
+// by pointing `current` at the directory, not by moving it.
+function newGenerationId(): string {
+  return `${JETLS_REVISION}-${randomBytes(4).toString("hex")}`;
+}
+
+export async function readCurrentGeneration(
+  containerPath: string,
+): Promise<string | undefined> {
+  try {
+    const pointer = JSON.parse(
+      await readFile(currentPointerPath(containerPath), "utf8"),
+    ) as { generation?: unknown };
+    if (
+      typeof pointer.generation !== "string" ||
+      pointer.generation !== path.basename(pointer.generation) ||
+      pointer.generation.startsWith(".")
+    ) {
+      return undefined;
+    }
+    const generationPath = path.join(containerPath, pointer.generation);
+    return (await directoryExists(generationPath)) ? generationPath : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// Written through a rename so a concurrent reader never sees a torn
+// pointer; the last concurrent publisher wins, and every published
+// generation is complete, so either winner is valid.
+async function writeCurrentGeneration(
+  containerPath: string,
+  generationId: string,
+): Promise<void> {
+  const pointerPath = currentPointerPath(containerPath);
+  const tempPath = `${pointerPath}.tmp`;
+  await writeFile(tempPath, JSON.stringify({ generation: generationId }));
+  await rename(tempPath, pointerPath);
+}
+
+export function lastUsedPath(basePath: string): string {
+  return path.join(basePath, LAST_USED_FILE);
+}
+
+// Records that a start resolved this generation (or runtime container),
+// so cleanup keeps what a still-open window may be running a server
+// from.
+async function touchLastUsed(basePath: string): Promise<void> {
+  await writeFile(lastUsedPath(basePath), "").catch(() => undefined);
+}
+
 function appsDirectory(depotPath: string): string {
   return path.join(depotPath, "environments", "apps");
 }
 
 export function managedEnvironment(depotPath: string): string {
   return path.join(appsDirectory(depotPath), "JETLS");
-}
-
-function appsBackupPath(depotPath: string): string {
-  return path.join(depotPath, "app-env-backup");
-}
-
-export function installPendingPath(depotPath: string): string {
-  return path.join(depotPath, "install-pending.json");
 }
 
 function managedManifest(depotPath: string): string {
@@ -500,9 +559,6 @@ export function createDefaultProcessRunner(
         windowsHide: true,
         detached,
       });
-      if (child.pid !== undefined) {
-        options.onPid?.(child.pid);
-      }
 
       child.stdout?.on("data", (chunk: Buffer) => {
         stdout = appendOutputTail(stdout, chunk);
@@ -542,7 +598,7 @@ export function createDefaultProcessRunner(
         timedOut = true;
         // A process that survives every termination attempt must not leave
         // this promise pending, but the settled result marks the survival
-        // so callers keep the depot lock instead of reusing the depot.
+        // so failure guidance can note the possibly-live process.
         void terminateProcess(
           { process: child, isClosed: () => closed, closedPromise },
           {
@@ -616,7 +672,6 @@ function createLineLogger(
 }
 
 function createInstallationOutputObserver(
-  operation: InstallationOperation,
   progress: ((message: string) => void) | undefined,
 ): ProcessOutputObserver {
   const phases = [
@@ -654,7 +709,7 @@ function createInstallationOutputObserver(
       for (const phase of phases) {
         if (!reported.has(phase.message) && phase.pattern.test(output)) {
           reported.add(phase.message);
-          emit(progress, `${operation} JETLS: ${phase.message}`);
+          emit(progress, `Installing JETLS: ${phase.message}`);
         }
       }
       recentOutput = combined.slice(-4096);
@@ -838,39 +893,42 @@ async function verifyPinnedJETLS(
   }
 }
 
-// The install stamp records the (pin, exact Julia version) pair the depot
-// last verified. While it matches, the per-start `jetls version` probe (a
-// full JETLS load) is skipped. A pin bump or Julia update flips a recorded
-// value; silent depot corruption does not, so managed serve failures drop
-// the stamp (`invalidateInstallStamp`) to restore the verify-and-repair
-// path on the next start.
-export function installStampPath(depotPath: string): string {
-  return path.join(depotPath, INSTALL_STAMP_FILE);
+// The install stamp records the (pin, exact Julia version) pair the
+// generation last verified, and marks the generation complete for
+// cleanup. While it matches, the per-start `jetls version` probe (a full
+// JETLS load) is skipped. A pin bump or Julia update flips a recorded
+// value; silent corruption does not, so managed serve failures drop the
+// stamp (`invalidateInstallStamp`) to restore the verify path on the
+// next start.
+export function installStampPath(generationPath: string): string {
+  return path.join(generationPath, INSTALL_STAMP_FILE);
 }
 
-async function matchesInstallStamp(context: RuntimeContext): Promise<boolean> {
+async function matchesInstallStamp(
+  generationPath: string,
+  juliaVersion: string,
+): Promise<boolean> {
   try {
     const stamp = JSON.parse(
-      await readFile(installStampPath(context.depotPath), "utf8"),
+      await readFile(installStampPath(generationPath), "utf8"),
     ) as { revision?: unknown; julia?: unknown };
-    return (
-      stamp.revision === JETLS_REVISION && stamp.julia === context.juliaVersion
-    );
+    return stamp.revision === JETLS_REVISION && stamp.julia === juliaVersion;
   } catch {
     return false;
   }
 }
 
 async function writeInstallStamp(
-  context: RuntimeContext,
+  generationPath: string,
+  juliaVersion: string,
   logger: ((message: string) => void) | undefined,
 ): Promise<void> {
-  const stampPath = installStampPath(context.depotPath);
+  const stampPath = installStampPath(generationPath);
   const tempPath = `${stampPath}.tmp`;
   try {
     await writeFile(
       tempPath,
-      JSON.stringify({ revision: JETLS_REVISION, julia: context.juliaVersion }),
+      JSON.stringify({ revision: JETLS_REVISION, julia: juliaVersion }),
     );
     await rename(tempPath, stampPath);
   } catch (error) {
@@ -882,12 +940,15 @@ async function writeInstallStamp(
 }
 
 /**
- * Drops the install stamp so the next `ensureManagedJETLS` re-verifies the
- * managed depot and repairs it if broken. Racing a concurrent stamp write is
- * benign: that write records a state that was verified just before.
+ * Drops the install stamp so the next `ensureManagedJETLS` re-verifies
+ * the current generation and replaces it if broken. Racing a concurrent
+ * stamp write is benign: that write records a state that was verified
+ * just before.
  */
-export async function invalidateInstallStamp(depotPath: string): Promise<void> {
-  await rm(installStampPath(depotPath), { force: true });
+export async function invalidateInstallStamp(
+  generationPath: string,
+): Promise<void> {
+  await rm(installStampPath(generationPath), { force: true });
 }
 
 async function isFile(filePath: string): Promise<boolean> {
@@ -902,377 +963,75 @@ function isNodeError(error: unknown, code: string): boolean {
   return (error as NodeJS.ErrnoException).code === code;
 }
 
-function processIsRunning(pid: number): boolean {
+async function pathAgeMs(candidate: string): Promise<number | undefined> {
   try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return isNodeError(error, "EPERM");
-  }
-}
-
-// The owner file is written through a rename so a concurrent reader never
-// sees a torn write. `activeGroup` records the managed process currently
-// (or last known to be) operating on the depot: it is detached from the
-// extension host, so the host's death alone does not prove the depot is
-// no longer being written.
-async function writeLockOwner(
-  lockPath: string,
-  activeGroup?: number,
-): Promise<void> {
-  const ownerPath = path.join(lockPath, "owner.json");
-  const tempPath = `${ownerPath}.tmp`;
-  await writeFile(
-    tempPath,
-    JSON.stringify({
-      pid: process.pid,
-      createdAt: new Date().toISOString(),
-      ...(activeGroup === undefined ? {} : { activeGroup }),
-    }),
-  );
-  await rename(tempPath, ownerPath);
-}
-
-// Marks the lock as ceded to the recorded surviving process: the owner
-// host no longer claims it, so reclaim judges the recorded process alone
-// and a retry — from this host or any other — proceeds as soon as the
-// process is confirmed gone. Without a recorded process the mark is not
-// written: host-PID liveness is then the only safety signal left, and it
-// has to keep blocking until the host exits.
-async function abandonLockToSurvivor(lockPath: string): Promise<void> {
-  const ownerPath = path.join(lockPath, "owner.json");
-  const owner = JSON.parse(await readFile(ownerPath, "utf8")) as {
-    activeGroup?: unknown;
-  };
-  if (typeof owner.activeGroup !== "number") {
-    return;
-  }
-  const tempPath = `${ownerPath}.tmp`;
-  await writeFile(tempPath, JSON.stringify({ ...owner, abandoned: true }));
-  await rename(tempPath, ownerPath);
-}
-
-// Probes the recorded process: a process group on POSIX, the direct
-// process on Windows (where the child tree cannot be enumerated).
-function activeGroupIsRunning(
-  group: number,
-  platform: NodeJS.Platform,
-): boolean {
-  try {
-    process.kill(platform === "win32" ? group : -group, 0);
-    return true;
-  } catch (error) {
-    return isNodeError(error, "EPERM");
-  }
-}
-
-// A reboot is the only event that proves an unconfirmable Windows process
-// tree is gone: `taskkill /T` needs a live parent, so a tree whose direct
-// process already exited can never be confirmed dead while the system
-// stays up.
-function predatesBoot(createdAt: unknown): boolean {
-  if (typeof createdAt !== "string") {
-    return false;
-  }
-  const created = Date.parse(createdAt);
-  return !Number.isNaN(created) && created < Date.now() - uptime() * 1000;
-}
-
-type LockReclaimResult = "reclaimed" | "busy" | "windows-unconfirmable";
-
-// Disposing of a stale lock with a plain `rm` would race concurrent
-// reclaimers: between judging a lock stale and removing it, another
-// waiter can reclaim the lock and re-create it, and the `rm` would then
-// destroy the fresh lock. An atomic `rename` first pins the removal to
-// the one directory that was judged; `verify` re-examines the stolen
-// instance, and a mismatch (a fresh lock created inside the window) is
-// moved back into place.
-let reclaimSequence = 0;
-
-async function stealStaleLock(
-  lockPath: string,
-  verify: (stolenPath: string) => Promise<boolean>,
-): Promise<boolean> {
-  const stolenPath = `${lockPath}.reclaim-${process.pid}-${reclaimSequence++}`;
-  try {
-    await rename(lockPath, stolenPath);
+    return Date.now() - (await stat(candidate)).mtimeMs;
   } catch {
-    // Already released or reclaimed by another waiter.
-    return true;
+    return undefined;
   }
-  if (await verify(stolenPath)) {
-    await rm(stolenPath, { recursive: true, force: true });
-    return true;
-  }
-  // A failed restore (the path was re-taken inside the window) must not
-  // escalate to removing an instance that may be live; leave it aside.
-  await rename(stolenPath, lockPath).catch(() => undefined);
-  return false;
 }
 
-async function reclaimStaleLock(
-  lockPath: string,
-  platform: NodeJS.Platform = process.platform,
-): Promise<LockReclaimResult> {
-  const ownerPath = path.join(lockPath, "owner.json");
-  try {
-    const owner = JSON.parse(await readFile(ownerPath, "utf8")) as {
-      pid?: unknown;
-      createdAt?: unknown;
-      activeGroup?: unknown;
-      abandoned?: unknown;
-    };
-    if (typeof owner.pid === "number") {
-      if (processIsRunning(owner.pid) && owner.abandoned !== true) {
-        // A live PID is treated as an active owner even though it could
-        // be an unrelated process that reused the PID after a crash: the
-        // owner's running Pkg processes cannot be fenced, so reclaiming a
-        // lock that might still be live risks concurrent depot mutation.
-        // The mistaken-identity case instead ends in the lock-wait
-        // timeout and a clear failure. An abandoned lock is exempt: its
-        // owner host has ceded it to the recorded process, which is
-        // judged below.
-        return "busy";
-      }
-      if (typeof owner.activeGroup === "number") {
-        if (activeGroupIsRunning(owner.activeGroup, platform)) {
-          // The dead host recorded a managed process that may still be
-          // writing to the depot after outliving its host.
-          return "busy";
-        }
-        // On Windows the record is only the direct process: its death
-        // says nothing about the child tree, so the lock is reclaimed
-        // only once the record provably predates the current boot.
-        if (platform === "win32" && !predatesBoot(owner.createdAt)) {
-          return "windows-unconfirmable";
-        }
-      }
-      const stolen = await stealStaleLock(lockPath, async (stolenPath) => {
-        try {
-          const current = JSON.parse(
-            await readFile(path.join(stolenPath, "owner.json"), "utf8"),
-          ) as { pid?: unknown; createdAt?: unknown };
-          return (
-            current.pid === owner.pid && current.createdAt === owner.createdAt
-          );
-        } catch {
-          return false;
-        }
-      });
-      return stolen ? "reclaimed" : "busy";
-    }
-  } catch {
-    // No readable owner; fall through to the incomplete-lock handling.
-  }
-  try {
-    const metadata = await stat(lockPath);
-    if (Date.now() - metadata.mtimeMs > INCOMPLETE_LOCK_GRACE_PERIOD) {
-      const stolen = await stealStaleLock(lockPath, async (stolenPath) => {
-        try {
-          await readFile(path.join(stolenPath, "owner.json"), "utf8");
-          // The instance gained an owner inside the window: not the
-          // judged one.
-          return false;
-        } catch {
-          // `rename` preserves the directory's own mtime, so the age
-          // judgment can be repeated on the stolen instance.
-          const current = await stat(stolenPath).catch(() => undefined);
-          return (
-            current === undefined ||
-            Date.now() - current.mtimeMs > INCOMPLETE_LOCK_GRACE_PERIOD
-          );
-        }
-      });
-      return stolen ? "reclaimed" : "busy";
-    }
-  } catch {
-    return "reclaimed";
-  }
-  return "busy";
-}
-
-export async function removeStaleLock(
-  lockPath: string,
-  platform: NodeJS.Platform = process.platform,
-): Promise<boolean> {
-  return (await reclaimStaleLock(lockPath, platform)) === "reclaimed";
-}
-
-async function survivorHint(lockPath: string): Promise<string> {
-  try {
-    const owner = JSON.parse(
-      await readFile(path.join(lockPath, "owner.json"), "utf8"),
-    ) as { activeGroup?: unknown };
-    if (typeof owner.activeGroup === "number") {
-      return (
-        " A JETLS process from a previous session may still be running " +
-        `(process group ${owner.activeGroup}).`
-      );
-    }
-  } catch {
-    // No readable owner; nothing to add.
-  }
-  return "";
-}
-
-interface DepotLockHandle {
-  release: () => Promise<void>;
-  abandon: () => Promise<void>;
-}
-
-async function acquireDepotLock(
-  depotPath: string,
+// The install lock only keeps concurrent hosts from duplicating a long
+// installation; it is not a safety boundary. Generations are immutable
+// and published through an atomic pointer update, so hosts installing
+// concurrently at worst waste work. That tolerance is what keeps the
+// lock simple: staleness is judged by age alone, `poll` lets a waiter
+// adopt a result published by the lock holder, and a waiter that
+// exhausts its budget proceeds without the lock.
+async function withInstallLock<T>(
+  containerPath: string,
+  logger: ((message: string) => void) | undefined,
   progress: ((message: string) => void) | undefined,
-  platform: NodeJS.Platform,
-): Promise<DepotLockHandle> {
-  const lockPath = `${depotPath}.lock`;
-  await mkdir(path.dirname(lockPath), { recursive: true });
-  // The lock holder is at worst running a full installation, so reuse its
-  // budget for the wait.
+  poll: () => Promise<T | undefined>,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const lockPath = path.join(containerPath, INSTALL_LOCK_DIR);
+  await mkdir(containerPath, { recursive: true });
   const deadline = Date.now() + TIMEOUTS.install;
   let reportedWait = false;
-
-  while (true) {
+  let locked = false;
+  while (!locked && Date.now() < deadline) {
     try {
       await mkdir(lockPath);
-      await writeLockOwner(lockPath);
-      return {
-        release: async () => {
-          // Only the recorded owner removes the directory: if a mistaken
-          // reclaim raced this operation, the path may already hold
-          // another host's lock.
-          try {
-            const owner = JSON.parse(
-              await readFile(path.join(lockPath, "owner.json"), "utf8"),
-            ) as { pid?: unknown };
-            if (owner.pid !== process.pid) {
-              return;
-            }
-          } catch {
-            // Missing or unreadable owner: still ours to remove.
-          }
-          await rm(lockPath, { recursive: true, force: true });
-        },
-        abandon: () => abandonLockToSurvivor(lockPath),
-      };
+      locked = true;
     } catch (error) {
       if (!isNodeError(error, "EEXIST")) {
         throw error;
       }
-      const reclaimResult = await reclaimStaleLock(lockPath, platform);
-      if (reclaimResult === "reclaimed") {
+      const age = await pathAgeMs(lockPath);
+      if (age === undefined) {
         continue;
       }
-      if (reclaimResult === "windows-unconfirmable") {
-        throw new ManagedStepError(
-          `The managed depot lock ${lockPath} belongs to a Windows process ` +
-            "tree whose exit cannot be confirmed during the current boot.",
-          "lock",
-          {
-            processMayBeAlive: true,
-            retryable: true,
-            summary: "Restart Windows before retrying managed JETLS.",
-            recovery:
-              "Recovery: restart Windows, then restart the language server. " +
-              "Retry and Reinstall cannot safely reclaim this lock during " +
-              "the current boot.",
-            cause: error,
-          },
-        );
+      if (age > LOCK_STALE_AGE) {
+        await rm(lockPath, { recursive: true, force: true });
+        continue;
+      }
+      const adopted = await poll();
+      if (adopted !== undefined) {
+        return adopted;
       }
       if (!reportedWait) {
-        emit(progress, "Waiting for another JETLS operation...");
+        emit(progress, "Waiting for another JETLS installation...");
         reportedWait = true;
-      }
-      if (Date.now() >= deadline) {
-        throw new Error(
-          `Timed out waiting for managed depot lock ${lockPath}.` +
-            (await survivorHint(lockPath)),
-          { cause: error },
-        );
       }
       await new Promise((resolve) => setTimeout(resolve, LOCK_RETRY_DELAY));
     }
   }
-}
-
-async function withDepotLock<T>(
-  depotPath: string,
-  progress: ((message: string) => void) | undefined,
-  platform: NodeJS.Platform,
-  operation: () => Promise<T>,
-): Promise<T> {
-  let lock: DepotLockHandle;
-  try {
-    lock = await acquireDepotLock(depotPath, progress, platform);
-  } catch (error) {
-    if (error instanceof ManagedStepError) {
-      throw error;
-    }
-    throw new ManagedStepError(errorMessage(error), "lock", { cause: error });
+  if (!locked) {
+    emit(
+      logger,
+      "Proceeding without the managed install lock after waiting out its budget.",
+    );
   }
-  let result: T;
   try {
-    result = await operation();
-  } catch (error) {
-    // A process that survived termination may still be mutating the
-    // depot. The lock is not released but ceded to that process — it was
-    // registered at spawn as the owner's `activeGroup` — so it stays in
-    // force, even after this host exits, exactly until the process is
-    // confirmed gone; then any host, including this one on a retry, can
-    // reclaim it.
-    if (stepProcessMayBeAlive(error)) {
-      await lock.abandon().catch(() => undefined);
-    } else {
-      await lock.release();
+    return await operation();
+  } finally {
+    if (locked) {
+      await rm(lockPath, { recursive: true, force: true }).catch(
+        () => undefined,
+      );
     }
-    throw error;
   }
-  await lock.release();
-  return result;
-}
-
-// Registers each spawned process in the lock owner file while it may be
-// operating on the depot, so a host that dies mid-operation leaves the
-// next host enough information not to reclaim the lock from under a
-// still-running process. The record is cleared only once the process is
-// confirmed gone; registration is best-effort, degrading to the
-// host-PID-only safety level when the owner file cannot be written.
-function registerLockProcesses(
-  runner: ProcessRunner,
-  lockPath: string,
-): ProcessRunner {
-  return async (command, args, options) => {
-    let registered: Promise<void> = Promise.resolve();
-    const result = await runner(command, args, {
-      ...options,
-      onPid: (pid) => {
-        registered = writeLockOwner(lockPath, pid).catch(() => undefined);
-      },
-    });
-    await registered;
-    if (result.processMayBeAlive !== true) {
-      await writeLockOwner(lockPath).catch(() => undefined);
-    }
-    return result;
-  };
-}
-
-function repairFailure(
-  verificationError: unknown,
-  installationError: unknown,
-): ManagedStepError {
-  return new ManagedStepError(
-    `The cached managed JETLS installation failed verification:\n${errorMessage(verificationError)}\n` +
-      `Failed to repair the managed JETLS installation:\n${errorMessage(installationError)}`,
-    "repair",
-    {
-      processMayBeAlive:
-        stepProcessMayBeAlive(installationError) ||
-        stepProcessMayBeAlive(verificationError),
-      summary: "Failed to repair the managed JETLS installation.",
-    },
-  );
 }
 
 async function directoryExists(candidate: string): Promise<boolean> {
@@ -1283,135 +1042,105 @@ async function directoryExists(candidate: string): Promise<boolean> {
   }
 }
 
-async function backupAppEnvironments(depotPath: string): Promise<boolean> {
-  if (!(await directoryExists(appsDirectory(depotPath)))) {
-    return false;
-  }
-  // A leftover backup without a pending marker belongs to a transaction
-  // whose environment was verified afterwards; it is safe to discard.
-  const backupPath = appsBackupPath(depotPath);
-  await rm(backupPath, { recursive: true, force: true });
-  await cp(appsDirectory(depotPath), backupPath, { recursive: true });
-  // The marker is written only once the backup is complete: while it
-  // exists, the environments are suspect and the backup is authoritative.
-  await writeFile(
-    installPendingPath(depotPath),
-    JSON.stringify({ revision: JETLS_REVISION }),
-  );
-  return true;
-}
-
-// Throws when the restore cannot be completed; the pending marker and
-// the backup are removed only on success, so a later start retries the
-// recovery instead of trusting a half-restored state.
-async function restoreAppEnvironments(
-  depotPath: string,
+// Removes what no start can need anymore: unpublished generations old
+// enough that no installation can still be producing them, published
+// generations that have gone unresolved for longer than any live window
+// plausibly stays open, and sibling runtime containers (other Julia
+// executables or minor versions) that no start has resolved for the
+// runtime retention. A container entry that is not a control file is
+// judged as a generation, which also ages out leftovers from older
+// layouts. The current generation and the active container are never
+// touched. Best-effort: a failure only defers cleanup.
+async function cleanupManagedStorage(
+  containerPath: string,
   logger: ((message: string) => void) | undefined,
 ): Promise<void> {
   try {
-    await rm(appsDirectory(depotPath), { recursive: true, force: true });
-    await rename(appsBackupPath(depotPath), appsDirectory(depotPath));
-    await rm(installPendingPath(depotPath), { force: true });
+    const currentGeneration = await readCurrentGeneration(containerPath);
+    for (const entry of await readdir(containerPath)) {
+      if (
+        entry === CURRENT_POINTER_FILE ||
+        entry === INSTALL_LOCK_DIR ||
+        entry === LAST_USED_FILE
+      ) {
+        continue;
+      }
+      const generationPath = path.join(containerPath, entry);
+      if (generationPath === currentGeneration) {
+        continue;
+      }
+      const published = await isFile(installStampPath(generationPath));
+      const age =
+        (await pathAgeMs(lastUsedPath(generationPath))) ??
+        (await pathAgeMs(generationPath));
+      const grace = published
+        ? GENERATION_RETENTION
+        : UNPUBLISHED_GENERATION_GRACE;
+      if (age !== undefined && age > grace) {
+        await rm(generationPath, { recursive: true, force: true });
+        emit(logger, `Removed old managed JETLS generation: ${generationPath}`);
+      }
+    }
+    const depotsPath = path.dirname(containerPath);
+    for (const entry of await readdir(depotsPath)) {
+      const runtimePath = path.join(depotsPath, entry);
+      if (runtimePath === containerPath) {
+        continue;
+      }
+      const age =
+        (await pathAgeMs(lastUsedPath(runtimePath))) ??
+        (await pathAgeMs(runtimePath));
+      if (age !== undefined && age > RUNTIME_RETENTION) {
+        await rm(runtimePath, { recursive: true, force: true });
+        emit(
+          logger,
+          `Removed managed JETLS storage of an unused Julia runtime: ${runtimePath}`,
+        );
+      }
+    }
+  } catch (error) {
     emit(
       logger,
-      "Restored the app environments after the failed installation.",
-    );
-  } catch (error) {
-    throw new ManagedStepError(
-      `Failed to restore the app environments backup: ${errorMessage(error)}`,
-      "install",
-      { cause: error },
+      `Managed storage cleanup was skipped: ${errorMessage(error)}`,
     );
   }
 }
 
-// Recovers from an installation a previous host never finished: the
-// pending marker means the environments may hold a partial write, while
-// the backup still holds the pre-installation state. Restoring first
-// keeps a crashed or surviving-then-killed update from destroying the
-// last known state, which taking a fresh backup would otherwise
-// overwrite.
-async function recoverPendingInstallation(
-  depotPath: string,
-  logger: ((message: string) => void) | undefined,
-): Promise<void> {
-  if (!(await isFile(installPendingPath(depotPath)))) {
-    return;
+async function stampedCurrentGeneration(
+  context: RuntimeContext,
+): Promise<string | undefined> {
+  const generation = await readCurrentGeneration(context.containerPath);
+  if (
+    generation !== undefined &&
+    (await matchesInstallStamp(generation, context.juliaVersion))
+  ) {
+    return generation;
   }
-  if (await directoryExists(appsBackupPath(depotPath))) {
-    await restoreAppEnvironments(depotPath, logger);
-  } else {
-    // An interrupted restore already consumed the backup, so the
-    // environments hold the restored state.
-    await rm(installPendingPath(depotPath), { force: true });
-  }
+  return undefined;
 }
 
-async function ensureInstallation(
+async function installGeneration(
   context: RuntimeContext,
   baseEnvironment: NodeJS.ProcessEnv,
-  launchEnvironment: NodeJS.ProcessEnv,
   runner: ProcessRunner,
   platform: NodeJS.Platform,
   logger: ((message: string) => void) | undefined,
   progress: ((message: string) => void) | undefined,
-): Promise<void> {
-  await recoverPendingInstallation(context.depotPath, logger);
-  const lockedRunner = registerLockProcesses(
-    runner,
-    `${context.depotPath}.lock`,
-  );
-  const installed = await isFile(managedManifest(context.depotPath));
-  if (installed && (await matchesInstallStamp(context))) {
-    return;
-  }
-  let verificationError: unknown;
-
-  if (installed) {
-    emit(progress, "Verifying JETLS...");
-    try {
-      await verifyPinnedJETLS(
-        context.juliaPath,
-        launchEnvironment,
-        lockedRunner,
-        platform,
-        logger,
-      );
-      await writeInstallStamp(context, logger);
-      return;
-    } catch (error) {
-      verificationError = error;
-      emit(
-        logger,
-        `The cached managed JETLS installation needs repair: ${errorMessage(error)}`,
-      );
-    }
-  }
-
-  const operation: InstallationOperation = installed
-    ? "Repairing"
-    : "Installing";
-  emit(progress, `${operation} JETLS...`);
-  await mkdir(context.depotPath, { recursive: true });
-  // The app environments directory (the JETLS environment and Pkg.Apps's
-  // `AppManifest.toml` under `environments/apps`) is the only state a
-  // failed `Pkg.Apps.add` can corrupt: `packages/` is content-addressed
-  // and append-only, and only the post-verify `Pkg.gc` deletes from it.
-  // Backing it up keeps a failed update or repair from changing the
-  // previous known state; the old package bodies it references are still
-  // in the depot, so a restored environment stays startable. The pending
-  // marker makes the transaction crash-safe: the recovery above restores
-  // this backup before anything could overwrite it.
-  const backedUp = await backupAppEnvironments(context.depotPath);
+): Promise<string> {
+  const generationId = newGenerationId();
+  const generationPath = path.join(context.containerPath, generationId);
+  emit(progress, "Installing JETLS...");
+  await mkdir(generationPath, { recursive: true });
   const privateEnvironment = { ...baseEnvironment };
   setEnvironmentValue(
     privateEnvironment,
     "JULIA_DEPOT_PATH",
-    // The trailing empty entry appends the bundled system depots so stdlib
-    // caches are reused, while the user depot stays out of the chain so
-    // the managed manifest only references packages that the user's own
-    // `Pkg.gc` cannot collect.
-    `${context.depotPath}${platformDelimiter(platform)}`,
+    // The trailing empty entry appends the bundled system depots so
+    // stdlib caches are reused, while the user depot stays out of the
+    // chain: the generation stays self-contained, so cleanup can delete
+    // it whole and the user's own `Pkg.gc` cannot collect anything it
+    // references.
+    `${generationPath}${platformDelimiter(platform)}`,
     platform,
   );
   // `Pkg.Apps.add` warns about an "app collision" when `which("jetls")`
@@ -1420,101 +1149,119 @@ async function ensureInstallation(
   // silences the warning.
   prependPathDirectory(
     privateEnvironment,
-    path.join(context.depotPath, "bin"),
+    path.join(generationPath, "bin"),
     platform,
   );
+  await runCheckedProcess(
+    context.juliaPath,
+    juliaScriptArgs(INSTALL_SCRIPT),
+    privateEnvironment,
+    "Managed JETLS installation",
+    "install",
+    TIMEOUTS.install,
+    runner,
+    platform,
+    logger,
+    createInstallationOutputObserver(progress),
+  );
+  emit(progress, "Verifying installed JETLS...");
+  await verifyPinnedJETLS(
+    context.juliaPath,
+    serverLaunchEnvironment(baseEnvironment, generationPath, platform),
+    runner,
+    platform,
+    logger,
+  );
+  await writeInstallStamp(generationPath, context.juliaVersion, logger);
+  await writeCurrentGeneration(context.containerPath, generationId);
+  return generationPath;
+}
 
-  try {
-    try {
-      await runCheckedProcess(
-        context.juliaPath,
-        juliaScriptArgs(INSTALL_SCRIPT),
-        privateEnvironment,
-        "Managed JETLS installation",
-        installed ? "repair" : "install",
-        TIMEOUTS.install,
-        lockedRunner,
-        platform,
-        logger,
-        createInstallationOutputObserver(operation, progress),
+// Resolves the generation to launch: the stamped current generation when
+// it matches, a re-verified current generation after a stamp mismatch
+// (e.g. a Julia patch update or a dropped stamp), and a freshly
+// installed generation otherwise. A failed or crashed installation
+// leaves the previous current generation untouched — even a process that
+// outlives its host only ever writes to the unpublished generation it
+// was producing, which cleanup eventually removes — so nothing needs
+// backups or restore transactions, and a retry can start immediately.
+async function resolveGeneration(
+  context: RuntimeContext,
+  baseEnvironment: NodeJS.ProcessEnv,
+  runner: ProcessRunner,
+  platform: NodeJS.Platform,
+  logger: ((message: string) => void) | undefined,
+  progress: ((message: string) => void) | undefined,
+  forceInstall: boolean,
+): Promise<string> {
+  const settle = async (generationPath: string): Promise<string> => {
+    await touchLastUsed(generationPath);
+    // The container-level marker is what keeps the whole runtime alive
+    // against the stale-runtime sweep.
+    await touchLastUsed(context.containerPath);
+    await cleanupManagedStorage(context.containerPath, logger);
+    return generationPath;
+  };
+  if (!forceInstall) {
+    const stamped = await stampedCurrentGeneration(context);
+    if (stamped !== undefined) {
+      return await settle(stamped);
+    }
+  }
+  return await withInstallLock(
+    context.containerPath,
+    logger,
+    progress,
+    // Adopt a generation published by the lock holder instead of
+    // duplicating its installation.
+    async () =>
+      forceInstall ? undefined : await stampedCurrentGeneration(context),
+    async () => {
+      if (!forceInstall) {
+        const stamped = await stampedCurrentGeneration(context);
+        if (stamped !== undefined) {
+          return await settle(stamped);
+        }
+        const current = await readCurrentGeneration(context.containerPath);
+        if (current !== undefined && (await isFile(managedManifest(current)))) {
+          emit(progress, "Verifying JETLS...");
+          try {
+            await verifyPinnedJETLS(
+              context.juliaPath,
+              serverLaunchEnvironment(baseEnvironment, current, platform),
+              runner,
+              platform,
+              logger,
+            );
+            await writeInstallStamp(current, context.juliaVersion, logger);
+            return await settle(current);
+          } catch (error) {
+            emit(
+              logger,
+              "The current managed JETLS installation failed verification " +
+                `and will be replaced: ${errorMessage(error)}`,
+            );
+          }
+        }
+      }
+      return await settle(
+        await installGeneration(
+          context,
+          baseEnvironment,
+          runner,
+          platform,
+          logger,
+          progress,
+        ),
       );
-    } catch (error) {
-      if (verificationError !== undefined) {
-        throw repairFailure(verificationError, error);
-      }
-      throw error;
-    }
-
-    emit(progress, "Verifying installed JETLS...");
-    await verifyPinnedJETLS(
-      context.juliaPath,
-      launchEnvironment,
-      lockedRunner,
-      platform,
-      logger,
-    );
-  } catch (error) {
-    // A surviving process may still be writing to the environments; leave
-    // the depot alone (the retained lock blocks concurrent use anyway, and
-    // the kept pending marker sends the next start through the recovery).
-    if (backedUp && !stepProcessMayBeAlive(error)) {
-      try {
-        await restoreAppEnvironments(context.depotPath, logger);
-      } catch (restoreError) {
-        // The installation error stays the surfaced one; the marker and
-        // the backup remain, so a later start retries the recovery.
-        emit(logger, errorMessage(restoreError));
-      }
-    }
-    throw error;
-  }
-  // The marker leaves first: the environments were just verified, so a
-  // crash from here on must not send the next start back to the backup.
-  await rm(installPendingPath(context.depotPath), { force: true });
-  await writeInstallStamp(context, logger);
-  // The verified installation must start regardless of backup cleanup.
-  try {
-    await rm(appsBackupPath(context.depotPath), {
-      recursive: true,
-      force: true,
-    });
-  } catch (error) {
-    emit(
-      logger,
-      `Failed to remove the app environments backup: ${errorMessage(error)}`,
-    );
-  }
-
-  emit(progress, "Cleaning up the JETLS depot...");
-  try {
-    await runCheckedProcess(
-      context.juliaPath,
-      juliaScriptArgs(GC_SCRIPT),
-      privateEnvironment,
-      "Managed JETLS depot garbage collection",
-      "gc",
-      TIMEOUTS.gc,
-      lockedRunner,
-      platform,
-      logger,
-    );
-  } catch (error) {
-    // A gc process that survived termination may still be deleting from the
-    // depot; only failures of a completed process are ignorable.
-    if (stepProcessMayBeAlive(error)) {
-      throw error;
-    }
-    emit(
-      logger,
-      `Managed JETLS depot garbage collection failed and was ignored: ${errorMessage(error)}`,
-    );
-  }
+    },
+  );
 }
 
 function managedError(
   error: unknown,
   juliaCommand: string,
-  depotPath: string | undefined,
+  containerPath: string | undefined,
   fallbackStage: ManagedStage,
 ): ManagedJETLSError {
   if (error instanceof ManagedJETLSError) {
@@ -1522,44 +1269,45 @@ function managedError(
   }
   const step = error instanceof ManagedStepError ? error : undefined;
   const stage = step?.stage ?? fallbackStage;
-  const processMayBeAlive = step?.processMayBeAlive === true;
   // A retry with the same configuration can help everywhere except when
   // the configured Julia command itself cannot be resolved; deterministic
   // per-error exceptions (e.g. an unsupported Julia version) override the
   // default at the throw site.
   const retryable = step?.retryable ?? stage !== "julia-resolution";
-  const mayRequireNetwork = stage === "install" || stage === "repair";
-  const summary = step?.summary ?? firstLine(errorMessage(error));
-  // A surviving process may still mutate the depot and the depot lock is
-  // deliberately kept, so a reinstall (which waits on that lock) or a
-  // manual deletion would not help until the process is gone. A
-  // non-retryable failure is a configuration problem that a reinstall
-  // would not fix either, so its hint points at the settings only. The
-  // process output itself is not embedded: the output channel has already
-  // streamed the full log.
-  const recovery =
-    step?.recovery ??
-    (processMayBeAlive
-      ? "Recovery: a managed Julia process may still be running and keeps " +
-        "the depot locked; end that process (or reboot) and retry — the " +
-        "lock is reclaimed once the process is confirmed gone."
-      : retryable
-        ? "Recovery: " +
-          (mayRequireNetwork ? "this step may need network access; " : "") +
-          "retry by restarting the language server. If the managed depot " +
-          "itself is broken, run the 'JETLS Client: Reinstall Server' " +
-          "command, or configure a self-managed server via the " +
-          "`jetls-client.executable` setting."
-        : "Recovery: adjust the `jetls-client.executable` setting (its " +
-          "`env`, or the `julia` installation it resolves) so a supported " +
-          "Julia is found, or point its `path` at a self-managed JETLS " +
-          "executable.");
+  const mayRequireNetwork = stage === "install";
+  const summary = firstLine(errorMessage(error));
+  // A process that survived termination only ever writes to the
+  // unpublished generation it was producing, so it cannot affect a
+  // retry; the note is purely informational. A non-retryable failure is
+  // a configuration problem that a reinstall would not fix either, so
+  // its hint points at the settings only. The process output itself is
+  // not embedded: the output channel has already streamed the full log.
+  const survivorNote =
+    step?.processMayBeAlive === true
+      ? "A managed Julia process may still be running in the background; " +
+        "it cannot affect a new installation attempt, though ending it " +
+        "(or rebooting) frees its resources.\n"
+      : "";
+  const recovery = retryable
+    ? "Recovery: " +
+      (mayRequireNetwork ? "this step may need network access; " : "") +
+      "retry by restarting the language server. If the managed " +
+      "installation itself is broken, run the 'JETLS Client: Reinstall " +
+      "Server' command, or configure a self-managed server via the " +
+      "`jetls-client.executable` setting."
+    : "Recovery: adjust the `jetls-client.executable` setting (its " +
+      "`env`, or the `julia` installation it resolves) so a supported " +
+      "Julia is found, or point its `path` at a self-managed JETLS " +
+      "executable.";
   return new ManagedJETLSError(
     `${errorMessage(error)}\n` +
       `Julia command: ${juliaCommand}\n` +
-      (depotPath === undefined ? "" : `Managed depot: ${depotPath}\n`) +
+      (containerPath === undefined
+        ? ""
+        : `Managed storage: ${containerPath}\n`) +
+      survivorNote +
       recovery,
-    { summary, retryable, processMayBeAlive },
+    { summary, retryable },
   );
 }
 
@@ -1581,8 +1329,8 @@ async function ensureRuntime(
   juliaPath: string,
   platform: NodeJS.Platform,
   runner: ProcessRunner,
-): Promise<RuntimeContext> {
-  let depotPath: string | undefined;
+): Promise<string> {
+  let containerPath: string | undefined;
   try {
     emit(options.progress, "Checking Julia version...");
     const juliaVersion = await queryJuliaVersion(
@@ -1592,7 +1340,7 @@ async function ensureRuntime(
       platform,
       options.logger,
     );
-    depotPath = managedDepotPath(storagePath, juliaPath, juliaVersion);
+    containerPath = managedDepotPath(storagePath, juliaPath, juliaVersion);
     if (!isSupportedJuliaVersion(juliaVersion)) {
       throw new ManagedStepError(
         `JETLS requires Julia ${JULIA_VERSION_LOWER_BOUND} through ` +
@@ -1601,29 +1349,19 @@ async function ensureRuntime(
         { retryable: false },
       );
     }
-
-    const launchEnvironment = serverLaunchEnvironment(
+    return await resolveGeneration(
+      { containerPath, juliaPath, juliaVersion },
       options.environment,
-      depotPath,
+      runner,
       platform,
+      options.logger,
+      options.progress,
+      options.forceInstall === true,
     );
-    const context = { depotPath, juliaPath, juliaVersion };
-    await withDepotLock(depotPath, options.progress, platform, async () => {
-      await ensureInstallation(
-        context,
-        options.environment,
-        launchEnvironment,
-        runner,
-        platform,
-        options.logger,
-        options.progress,
-      );
-    });
-    return context;
   } catch (error) {
     // Untagged errors here come from filesystem steps of the installation
     // machinery itself.
-    throw managedError(error, juliaPath, depotPath, "install");
+    throw managedError(error, juliaPath, containerPath, "install");
   }
 }
 
@@ -1661,6 +1399,11 @@ async function resolveManagedRuntime(
   }
 }
 
+/**
+ * Resolves (installing or verifying as needed) the managed JETLS
+ * installation and returns the launch configuration; `depotPath` is the
+ * generation depot the server launches from.
+ */
 export async function ensureManagedJETLS(
   options: ManagedInstallationOptions,
 ): Promise<ManagedJETLSInstallation> {
@@ -1668,7 +1411,7 @@ export async function ensureManagedJETLS(
   const { platform, runner, storagePath, juliaPath } =
     await resolveManagedRuntime(options);
 
-  const context = await ensureRuntime(
+  const generationPath = await ensureRuntime(
     options,
     storagePath,
     juliaPath,
@@ -1676,54 +1419,8 @@ export async function ensureManagedJETLS(
     runner,
   );
   return {
-    env: serverLaunchEnvironment(
-      options.environment,
-      context.depotPath,
-      platform,
-    ),
-    depotPath: context.depotPath,
-    juliaPath: context.juliaPath,
+    env: serverLaunchEnvironment(options.environment, generationPath, platform),
+    depotPath: generationPath,
+    juliaPath,
   };
-}
-
-/**
- * Removes the managed depot of the current Julia runtime. When `confirm`
- * is given it runs with the resolved depot path before anything is
- * touched (the server processes launched from the depot may still be
- * running at that point); returning `false` cancels the uninstall and
- * the function resolves to `undefined`.
- */
-export async function uninstallManagedJETLS(
-  options: ManagedInstallationOptions,
-  confirm?: (depotPath: string) => boolean | Promise<boolean>,
-): Promise<string | undefined> {
-  const { platform, runner, storagePath, juliaPath } =
-    await resolveManagedRuntime(options);
-
-  let depotPath: string | undefined;
-  try {
-    const juliaVersion = await queryJuliaVersion(
-      juliaPath,
-      options.environment,
-      runner,
-      platform,
-      options.logger,
-    );
-    const resolvedDepot = managedDepotPath(
-      storagePath,
-      juliaPath,
-      juliaVersion,
-    );
-    depotPath = resolvedDepot;
-    if (confirm !== undefined && !(await confirm(resolvedDepot))) {
-      return undefined;
-    }
-    await withDepotLock(resolvedDepot, options.progress, platform, async () => {
-      await rm(resolvedDepot, { recursive: true, force: true });
-    });
-    emit(options.logger, `Removed managed JETLS depot: ${resolvedDepot}`);
-    return resolvedDepot;
-  } catch (error) {
-    throw managedError(error, juliaPath, depotPath, "uninstall");
-  }
 }

--- a/jetls-client/src/server-lifecycle.ts
+++ b/jetls-client/src/server-lifecycle.ts
@@ -15,7 +15,6 @@ import {
   invalidateInstallStamp,
   ManagedJETLSError,
   managedJETLSCommands,
-  uninstallManagedJETLS,
 } from "./managed-installation";
 import {
   getServerConfig,
@@ -90,12 +89,9 @@ function showManagedFailureNotification(err: Error): void {
   const outputButton = "Show JETLS output";
   const settingsButton = "Open settings";
   const buttons: string[] = [];
-  // A retry cannot help while a surviving process may still hold the depot
-  // lock, and a configuration problem needs a settings change first.
-  if (
-    details === undefined ||
-    (details.retryable && !details.processMayBeAlive)
-  ) {
+  // A configuration problem needs a settings change before a retry can
+  // help.
+  if (details === undefined || details.retryable) {
     buttons.push(retryButton);
   }
   buttons.push(outputButton);
@@ -120,11 +116,12 @@ function showManagedFailureNotification(err: Error): void {
 
 // Managed failures take two distinct paths. A setup failure happens before
 // `ensureManagedJETLS` produced a verified installation: nothing new is
-// known about any depot's verified state, so no install stamp is touched.
-// A server failure comes from a process launched out of a verified depot
-// and is the one corruption signal the install stamp cannot see, so the
-// stamp of the depot this lifecycle actually used is dropped: the next
-// start then re-verifies that depot and repairs it if needed.
+// known about any generation's verified state, so no install stamp is
+// touched. A server failure comes from a process launched out of a
+// verified generation and is the one corruption signal the install stamp
+// cannot see, so the stamp of the generation this lifecycle actually used
+// is dropped: the next start then re-verifies that generation and
+// replaces it with a fresh one if broken.
 function handleManagedSetupFailure(err: Error): void {
   outputChannel.appendLine(
     `[jetls-client] Failed to set up the managed JETLS: ${err.message}`,
@@ -217,7 +214,9 @@ async function startLanguageServer() {
         logger: (message) =>
           outputChannel.appendLine(`[jetls-client] ${message}`),
         progress: (message) => statusBar.showManagedProgress(message),
+        forceInstall: forceManagedInstall,
       });
+      forceManagedInstall = false;
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
       if (!deactivating && !restartRunner.pending) {
@@ -600,14 +599,18 @@ export function requestLanguageServerRestart(): void {
   });
 }
 
+// Set by `reinstallServer` and consumed by the next managed setup; it
+// stays set until an installation succeeds, so a Retry after a failed
+// reinstall still installs from scratch.
+let forceManagedInstall = false;
+
 /**
  * Reinstalls the managed JETLS from scratch: after a modal confirmation
- * the managed depot is removed and the server restarts, which installs
- * it anew. The running server is stopped only once the user has
- * confirmed (any in-flight startup attempt is cancelled and awaited,
- * bounded, before the depot is touched), and the restart is requested
- * only when the removal succeeded: a failed removal surfaces the
- * failure UI, whose Retry action restarts explicitly.
+ * the server restarts with the next managed setup forced to install a
+ * fresh generation, ignoring the verified current one. Nothing is
+ * deleted up front — superseded generations are cleaned up later — so a
+ * failed reinstall leaves the previous installation in place and
+ * surfaces the ordinary failure UI.
  */
 export async function reinstallServer(): Promise<void> {
   if (deactivating) {
@@ -620,86 +623,23 @@ export async function reinstallServer(): Promise<void> {
     );
     return;
   }
-  const executable = serverConfig.executable as {
-    env?: Record<string, string>;
-  };
-
-  let serverStopped = false;
-  try {
-    const removedPath = await uninstallManagedJETLS(
-      {
-        storagePath: managedStoragePath,
-        environment: executableEnvironment(executable),
-        logger: (message) =>
-          outputChannel.appendLine(`[jetls-client] ${message}`),
-      },
-      async (depotPath) => {
-        const reinstallButton = "Reinstall";
-        const choice = await vscode.window.showWarningMessage(
-          "Reinstall the JETLS language server?",
-          {
-            modal: true,
-            detail:
-              `This deletes the managed depot at ${depotPath}, including ` +
-              "the cached JETLS server and its precompile caches. " +
-              "Recreating the installation may require network access.",
-          },
-          reinstallButton,
-        );
-        if (choice !== reinstallButton) {
-          return false;
-        }
-        // Stop the server only once the user has confirmed: it still runs
-        // out of the depot that is about to be deleted. A stop that cannot
-        // be confirmed aborts the reinstall by throwing — deleting the
-        // depot under a live server would corrupt the reinstalled state.
-        serverStopped = true;
-        await stopServerForReinstall();
-        statusBar.showManagedProgress("Reinstalling JETLS...");
-        return true;
-      },
-    );
-    if (removedPath === undefined) {
-      return;
-    }
-    void vscode.window.showInformationMessage(
-      `Removed the managed JETLS installation at ${removedPath}.`,
-    );
-  } catch (err) {
-    const error = err instanceof Error ? err : new Error(String(err));
-    // No automatic restart: it would rerun the failing path right away.
-    // The failure notification offers Retry instead. Before the
-    // confirmation the server was never stopped, so the status bar still
-    // reflects its actual state.
-    if (serverStopped) {
-      statusBar.showManagedFailure(managedFailureSummary(error));
-    }
-    handleManagedSetupFailure(error);
+  const reinstallButton = "Reinstall";
+  const choice = await vscode.window.showWarningMessage(
+    "Reinstall the JETLS language server?",
+    {
+      modal: true,
+      detail:
+        "This reinstalls the pinned JETLS release into fresh managed " +
+        "storage, which may require network access. The previous " +
+        "installation is cleaned up automatically later.",
+    },
+    reinstallButton,
+  );
+  if (choice !== reinstallButton) {
     return;
   }
+  forceManagedInstall = true;
   requestLanguageServerRestart();
-}
-
-// Throws when the shutdown cannot be confirmed, so the caller aborts
-// instead of deleting a depot a live server may still be using.
-async function stopServerForReinstall(): Promise<void> {
-  void versionPreflight.terminate().catch(() => undefined);
-  cancelServerStartup?.();
-  if (!(await awaitWithTimeout(restartRunner.active, TIMEOUTS.serverStop))) {
-    throw new Error(
-      "Timed out waiting for the in-flight server lifecycle to settle.",
-    );
-  }
-  if (languageClient?.needsStop()) {
-    try {
-      await languageClient.stop(TIMEOUTS.serverStop);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      throw new Error(`Failed to stop the language client: ${message}`, {
-        cause: err,
-      });
-    }
-  }
 }
 
 export function restartOnServerConfigChange(): void {

--- a/jetls-client/test/managed-installation.test.ts
+++ b/jetls-client/test/managed-installation.test.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process";
 import {
   chmod,
   mkdir,
@@ -22,19 +21,19 @@ import {
   JETLS_REVISION,
   ManagedJETLSError,
   createDefaultProcessRunner,
+  currentPointerPath,
   ensureManagedJETLS,
-  installPendingPath,
   installStampPath,
   invalidateInstallStamp,
   isPinnedJETLSVersion,
   isSupportedJuliaVersion,
+  lastUsedPath,
   managedEnvironment,
   managedDepotPath,
   managedJETLSCommands,
   needsWindowsBatchShell,
   parseJuliaVersion,
-  removeStaleLock,
-  uninstallManagedJETLS,
+  readCurrentGeneration,
   resolveExecutable,
   runtimeKey,
   serverLaunchEnvironment,
@@ -87,7 +86,6 @@ function fakeRunner(
         timeoutMs: options.timeoutMs,
         onStdout: options.onStdout,
         onStderr: options.onStderr,
-        onPid: options.onPid,
       },
     };
     calls.push(call);
@@ -138,7 +136,6 @@ function standardRunner(
   juliaPath: string,
   options: {
     jetlsVersions?: ProcessResult[];
-    gcResult?: ProcessResult;
     installDelay?: number;
     installOutput?: (call: ProcessCall) => void;
     onInstallOutput?: () => void;
@@ -161,9 +158,6 @@ function standardRunner(
       }
       return success("installed\n");
     }
-    if (call.command === juliaPath && script?.includes("Pkg.gc")) {
-      return options.gcResult ?? success();
-    }
     if (call.command === juliaPath && script !== undefined) {
       return success("1.12.2\n");
     }
@@ -179,16 +173,66 @@ function standardRunner(
   });
 }
 
-async function createAppManifest(
+// Seeds a generation the way a completed installation leaves it: a
+// manifest inside the generation depot, the `current` pointer naming it,
+// and (unless disabled) a matching install stamp.
+async function seedGeneration(
   storagePath: string,
   juliaPath: string,
-  juliaVersion = "1.12.2",
+  options: {
+    juliaVersion?: string;
+    stampJuliaVersion?: string;
+    stamped?: boolean;
+    id?: string;
+  } = {},
 ): Promise<string> {
-  const depotPath = managedDepotPath(storagePath, juliaPath, juliaVersion);
-  const manifest = path.join(managedEnvironment(depotPath), "Manifest.toml");
+  const juliaVersion = options.juliaVersion ?? "1.12.2";
+  const containerPath = managedDepotPath(storagePath, juliaPath, juliaVersion);
+  const id = options.id ?? `${JETLS_REVISION}-seeded`;
+  const generationPath = path.join(containerPath, id);
+  const manifest = path.join(
+    managedEnvironment(generationPath),
+    "Manifest.toml",
+  );
   await mkdir(path.dirname(manifest), { recursive: true });
   await writeFile(manifest, "");
-  return manifest;
+  if (options.stamped !== false) {
+    await writeFile(
+      installStampPath(generationPath),
+      JSON.stringify({
+        revision: JETLS_REVISION,
+        julia: options.stampJuliaVersion ?? juliaVersion,
+      }),
+    );
+  }
+  await writeFile(
+    currentPointerPath(containerPath),
+    JSON.stringify({ generation: id }),
+  );
+  return generationPath;
+}
+
+// Creates a generation directory without touching the `current` pointer,
+// for exercising cleanup of unreferenced generations.
+async function seedUnreferencedGeneration(
+  containerPath: string,
+  id: string,
+  stamped: boolean,
+): Promise<string> {
+  const generationPath = path.join(containerPath, id);
+  await mkdir(generationPath, { recursive: true });
+  if (stamped) {
+    await writeFile(
+      installStampPath(generationPath),
+      JSON.stringify({ revision: JETLS_REVISION, julia: "1.12.2" }),
+    );
+  }
+  return generationPath;
+}
+
+async function setAgeMs(target: string, ageMs: number): Promise<void> {
+  const time = new Date(Date.now() - ageMs);
+  await utimes(target, time, time);
 }
 
 function isJETLSVersionCall(call: ProcessCall): boolean {
@@ -235,7 +279,9 @@ test("keys depots by executable and Julia minor version", () => {
   assert.equal(firstPatch, nextPatch);
   assert.notEqual(firstPatch, runtimeKey("/runtime/bin/julia", "1.13.0"));
   assert.notEqual(firstPatch, runtimeKey("/other/bin/julia", "1.12.2"));
-  assert.match(firstPatch, /^[0-9a-f]{16}$/);
+  // The minor version reads in the clear; only the executable path is
+  // hashed.
+  assert.match(firstPatch, /^v1\.12-[0-9a-f]{8}$/);
 });
 
 test("resolves Julia from the supplied PATH and handles explicit paths", async () => {
@@ -345,9 +391,13 @@ test("recognizes only the exact pinned JETLS version", () => {
   );
 });
 
-test("uses a verified cached installation without reinstalling", async () => {
+test("uses a verified current generation without reinstalling", async () => {
   await withFixture(async (fixture) => {
-    await createAppManifest(fixture.storagePath, fixture.juliaPath);
+    const generationPath = await seedGeneration(
+      fixture.storagePath,
+      fixture.juliaPath,
+      { stamped: false },
+    );
     const fake = standardRunner(fixture.juliaPath);
     const environment: NodeJS.ProcessEnv = {
       ...fixture.environment,
@@ -361,6 +411,7 @@ test("uses a verified cached installation without reinstalling", async () => {
     });
 
     assert.equal(installation.juliaPath, fixture.juliaPath);
+    assert.equal(installation.depotPath, generationPath);
     assert.equal(
       installation.env.JULIA_DEPOT_PATH,
       `${installation.depotPath}${path.delimiter}user-depot`,
@@ -384,21 +435,14 @@ test("uses a verified cached installation without reinstalling", async () => {
       `${installation.depotPath}${path.delimiter}user-depot`,
     );
     assert.equal(callsWithScript(fake.calls, "Pkg.Apps.add").length, 0);
-    assert.equal(callsWithScript(fake.calls, "Pkg.gc").length, 0);
   });
 });
 
 test("skips the version probe when the install stamp matches", async () => {
   await withFixture(async (fixture) => {
-    await createAppManifest(fixture.storagePath, fixture.juliaPath);
-    const depotPath = managedDepotPath(
+    const generationPath = await seedGeneration(
       fixture.storagePath,
       fixture.juliaPath,
-      "1.12.2",
-    );
-    await writeFile(
-      installStampPath(depotPath),
-      JSON.stringify({ revision: JETLS_REVISION, julia: "1.12.2" }),
     );
     const fake = standardRunner(fixture.juliaPath);
 
@@ -408,7 +452,7 @@ test("skips the version probe when the install stamp matches", async () => {
       processRunner: fake.runner,
     });
 
-    assert.equal(installation.depotPath, depotPath);
+    assert.equal(installation.depotPath, generationPath);
     assert.equal(fake.calls.length, 1);
     assert.equal(scriptFor(fake.calls[0]), "print(stdout, VERSION)");
   });
@@ -416,7 +460,9 @@ test("skips the version probe when the install stamp matches", async () => {
 
 test("stamps a verified installation for later fast starts", async () => {
   await withFixture(async (fixture) => {
-    await createAppManifest(fixture.storagePath, fixture.juliaPath);
+    await seedGeneration(fixture.storagePath, fixture.juliaPath, {
+      stamped: false,
+    });
     const fake = standardRunner(fixture.juliaPath);
     const options: ManagedInstallationOptions = {
       storagePath: fixture.storagePath,
@@ -438,15 +484,10 @@ test("stamps a verified installation for later fast starts", async () => {
 
 test("re-verifies when the stamp records another Julia patch version", async () => {
   await withFixture(async (fixture) => {
-    await createAppManifest(fixture.storagePath, fixture.juliaPath);
-    const depotPath = managedDepotPath(
+    const generationPath = await seedGeneration(
       fixture.storagePath,
       fixture.juliaPath,
-      "1.12.2",
-    );
-    await writeFile(
-      installStampPath(depotPath),
-      JSON.stringify({ revision: JETLS_REVISION, julia: "1.12.1" }),
+      { stampJuliaVersion: "1.12.1" },
     );
     const fake = standardRunner(fixture.juliaPath);
 
@@ -458,7 +499,7 @@ test("re-verifies when the stamp records another Julia patch version", async () 
 
     assert.equal(jetlsVersionCalls(fake.calls).length, 1);
     const stamp = JSON.parse(
-      await readFile(installStampPath(depotPath), "utf8"),
+      await readFile(installStampPath(generationPath), "utf8"),
     ) as { julia: string };
     assert.equal(stamp.julia, "1.12.2");
   });
@@ -466,7 +507,9 @@ test("re-verifies when the stamp records another Julia patch version", async () 
 
 test("invalidating the stamp restores the version probe", async () => {
   await withFixture(async (fixture) => {
-    await createAppManifest(fixture.storagePath, fixture.juliaPath);
+    await seedGeneration(fixture.storagePath, fixture.juliaPath, {
+      stamped: false,
+    });
     const fake = standardRunner(fixture.juliaPath);
     const options: ManagedInstallationOptions = {
       storagePath: fixture.storagePath,
@@ -483,7 +526,7 @@ test("invalidating the stamp restores the version probe", async () => {
   });
 });
 
-test("installs and verifies the exact pin in a private depot", async () => {
+test("installs and verifies the exact pin in a private generation depot", async () => {
   await withFixture(async (fixture) => {
     const fake = standardRunner(fixture.juliaPath);
     const progress: string[] = [];
@@ -499,11 +542,24 @@ test("installs and verifies the exact pin in a private depot", async () => {
       progress: (message) => progress.push(message),
     });
 
+    const containerPath = managedDepotPath(
+      fixture.storagePath,
+      fixture.juliaPath,
+      "1.12.2",
+    );
+    // The generation lives directly inside the container and is
+    // published through the `current` pointer.
+    assert.equal(path.dirname(installation.depotPath), containerPath);
+    assert.ok(path.basename(installation.depotPath).startsWith(JETLS_REVISION));
+    assert.equal(
+      await readCurrentGeneration(containerPath),
+      installation.depotPath,
+    );
+    await stat(installStampPath(installation.depotPath));
+
     const installCalls = callsWithScript(fake.calls, "Pkg.Apps.add");
-    const gcCalls = callsWithScript(fake.calls, "Pkg.gc");
     const versionCalls = jetlsVersionCalls(fake.calls);
     assert.equal(installCalls.length, 1);
-    assert.equal(gcCalls.length, 1);
     assert.equal(versionCalls.length, 1);
     assert.match(
       scriptFor(installCalls[0]) ?? "",
@@ -513,8 +569,9 @@ test("installs and verifies the exact pin in a private depot", async () => {
       scriptFor(installCalls[0]) ?? "",
       new RegExp(`rev="${JETLS_REVISION}"`),
     );
-    // The depot's own `bin` leads the install PATH, keeping `Pkg.Apps.add`
-    // from warning about a colliding `jetls` elsewhere on `PATH`.
+    // The generation's own `bin` leads the install PATH, keeping
+    // `Pkg.Apps.add` from warning about a colliding `jetls` elsewhere on
+    // `PATH`.
     assert.ok(
       (installCalls[0].options.env.PATH ?? "").startsWith(
         `${path.join(installation.depotPath, "bin")}${path.delimiter}`,
@@ -522,10 +579,6 @@ test("installs and verifies the exact pin in a private depot", async () => {
     );
     assert.equal(
       installCalls[0].options.env.JULIA_DEPOT_PATH,
-      `${installation.depotPath}${path.delimiter}`,
-    );
-    assert.equal(
-      gcCalls[0].options.env.JULIA_DEPOT_PATH,
       `${installation.depotPath}${path.delimiter}`,
     );
     assert.equal(
@@ -537,8 +590,7 @@ test("installs and verifies the exact pin in a private depot", async () => {
       `${installation.depotPath}${path.delimiter}user-depot`,
     );
     assert.ok(progress.some((message) => message.startsWith("Installing")));
-    assert.equal(progress.at(-1), "Cleaning up the JETLS depot...");
-    await assert.rejects(stat(`${installation.depotPath}.lock`));
+    await assert.rejects(stat(path.join(containerPath, "install.lock")));
   });
 });
 
@@ -659,9 +711,15 @@ test("keeps phases from the head of oversized output chunks", async () => {
   });
 });
 
-test("repairs a cached installation after failed verification", async () => {
+test("replaces the current generation after failed verification", async () => {
   await withFixture(async (fixture) => {
-    await createAppManifest(fixture.storagePath, fixture.juliaPath);
+    const seeded = await seedGeneration(
+      fixture.storagePath,
+      fixture.juliaPath,
+      {
+        stamped: false,
+      },
+    );
     const fake = standardRunner(fixture.juliaPath, {
       jetlsVersions: [
         failure(1, "broken stdout\n", "broken stderr\n"),
@@ -680,31 +738,39 @@ test("repairs a cached installation after failed verification", async () => {
     assert.equal(installation.juliaPath, fixture.juliaPath);
     assert.equal(callsWithScript(fake.calls, "Pkg.Apps.add").length, 1);
     assert.equal(jetlsVersionCalls(fake.calls).length, 2);
-    assert.ok(progress.includes("Repairing JETLS: Precompiling..."));
-    // The verified repair stamps the depot and consumes its backup and
-    // pending marker.
+    assert.ok(progress.includes("Installing JETLS: Precompiling..."));
+    // The replacement is a fresh generation; the broken one stays behind
+    // for cleanup instead of being repaired in place.
+    assert.notEqual(installation.depotPath, seeded);
     await stat(installStampPath(installation.depotPath));
-    await assert.rejects(
-      stat(path.join(installation.depotPath, "app-env-backup")),
+    const containerPath = managedDepotPath(
+      fixture.storagePath,
+      fixture.juliaPath,
+      "1.12.2",
     );
-    await assert.rejects(stat(installPendingPath(installation.depotPath)));
+    assert.equal(
+      await readCurrentGeneration(containerPath),
+      installation.depotPath,
+    );
   });
 });
 
-test("fails after one repair when the installed version still mismatches", async () => {
+test("fails when the fresh installation still mismatches the pin", async () => {
   await withFixture(async (fixture) => {
-    const manifest = await createAppManifest(
+    const seeded = await seedGeneration(
       fixture.storagePath,
       fixture.juliaPath,
+      {
+        stamped: false,
+      },
     );
-    await writeFile(manifest, "old manifest\n");
     const oldVersion = success(
       "jetls version 2026-08-05, julia version 1.12.2\n",
     );
     const fake = standardRunner(fixture.juliaPath, {
       jetlsVersions: [oldVersion, oldVersion],
     });
-    const expectedDepot = managedDepotPath(
+    const containerPath = managedDepotPath(
       fixture.storagePath,
       fixture.juliaPath,
       "1.12.2",
@@ -720,45 +786,40 @@ test("fails after one repair when the installed version still mismatches", async
         assert.ok(error instanceof ManagedJETLSError);
         assert.match(error.message, new RegExp(`expected ${JETLS_REVISION}`));
         assert.match(error.message, /Julia command:/);
-        assert.ok(error.message.includes(expectedDepot));
+        assert.ok(error.message.includes(containerPath));
         // The recovery hint speaks in VSCode terms, not internal API names.
         assert.match(error.message, /Reinstall Server/);
-        assert.doesNotMatch(
-          error.message,
-          /resetManagedJETLS|uninstallManagedJETLS/,
-        );
         assert.equal(error.retryable, true);
         assert.match(error.summary, /unexpected version/);
         return true;
       },
     );
     assert.equal(callsWithScript(fake.calls, "Pkg.Apps.add").length, 1);
-    assert.equal(callsWithScript(fake.calls, "Pkg.gc").length, 0);
-    // The failed process has exited, so the depot lock is released.
-    await assert.rejects(stat(`${expectedDepot}.lock`));
-    // The failed verification restores the previous environment and
-    // writes no stamp.
-    assert.equal(await readFile(manifest, "utf8"), "old manifest\n");
-    await assert.rejects(stat(installStampPath(expectedDepot)));
-    await assert.rejects(stat(path.join(expectedDepot, "app-env-backup")));
+    // The failed installation publishes nothing: the pointer still names
+    // the previous generation and the failed one carries no stamp.
+    assert.equal(await readCurrentGeneration(containerPath), seeded);
+    await assert.rejects(stat(path.join(containerPath, "install.lock")));
   });
 });
 
-test("a failed update restores the previous app environment", async () => {
+test("a failed update leaves the current generation untouched", async () => {
   await withFixture(async (fixture) => {
-    const manifest = await createAppManifest(
+    // The current generation carries a stamp for an older pin, as after
+    // an extension update.
+    const seeded = await seedGeneration(
       fixture.storagePath,
       fixture.juliaPath,
+      {
+        stampJuliaVersion: "1.12.2",
+      },
     );
-    await writeFile(manifest, "old manifest\n");
-    const environmentDir = path.dirname(manifest);
-    const appsDir = path.dirname(environmentDir);
-    await writeFile(path.join(environmentDir, "Project.toml"), "old project\n");
     await writeFile(
-      path.join(appsDir, "AppManifest.toml"),
-      "old appmanifest\n",
+      installStampPath(seeded),
+      JSON.stringify({ revision: "2026-08-05", julia: "1.12.2" }),
     );
-    const depotPath = managedDepotPath(
+    const manifest = path.join(managedEnvironment(seeded), "Manifest.toml");
+    await writeFile(manifest, "old manifest\n");
+    const containerPath = managedDepotPath(
       fixture.storagePath,
       fixture.juliaPath,
       "1.12.2",
@@ -766,20 +827,13 @@ test("a failed update restores the previous app environment", async () => {
     const fake = fakeRunner(async (call) => {
       const script = scriptFor(call);
       if (script?.includes("Pkg.Apps.add")) {
-        // A failed update may have partially rewritten the environment
-        // and the app manifest before erroring out.
-        await writeFile(manifest, "clobbered manifest\n");
-        await writeFile(
-          path.join(appsDir, "AppManifest.toml"),
-          "clobbered appmanifest\n",
-        );
         return failure(1, "", "could not download package sources\n");
       }
       if (script !== undefined) {
         return success("1.12.2\n");
       }
       if (isJETLSVersionCall(call)) {
-        // The cached installation still reports the previous pin.
+        // The current installation still reports the previous pin.
         return success("jetls version 2026-08-05, julia version 1.12.2\n");
       }
       throw new Error(`Unexpected process call: ${JSON.stringify(call)}`);
@@ -794,136 +848,22 @@ test("a failed update restores the previous app environment", async () => {
       }),
       (error: unknown) => {
         assert.ok(error instanceof ManagedJETLSError);
-        assert.equal(
-          error.summary,
-          "Failed to repair the managed JETLS installation.",
-        );
+        assert.match(error.summary, /Managed JETLS installation failed/);
         return true;
       },
     );
 
+    // The failed installation went to its own generation: the previous
+    // one, including its environment, is untouched and still current.
     assert.equal(await readFile(manifest, "utf8"), "old manifest\n");
-    assert.equal(
-      await readFile(path.join(environmentDir, "Project.toml"), "utf8"),
-      "old project\n",
-    );
-    assert.equal(
-      await readFile(path.join(appsDir, "AppManifest.toml"), "utf8"),
-      "old appmanifest\n",
-    );
-    await assert.rejects(stat(installStampPath(depotPath)));
-    await assert.rejects(stat(path.join(depotPath, "app-env-backup")));
-    await assert.rejects(stat(installPendingPath(depotPath)));
-    await assert.rejects(stat(`${depotPath}.lock`));
+    assert.equal(await readCurrentGeneration(containerPath), seeded);
+    await assert.rejects(stat(path.join(containerPath, "install.lock")));
   });
 });
 
-test("recovers the pre-crash backup before repairing", async () => {
+test("a surviving installer does not block a retry", async () => {
   await withFixture(async (fixture) => {
-    const manifest = await createAppManifest(
-      fixture.storagePath,
-      fixture.juliaPath,
-    );
-    await writeFile(manifest, "partial manifest\n");
-    const depotPath = managedDepotPath(
-      fixture.storagePath,
-      fixture.juliaPath,
-      "1.12.2",
-    );
-    // A crashed update left the pending marker, the pre-update backup,
-    // and a partially written environment behind.
-    const backupPath = path.join(depotPath, "app-env-backup");
-    await mkdir(path.join(backupPath, "JETLS"), { recursive: true });
-    await writeFile(
-      path.join(backupPath, "JETLS", "Manifest.toml"),
-      "good manifest\n",
-    );
-    await writeFile(
-      installPendingPath(depotPath),
-      JSON.stringify({ revision: JETLS_REVISION }),
-    );
-    const fake = fakeRunner(async (call) => {
-      const script = scriptFor(call);
-      if (script?.includes("Pkg.Apps.add")) {
-        return failure(1, "", "could not download package sources\n");
-      }
-      if (script !== undefined) {
-        return success("1.12.2\n");
-      }
-      if (isJETLSVersionCall(call)) {
-        return success("jetls version 2026-08-05, julia version 1.12.2\n");
-      }
-      throw new Error(`Unexpected process call: ${JSON.stringify(call)}`);
-    });
-
-    await assert.rejects(
-      ensureManagedJETLS({
-        storagePath: fixture.storagePath,
-        environment: fixture.environment,
-        processRunner: fake.runner,
-      }),
-    );
-
-    // The pre-crash state was restored before the fresh backup could
-    // overwrite it, and it survived the failed repair.
-    assert.equal(await readFile(manifest, "utf8"), "good manifest\n");
-    await assert.rejects(stat(installPendingPath(depotPath)));
-    await assert.rejects(stat(backupPath));
-  });
-});
-
-test("discards a stale backup without a pending marker", async () => {
-  await withFixture(async (fixture) => {
-    const manifest = await createAppManifest(
-      fixture.storagePath,
-      fixture.juliaPath,
-    );
-    await writeFile(manifest, "current manifest\n");
-    const depotPath = managedDepotPath(
-      fixture.storagePath,
-      fixture.juliaPath,
-      "1.12.2",
-    );
-    // A backup without a marker comes from a transaction that verified
-    // its environment afterwards; it must not be restored.
-    const backupPath = path.join(depotPath, "app-env-backup");
-    await mkdir(path.join(backupPath, "JETLS"), { recursive: true });
-    await writeFile(
-      path.join(backupPath, "JETLS", "Manifest.toml"),
-      "ancient manifest\n",
-    );
-    const fake = standardRunner(fixture.juliaPath, {
-      jetlsVersions: [
-        failure(1, "", "broken\n"),
-        success(`jetls version ${JETLS_REVISION}, julia version 1.12.2\n`),
-      ],
-    });
-
-    await ensureManagedJETLS({
-      storagePath: fixture.storagePath,
-      environment: fixture.environment,
-      processRunner: fake.runner,
-    });
-
-    assert.equal(await readFile(manifest, "utf8"), "current manifest\n");
-    await assert.rejects(stat(backupPath));
-    await assert.rejects(stat(installPendingPath(depotPath)));
-  });
-});
-
-test("a surviving installer leaves the backup and pending marker", async () => {
-  await withFixture(async (fixture) => {
-    const manifest = await createAppManifest(
-      fixture.storagePath,
-      fixture.juliaPath,
-    );
-    await writeFile(manifest, "old manifest\n");
-    const depotPath = managedDepotPath(
-      fixture.storagePath,
-      fixture.juliaPath,
-      "1.12.2",
-    );
-    const fake = fakeRunner(async (call) => {
+    const surviving = fakeRunner(async (call) => {
       const script = scriptFor(call);
       if (script?.includes("Pkg.Apps.add")) {
         return {
@@ -939,9 +879,6 @@ test("a surviving installer leaves the backup and pending marker", async () => {
       if (script !== undefined) {
         return success("1.12.2\n");
       }
-      if (isJETLSVersionCall(call)) {
-        return failure(1, "", "broken\n");
-      }
       throw new Error(`Unexpected process call: ${JSON.stringify(call)}`);
     });
 
@@ -949,153 +886,42 @@ test("a surviving installer leaves the backup and pending marker", async () => {
       ensureManagedJETLS({
         storagePath: fixture.storagePath,
         environment: fixture.environment,
-        processRunner: fake.runner,
+        processRunner: surviving.runner,
       }),
       (error: unknown) => {
         assert.ok(error instanceof ManagedJETLSError);
-        assert.equal(error.processMayBeAlive, true);
+        // The survivor only writes to its own unpublished generation, so
+        // a retry can help and the message merely notes the process.
+        assert.equal(error.retryable, true);
+        assert.match(error.message, /may still be running in the background/);
         return true;
       },
     );
 
-    // The surviving installer may still write: nothing is restored, and
-    // the kept marker sends the next start through the recovery.
-    await stat(installPendingPath(depotPath));
-    assert.equal(
-      await readFile(
-        path.join(depotPath, "app-env-backup", "JETLS", "Manifest.toml"),
-        "utf8",
-      ),
-      "old manifest\n",
+    // The retry installs into a fresh generation and succeeds while the
+    // survivor's generation stays behind for cleanup.
+    const fake = standardRunner(fixture.juliaPath);
+    const installation = await ensureManagedJETLS({
+      storagePath: fixture.storagePath,
+      environment: fixture.environment,
+      processRunner: fake.runner,
+    });
+    assert.equal(callsWithScript(fake.calls, "Pkg.Apps.add").length, 1);
+    const containerPath = managedDepotPath(
+      fixture.storagePath,
+      fixture.juliaPath,
+      "1.12.2",
     );
-    await stat(`${depotPath}.lock`);
+    assert.equal(
+      await readCurrentGeneration(containerPath),
+      installation.depotPath,
+    );
+    const generations = (await readdir(containerPath)).filter((entry) =>
+      entry.startsWith(JETLS_REVISION),
+    );
+    assert.equal(generations.length, 2);
   });
 });
-
-posixOnlyTest(
-  "aborts the start when the pending recovery cannot restore",
-  async () => {
-    await withFixture(async (fixture) => {
-      const manifest = await createAppManifest(
-        fixture.storagePath,
-        fixture.juliaPath,
-      );
-      const depotPath = managedDepotPath(
-        fixture.storagePath,
-        fixture.juliaPath,
-        "1.12.2",
-      );
-      const backupPath = path.join(depotPath, "app-env-backup");
-      await mkdir(path.join(backupPath, "JETLS"), { recursive: true });
-      await writeFile(
-        path.join(backupPath, "JETLS", "Manifest.toml"),
-        "good manifest\n",
-      );
-      await writeFile(
-        installPendingPath(depotPath),
-        JSON.stringify({ revision: JETLS_REVISION }),
-      );
-      // A read-only parent makes the apps directory undeletable, so the
-      // restore cannot complete.
-      const environmentsDir = path.dirname(
-        path.dirname(path.dirname(manifest)),
-      );
-      await chmod(environmentsDir, 0o555);
-      const fake = standardRunner(fixture.juliaPath);
-
-      try {
-        await assert.rejects(
-          ensureManagedJETLS({
-            storagePath: fixture.storagePath,
-            environment: fixture.environment,
-            processRunner: fake.runner,
-          }),
-          /Failed to restore the app environments backup/,
-        );
-      } finally {
-        await chmod(environmentsDir, 0o755);
-      }
-
-      // The marker and the backup survive, so a later start can retry.
-      await stat(installPendingPath(depotPath));
-      await stat(path.join(backupPath, "JETLS", "Manifest.toml"));
-    });
-  },
-);
-
-posixOnlyTest(
-  "keeps the marker and backup when the rollback cannot restore",
-  async () => {
-    await withFixture(async (fixture) => {
-      const manifest = await createAppManifest(
-        fixture.storagePath,
-        fixture.juliaPath,
-      );
-      await writeFile(manifest, "old manifest\n");
-      const depotPath = managedDepotPath(
-        fixture.storagePath,
-        fixture.juliaPath,
-        "1.12.2",
-      );
-      const environmentsDir = path.dirname(
-        path.dirname(path.dirname(manifest)),
-      );
-      const logs: string[] = [];
-      const fake = fakeRunner(async (call) => {
-        const script = scriptFor(call);
-        if (script?.includes("Pkg.Apps.add")) {
-          // Break the restore before the install failure returns.
-          await chmod(environmentsDir, 0o555);
-          return failure(1, "", "could not download package sources\n");
-        }
-        if (script !== undefined) {
-          return success("1.12.2\n");
-        }
-        if (isJETLSVersionCall(call)) {
-          return failure(1, "", "broken\n");
-        }
-        throw new Error(`Unexpected process call: ${JSON.stringify(call)}`);
-      });
-
-      try {
-        await assert.rejects(
-          ensureManagedJETLS({
-            storagePath: fixture.storagePath,
-            environment: fixture.environment,
-            processRunner: fake.runner,
-            logger: (message) => logs.push(message),
-          }),
-          (error: unknown) => {
-            assert.ok(error instanceof ManagedJETLSError);
-            // The installation error stays the surfaced one.
-            assert.match(
-              error.summary,
-              /Failed to repair the managed JETLS installation/,
-            );
-            return true;
-          },
-        );
-      } finally {
-        await chmod(environmentsDir, 0o755);
-      }
-
-      assert.ok(
-        logs.some((message) =>
-          message.includes("Failed to restore the app environments backup"),
-        ),
-      );
-      // The marker and the backup survive, so a later start can retry.
-      await stat(installPendingPath(depotPath));
-      assert.equal(
-        await readFile(
-          path.join(depotPath, "app-env-backup", "JETLS", "Manifest.toml"),
-          "utf8",
-        ),
-        "old manifest\n",
-      );
-    });
-  },
-);
 
 test("classifies first-install failures as retryable install errors", async () => {
   await withFixture(async (fixture) => {
@@ -1124,7 +950,6 @@ test("classifies first-install failures as retryable install errors", async () =
       (error: unknown) => {
         assert.ok(error instanceof ManagedJETLSError);
         assert.equal(error.retryable, true);
-        assert.equal(error.processMayBeAlive, false);
         assert.equal(
           error.summary,
           "Managed JETLS installation failed with status 1",
@@ -1135,48 +960,8 @@ test("classifies first-install failures as retryable install errors", async () =
       },
     );
 
-    // The failed process has exited, so the lock is released, and a first
-    // install has no previous environment to back up.
-    await assert.rejects(stat(`${expectedDepot}.lock`));
-    await assert.rejects(stat(path.join(expectedDepot, "app-env-backup")));
-    await assert.rejects(stat(installPendingPath(expectedDepot)));
-  });
-});
-
-test("classifies a failed repair of a broken cache as a repair error", async () => {
-  await withFixture(async (fixture) => {
-    await createAppManifest(fixture.storagePath, fixture.juliaPath);
-    const fake = fakeRunner(async (call) => {
-      const script = scriptFor(call);
-      if (script?.includes("Pkg.Apps.add")) {
-        return failure(1, "", "could not download package sources\n");
-      }
-      if (script !== undefined) {
-        return success("1.12.2\n");
-      }
-      if (isJETLSVersionCall(call)) {
-        return failure(1, "", "broken installation\n");
-      }
-      throw new Error(`Unexpected process call: ${JSON.stringify(call)}`);
-    });
-
-    await assert.rejects(
-      ensureManagedJETLS({
-        storagePath: fixture.storagePath,
-        environment: fixture.environment,
-        processRunner: fake.runner,
-      }),
-      (error: unknown) => {
-        assert.ok(error instanceof ManagedJETLSError);
-        assert.equal(error.retryable, true);
-        assert.match(error.message, /may need network access/);
-        assert.equal(
-          error.summary,
-          "Failed to repair the managed JETLS installation.",
-        );
-        return true;
-      },
-    );
+    // The failed process has exited, so the install lock is released.
+    await assert.rejects(stat(path.join(expectedDepot, "install.lock")));
   });
 });
 
@@ -1226,119 +1011,160 @@ test("classifies an unresolvable Julia command as a resolution failure", async (
   });
 });
 
-test("ignores garbage collection failure after a verified install", async () => {
+test("force install replaces a verified current generation", async () => {
   await withFixture(async (fixture) => {
-    const fake = standardRunner(fixture.juliaPath, {
-      gcResult: failure(1, "gc stdout\n", "gc stderr\n"),
-    });
-    const logs: string[] = [];
+    const seeded = await seedGeneration(fixture.storagePath, fixture.juliaPath);
+    const fake = standardRunner(fixture.juliaPath);
 
     const installation = await ensureManagedJETLS({
       storagePath: fixture.storagePath,
       environment: fixture.environment,
       processRunner: fake.runner,
-      logger: (message) => logs.push(message),
+      forceInstall: true,
     });
 
-    assert.equal(installation.juliaPath, fixture.juliaPath);
-    assert.equal(callsWithScript(fake.calls, "Pkg.gc").length, 1);
-    assert.ok(logs.some((message) => message.includes("gc stdout")));
-    assert.ok(
-      logs.some((message) =>
-        message.includes("garbage collection failed and was ignored"),
-      ),
-    );
-  });
-});
-
-test("uninstalls the managed depot for the current Julia runtime", async () => {
-  await withFixture(async (fixture) => {
-    const depotPath = managedDepotPath(
+    assert.equal(callsWithScript(fake.calls, "Pkg.Apps.add").length, 1);
+    assert.notEqual(installation.depotPath, seeded);
+    const containerPath = managedDepotPath(
       fixture.storagePath,
       fixture.juliaPath,
       "1.12.2",
     );
-    await mkdir(depotPath, { recursive: true });
-    await writeFile(path.join(depotPath, "state"), "managed");
-    const fake = standardRunner(fixture.juliaPath);
-
-    const confirmed: string[] = [];
-
-    const removedPath = await uninstallManagedJETLS(
-      {
-        storagePath: fixture.storagePath,
-        environment: fixture.environment,
-        processRunner: fake.runner,
-      },
-      (candidate) => {
-        confirmed.push(candidate);
-        return true;
-      },
-    );
-
-    assert.equal(removedPath, depotPath);
-    // The confirmation sees the exact depot the uninstall then deletes.
-    assert.deepEqual(confirmed, [depotPath]);
-    await assert.rejects(stat(depotPath));
-    await assert.rejects(stat(`${depotPath}.lock`));
-    assert.equal(fake.calls.length, 1);
-    assert.equal(scriptFor(fake.calls[0]), "print(stdout, VERSION)");
-  });
-});
-
-test("a declined uninstall confirmation deletes nothing", async () => {
-  await withFixture(async (fixture) => {
-    const depotPath = managedDepotPath(
-      fixture.storagePath,
-      fixture.juliaPath,
-      "1.12.2",
-    );
-    await mkdir(depotPath, { recursive: true });
-    await writeFile(path.join(depotPath, "state"), "managed");
-    const fake = standardRunner(fixture.juliaPath);
-
-    const removedPath = await uninstallManagedJETLS(
-      {
-        storagePath: fixture.storagePath,
-        environment: fixture.environment,
-        processRunner: fake.runner,
-      },
-      () => false,
-    );
-
-    assert.equal(removedPath, undefined);
     assert.equal(
-      await readFile(path.join(depotPath, "state"), "utf8"),
-      "managed",
+      await readCurrentGeneration(containerPath),
+      installation.depotPath,
     );
-    await assert.rejects(stat(`${depotPath}.lock`));
+    // The previous generation is left for cleanup, not deleted up front:
+    // another window may still be running a server from it.
+    await stat(seeded);
   });
 });
 
-test("filesystem lock serializes concurrent ensures for the same depot", async () => {
+test("cleanup removes aged generations but never the current one", async () => {
   await withFixture(async (fixture) => {
-    // The fake install leaves the manifest behind like the real one, so
-    // the lock-race loser can recognize the winner's finished work.
-    const fake = fakeRunner(async (call) => {
-      const script = scriptFor(call);
-      if (script?.includes("Pkg.Apps.add")) {
-        await new Promise((resolve) => setTimeout(resolve, 150));
-        await createAppManifest(fixture.storagePath, fixture.juliaPath);
-        return success("installed\n");
-      }
-      if (script?.includes("Pkg.gc")) {
-        return success();
-      }
-      if (script !== undefined) {
-        return success("1.12.2\n");
-      }
-      if (isJETLSVersionCall(call)) {
-        return success(
-          `jetls version ${JETLS_REVISION}, julia version 1.12.2\n`,
-        );
-      }
-      throw new Error(`Unexpected process call: ${JSON.stringify(call)}`);
+    const seeded = await seedGeneration(fixture.storagePath, fixture.juliaPath);
+    const containerPath = managedDepotPath(
+      fixture.storagePath,
+      fixture.juliaPath,
+      "1.12.2",
+    );
+    // An old unpublished generation (a crashed or surviving install), an
+    // old published one (long superseded), and a fresh published one.
+    const crashed = await seedUnreferencedGeneration(
+      containerPath,
+      "crashed",
+      false,
+    );
+    await setAgeMs(crashed, 25 * 60 * 60 * 1000);
+    const superseded = await seedUnreferencedGeneration(
+      containerPath,
+      "superseded",
+      true,
+    );
+    await writeFile(lastUsedPath(superseded), "");
+    await setAgeMs(lastUsedPath(superseded), 8 * 24 * 60 * 60 * 1000);
+    const recent = await seedUnreferencedGeneration(
+      containerPath,
+      "recent",
+      true,
+    );
+    await writeFile(lastUsedPath(recent), "");
+    // The current generation is exempt from the age judgment entirely.
+    await writeFile(lastUsedPath(seeded), "");
+    await setAgeMs(lastUsedPath(seeded), 30 * 24 * 60 * 60 * 1000);
+    const fake = standardRunner(fixture.juliaPath);
+
+    const installation = await ensureManagedJETLS({
+      storagePath: fixture.storagePath,
+      environment: fixture.environment,
+      processRunner: fake.runner,
     });
+
+    assert.equal(installation.depotPath, seeded);
+    await assert.rejects(stat(crashed));
+    await assert.rejects(stat(superseded));
+    await stat(recent);
+    await stat(seeded);
+    // The resolution marks both the generation and the runtime container
+    // as used.
+    await stat(lastUsedPath(seeded));
+    await stat(lastUsedPath(containerPath));
+  });
+});
+
+test("cleanup removes runtime containers of Julia versions no longer used", async () => {
+  await withFixture(async (fixture) => {
+    await seedGeneration(fixture.storagePath, fixture.juliaPath);
+    const containerPath = managedDepotPath(
+      fixture.storagePath,
+      fixture.juliaPath,
+      "1.12.2",
+    );
+    const depotsPath = path.dirname(containerPath);
+    // A runtime nothing resolved past the retention, one still in use,
+    // and a marker-less leftover (e.g. a legacy lock directory) judged by
+    // its own mtime.
+    const staleRuntime = path.join(depotsPath, "stale-runtime");
+    await mkdir(staleRuntime, { recursive: true });
+    await writeFile(lastUsedPath(staleRuntime), "");
+    await setAgeMs(lastUsedPath(staleRuntime), 31 * 24 * 60 * 60 * 1000);
+    const liveRuntime = path.join(depotsPath, "live-runtime");
+    await mkdir(liveRuntime, { recursive: true });
+    await writeFile(lastUsedPath(liveRuntime), "");
+    const leftover = path.join(depotsPath, "leftover.lock");
+    await mkdir(leftover, { recursive: true });
+    await setAgeMs(leftover, 31 * 24 * 60 * 60 * 1000);
+    const fake = standardRunner(fixture.juliaPath);
+
+    await ensureManagedJETLS({
+      storagePath: fixture.storagePath,
+      environment: fixture.environment,
+      processRunner: fake.runner,
+    });
+
+    await assert.rejects(stat(staleRuntime));
+    await assert.rejects(stat(leftover));
+    await stat(liveRuntime);
+    await stat(containerPath);
+  });
+});
+
+test("cleanup ages out entries outside the generation layout", async () => {
+  await withFixture(async (fixture) => {
+    const seeded = await seedGeneration(fixture.storagePath, fixture.juliaPath);
+    const containerPath = managedDepotPath(
+      fixture.storagePath,
+      fixture.juliaPath,
+      "1.12.2",
+    );
+    // Leftovers from an older layout are judged like unpublished
+    // generations: removed once aged, kept while fresh.
+    const legacyDir = path.join(containerPath, "environments");
+    await mkdir(path.join(legacyDir, "apps"), { recursive: true });
+    await setAgeMs(legacyDir, 25 * 60 * 60 * 1000);
+    const legacyFile = path.join(containerPath, "install-stamp.json");
+    await writeFile(legacyFile, "{}");
+    await setAgeMs(legacyFile, 25 * 60 * 60 * 1000);
+    const freshEntry = path.join(containerPath, "fresh-entry");
+    await mkdir(freshEntry, { recursive: true });
+    const fake = standardRunner(fixture.juliaPath);
+
+    await ensureManagedJETLS({
+      storagePath: fixture.storagePath,
+      environment: fixture.environment,
+      processRunner: fake.runner,
+    });
+
+    await assert.rejects(stat(legacyDir));
+    await assert.rejects(stat(legacyFile));
+    await stat(freshEntry);
+    await stat(seeded);
+  });
+});
+
+test("the install lock serializes concurrent ensures for the same runtime", async () => {
+  await withFixture(async (fixture) => {
+    const fake = standardRunner(fixture.juliaPath, { installDelay: 150 });
     const options: ManagedInstallationOptions = {
       storagePath: fixture.storagePath,
       environment: fixture.environment,
@@ -1352,379 +1178,38 @@ test("filesystem lock serializes concurrent ensures for the same depot", async (
 
     assert.equal(first.depotPath, second.depotPath);
     // Both callers query the Julia version, but the loser of the lock
-    // race finds the winner's verified installation and stamp.
+    // race adopts the winner's published generation instead of
+    // duplicating the installation.
     assert.equal(
       callsWithScript(fake.calls, "print(stdout, VERSION)").length,
       2,
     );
     assert.equal(callsWithScript(fake.calls, "Pkg.Apps.add").length, 1);
     assert.equal(jetlsVersionCalls(fake.calls).length, 1);
-    assert.equal(callsWithScript(fake.calls, "Pkg.gc").length, 1);
   });
 });
 
-async function seedLock(
-  depotPath: string,
-  owner?: Record<string, unknown>,
-): Promise<string> {
-  const lockPath = `${depotPath}.lock`;
-  await mkdir(lockPath, { recursive: true });
-  if (owner !== undefined) {
-    await writeFile(path.join(lockPath, "owner.json"), JSON.stringify(owner));
-  }
-  return lockPath;
-}
-
-test("reclaims a lock whose owner process is dead", async () => {
+test("removes a stale install lock by age", async () => {
   await withFixture(async (fixture) => {
-    const depotPath = managedDepotPath(
+    const containerPath = managedDepotPath(
       fixture.storagePath,
       fixture.juliaPath,
       "1.12.2",
     );
-    await seedLock(depotPath, {
-      pid: 999999999,
-      createdAt: new Date().toISOString(),
-    });
+    const lockPath = path.join(containerPath, "install.lock");
+    await mkdir(lockPath, { recursive: true });
+    // Older than the whole installation budget: its holder is dead.
+    await setAgeMs(lockPath, 17 * 60 * 1000);
     const fake = standardRunner(fixture.juliaPath);
-
-    const installation = await ensureManagedJETLS({
-      storagePath: fixture.storagePath,
-      environment: fixture.environment,
-      processRunner: fake.runner,
-    });
-
-    assert.equal(installation.depotPath, depotPath);
-    await assert.rejects(stat(`${depotPath}.lock`));
-  });
-});
-
-test("reclaims an incomplete lock after the grace period", async () => {
-  await withFixture(async (fixture) => {
-    const depotPath = managedDepotPath(
-      fixture.storagePath,
-      fixture.juliaPath,
-      "1.12.2",
-    );
-    // A lock directory without a readable owner is a crashed acquisition;
-    // it is reclaimed once its mtime has outlived the grace period.
-    const lockPath = await seedLock(depotPath);
-    const past = new Date(Date.now() - 60 * 1000);
-    await utimes(lockPath, past, past);
-    const fake = standardRunner(fixture.juliaPath);
-
-    const installation = await ensureManagedJETLS({
-      storagePath: fixture.storagePath,
-      environment: fixture.environment,
-      processRunner: fake.runner,
-    });
-
-    assert.equal(installation.depotPath, depotPath);
-    await assert.rejects(stat(`${depotPath}.lock`));
-  });
-});
-
-posixOnlyTest(
-  "keeps a dead host's lock while its surviving process lives",
-  async () => {
-    await withFixture(async (fixture) => {
-      const depotPath = managedDepotPath(
-        fixture.storagePath,
-        fixture.juliaPath,
-        "1.12.2",
-      );
-      // The managed process outlived its extension host: the host PID is
-      // dead, but the recorded process group still runs detached.
-      const survivor = spawn("sleep", ["30"], {
-        detached: true,
-        stdio: "ignore",
-      });
-      const survivorPid = survivor.pid;
-      assert.ok(survivorPid !== undefined);
-      try {
-        const lockPath = await seedLock(depotPath, {
-          pid: 999999999,
-          createdAt: new Date().toISOString(),
-          activeGroup: survivorPid,
-        });
-
-        assert.equal(await removeStaleLock(lockPath), false);
-        await stat(lockPath);
-
-        const exited = new Promise((resolve) => survivor.once("exit", resolve));
-        process.kill(-survivorPid, "SIGKILL");
-        await exited;
-
-        assert.equal(await removeStaleLock(lockPath), true);
-        await assert.rejects(stat(lockPath));
-      } finally {
-        try {
-          process.kill(-survivorPid, "SIGKILL");
-        } catch {
-          // Already gone.
-        }
-      }
-    });
-  },
-);
-
-test("records the active process in the lock owner while it runs", async () => {
-  await withFixture(async (fixture) => {
-    const depotPath = managedDepotPath(
-      fixture.storagePath,
-      fixture.juliaPath,
-      "1.12.2",
-    );
-    const ownerPath = path.join(`${depotPath}.lock`, "owner.json");
-    const fake = fakeRunner(async (call) => {
-      const script = scriptFor(call);
-      if (script?.includes("Pkg.Apps.add")) {
-        call.options.onPid?.(7777);
-        // The registration write races the (fake) process start; poll
-        // briefly for it to land.
-        let owner: { activeGroup?: number } = {};
-        for (let attempt = 0; attempt < 100; attempt += 1) {
-          try {
-            owner = JSON.parse(await readFile(ownerPath, "utf8")) as {
-              activeGroup?: number;
-            };
-            if (owner.activeGroup === 7777) {
-              break;
-            }
-          } catch {
-            // Not written yet.
-          }
-          await new Promise((resolve) => setTimeout(resolve, 10));
-        }
-        assert.equal(owner.activeGroup, 7777);
-        return success("installed\n");
-      }
-      if (script?.includes("Pkg.gc")) {
-        return success();
-      }
-      if (script !== undefined) {
-        return success("1.12.2\n");
-      }
-      if (isJETLSVersionCall(call)) {
-        return success(
-          `jetls version ${JETLS_REVISION}, julia version 1.12.2\n`,
-        );
-      }
-      throw new Error(`Unexpected process call: ${JSON.stringify(call)}`);
-    });
 
     await ensureManagedJETLS({
       storagePath: fixture.storagePath,
       environment: fixture.environment,
       processRunner: fake.runner,
     });
-  });
-});
 
-test("clears the completed process from the lock owner", async () => {
-  await withFixture(async (fixture) => {
-    const depotPath = managedDepotPath(
-      fixture.storagePath,
-      fixture.juliaPath,
-      "1.12.2",
-    );
-    const fake = fakeRunner(async (call) => {
-      const script = scriptFor(call);
-      if (script?.includes("Pkg.Apps.add")) {
-        call.options.onPid?.(7777);
-        return success("installed\n");
-      }
-      if (script !== undefined) {
-        return success("1.12.2\n");
-      }
-      if (isJETLSVersionCall(call)) {
-        // The post-install verification survives termination without ever
-        // reporting a pid, keeping the lock with no recorded process.
-        return {
-          status: null,
-          stdout: "",
-          stderr: "",
-          error:
-            "Process timed out after 10 ms. " +
-            "The process did not exit after termination.",
-          processMayBeAlive: true,
-        };
-      }
-      throw new Error(`Unexpected process call: ${JSON.stringify(call)}`);
-    });
-
-    await assert.rejects(
-      ensureManagedJETLS({
-        storagePath: fixture.storagePath,
-        environment: fixture.environment,
-        processRunner: fake.runner,
-      }),
-    );
-
-    // The installer that completed was cleared from the owner file; only
-    // the host PID remains.
-    const owner = JSON.parse(
-      await readFile(path.join(`${depotPath}.lock`, "owner.json"), "utf8"),
-    ) as { activeGroup?: number };
-    assert.equal(owner.activeGroup, undefined);
-  });
-});
-
-test("keeps a dead Windows host's lock until a reboot confirms the tree", async () => {
-  await withFixture(async (fixture) => {
-    const depotPath = managedDepotPath(
-      fixture.storagePath,
-      fixture.juliaPath,
-      "1.12.2",
-    );
-    // The recorded process is dead, but on Windows its child tree cannot
-    // be confirmed dead while the system stays up.
-    const lockPath = await seedLock(depotPath, {
-      pid: 999999999,
-      createdAt: new Date().toISOString(),
-      activeGroup: 999999998,
-    });
-
-    assert.equal(await removeStaleLock(lockPath, "win32"), false);
-    await stat(lockPath);
-
-    // A record from before the current boot proves the tree is gone.
-    await writeFile(
-      path.join(lockPath, "owner.json"),
-      JSON.stringify({
-        pid: 999999999,
-        createdAt: "2000-01-01T00:00:00.000Z",
-        activeGroup: 999999998,
-      }),
-    );
-    assert.equal(await removeStaleLock(lockPath, "win32"), true);
+    assert.equal(callsWithScript(fake.calls, "Pkg.Apps.add").length, 1);
     await assert.rejects(stat(lockPath));
-  });
-});
-
-test("reclaims an abandoned lock once its recorded survivor is gone", async () => {
-  await withFixture(async (fixture) => {
-    const depotPath = managedDepotPath(
-      fixture.storagePath,
-      fixture.juliaPath,
-      "1.12.2",
-    );
-    // The owner host (this process) is alive but has ceded the lock to a
-    // survivor that is now gone.
-    const lockPath = await seedLock(depotPath, {
-      pid: process.pid,
-      createdAt: new Date().toISOString(),
-      activeGroup: 999999998,
-      abandoned: true,
-    });
-
-    assert.equal(await removeStaleLock(lockPath, "linux"), true);
-    await assert.rejects(stat(lockPath));
-    // The steal-by-rename reclaim leaves no renamed instance behind.
-    const siblings = await readdir(path.dirname(lockPath));
-    assert.ok(siblings.every((entry) => !entry.includes(".reclaim-")));
-  });
-});
-
-test("keeps an abandoned lock while its recorded survivor lives", async () => {
-  await withFixture(async (fixture) => {
-    const depotPath = managedDepotPath(
-      fixture.storagePath,
-      fixture.juliaPath,
-      "1.12.2",
-    );
-    // `activeGroup` is probed directly on win32, so the test process can
-    // stand in for a live survivor; `createdAt` predates the boot so
-    // only the group probe keeps the lock in force.
-    const lockPath = await seedLock(depotPath, {
-      pid: process.pid,
-      createdAt: "2000-01-01T00:00:00.000Z",
-      activeGroup: process.pid,
-      abandoned: true,
-    });
-
-    assert.equal(await removeStaleLock(lockPath, "win32"), false);
-    await stat(lockPath);
-  });
-});
-
-test("keeps an abandoned Windows lock until a reboot confirms the survivor", async () => {
-  await withFixture(async (fixture) => {
-    const depotPath = managedDepotPath(
-      fixture.storagePath,
-      fixture.juliaPath,
-      "1.12.2",
-    );
-    const lockPath = await seedLock(depotPath, {
-      pid: process.pid,
-      createdAt: new Date().toISOString(),
-      activeGroup: 999999998,
-      abandoned: true,
-    });
-
-    assert.equal(await removeStaleLock(lockPath, "win32"), false);
-    await stat(lockPath);
-
-    await writeFile(
-      path.join(lockPath, "owner.json"),
-      JSON.stringify({
-        pid: process.pid,
-        createdAt: "2000-01-01T00:00:00.000Z",
-        activeGroup: 999999998,
-        abandoned: true,
-      }),
-    );
-    assert.equal(await removeStaleLock(lockPath, "win32"), true);
-    await assert.rejects(stat(lockPath));
-  });
-});
-
-test("fails immediately with reboot guidance for an unconfirmable Windows lock", async () => {
-  await withFixture(async (fixture) => {
-    const depotPath = managedDepotPath(
-      fixture.storagePath,
-      fixture.juliaPath,
-      "1.12.2",
-    );
-    const lockPath = await seedLock(depotPath, {
-      pid: 999999999,
-      createdAt: new Date().toISOString(),
-      activeGroup: 999999998,
-    });
-    const fake = standardRunner(fixture.juliaPath);
-    // Keep a regression from waiting for the full installation timeout.
-    const releaseStuckLock = setTimeout(() => {
-      void rm(lockPath, { recursive: true, force: true });
-    }, 500);
-
-    try {
-      await assert.rejects(
-        ensureManagedJETLS({
-          storagePath: fixture.storagePath,
-          environment: fixture.environment,
-          juliaCommand: fixture.juliaPath,
-          processRunner: fake.runner,
-          platform: "win32",
-        }),
-        (error: unknown) => {
-          assert.ok(error instanceof ManagedJETLSError);
-          assert.equal(error.processMayBeAlive, true);
-          assert.equal(error.retryable, true);
-          assert.match(error.summary, /Restart Windows/);
-          assert.match(error.message, /restart Windows/);
-          assert.doesNotMatch(error.message, /Reinstall Server/);
-          return true;
-        },
-      );
-    } finally {
-      clearTimeout(releaseStuckLock);
-    }
-
-    assert.equal(
-      callsWithScript(fake.calls, "print(stdout, VERSION)").length,
-      1,
-    );
-    assert.equal(callsWithScript(fake.calls, "Pkg.Apps.add").length, 0);
   });
 });
 
@@ -1954,117 +1439,6 @@ test("marks survival when group members outlive the closed parent", async () => 
     /Process timed out after 10 ms\. The process did not exit after termination\./,
   );
 });
-
-test("keeps the depot lock when the install process survives termination", async () => {
-  await withFixture(async (fixture) => {
-    const fake = fakeRunner(async (call) => {
-      const script = scriptFor(call);
-      if (
-        call.command === fixture.juliaPath &&
-        script?.includes("Pkg.Apps.add")
-      ) {
-        call.options.onPid?.(4321);
-        return {
-          status: null,
-          stdout: "",
-          stderr: "",
-          error:
-            "Process timed out after 10 ms. " +
-            "The process did not exit after termination.",
-          processMayBeAlive: true,
-        };
-      }
-      if (call.command === fixture.juliaPath && script !== undefined) {
-        return success("1.12.2\n");
-      }
-      throw new Error(`Unexpected process call: ${JSON.stringify(call)}`);
-    });
-    const depotPath = managedDepotPath(
-      fixture.storagePath,
-      fixture.juliaPath,
-      "1.12.2",
-    );
-
-    await assert.rejects(
-      ensureManagedJETLS({
-        storagePath: fixture.storagePath,
-        environment: fixture.environment,
-        processRunner: fake.runner,
-      }),
-      (error: unknown) => {
-        assert.ok(error instanceof ManagedJETLSError);
-        assert.match(error.message, /did not exit after termination/);
-        // The recovery hint must not point at reinstall or manual
-        // deletion, which would wait on or race the surviving process.
-        assert.match(error.message, /end that process \(or reboot\)/);
-        assert.equal(error.processMayBeAlive, true);
-        return true;
-      },
-    );
-
-    // The surviving installer may still write to the depot: the lock
-    // stays, and its owner file still records the process registered at
-    // spawn — marked abandoned, so any host (including this one on a
-    // retry) reclaims the lock exactly once that process group is
-    // confirmed gone.
-    await stat(`${depotPath}.lock`);
-    const owner = JSON.parse(
-      await readFile(path.join(`${depotPath}.lock`, "owner.json"), "utf8"),
-    ) as { activeGroup?: number; abandoned?: boolean };
-    assert.equal(owner.activeGroup, 4321);
-    assert.equal(owner.abandoned, true);
-  });
-});
-
-posixOnlyTest(
-  "retry reclaims the abandoned lock once the survivor is gone",
-  async () => {
-    await withFixture(async (fixture) => {
-      const surviving = fakeRunner(async (call) => {
-        const script = scriptFor(call);
-        if (
-          call.command === fixture.juliaPath &&
-          script?.includes("Pkg.Apps.add")
-        ) {
-          call.options.onPid?.(999999998);
-          return {
-            status: null,
-            stdout: "",
-            stderr: "",
-            error: "The process did not exit after termination.",
-            processMayBeAlive: true,
-          };
-        }
-        if (call.command === fixture.juliaPath && script !== undefined) {
-          return success("1.12.2\n");
-        }
-        throw new Error(`Unexpected process call: ${JSON.stringify(call)}`);
-      });
-      await assert.rejects(
-        ensureManagedJETLS({
-          storagePath: fixture.storagePath,
-          environment: fixture.environment,
-          processRunner: surviving.runner,
-        }),
-        /did not exit after termination/,
-      );
-
-      // The recorded survivor is a dead PID, so the retry reclaims the
-      // abandoned lock even though the abandoning host is this process.
-      const fake = standardRunner(fixture.juliaPath);
-      const installation = await ensureManagedJETLS({
-        storagePath: fixture.storagePath,
-        environment: fixture.environment,
-        processRunner: fake.runner,
-      });
-      assert.equal(
-        installation.depotPath,
-        managedDepotPath(fixture.storagePath, fixture.juliaPath, "1.12.2"),
-      );
-      await assert.rejects(stat(`${installation.depotPath}.lock`));
-    });
-  },
-);
 
 test("terminates timed-out process trees with taskkill on Windows", async () => {
   const child = new FakeChildProcess();


### PR DESCRIPTION
The managed installation updated one shared depot per Julia runtime in place. Keeping that safe required heavy machinery (environment backups with a crash-safe pending marker, process tracking in the lock owner file, steal-by-rename lock reclaim, a Windows reboot boundary) and still could not protect a server another VSCode window was running out of the same depot: an update or reinstall in one window could delete packages and caches under a live server in another.

Installations now live in immutable generations:

- Each installation goes to a fresh self-contained depot under `jetls-depots/<runtimeKey>/<revision>-<random>` (runtime key like `v1.12-<hash8>`: Julia minor version in the clear, executable path hashed) and is published by atomically rewriting the container's `current` pointer file. Published generations are never mutated, so a failed, crashed, or surviving installation only strands its own unpublished directory and the previous installation keeps working — in every window.
- That immutability deletes the recovery machinery wholesale: backups, the pending marker, lock owner tracking, survivor handoff, reclaim races, the Windows reboot branch, and the post-install `Pkg.gc` pass (net −996 lines).
- The install lock is only a duplicate-work guard now: reclaimed by age, waiters adopt the generation the holder publishes, and safety never depends on it. Failures are always retryable, and `JETLS Client: Reinstall Server` just forces a fresh generation, deleting nothing up front.
- Cleanup runs after each successful start: unpublished generations go after 24 hours, superseded generations after 7 days unused, and whole runtime containers — stranded when the user switches Julia executables or minor versions — after 30 days unused. The current generation and the active container are never removed.

The commit message records the full design rationale.
