### PR TITLE
jetls-client: Managed installation follow-up fixes

### DIFF
--- a/jetls-client/README.md
+++ b/jetls-client/README.md
@@ -92,6 +92,10 @@ through the `jetls-client.executable` setting:
   }
   ```
 
+  The command must be the Julia executable itself (on Windows,
+  `julia.exe` rather than a `.bat`/`.cmd` wrapper), since the managed
+  installation launches it directly.
+
 - To use a JETLS binary you manage yourself, specify its `path`.
   This bypasses managed installation and updates:
 

--- a/jetls-client/src/constants.ts
+++ b/jetls-client/src/constants.ts
@@ -19,8 +19,8 @@ export const TIMEOUTS = {
   /**
    * Budget for Julia precompilation: bounds the whole version preflight,
    * re-arms the serve startup countdown when precompilation is detected, and
-   * bounds the managed installation's `jetls version` pin check, which may
-   * re-precompile after a Julia patch update invalidates the caches.
+   * bounds the managed installation's post-install `jetls version` pin check,
+   * which loads from the caches the installation just precompiled.
    */
   precompilation: 5 * 60 * 1000,
   /**
@@ -46,9 +46,11 @@ export const TIMEOUTS = {
    */
   juliaVersion: 1 * 60 * 1000,
   /**
-   * Budget for installing the pinned JETLS release, the only managed step
-   * that legitimately runs long: it downloads and fully precompiles the
-   * JETLS dependency tree. Also reused as the install-lock wait budget.
+   * Budget for installing the pinned JETLS release, which downloads and
+   * fully precompiles the JETLS dependency tree. Also bounds the
+   * re-verification of an existing generation after an install-stamp
+   * mismatch (e.g. a Julia patch update), which may re-precompile that tree
+   * from scratch, and is reused as the install-lock wait budget.
    */
   install: 15 * 60 * 1000,
 } as const;

--- a/jetls-client/src/managed-installation.ts
+++ b/jetls-client/src/managed-installation.ts
@@ -499,17 +499,26 @@ export async function readCurrentGeneration(
   }
 }
 
-// Written through a rename so a concurrent reader never sees a torn
-// pointer; the last concurrent publisher wins, and every published
-// generation is complete, so either winner is valid.
+// Publishes a file through a uniquely named temp file and a rename, so
+// a concurrent reader never sees torn content and concurrent publishers
+// (possible when the install lock was bypassed) cannot write into or
+// rename away each other's temp; the last rename wins.
+async function replaceFile(filePath: string, content: string): Promise<void> {
+  const tempPath = `${filePath}.${randomBytes(4).toString("hex")}.tmp`;
+  await writeFile(tempPath, content);
+  await rename(tempPath, filePath);
+}
+
+// The last concurrent publisher wins; every published generation is
+// complete, so either winner is valid.
 async function writeCurrentGeneration(
   containerPath: string,
   generationId: string,
 ): Promise<void> {
-  const pointerPath = currentPointerPath(containerPath);
-  const tempPath = `${pointerPath}.tmp`;
-  await writeFile(tempPath, JSON.stringify({ generation: generationId }));
-  await rename(tempPath, pointerPath);
+  await replaceFile(
+    currentPointerPath(containerPath),
+    JSON.stringify({ generation: generationId }),
+  );
 }
 
 export function lastUsedPath(basePath: string): string {
@@ -1100,14 +1109,11 @@ async function writeInstallStamp(
   juliaVersion: string,
   logger: ((message: string) => void) | undefined,
 ): Promise<void> {
-  const stampPath = installStampPath(generationPath);
-  const tempPath = `${stampPath}.tmp`;
   try {
-    await writeFile(
-      tempPath,
+    await replaceFile(
+      installStampPath(generationPath),
       JSON.stringify({ revision: JETLS_REVISION, julia: juliaVersion }),
     );
-    await rename(tempPath, stampPath);
   } catch (error) {
     emit(
       logger,

--- a/jetls-client/src/managed-installation.ts
+++ b/jetls-client/src/managed-installation.ts
@@ -49,9 +49,12 @@ const JULIA_VERSION_SCRIPT = "print(stdout, VERSION)";
 const INSTALL_SCRIPT = `using Pkg; Pkg.Apps.add(; url="${JETLS_REPOSITORY}", rev="${JETLS_REVISION}")`;
 const JULIA_BASE_ARGS = ["--startup-file=no", "--history-file=no"] as const;
 const LOCK_RETRY_DELAY = 100;
-// A lock older than the whole installation budget belongs to a dead
-// host; a margin absorbs clock skew between hosts.
-const LOCK_STALE_AGE = TIMEOUTS.install + 60 * 1000;
+// A lock older than the longest legitimate hold (a failed
+// re-verification of the current generation followed by a fresh
+// installation with its own verification) belongs to a dead host; a
+// margin absorbs clock skew between hosts.
+const LOCK_STALE_AGE =
+  2 * TIMEOUTS.install + TIMEOUTS.precompilation + 60 * 1000;
 // An unpublished generation may hold an installation still in progress
 // (including one whose process outlived its host), so it is only removed
 // well past any plausible installation lifetime.
@@ -1043,6 +1046,7 @@ export function isPinnedJETLSVersion(output: string): boolean {
 async function verifyPinnedJETLS(
   juliaPath: string,
   environment: NodeJS.ProcessEnv,
+  timeoutMs: number,
   runner: ProcessRunner,
   platform: NodeJS.Platform,
   logger: ((message: string) => void) | undefined,
@@ -1053,7 +1057,7 @@ async function verifyPinnedJETLS(
     environment,
     "JETLS version check",
     "verify",
-    TIMEOUTS.precompilation,
+    timeoutMs,
     runner,
     platform,
     logger,
@@ -1341,6 +1345,9 @@ async function installGeneration(
   await verifyPinnedJETLS(
     context.juliaPath,
     serverLaunchEnvironment(baseEnvironment, generationPath, platform),
+    // The installation above precompiled the generation, so this load
+    // only confirms the pin from warm caches.
+    TIMEOUTS.precompilation,
     runner,
     platform,
     logger,
@@ -1415,6 +1422,14 @@ async function resolveGeneration(
             await verifyPinnedJETLS(
               context.juliaPath,
               serverLaunchEnvironment(baseEnvironment, current, platform),
+              // A stamp mismatch typically means a Julia patch update
+              // invalidated every precompile cache, so this load may
+              // legitimately re-precompile the whole JETLS tree. The
+              // plain precompilation budget can expire mid-compile, and
+              // the resulting fallback install would re-download
+              // everything (breaking offline starts), so give the
+              // re-verification the full installation budget.
+              TIMEOUTS.install,
               runner,
               platform,
               logger,

--- a/jetls-client/src/managed-installation.ts
+++ b/jetls-client/src/managed-installation.ts
@@ -1288,6 +1288,16 @@ async function cleanupManagedStorage(
   }
 }
 
+// Cleanup runs detached from the start that triggered it: removing an
+// old generation deletes a whole depot tree, which must not add its
+// disk latency to the server launch. The latest run is tracked so
+// tests can await a deterministic state.
+let pendingCleanup: Promise<void> = Promise.resolve();
+
+export function managedCleanupSettled(): Promise<void> {
+  return pendingCleanup;
+}
+
 async function stampedCurrentGeneration(
   context: RuntimeContext,
 ): Promise<string | undefined> {
@@ -1397,7 +1407,7 @@ async function resolveGeneration(
     // The container-level marker is what keeps the whole runtime alive
     // against the stale-runtime sweep.
     await touchLastUsed(context.containerPath);
-    await cleanupManagedStorage(context.containerPath, logger);
+    pendingCleanup = cleanupManagedStorage(context.containerPath, logger);
     return generationPath;
   };
   if (!forceInstall) {

--- a/jetls-client/src/managed-installation.ts
+++ b/jetls-client/src/managed-installation.ts
@@ -1623,6 +1623,20 @@ async function resolveManagedRuntime(
       options.environment,
       platform,
     );
+    // Managed processes and the managed server launch the resolved
+    // Julia directly, never through a shell: `cmd.exe` would mangle the
+    // unquoted `-e` scripts, and the shell-less server spawn refuses
+    // batch scripts outright. A batch wrapper therefore cannot work and
+    // is rejected as a configuration error instead of failing later
+    // with confusing Julia usage errors.
+    if (needsWindowsBatchShell(juliaPath, platform)) {
+      throw new Error(
+        `The Julia command resolves to a batch script: ${juliaPath}\n` +
+          "The managed installation launches Julia directly and cannot " +
+          "run batch scripts; point the command at the Julia executable " +
+          "itself (e.g. `julia.exe`).",
+      );
+    }
     return { platform, runner, storagePath, juliaPath };
   } catch (error) {
     throw managedError(

--- a/jetls-client/src/managed-installation.ts
+++ b/jetls-client/src/managed-installation.ts
@@ -66,6 +66,11 @@ const GENERATION_RETENTION = 7 * 24 * 60 * 60 * 1000;
 // because reclaiming a runtime the user switches back to costs a full
 // reinstall.
 const RUNTIME_RETENTION = 30 * 24 * 60 * 60 * 1000;
+// The last-used markers only record starts, so a window that keeps a
+// server running without restarting would age past the retentions above
+// while still using its generation; callers re-touch the markers at
+// this interval while their server runs.
+export const LAST_USED_REFRESH_INTERVAL = 60 * 60 * 1000;
 
 export interface ProcessResult {
   status: number | null;
@@ -513,6 +518,19 @@ export function lastUsedPath(basePath: string): string {
 // from.
 async function touchLastUsed(basePath: string): Promise<void> {
   await writeFile(lastUsedPath(basePath), "").catch(() => undefined);
+}
+
+/**
+ * Refreshes the last-used markers of a resolved generation and its
+ * runtime container, so cleanup in other windows keeps both alive while
+ * a long-running session still uses them. Best-effort like the markers
+ * themselves.
+ */
+export async function touchManagedInstallation(
+  depotPath: string,
+): Promise<void> {
+  await touchLastUsed(depotPath);
+  await touchLastUsed(path.dirname(depotPath));
 }
 
 function appsDirectory(depotPath: string): string {
@@ -1352,6 +1370,15 @@ async function resolveGeneration(
   onInstallStep: (() => () => void) | undefined,
   onInstallOutput: ((line: string) => void) | undefined,
 ): Promise<string> {
+  // Mark the container in use before the resolution work: a fresh
+  // install can hold it unresolved for many minutes, during which
+  // cleanup in another window would still judge it by its last start.
+  // Failures fall through to the resolution itself, which reads the
+  // markers only best-effort and surfaces real filesystem problems.
+  await mkdir(context.containerPath, { recursive: true }).catch(
+    () => undefined,
+  );
+  await touchLastUsed(context.containerPath);
   const settle = async (generationPath: string): Promise<string> => {
     await touchLastUsed(generationPath);
     // The container-level marker is what keeps the whole runtime alive

--- a/jetls-client/src/server-lifecycle.ts
+++ b/jetls-client/src/server-lifecycle.ts
@@ -396,10 +396,16 @@ async function startLanguageServer() {
     precompilationTimeoutMs: TIMEOUTS.precompilation,
     appendLine: (message) => outputChannel.appendLine(message),
     onPrecompiling: () => statusBar.show("precompiling"),
-    onProcessError: (error) =>
-      managedDepotPath === undefined
-        ? handleSpawnError(error, baseCommand)
-        : handleManagedServerFailure(error, managedDepotPath),
+    onProcessError: (error) => {
+      if (deactivating || restartRunner.active !== undefined) {
+        return;
+      }
+      if (managedDepotPath === undefined) {
+        handleSpawnError(error, baseCommand);
+      } else {
+        handleManagedServerFailure(error, managedDepotPath);
+      }
+    },
     registerCancel: (cancel) => {
       cancelServerStartup = cancel;
     },

--- a/jetls-client/src/server-lifecycle.ts
+++ b/jetls-client/src/server-lifecycle.ts
@@ -755,6 +755,7 @@ function awaitWithTimeout(
 export async function shutdownServerLifecycle(): Promise<void> {
   deactivating = true;
   managedSetupAbort?.abort();
+  cancelServerStartup?.();
   try {
     await versionPreflight.terminate();
   } catch (err) {

--- a/jetls-client/src/server-lifecycle.ts
+++ b/jetls-client/src/server-lifecycle.ts
@@ -13,9 +13,11 @@ import { JETLS_CLIENT_SETTINGS_SECTION, TIMEOUTS } from "./constants";
 import {
   ensureManagedJETLS,
   invalidateInstallStamp,
+  LAST_USED_REFRESH_INTERVAL,
   ManagedInstallationCancelledError,
   ManagedJETLSError,
   managedJETLSCommands,
+  touchManagedInstallation,
 } from "./managed-installation";
 import {
   getServerConfig,
@@ -193,6 +195,9 @@ async function startLanguageServer() {
   if (deactivating) {
     return;
   }
+  // The previous server (whose installation the refresh kept alive) is
+  // already stopped by the time a new start runs.
+  stopManagedLastUsedRefresh();
   statusBar.show("checking");
 
   const serverConfig = getServerConfig();
@@ -613,6 +618,13 @@ async function startLanguageServer() {
     outputChannel.appendLine("[jetls-client] JETLS is ready!");
   }
 
+  if (managedDepotPath !== undefined) {
+    const depotPath = managedDepotPath;
+    managedLastUsedRefresh = setInterval(() => {
+      void touchManagedInstallation(depotPath);
+    }, LAST_USED_REFRESH_INTERVAL);
+  }
+
   // Register handler for workspace/configuration requests after client starts
   languageClient.onRequest(
     "workspace/configuration",
@@ -691,6 +703,18 @@ let forceManagedInstall = false;
 // strands its unpublished generation.
 let managedSetupAbort: AbortController | undefined;
 
+// Re-touches the running managed server's last-used markers: cleanup in
+// other windows judges liveness by them, and they otherwise only record
+// starts, which a long-lived session outlives.
+let managedLastUsedRefresh: NodeJS.Timeout | undefined;
+
+function stopManagedLastUsedRefresh(): void {
+  if (managedLastUsedRefresh !== undefined) {
+    clearInterval(managedLastUsedRefresh);
+    managedLastUsedRefresh = undefined;
+  }
+}
+
 /**
  * Reinstalls the managed JETLS from scratch: after a modal confirmation
  * the server restarts with the next managed setup forced to install a
@@ -760,6 +784,7 @@ function awaitWithTimeout(
 
 export async function shutdownServerLifecycle(): Promise<void> {
   deactivating = true;
+  stopManagedLastUsedRefresh();
   managedSetupAbort?.abort();
   cancelServerStartup?.();
   try {

--- a/jetls-client/src/server-lifecycle.ts
+++ b/jetls-client/src/server-lifecycle.ts
@@ -280,7 +280,7 @@ async function startLanguageServer() {
         // deactivation would have set the flags above): no failure UI,
         // but the status bar must not keep showing progress, and the
         // notification offers the way back in.
-        statusBar.showManagedFailure("The JETLS installation was cancelled.");
+        statusBar.showManagedCancelled();
         const retryButton = "Retry";
         const outputButton = "Show JETLS output";
         void vscode.window

--- a/jetls-client/src/server-lifecycle.ts
+++ b/jetls-client/src/server-lifecycle.ts
@@ -243,6 +243,7 @@ async function startLanguageServer() {
         // cancellable progress notification for its duration; routine
         // starts stay on the status bar alone.
         onInstallStep: () => {
+          let ended = false;
           let end!: () => void;
           const done = new Promise<void>((resolve) => {
             end = resolve;
@@ -254,12 +255,22 @@ async function startLanguageServer() {
               cancellable: true,
             },
             (progress, token) => {
-              installProgress = progress;
-              token.onCancellationRequested(() => setupAbort.abort());
+              // VS Code runs this task asynchronously, so a step that
+              // failed immediately may have ended before it: publishing
+              // the progress then would leave a stale reference behind
+              // the cleanup below.
+              if (!ended) {
+                installProgress = progress;
+                const cancellation = token.onCancellationRequested(() =>
+                  setupAbort.abort(),
+                );
+                void done.then(() => cancellation.dispose());
+              }
               return done;
             },
           );
           return () => {
+            ended = true;
             installProgress = undefined;
             end();
           };

--- a/jetls-client/src/status-bar.ts
+++ b/jetls-client/src/status-bar.ts
@@ -138,6 +138,28 @@ export class StartupStatusBar {
     this.item.show();
   }
 
+  /**
+   * Shows that the managed installation was cancelled: a deliberate
+   * stop rather than a failure, so the item keeps the stopped server
+   * visible without the error styling.
+   */
+  showManagedCancelled(): void {
+    if (this.suppressed) {
+      return;
+    }
+    this.clearHideTimer();
+    this.managedProgress = false;
+    this.item.text = "$(circle-slash) JETLS installation cancelled";
+    this.item.tooltip =
+      "The JETLS installation was cancelled. Restart the language server " +
+      "to retry.\nClick to open the JETLS output.";
+    this.item.backgroundColor = new vscode.ThemeColor(
+      "statusBarItem.warningBackground",
+    );
+    this.item.command = SHOW_OUTPUT_COMMAND;
+    this.item.show();
+  }
+
   /** Ignore further status updates; used once deactivation has started. */
   suppress(): void {
     this.suppressed = true;

--- a/jetls-client/test/managed-installation.test.ts
+++ b/jetls-client/test/managed-installation.test.ts
@@ -37,6 +37,7 @@ import {
   resolveExecutable,
   runtimeKey,
   serverLaunchEnvironment,
+  touchManagedInstallation,
   type ManagedInstallationOptions,
   type ProcessResult,
   type ProcessRunner,
@@ -1358,6 +1359,61 @@ test("cleanup ages out entries outside the generation layout", async () => {
     await assert.rejects(stat(legacyFile));
     await stat(freshEntry);
     await stat(seeded);
+  });
+});
+
+test("marks the runtime container in use before installing", async () => {
+  await withFixture(async (fixture) => {
+    const fake = fakeRunner(async (call) => {
+      const script = scriptFor(call);
+      if (script?.includes("Pkg.Apps.add")) {
+        return failure(1, "", "network down");
+      }
+      return success("1.12.2\n");
+    });
+
+    await assert.rejects(
+      ensureManagedJETLS({
+        storagePath: fixture.storagePath,
+        environment: fixture.environment,
+        processRunner: fake.runner,
+      }),
+      ManagedJETLSError,
+    );
+
+    // The failed install never settles, so only the up-front marker can
+    // exist: it is what keeps cleanup in another window from removing a
+    // dormant container while a start is still resolving it.
+    const containerPath = managedDepotPath(
+      fixture.storagePath,
+      fixture.juliaPath,
+      "1.12.2",
+    );
+    await stat(lastUsedPath(containerPath));
+  });
+});
+
+test("re-touching an installation refreshes its liveness markers", async () => {
+  await withFixture(async (fixture) => {
+    const generationPath = await seedGeneration(
+      fixture.storagePath,
+      fixture.juliaPath,
+    );
+    const containerPath = path.dirname(generationPath);
+    const dayMs = 24 * 60 * 60 * 1000;
+    await writeFile(lastUsedPath(generationPath), "");
+    await writeFile(lastUsedPath(containerPath), "");
+    await setAgeMs(lastUsedPath(generationPath), 10 * dayMs);
+    await setAgeMs(lastUsedPath(containerPath), 40 * dayMs);
+
+    await touchManagedInstallation(generationPath);
+
+    const generationAge =
+      Date.now() - (await stat(lastUsedPath(generationPath))).mtimeMs;
+    const containerAge =
+      Date.now() - (await stat(lastUsedPath(containerPath))).mtimeMs;
+    assert.ok(generationAge < dayMs);
+    assert.ok(containerAge < dayMs);
   });
 });
 

--- a/jetls-client/test/managed-installation.test.ts
+++ b/jetls-client/test/managed-installation.test.ts
@@ -1221,6 +1221,33 @@ test("classifies an unresolvable Julia command as a resolution failure", async (
   });
 });
 
+test("rejects a Julia command that resolves to a batch script", async () => {
+  await withFixture(async (fixture) => {
+    const batchPath = path.join(fixture.root, "runtime", "bin", "julia.bat");
+    await writeFile(batchPath, "@echo off\r\n");
+    await chmod(batchPath, 0o755);
+    const fake = fakeRunner(async () => success("1.12.2\n"));
+
+    await assert.rejects(
+      ensureManagedJETLS({
+        storagePath: fixture.storagePath,
+        environment: fixture.environment,
+        juliaCommand: batchPath,
+        platform: "win32",
+        processRunner: fake.runner,
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof ManagedJETLSError);
+        assert.equal(error.retryable, false);
+        assert.match(error.summary, /resolves to a batch script/);
+        return true;
+      },
+    );
+    // The rejection happens before any managed process runs.
+    assert.equal(fake.calls.length, 0);
+  });
+});
+
 test("force install replaces a verified current generation", async () => {
   await withFixture(async (fixture) => {
     const seeded = await seedGeneration(fixture.storagePath, fixture.juliaPath);

--- a/jetls-client/test/managed-installation.test.ts
+++ b/jetls-client/test/managed-installation.test.ts
@@ -30,6 +30,7 @@ import {
   isPinnedJETLSVersion,
   isSupportedJuliaVersion,
   lastUsedPath,
+  managedCleanupSettled,
   managedEnvironment,
   managedDepotPath,
   managedJETLSCommands,
@@ -131,6 +132,9 @@ async function withFixture(
       },
     });
   } finally {
+    // A cleanup detached by a `settle` may still be walking the
+    // fixture tree; let it finish before pulling the tree away.
+    await managedCleanupSettled();
     await rm(root, { recursive: true, force: true });
   }
 }
@@ -1318,6 +1322,7 @@ test("cleanup removes aged generations but never the current one", async () => {
     });
 
     assert.equal(installation.depotPath, seeded);
+    await managedCleanupSettled();
     await assert.rejects(stat(crashed));
     await assert.rejects(stat(superseded));
     await stat(recent);
@@ -1359,6 +1364,7 @@ test("cleanup removes runtime containers of Julia versions no longer used", asyn
       processRunner: fake.runner,
     });
 
+    await managedCleanupSettled();
     await assert.rejects(stat(staleRuntime));
     await assert.rejects(stat(leftover));
     await stat(liveRuntime);
@@ -1392,6 +1398,7 @@ test("cleanup ages out entries outside the generation layout", async () => {
       processRunner: fake.runner,
     });
 
+    await managedCleanupSettled();
     await assert.rejects(stat(legacyDir));
     await assert.rejects(stat(legacyFile));
     await stat(freshEntry);

--- a/jetls-client/test/managed-installation.test.ts
+++ b/jetls-client/test/managed-installation.test.ts
@@ -16,6 +16,7 @@ import { test } from "node:test";
 
 import jetlsVersion from "../JETLS_VERSION.json";
 
+import { TIMEOUTS } from "../src/constants";
 import {
   JETLS_REPOSITORY,
   JETLS_REVISION,
@@ -503,7 +504,12 @@ test("re-verifies when the stamp records another Julia patch version", async () 
       processRunner: fake.runner,
     });
 
-    assert.equal(jetlsVersionCalls(fake.calls).length, 1);
+    const verifyCalls = jetlsVersionCalls(fake.calls);
+    assert.equal(verifyCalls.length, 1);
+    // The mismatch may mean every precompile cache went stale, so the
+    // re-verification gets the full installation budget: a timeout here
+    // would force a fresh install, which needs network access.
+    assert.equal(verifyCalls[0].options.timeoutMs, TIMEOUTS.install);
     const stamp = JSON.parse(
       await readFile(installStampPath(generationPath), "utf8"),
     ) as { julia: string };
@@ -567,6 +573,10 @@ test("installs and verifies the exact pin in a private generation depot", async 
     const versionCalls = jetlsVersionCalls(fake.calls);
     assert.equal(installCalls.length, 1);
     assert.equal(versionCalls.length, 1);
+    assert.equal(installCalls[0].options.timeoutMs, TIMEOUTS.install);
+    // The post-install verification loads from freshly precompiled
+    // caches, so it keeps the plain precompilation budget.
+    assert.equal(versionCalls[0].options.timeoutMs, TIMEOUTS.precompilation);
     assert.match(
       scriptFor(installCalls[0]) ?? "",
       new RegExp(`url="${JETLS_REPOSITORY.replaceAll(".", "\\.")}"`),
@@ -1453,8 +1463,12 @@ test("removes a stale install lock by age", async () => {
     );
     const lockPath = path.join(containerPath, "install.lock");
     await mkdir(lockPath, { recursive: true });
-    // Older than the whole installation budget: its holder is dead.
-    await setAgeMs(lockPath, 17 * 60 * 1000);
+    // Older than the longest legitimate hold (re-verification plus a
+    // fresh installation with its verification): its holder is dead.
+    await setAgeMs(
+      lockPath,
+      2 * TIMEOUTS.install + TIMEOUTS.precompilation + 2 * 60 * 1000,
+    );
     const fake = standardRunner(fixture.juliaPath);
 
     await ensureManagedJETLS({


### PR DESCRIPTION
This PR collects nine follow-up fixes from a review of the recent managed installation work (#871, #872 and the surrounding commits). Each commit is self-contained and carries the full details in its message; this is the digest.

## Lifecycle fixes

- **Cancel the in-flight startup connection on deactivate** — `shutdownServerLifecycle` aborted the managed setup and the version preflight but, unlike the restart path, never cancelled a spawned server still waiting for its pipe/socket transport connection, so deactivation spent its whole bounded wait on a connect attempt that no longer mattered. Shutdown now cancels it, symmetric with restarts.
- **Stop double-handling server spawn errors** — the transports invoke `onProcessError` and then reject the connection attempt with the same error, which the `languageClient.start()` catch also handles during the extension's own start flow, so a spawn failure (e.g. a missing executable) surfaced two error notifications and a duplicate install-stamp invalidation. `onProcessError` now stands down while the extension's own lifecycle owns the failure surface, leaving it to cover only the restarts vscode-languageclient initiates on its own, where no catch is in flight.

## Managed storage robustness

- **Keep in-use managed storage alive against cleanup** — cleanup judges liveness by last-used markers that were only written when a start finished resolving its generation. A dormant runtime container being revived could therefore be removed by another window's cleanup mid-install, and a window that keeps its server running past the generation/runtime retentions could lose its (superseded) generation or container under a still-running server. The container marker is now touched up front, and the client re-touches the resolved generation and its container hourly while the managed server runs.
- **Give managed re-verification the installation budget** — after an install-stamp mismatch (typically a Julia patch update) the re-verification re-precompiles the whole JETLS dependency tree, but ran under the 5-minute precompilation budget. A timeout counted as a broken generation and forced a fresh install, which re-downloads every dependency and therefore needs network access — breaking offline starts after a Julia patch update. The re-verification now gets the full installation budget (the post-install check keeps the short one, since it loads from warm caches), and `LOCK_STALE_AGE` grows to cover the longest legitimate lock hold.
- **Publish managed files through unique temp names** — the `current` pointer and the install stamp staged their atomic rename through fixed temp names, so two publishers racing without the (best-effort) install lock could truncate or rename away each other's temp, turning a completed installation into a spurious `ENOENT` failure. Both now stage through a shared helper using randomly suffixed temp names.
- **Run managed storage cleanup off the startup path** — `settle` awaited the storage cleanup, so removing an aged generation or a stale runtime container (whole depot trees) delayed the server launch, including the stamped fast path. Cleanup now runs detached; tests await it deterministically through `managedCleanupSettled`.

## Configuration and UI

- **Reject batch-script Julia commands in managed mode** — a `JULIA_APPS_JULIA_CMD` resolving to a `.bat`/`.cmd` wrapper failed deep into setup with opaque Julia usage errors, because `shell: true` joins the `-e` scripts into the `cmd.exe` command line unquoted — and the shell-less managed server spawn could never launch a batch script anyway. The resolution now rejects batch scripts up front as a non-retryable configuration error, and the README documents that the command must be the Julia executable itself.
- **Show a dedicated status for cancelled installations** — cancelling from the installation progress notification showed "Managed JETLS failed" with error styling even though nothing failed. There is now a dedicated cancelled state with warning styling and a hint that restarting the language server retries.
- **Fix stale progress publication in the install step** — the `withProgress` task callback runs asynchronously, so an install step that failed immediately could have a stale progress reference republished after its cleanup ran; the callback now skips publishing once the step has ended and disposes the cancellation listener.

Every commit passed `npm run check` and the test suite, which grows from 78 to 81 tests. The two lifecycle fixes address behavior released in v0.8.0 and add CHANGELOG entries; the rest fix unreleased managed-installation work and deliberately add none.
