### PR TITLE
jetls-client: Cancel managed setups on restart and deactivate

### DIFF
--- a/jetls-client/CHANGELOG.md
+++ b/jetls-client/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project uses [calendar versioning](https://calver.org/) (`YYYY.M.D`, th
   Set `jetls-client.executable.env.JULIA_APPS_JULIA_CMD` to select another Julia executable, or specify `jetls-client.executable.path` or a full command array to bypass managed installation.
 
 - Added status bar updates and live process output for managed installation checks, downloads, startup, and failures.
-  Failure notifications offer to retry and to show the JETLS output with the full details; configuration problems additionally offer to open the executable setting.
+  Actual installations additionally show a progress notification ticking with the live installation output, whose `Cancel` button aborts the installation without affecting the previously installed server.
+  Failure notifications offer to show the JETLS output with the full details, plus a retry when retrying can help; configuration problems offer to open the executable setting instead.
 
 - Added the `JETLS Client: Reinstall Server` command for recovering from a broken managed installation.
   The command asks for confirmation and installs a fresh copy, since reinstalling may require network access.

--- a/jetls-client/README.md
+++ b/jetls-client/README.md
@@ -56,7 +56,8 @@ storage.
 
 The first installation and each managed update require network access.
 Once installed, the cached server can start while offline. The status bar shows
-whether managed JETLS is being checked, installed, started, or has failed.
+whether managed JETLS is being checked, installed, started, or has failed, and
+installations show a progress notification from which they can be cancelled.
 
 The extension launches only the exact JETLS version its release pins. When
 that version cannot be installed or verified — for example, while offline —

--- a/jetls-client/src/managed-installation.ts
+++ b/jetls-client/src/managed-installation.ts
@@ -77,6 +77,8 @@ export interface ProcessResult {
    * be running, so resources it can touch must not be treated as reusable.
    */
   processMayBeAlive?: boolean;
+  /** Set when the process was terminated by the caller's abort signal. */
+  cancelled?: boolean;
 }
 
 export interface ProcessRunnerOptions {
@@ -85,6 +87,8 @@ export interface ProcessRunnerOptions {
   timeoutMs: number;
   onStdout?: (chunk: string) => void;
   onStderr?: (chunk: string) => void;
+  /** Terminates the process (with escalation) when aborted. */
+  signal?: AbortSignal;
 }
 
 export type ProcessRunner = (
@@ -106,6 +110,27 @@ export interface ManagedInstallationOptions {
    * for recovering from corruption the verification cannot see.
    */
   forceInstall?: boolean;
+  /**
+   * Cancels the setup when aborted: running managed processes are
+   * terminated and the whole call rejects with
+   * `ManagedInstallationCancelledError`. An installation cancelled
+   * mid-flight only strands its unpublished generation, which cleanup
+   * removes later.
+   */
+  signal?: AbortSignal;
+  /**
+   * Called when the long installation step begins; the returned
+   * callback fires when it ends, regardless of outcome. Lets the UI
+   * scope install-only affordances (e.g. a cancellable notification)
+   * without parsing progress messages.
+   */
+  onInstallStep?: () => () => void;
+  /**
+   * Receives each completed stderr line of the installation process,
+   * sanitized and truncated for direct display, so the UI can show live
+   * evidence of progress alongside the coarse phase messages.
+   */
+  onInstallOutput?: (line: string) => void;
 }
 
 export interface ManagedJETLSInstallation {
@@ -154,6 +179,24 @@ class ManagedStepError extends Error {
     this.stage = stage;
     this.processMayBeAlive = options.processMayBeAlive === true;
     this.retryable = options.retryable;
+  }
+}
+
+/**
+ * Deliberate cancellation of a managed setup (a restart superseding it,
+ * or the extension deactivating). Not a failure: callers suppress the
+ * failure UI for it.
+ */
+export class ManagedInstallationCancelledError extends Error {
+  constructor() {
+    super("The managed JETLS setup was cancelled.");
+    this.name = "ManagedInstallationCancelledError";
+  }
+}
+
+function throwIfCancelled(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw new ManagedInstallationCancelledError();
   }
 }
 
@@ -539,10 +582,22 @@ export function createDefaultProcessRunner(
     overrides.terminationTimeoutMs ?? TIMEOUTS.processTermination;
   return async (command, args, options) => {
     return await new Promise<ProcessResult>((resolve) => {
+      const signal = options.signal;
+      if (signal?.aborted) {
+        resolve({
+          status: null,
+          stdout: "",
+          stderr: "",
+          error: "The process was cancelled.",
+          cancelled: true,
+        });
+        return;
+      }
       let stdout: Buffer = Buffer.alloc(0);
       let stderr: Buffer = Buffer.alloc(0);
       let settled = false;
       let timedOut = false;
+      let aborted = false;
       let closed = false;
       let closeStatus: number | null = null;
       let resolveClosed!: () => void;
@@ -579,26 +634,31 @@ export function createDefaultProcessRunner(
         }
         settled = true;
         clearTimeout(timeoutHandle);
+        signal?.removeEventListener("abort", onAbort);
         const timeoutMessage = timedOut
           ? `Process timed out after ${options.timeoutMs} ms.`
           : undefined;
+        const cancelMessage = aborted
+          ? "The process was cancelled."
+          : undefined;
         const processError =
-          [timeoutMessage, error?.message].filter(Boolean).join(" ") ||
-          undefined;
+          [timeoutMessage, cancelMessage, error?.message]
+            .filter(Boolean)
+            .join(" ") || undefined;
         resolve({
           status,
           stdout: stdout.toString(),
           stderr: stderr.toString(),
           error: processError,
           ...(processMayBeAlive ? { processMayBeAlive } : {}),
+          ...(aborted ? { cancelled: true } : {}),
         });
       };
 
-      const timeoutHandle = setTimeout(() => {
-        timedOut = true;
-        // A process that survives every termination attempt must not leave
-        // this promise pending, but the settled result marks the survival
-        // so failure guidance can note the possibly-live process.
+      // A process that survives every termination attempt must not leave
+      // this promise pending, but the settled result marks the survival
+      // so failure guidance can note the possibly-live process.
+      const terminateAndFinish = (): void => {
         void terminateProcess(
           { process: child, isClosed: () => closed, closedPromise },
           {
@@ -620,13 +680,27 @@ export function createDefaultProcessRunner(
             );
           },
         );
+      };
+
+      const timeoutHandle = setTimeout(() => {
+        timedOut = true;
+        terminateAndFinish();
       }, options.timeoutMs);
 
+      const onAbort = (): void => {
+        if (settled || timedOut) {
+          return;
+        }
+        aborted = true;
+        terminateAndFinish();
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+
       child.on("error", (error: Error) => {
-        // Signal-delivery failures after the timeout are owned by the
-        // termination flow, which settles only once the process state is
-        // known.
-        if (timedOut) {
+        // Signal-delivery failures after a timeout or abort are owned by
+        // the termination flow, which settles only once the process state
+        // is known.
+        if (timedOut || aborted) {
           return;
         }
         finish(null, error);
@@ -635,9 +709,10 @@ export function createDefaultProcessRunner(
         closed = true;
         closeStatus = status;
         resolveClosed();
-        // After a timeout only the termination flow settles: the direct
-        // process closing says nothing about surviving group members.
-        if (timedOut) {
+        // After a timeout or abort only the termination flow settles: the
+        // direct process closing says nothing about surviving group
+        // members.
+        if (timedOut || aborted) {
           return;
         }
         finish(status);
@@ -671,8 +746,35 @@ function createLineLogger(
   };
 }
 
+const INSTALL_OUTPUT_LINE_LIMIT = 100;
+
+// Assembles display-ready lines out of raw output chunks: `\r` counts
+// as a line break so in-place progress redraws (e.g. Pkg's precompile
+// bar) surface as fresh lines instead of piling up in one.
+function createInstallOutputLineEmitter(
+  onLine: (line: string) => void,
+): (chunk: string) => void {
+  let pending = "";
+  return (chunk) => {
+    const lines = `${pending}${chunk}`.split(/\r\n|\r|\n/);
+    pending = lines.pop() ?? "";
+    for (const line of lines) {
+      const cleaned = stripVTControlCharacters(line).trim();
+      if (cleaned === "") {
+        continue;
+      }
+      onLine(
+        cleaned.length > INSTALL_OUTPUT_LINE_LIMIT
+          ? `${cleaned.slice(0, INSTALL_OUTPUT_LINE_LIMIT - 1)}…`
+          : cleaned,
+      );
+    }
+  };
+}
+
 function createInstallationOutputObserver(
   progress: ((message: string) => void) | undefined,
+  onOutputLine: ((line: string) => void) | undefined,
 ): ProcessOutputObserver {
   const phases = [
     {
@@ -716,9 +818,17 @@ function createInstallationOutputObserver(
     };
   };
 
+  const stderrObserver = createStreamObserver();
+  const lineEmitter =
+    onOutputLine === undefined
+      ? undefined
+      : createInstallOutputLineEmitter(onOutputLine);
   return {
     onStdout: createStreamObserver(),
-    onStderr: createStreamObserver(),
+    onStderr: (chunk) => {
+      stderrObserver(chunk);
+      lineEmitter?.(chunk);
+    },
   };
 }
 
@@ -797,6 +907,9 @@ async function runCheckedProcess(
     logger,
     outputObserver,
   );
+  if (result.cancelled === true) {
+    throw new ManagedInstallationCancelledError();
+  }
   if (result.status !== 0 || result.error !== undefined) {
     const status =
       result.status === null ? "unavailable" : String(result.status);
@@ -982,6 +1095,7 @@ async function withInstallLock<T>(
   containerPath: string,
   logger: ((message: string) => void) | undefined,
   progress: ((message: string) => void) | undefined,
+  signal: AbortSignal | undefined,
   poll: () => Promise<T | undefined>,
   operation: () => Promise<T>,
 ): Promise<T> {
@@ -991,6 +1105,7 @@ async function withInstallLock<T>(
   let reportedWait = false;
   let locked = false;
   while (!locked && Date.now() < deadline) {
+    throwIfCancelled(signal);
     try {
       await mkdir(lockPath);
       locked = true;
@@ -1099,10 +1214,7 @@ async function cleanupManagedStorage(
       }
     }
   } catch (error) {
-    emit(
-      logger,
-      `Managed storage cleanup was skipped: ${errorMessage(error)}`,
-    );
+    emit(logger, `Managed storage cleanup was skipped: ${errorMessage(error)}`);
   }
 }
 
@@ -1126,6 +1238,7 @@ async function installGeneration(
   platform: NodeJS.Platform,
   logger: ((message: string) => void) | undefined,
   progress: ((message: string) => void) | undefined,
+  onInstallOutput: ((line: string) => void) | undefined,
 ): Promise<string> {
   const generationId = newGenerationId();
   const generationPath = path.join(context.containerPath, generationId);
@@ -1162,7 +1275,7 @@ async function installGeneration(
     runner,
     platform,
     logger,
-    createInstallationOutputObserver(progress),
+    createInstallationOutputObserver(progress, onInstallOutput),
   );
   emit(progress, "Verifying installed JETLS...");
   await verifyPinnedJETLS(
@@ -1193,6 +1306,9 @@ async function resolveGeneration(
   logger: ((message: string) => void) | undefined,
   progress: ((message: string) => void) | undefined,
   forceInstall: boolean,
+  signal: AbortSignal | undefined,
+  onInstallStep: (() => () => void) | undefined,
+  onInstallOutput: ((line: string) => void) | undefined,
 ): Promise<string> {
   const settle = async (generationPath: string): Promise<string> => {
     await touchLastUsed(generationPath);
@@ -1212,6 +1328,7 @@ async function resolveGeneration(
     context.containerPath,
     logger,
     progress,
+    signal,
     // Adopt a generation published by the lock holder instead of
     // duplicating its installation.
     async () =>
@@ -1236,6 +1353,9 @@ async function resolveGeneration(
             await writeInstallStamp(current, context.juliaVersion, logger);
             return await settle(current);
           } catch (error) {
+            if (error instanceof ManagedInstallationCancelledError) {
+              throw error;
+            }
             emit(
               logger,
               "The current managed JETLS installation failed verification " +
@@ -1244,16 +1364,22 @@ async function resolveGeneration(
           }
         }
       }
-      return await settle(
-        await installGeneration(
-          context,
-          baseEnvironment,
-          runner,
-          platform,
-          logger,
-          progress,
-        ),
-      );
+      const endInstallStep = onInstallStep?.();
+      try {
+        return await settle(
+          await installGeneration(
+            context,
+            baseEnvironment,
+            runner,
+            platform,
+            logger,
+            progress,
+            onInstallOutput,
+          ),
+        );
+      } finally {
+        endInstallStep?.();
+      }
     },
   );
 }
@@ -1332,6 +1458,7 @@ async function ensureRuntime(
 ): Promise<string> {
   let containerPath: string | undefined;
   try {
+    throwIfCancelled(options.signal);
     emit(options.progress, "Checking Julia version...");
     const juliaVersion = await queryJuliaVersion(
       juliaPath,
@@ -1357,8 +1484,16 @@ async function ensureRuntime(
       options.logger,
       options.progress,
       options.forceInstall === true,
+      options.signal,
+      options.onInstallStep,
+      options.onInstallOutput,
     );
   } catch (error) {
+    // A cancellation is not a failure; it passes through unclassified so
+    // callers can suppress the failure UI.
+    if (error instanceof ManagedInstallationCancelledError) {
+      throw error;
+    }
     // Untagged errors here come from filesystem steps of the installation
     // machinery itself.
     throw managedError(error, juliaPath, containerPath, "install");
@@ -1372,6 +1507,19 @@ interface ManagedRuntimeSelection {
   juliaPath: string;
 }
 
+// Every managed process observes the setup's abort signal; attaching it
+// to the runner here spares each step from threading it through.
+function attachAbortSignal(
+  runner: ProcessRunner,
+  signal: AbortSignal | undefined,
+): ProcessRunner {
+  if (signal === undefined) {
+    return runner;
+  }
+  return (command, args, options) =>
+    runner(command, args, { ...options, signal });
+}
+
 async function resolveManagedRuntime(
   options: ManagedInstallationOptions,
 ): Promise<ManagedRuntimeSelection> {
@@ -1379,7 +1527,10 @@ async function resolveManagedRuntime(
     throw new Error("storagePath must not be empty.");
   }
   const platform = options.platform ?? process.platform;
-  const runner = options.processRunner ?? defaultProcessRunner;
+  const runner = attachAbortSignal(
+    options.processRunner ?? defaultProcessRunner,
+    options.signal,
+  );
   const storagePath = path.resolve(options.storagePath);
   const requestedJuliaCommand = configuredJuliaCommand(options);
   try {

--- a/jetls-client/src/server-lifecycle.ts
+++ b/jetls-client/src/server-lifecycle.ts
@@ -13,6 +13,7 @@ import { JETLS_CLIENT_SETTINGS_SECTION, TIMEOUTS } from "./constants";
 import {
   ensureManagedJETLS,
   invalidateInstallStamp,
+  ManagedInstallationCancelledError,
   ManagedJETLSError,
   managedJETLSCommands,
 } from "./managed-installation";
@@ -207,23 +208,95 @@ async function startLanguageServer() {
       env?: Record<string, string>;
     };
     let installation;
+    const setupAbort = new AbortController();
+    managedSetupAbort = setupAbort;
+    let installProgress: vscode.Progress<{ message?: string }> | undefined;
     try {
       installation = await ensureManagedJETLS({
         storagePath: managedStoragePath,
         environment: executableEnvironment(executable),
         logger: (message) =>
           outputChannel.appendLine(`[jetls-client] ${message}`),
-        progress: (message) => statusBar.showManagedProgress(message),
+        progress: (message) => {
+          statusBar.showManagedProgress(message);
+          installProgress?.report({
+            message: message.startsWith("Installing JETLS: ")
+              ? message.slice("Installing JETLS: ".length)
+              : message,
+          });
+        },
         forceInstall: forceManagedInstall,
+        signal: setupAbort.signal,
+        // Live output lines make a long installation visibly alive: the
+        // status bar keeps the coarse phase while its tooltip and the
+        // progress notification tick with the latest line.
+        onInstallOutput: (line) => {
+          statusBar.showManagedProgressDetail(line);
+          installProgress?.report({ message: line });
+        },
+        // The actual installation (the only open-ended long step) gets a
+        // cancellable progress notification for its duration; routine
+        // starts stay on the status bar alone.
+        onInstallStep: () => {
+          let end!: () => void;
+          const done = new Promise<void>((resolve) => {
+            end = resolve;
+          });
+          void vscode.window.withProgress(
+            {
+              location: vscode.ProgressLocation.Notification,
+              title: "Installing JETLS",
+              cancellable: true,
+            },
+            (progress, token) => {
+              installProgress = progress;
+              token.onCancellationRequested(() => setupAbort.abort());
+              return done;
+            },
+          );
+          return () => {
+            installProgress = undefined;
+            end();
+          };
+        },
       });
       forceManagedInstall = false;
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
-      if (!deactivating && !restartRunner.pending) {
+      if (
+        !deactivating &&
+        !restartRunner.pending &&
+        !(error instanceof ManagedInstallationCancelledError)
+      ) {
         statusBar.showManagedFailure(managedFailureSummary(error));
         handleManagedSetupFailure(error);
+      } else if (!deactivating && !restartRunner.pending) {
+        // Cancelled from the installation notification (a restart or
+        // deactivation would have set the flags above): no failure UI,
+        // but the status bar must not keep showing progress, and the
+        // notification offers the way back in.
+        statusBar.showManagedFailure("The JETLS installation was cancelled.");
+        const retryButton = "Retry";
+        const outputButton = "Show JETLS output";
+        void vscode.window
+          .showInformationMessage(
+            "The JETLS installation was cancelled.",
+            retryButton,
+            outputButton,
+          )
+          .then((choice) => {
+            if (choice === retryButton) {
+              requestLanguageServerRestart();
+            } else if (choice === outputButton) {
+              void vscode.commands.executeCommand("jetls-client.showOutput");
+            }
+          });
       }
       throw error;
+    } finally {
+      if (managedSetupAbort === setupAbort) {
+        managedSetupAbort = undefined;
+      }
     }
     outputChannel.appendLine(
       `[jetls-client] Using managed JETLS from ${installation.depotPath}`,
@@ -591,6 +664,9 @@ export function requestLanguageServerRestart(): void {
   // Likewise kill a spawned server still waiting for its transport
   // connection; the transport turns this into a no-op once connected.
   cancelServerStartup?.();
+  // And cancel an in-flight managed installation, which can run for
+  // minutes: the rerun queued above starts over from the current state.
+  managedSetupAbort?.abort();
   void lifecycle.catch((err) => {
     const message = err instanceof Error ? err.message : String(err);
     outputChannel.appendLine(
@@ -603,6 +679,11 @@ export function requestLanguageServerRestart(): void {
 // stays set until an installation succeeds, so a Retry after a failed
 // reinstall still installs from scratch.
 let forceManagedInstall = false;
+
+// Aborts the in-flight managed setup, so a restart or deactivation does
+// not wait behind a long installation; the cancelled installation only
+// strands its unpublished generation.
+let managedSetupAbort: AbortController | undefined;
 
 /**
  * Reinstalls the managed JETLS from scratch: after a modal confirmation
@@ -673,6 +754,7 @@ function awaitWithTimeout(
 
 export async function shutdownServerLifecycle(): Promise<void> {
   deactivating = true;
+  managedSetupAbort?.abort();
   try {
     await versionPreflight.terminate();
   } catch (err) {

--- a/jetls-client/src/status-bar.ts
+++ b/jetls-client/src/status-bar.ts
@@ -19,6 +19,7 @@ export class StartupStatusBar {
   private readonly item: vscode.StatusBarItem;
   private hideTimer: NodeJS.Timeout | undefined;
   private suppressed = false;
+  private managedProgress = false;
 
   constructor() {
     this.item = vscode.window.createStatusBarItem(
@@ -34,6 +35,7 @@ export class StartupStatusBar {
       return;
     }
     this.clearHideTimer();
+    this.managedProgress = false;
 
     this.item.backgroundColor = undefined;
     this.item.command = SHOW_OUTPUT_COMMAND;
@@ -97,11 +99,23 @@ export class StartupStatusBar {
       return;
     }
     this.clearHideTimer();
+    this.managedProgress = true;
     this.item.backgroundColor = undefined;
     this.item.command = SHOW_OUTPUT_COMMAND;
     this.item.text = `$(sync~spin) ${message}`;
     this.item.tooltip = "Setting up the managed JETLS installation.";
     this.item.show();
+  }
+
+  /**
+   * Updates only the tooltip with the latest installation output line;
+   * a no-op unless the managed-progress spinner is showing.
+   */
+  showManagedProgressDetail(line: string): void {
+    if (this.suppressed || !this.managedProgress) {
+      return;
+    }
+    this.item.tooltip = `${line}\nClick to open the JETLS output.`;
   }
 
   /**
@@ -114,6 +128,7 @@ export class StartupStatusBar {
       return;
     }
     this.clearHideTimer();
+    this.managedProgress = false;
     this.item.text = "$(error) Managed JETLS failed";
     this.item.tooltip = `${summary}\nClick to open the JETLS output.`;
     this.item.backgroundColor = new vscode.ThemeColor(

--- a/jetls-client/test/managed-installation.test.ts
+++ b/jetls-client/test/managed-installation.test.ts
@@ -19,6 +19,7 @@ import jetlsVersion from "../JETLS_VERSION.json";
 import {
   JETLS_REPOSITORY,
   JETLS_REVISION,
+  ManagedInstallationCancelledError,
   ManagedJETLSError,
   createDefaultProcessRunner,
   currentPointerPath,
@@ -86,6 +87,7 @@ function fakeRunner(
         timeoutMs: options.timeoutMs,
         onStdout: options.onStdout,
         onStderr: options.onStderr,
+        signal: options.signal,
       },
     };
     calls.push(call);
@@ -923,6 +925,200 @@ test("a surviving installer does not block a retry", async () => {
   });
 });
 
+test("a cancelled installation rejects without publishing", async () => {
+  await withFixture(async (fixture) => {
+    const abort = new AbortController();
+    const fake = fakeRunner(async (call) => {
+      const script = scriptFor(call);
+      if (script?.includes("Pkg.Apps.add")) {
+        // The runner-level abort settles the process with the
+        // cancellation marker.
+        abort.abort();
+        return {
+          status: null,
+          stdout: "",
+          stderr: "",
+          error: "The process was cancelled.",
+          cancelled: true,
+        };
+      }
+      if (script !== undefined) {
+        return success("1.12.2\n");
+      }
+      throw new Error(`Unexpected process call: ${JSON.stringify(call)}`);
+    });
+
+    await assert.rejects(
+      ensureManagedJETLS({
+        storagePath: fixture.storagePath,
+        environment: fixture.environment,
+        processRunner: fake.runner,
+        signal: abort.signal,
+      }),
+      ManagedInstallationCancelledError,
+    );
+
+    const containerPath = managedDepotPath(
+      fixture.storagePath,
+      fixture.juliaPath,
+      "1.12.2",
+    );
+    assert.equal(await readCurrentGeneration(containerPath), undefined);
+    await assert.rejects(stat(path.join(containerPath, "install.lock")));
+    // The setup attached its signal to every managed process.
+    assert.ok(fake.calls.every((call) => call.options.signal === abort.signal));
+  });
+});
+
+test("an already-aborted setup rejects before any process runs", async () => {
+  await withFixture(async (fixture) => {
+    const abort = new AbortController();
+    abort.abort();
+    const fake = standardRunner(fixture.juliaPath);
+
+    await assert.rejects(
+      ensureManagedJETLS({
+        storagePath: fixture.storagePath,
+        environment: fixture.environment,
+        processRunner: fake.runner,
+        signal: abort.signal,
+      }),
+      ManagedInstallationCancelledError,
+    );
+    assert.equal(fake.calls.length, 0);
+  });
+});
+
+test("reports the installation step boundaries to the caller", async () => {
+  await withFixture(async (fixture) => {
+    const events: string[] = [];
+    const fake = standardRunner(fixture.juliaPath, {
+      onInstallOutput: () => events.push("install"),
+    });
+    const options: ManagedInstallationOptions = {
+      storagePath: fixture.storagePath,
+      environment: fixture.environment,
+      processRunner: fake.runner,
+      onInstallStep: () => {
+        events.push("begin");
+        return () => events.push("end");
+      },
+    };
+
+    await ensureManagedJETLS(options);
+    assert.deepEqual(events, ["begin", "install", "end"]);
+
+    // The stamped fast path never enters the installation step.
+    await ensureManagedJETLS(options);
+    assert.deepEqual(events, ["begin", "install", "end"]);
+  });
+});
+
+test("streams sanitized installation output lines to the caller", async () => {
+  await withFixture(async (fixture) => {
+    const lines: string[] = [];
+    const fake = standardRunner(fixture.juliaPath, {
+      installOutput: (call) => {
+        // A colored line split across chunks, in-place `\r` progress
+        // redraws, an oversized line, and a blank line.
+        call.options.onStderr?.("\u001b[32m  Installed\u001b[39m Cra");
+        call.options.onStderr?.(
+          "yons ─ v4.1.1\nProgress [==>  ]\rProgress [====>]\r\n",
+        );
+        call.options.onStderr?.(`${"x".repeat(150)}\n\n`);
+      },
+    });
+
+    await ensureManagedJETLS({
+      storagePath: fixture.storagePath,
+      environment: fixture.environment,
+      processRunner: fake.runner,
+      onInstallOutput: (line) => lines.push(line),
+    });
+
+    assert.deepEqual(lines.slice(0, 3), [
+      "Installed Crayons ─ v4.1.1",
+      "Progress [==>  ]",
+      "Progress [====>]",
+    ]);
+    assert.equal(lines[3], `${"x".repeat(99)}…`);
+    assert.equal(lines.length, 4);
+
+    // The stamped fast path runs no installation and emits no lines.
+    lines.length = 0;
+    await ensureManagedJETLS({
+      storagePath: fixture.storagePath,
+      environment: fixture.environment,
+      processRunner: standardRunner(fixture.juliaPath).runner,
+      onInstallOutput: (line) => lines.push(line),
+    });
+    assert.deepEqual(lines, []);
+  });
+});
+
+test("the installation step ends when the installation fails", async () => {
+  await withFixture(async (fixture) => {
+    const events: string[] = [];
+    const fake = fakeRunner(async (call) => {
+      const script = scriptFor(call);
+      if (script?.includes("Pkg.Apps.add")) {
+        return failure(1, "", "could not download package sources\n");
+      }
+      if (script !== undefined) {
+        return success("1.12.2\n");
+      }
+      throw new Error(`Unexpected process call: ${JSON.stringify(call)}`);
+    });
+
+    await assert.rejects(
+      ensureManagedJETLS({
+        storagePath: fixture.storagePath,
+        environment: fixture.environment,
+        processRunner: fake.runner,
+        onInstallStep: () => {
+          events.push("begin");
+          return () => events.push("end");
+        },
+      }),
+    );
+    assert.deepEqual(events, ["begin", "end"]);
+  });
+});
+
+test("a cancelled verification does not trigger a replacement install", async () => {
+  await withFixture(async (fixture) => {
+    await seedGeneration(fixture.storagePath, fixture.juliaPath, {
+      stamped: false,
+    });
+    const fake = fakeRunner(async (call) => {
+      const script = scriptFor(call);
+      if (script !== undefined) {
+        return success("1.12.2\n");
+      }
+      if (isJETLSVersionCall(call)) {
+        return {
+          status: null,
+          stdout: "",
+          stderr: "",
+          error: "The process was cancelled.",
+          cancelled: true,
+        };
+      }
+      throw new Error(`Unexpected process call: ${JSON.stringify(call)}`);
+    });
+
+    await assert.rejects(
+      ensureManagedJETLS({
+        storagePath: fixture.storagePath,
+        environment: fixture.environment,
+        processRunner: fake.runner,
+      }),
+      ManagedInstallationCancelledError,
+    );
+    assert.equal(callsWithScript(fake.calls, "Pkg.Apps.add").length, 0);
+  });
+});
+
 test("classifies first-install failures as retryable install errors", async () => {
   await withFixture(async (fixture) => {
     const fake = fakeRunner(async (call) => {
@@ -1438,6 +1634,59 @@ test("marks survival when group members outlive the closed parent", async () => 
     result.error ?? "",
     /Process timed out after 10 ms\. The process did not exit after termination\./,
   );
+});
+
+test("terminates the process group and marks cancellation on abort", async () => {
+  const child = new FakeChildProcess();
+  child.onKill = () => child.close(null, "SIGTERM");
+  const groupSignals: [number, NodeJS.Signals][] = [];
+  const runner = createDefaultProcessRunner({
+    spawnProcess: () => child.asChildProcess(),
+    platform: "darwin",
+    terminationTimeoutMs: 20,
+    killProcessGroup: (pid, signal) => {
+      groupSignals.push([pid, signal]);
+      child.kill(signal);
+    },
+    isProcessGroupAlive: () => false,
+  });
+  const abort = new AbortController();
+
+  const resultPromise = runner("cmd", [], {
+    env: {},
+    shell: false,
+    timeoutMs: 60 * 1000,
+    signal: abort.signal,
+  });
+  abort.abort();
+  const result = await resultPromise;
+
+  assert.equal(result.cancelled, true);
+  assert.match(result.error ?? "", /The process was cancelled\./);
+  assert.deepEqual(groupSignals, [[1234, "SIGTERM"]]);
+  assert.equal(result.processMayBeAlive, undefined);
+});
+
+test("does not spawn when the signal is already aborted", async () => {
+  const abort = new AbortController();
+  abort.abort();
+  const spawnCalls: SpawnCall[] = [];
+  const runner = createDefaultProcessRunner({
+    spawnProcess: (command, args, options) => {
+      spawnCalls.push({ command, args, options });
+      return new FakeChildProcess().asChildProcess();
+    },
+  });
+
+  const result = await runner("cmd", [], {
+    env: {},
+    shell: false,
+    timeoutMs: 1000,
+    signal: abort.signal,
+  });
+
+  assert.equal(result.cancelled, true);
+  assert.equal(spawnCalls.length, 0);
 });
 
 test("terminates timed-out process trees with taskkill on Windows", async () => {


### PR DESCRIPTION
`ensureManagedJETLS` could not be interrupted once started. A restart request — a settings change or an explicit command — was queued by the lifecycle runner behind the in-flight setup, so it could wait up to the full installation budget of fifteen minutes before applying the new configuration. Deactivation likewise gave up after its bounded wait while the detached installer kept running after the extension host exited, leaving the install lock held until its age-based reclaim.

`ManagedInstallationOptions` now carries an `AbortSignal`. The signal is attached to the process runner once in `resolveManagedRuntime`, so every managed process observes it without threading it through each step; on abort the default runner terminates the running process with the same escalation flow as a timeout (process-group SIGTERM then SIGKILL, `taskkill /T /F` on Windows) and settles its result with a `cancelled` marker. `runCheckedProcess` turns that marker into a dedicated `ManagedInstallationCancelledError`, which passes through unclassified — it is a deliberate cancellation, not a failure, so the lifecycle suppresses the failure notification for it. Cancellation checkpoints at the setup entry and in the install-lock wait loop cover the phases that run no process, and a cancelled re-verification of the current generation propagates instead of falling through to a replacement install.

The generation design keeps the cancelled state trivial: an aborted installation only strands its unpublished generation for cleanup, the install lock is released on the way out, and the sticky reinstall flag survives the cancellation, so a superseding restart still installs from scratch when one was requested. The lifecycle holds one `AbortController` per managed attempt and aborts it from `requestLanguageServerRestart` and `shutdownServerLifecycle`.

Tests cover the runner-level abort (group termination and the cancellation marker, and no spawn under an already-aborted signal) and the setup-level behavior: a cancelled installation rejects with the cancellation error without publishing and with the lock released, an already-aborted setup runs no process at all, and a cancelled verification does not trigger a replacement install.