### PR TITLE
jetls-client: v2026.8.28

### DIFF
--- a/jetls-client/CHANGELOG.md
+++ b/jetls-client/CHANGELOG.md
@@ -8,7 +8,13 @@ and this project uses [calendar versioning](https://calver.org/) (`YYYY.M.D`, th
 ## Unreleased
 
 - Commit: [`HEAD`](https://github.com/aviatesk/JETLS.jl/commit/HEAD)
-- Diff: [`8a6998f1b...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/8a6998f1b...HEAD)
+- Diff: [`jetls-client/v2026.8.28...HEAD`](https://github.com/aviatesk/JETLS.jl/compare/jetls-client/v2026.8.28...HEAD)
+
+## v2026.8.28
+
+- Commit: [`jetls-client/v2026.8.28`](https://github.com/aviatesk/JETLS.jl/tree/jetls-client/v2026.8.28)
+- Diff: [`8a6998f1b...jetls-client/v2026.8.28`](https://github.com/aviatesk/JETLS.jl/compare/8a6998f1b...jetls-client/v2026.8.28)
+- Pinned JETLS: [`2026-08-28`](https://github.com/aviatesk/JETLS.jl/releases/tag/2026-08-28)
 
 ### Added
 

--- a/jetls-client/JETLS_VERSION.json
+++ b/jetls-client/JETLS_VERSION.json
@@ -1,5 +1,5 @@
 {
-  "revision": "2026-08-23",
+  "revision": "2026-08-28",
   "julia": {
     "lower": "1.12.2",
     "upperMinor": "1.13"

--- a/jetls-client/package-lock.json
+++ b/jetls-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jetls-client",
-  "version": "0.8.0",
+  "version": "2026.8.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jetls-client",
-      "version": "0.8.0",
+      "version": "2026.8.28",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^10.1.0",

--- a/jetls-client/package.json
+++ b/jetls-client/package.json
@@ -4,7 +4,7 @@
   "description": "A new language server for Julia",
   "author": "Shuhei Kadowaki",
   "license": "MIT",
-  "version": "0.8.0",
+  "version": "2026.8.28",
   "repository": {
     "type": "git",
     "url": "https://github.com/aviatesk/JETLS.jl",


### PR DESCRIPTION
This PR releases jetls-client `v2026.8.28`, pinning the JETLS release `2026-08-28`.

Merging this PR publishes the extension to the Marketplace and pushes the `jetls-client/v2026.8.28` tag.