### PR TITLE
jetls-client: Check Julia bounds with compat hyphen-range semantics

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -584,7 +584,7 @@ The managed default installs the JETLS release tag pinned in
 [`jetls-client/JETLS_VERSION.json`](./jetls-client/JETLS_VERSION.json),
 which also records the supported Julia version bounds. The bounds must
 mirror the pinned release's `julia` compat entry in `Project.toml`, which
-is expected to stay in the `<lower> - <upper.minor>` hyphen-range form;
+is expected to stay in the `<lower> - <upper>` hyphen-range form;
 the release script and CI check the pinned tag and this correspondence
 automatically.
 

--- a/jetls-client/JETLS_VERSION.json
+++ b/jetls-client/JETLS_VERSION.json
@@ -2,6 +2,6 @@
   "revision": "2026-08-23",
   "julia": {
     "lower": "1.12.2",
-    "upperMinor": "1.13"
+    "upper": "1.13"
   }
 }

--- a/jetls-client/src/managed-installation.ts
+++ b/jetls-client/src/managed-installation.ts
@@ -36,7 +36,7 @@ const INSTALL_LOCK_DIR = "install.lock";
 const INSTALL_STAMP_FILE = "install-stamp.json";
 const LAST_USED_FILE = "last-used";
 const JULIA_VERSION_LOWER_BOUND: string = JETLS_VERSION.julia.lower;
-const JULIA_VERSION_UPPER_MINOR: string = JETLS_VERSION.julia.upperMinor;
+const JULIA_VERSION_UPPER_BOUND: string = JETLS_VERSION.julia.upper;
 
 const JULIA_VERSION_SCRIPT = "print(stdout, VERSION)";
 // The installation must go through `Pkg.Apps`: JETLS releases pin their
@@ -355,25 +355,67 @@ function compareJuliaVersions(left: JuliaVersion, right: JuliaVersion): number {
   return left.patch - right.patch;
 }
 
-export function isSupportedJuliaVersion(version: string): boolean {
+interface JuliaVersionBound {
+  major: number;
+  minor?: number;
+  patch?: number;
+}
+
+function parseJuliaVersionBound(bound: string): JuliaVersionBound | undefined {
+  const match = /^(\d+)(?:\.(\d+)(?:\.(\d+))?)?$/.exec(bound.trim());
+  if (match === null) {
+    return undefined;
+  }
+  return {
+    major: Number(match[1]),
+    ...(match[2] === undefined ? {} : { minor: Number(match[2]) }),
+    ...(match[3] === undefined ? {} : { patch: Number(match[3]) }),
+  };
+}
+
+// The bounds carry Julia's `"<lower> - <upper>"` hyphen-range compat
+// semantics: components omitted from the lower bound default to zero,
+// while components omitted from the upper bound act as wildcards, so an
+// upper bound of `1.13` admits every `1.13.x` whereas `1.13.1` rejects
+// `1.13.2`.
+export function isSupportedJuliaVersion(
+  version: string,
+  lowerBound: string = JULIA_VERSION_LOWER_BOUND,
+  upperBound: string = JULIA_VERSION_UPPER_BOUND,
+): boolean {
   const parsed = parseJuliaVersion(version);
   if (parsed === undefined) {
     return false;
   }
-  const lower = parseJuliaVersion(JULIA_VERSION_LOWER_BOUND);
-  const upperMinor = parseJuliaVersion(`${JULIA_VERSION_UPPER_MINOR}.0`);
-  if (lower === undefined || upperMinor === undefined) {
+  const lower = parseJuliaVersionBound(lowerBound);
+  const upper = parseJuliaVersionBound(upperBound);
+  if (lower === undefined || upper === undefined) {
     throw new Error("Invalid Julia version bounds in JETLS_VERSION.json.");
   }
-  const firstUnsupported = {
-    major: upperMinor.major,
-    minor: upperMinor.minor + 1,
-    patch: 0,
+  const lowerVersion = {
+    major: lower.major,
+    minor: lower.minor ?? 0,
+    patch: lower.patch ?? 0,
   };
+  const firstUnsupported =
+    upper.minor === undefined
+      ? { major: upper.major + 1, minor: 0, patch: 0 }
+      : upper.patch === undefined
+        ? { major: upper.major, minor: upper.minor + 1, patch: 0 }
+        : { major: upper.major, minor: upper.minor, patch: upper.patch + 1 };
   return (
-    compareJuliaVersions(parsed, lower) >= 0 &&
+    compareJuliaVersions(parsed, lowerVersion) >= 0 &&
     compareJuliaVersions(parsed, firstUnsupported) < 0
   );
+}
+
+function supportedJuliaRangeDescription(): string {
+  const upper = parseJuliaVersionBound(JULIA_VERSION_UPPER_BOUND);
+  const upperDescription =
+    upper?.patch === undefined
+      ? `${JULIA_VERSION_UPPER_BOUND}.x`
+      : JULIA_VERSION_UPPER_BOUND;
+  return `${JULIA_VERSION_LOWER_BOUND} through ${upperDescription}`;
 }
 
 export function juliaMinorVersion(version: string): string {
@@ -1470,8 +1512,8 @@ async function ensureRuntime(
     containerPath = managedDepotPath(storagePath, juliaPath, juliaVersion);
     if (!isSupportedJuliaVersion(juliaVersion)) {
       throw new ManagedStepError(
-        `JETLS requires Julia ${JULIA_VERSION_LOWER_BOUND} through ` +
-          `${JULIA_VERSION_UPPER_MINOR}.x; found Julia ${juliaVersion}.`,
+        `JETLS requires Julia ${supportedJuliaRangeDescription()}; ` +
+          `found Julia ${juliaVersion}.`,
         "julia-version",
         { retryable: false },
       );

--- a/jetls-client/test/managed-installation.test.ts
+++ b/jetls-client/test/managed-installation.test.ts
@@ -33,7 +33,6 @@ import {
   managedDepotPath,
   managedJETLSCommands,
   needsWindowsBatchShell,
-  parseJuliaVersion,
   readCurrentGeneration,
   resolveExecutable,
   runtimeKey,
@@ -247,32 +246,36 @@ function jetlsVersionCalls(calls: ProcessCall[]): ProcessCall[] {
 
 const posixOnlyTest = process.platform === "win32" ? test.skip : test;
 
-test("reads the supported Julia version range from JETLS_VERSION.json", () => {
-  const lower = parseJuliaVersion(jetlsVersion.julia.lower);
-  const upper = /^(\d+)\.(\d+)$/.exec(jetlsVersion.julia.upperMinor);
-  assert.ok(lower !== undefined);
-  assert.ok(upper !== null);
+test("checks Julia versions with hyphen-range compat semantics", () => {
+  assert.equal(isSupportedJuliaVersion("1.12.2", "1.12.2", "1.13"), true);
+  assert.equal(isSupportedJuliaVersion("1.12.1", "1.12.2", "1.13"), false);
+  // A minor-only upper bound admits every patch of that minor.
+  assert.equal(isSupportedJuliaVersion("1.13.999", "1.12.2", "1.13"), true);
+  assert.equal(isSupportedJuliaVersion("1.14.0", "1.12.2", "1.13"), false);
+  // A patch-specified upper bound is an inclusive exact cutoff.
+  assert.equal(isSupportedJuliaVersion("1.13.1", "1.12.2", "1.13.1"), true);
+  assert.equal(isSupportedJuliaVersion("1.13.2", "1.12.2", "1.13.1"), false);
+  // Components omitted from the lower bound default to zero.
+  assert.equal(isSupportedJuliaVersion("1.12.0", "1.12", "1.13"), true);
+  assert.equal(isSupportedJuliaVersion("1.11.9", "1.12", "1.13"), false);
+  // A major-only upper bound admits every minor of that major.
+  assert.equal(isSupportedJuliaVersion("1.99.0", "1.12.2", "1"), true);
+  assert.equal(isSupportedJuliaVersion("2.0.0", "1.12.2", "1"), false);
+  assert.equal(isSupportedJuliaVersion("invalid"), false);
+  assert.throws(() => isSupportedJuliaVersion("1.12.2", "bad", "1.13"));
+});
 
-  assert.equal(isSupportedJuliaVersion(jetlsVersion.julia.lower), true);
-  if (lower.patch > 0) {
-    assert.equal(
-      isSupportedJuliaVersion(
-        `${lower.major}.${lower.minor}.${lower.patch - 1}`,
-      ),
-      false,
-    );
-  }
-  const upperMajor = Number(upper[1]);
-  const upperMinor = Number(upper[2]);
+test("reads the supported Julia version range from JETLS_VERSION.json", () => {
+  const lower = /^(\d+)(?:\.(\d+))?(?:\.(\d+))?$/.exec(
+    jetlsVersion.julia.lower,
+  );
+  assert.ok(lower !== null);
+  // The recorded bounds parse and span a non-empty range: the version
+  // the lower bound completes to is itself supported.
   assert.equal(
-    isSupportedJuliaVersion(`${upperMajor}.${upperMinor}.999`),
+    isSupportedJuliaVersion(`${lower[1]}.${lower[2] ?? 0}.${lower[3] ?? 0}`),
     true,
   );
-  assert.equal(
-    isSupportedJuliaVersion(`${upperMajor}.${upperMinor + 1}.0`),
-    false,
-  );
-  assert.equal(isSupportedJuliaVersion("invalid"), false);
 });
 
 test("keys depots by executable and Julia minor version", () => {

--- a/scripts/check-jetls-client-julia-bounds.sh
+++ b/scripts/check-jetls-client-julia-bounds.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Checks that the julia bounds in jetls-client/JETLS_VERSION.json mirror
 # the pinned JETLS release's `julia` compat entry, which is required to
-# stay in the `<lower> - <upper.minor>` hyphen-range form this
-# comparison assumes; drift in either direction fails the check.
+# stay in the `<lower> - <upper>` hyphen-range form this comparison
+# assumes; drift in either direction fails the check.
 #
 # Usage: check-jetls-client-julia-bounds.sh [<committish>]
 #
@@ -17,7 +17,7 @@ cd "$(dirname "$0")/.."
 MANIFEST=jetls-client/JETLS_VERSION.json
 REVISION=$(node -p "require('./$MANIFEST').revision")
 JULIA_LOWER=$(node -p "require('./$MANIFEST').julia.lower")
-JULIA_UPPER_MINOR=$(node -p "require('./$MANIFEST').julia.upperMinor")
+JULIA_UPPER=$(node -p "require('./$MANIFEST').julia.upper")
 
 if [[ $# -ge 1 ]]; then
     PROJECT_TOML=$(git show "$1:Project.toml")
@@ -33,8 +33,8 @@ if [[ -z "$COMPAT" ]]; then
     echo "Error: could not read the julia compat entry of the pinned release $REVISION."
     exit 1
 fi
-if [[ "$COMPAT" != "$JULIA_LOWER - $JULIA_UPPER_MINOR" ]]; then
-    echo "Error: julia bounds in $MANIFEST ($JULIA_LOWER - $JULIA_UPPER_MINOR)" \
+if [[ "$COMPAT" != "$JULIA_LOWER - $JULIA_UPPER" ]]; then
+    echo "Error: julia bounds in $MANIFEST ($JULIA_LOWER - $JULIA_UPPER)" \
         "do not match the pinned release's julia compat ($COMPAT)."
     exit 1
 fi


### PR DESCRIPTION
`JETLS_VERSION.json` recorded the supported Julia range as an asymmetric pair: a patch-specified `lower` and a minor-only `upperMinor`. Each key hardcoded one specificity, so the schema could not express a patch-limited upper bound such as `1.13.1`, and the client's version check baked in the minor-only interpretation.

This change renames the keys to a symmetric `lower`/`upper` pair and makes `isSupportedJuliaVersion` interpret both with Julia's `"<lower> - <upper>"` hyphen-range compat semantics: components omitted from the lower bound default to zero, while components omitted from the upper bound act as wildcards. An upper bound of `1.13` therefore admits every `1.13.x`, whereas `1.13.1` rejects `v1.13.2`. The `julia` entry now mirrors the pinned release's compat entry verbatim in both components, so
`check-jetls-client-julia-bounds.sh` keeps working whether a release pins a minor- or patch-specified bound, and the unsupported-version message appends `.x` only when the upper bound actually omits the patch.

The version-range tests now exercise both bound forms deterministically through optional bound parameters on `isSupportedJuliaVersion`, with a remaining sanity test that the bounds recorded in `JETLS_VERSION.json` parse and span a non-empty range.