### PR TITLE
deps: Update JS/JL revisions and adapt to JuliaLang/julia#62862

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 >
 > Note: Path glob patterns use `/` as the separator on all platforms, including Windows; backslashes are not supported as separators.
 
+### Changed
+
+- Updated JuliaSyntax.jl and JuliaLowering.jl revisions, bringing in JuliaLowering bugfixes for various lowering edge cases found in real-world packages ([JuliaLang/julia#62862](https://github.com/JuliaLang/julia/pull/62862)).
+
 ## 2026-08-29
 
 - Commit: [`8dab3d9`](https://github.com/aviatesk/JETLS.jl/commit/8dab3d9)

--- a/Project.toml
+++ b/Project.toml
@@ -30,8 +30,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [sources]
 Compiler = {path = "Compiler"}
 JET = {rev = "2744e2ef", url = "https://github.com/aviatesk/JET.jl"}
-JuliaLowering = {rev = "2fefd0127e", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
-JuliaSyntax = {rev = "2fefd0127e", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
+JuliaLowering = {rev = "537a4c16f1", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
+JuliaSyntax = {rev = "537a4c16f1", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
 LSP = {path = "LSP"}
 
 [compat]

--- a/src/analysis/occurrence-analysis.jl
+++ b/src/analysis/occurrence-analysis.jl
@@ -124,6 +124,29 @@ function compute_binding_occurrences(
         union!(existing, local_occs)
     end
 
+    # Typedef lowering also emits an explicit `global` decl for the type name
+    # (JuliaLang/julia#62862) that resolves to a binding distinct from the alias
+    # target above. Fold such same-`(mod, name)` global entries into the alias
+    # target, skipping occurrences it already covers at the same range.
+    for (_, global_binfo) in alias_remaps
+        target_occs = occurrences[global_binfo]
+        duplicates = JL.BindingInfo[]
+        for binfo in keys(occurrences)
+            binfo === global_binfo && continue
+            is_matching_global_binding(binfo, global_binfo) || continue
+            push!(duplicates, binfo)
+        end
+        for binfo in duplicates
+            for occ in pop!(occurrences, binfo)
+                any(target_occs) do existing
+                    existing.kind === occ.kind &&
+                        JS.byte_range(existing.tree) == JS.byte_range(occ.tree)
+                end && continue
+                push!(target_occs, occ)
+            end
+        end
+    end
+
     return occurrences
 end
 

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -1631,6 +1631,10 @@ function per_stmt_diagnostics!(
         jl_lower_for_scope_resolution(context_module, world, st0;
             recover_from_macro_errors=false, convert_closures=true, soft_scope)
     catch err
+        # JL wraps old-style macro invocation failures in `LoadError` (JuliaLang/julia#62862)
+        if err isa LoadError && err.error isa JL.MacroExpansionError
+            err = err.error
+        end
         if err isa JL.LoweringError
             if !err.internal
                 for (st, msg) in zip(err.sts, err.msgs)


### PR DESCRIPTION
Update the JuliaSyntax/JuliaLowering pins from 2fefd0127e to 537a4c16f1. The JuliaLowering bugfix batch JuliaLang/julia#62862 included in this range changes two behaviors JETLS relied on, so this commit also adapts the affected code paths:

- Old-style macro invocation failures are now rethrown wrapped as `LoadError(file, line, MacroExpansionError(...))` instead of a bare `MacroExpansionError`, so the `err isa JL.MacroExpansionError` check in `per_stmt_diagnostics!` no longer matched and macro expansion error diagnostics silently disappeared. The catch handler now unwraps the `LoadError` before dispatching on the error type.

- `expand_struct_def`/`expand_typegroup_def` now emit an explicit `global` declaration for the type name ahead of the lowered definition. That node resolves to a `:global` binding distinct from the internal one the type-alias normalization in `compute_binding_occurrences` re-keys onto, so the struct name gained a duplicate `:decl` occurrence. Such same-`(mod, name)` global entries are now folded into the alias target, skipping occurrences already covered at the same byte range.

Both regressions were caught by the existing test suite (`test_lowering_diagnostic.jl` and `test_occurrence_analysis.jl`); the full suite passes with this commit.