### PR TITLE
diagnostic: Clarify method errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- `inference/method-error` now distinguishes ambiguous calls from calls with no matching method, lists the conflicting or closest candidate methods, and suggests a disambiguating signature when possible.
+
+- `inference/method-error` no longer reports a redundant `Core.kwcall` method error when the unsupported keyword argument diagnostic already explains the failure.
+
 - `inference/field-error` now reports field accesses whose receiver may be a type without the field: `x.regex` where `x::Union{Nothing,Regex}` reports a `FieldError` for the `Nothing` case, and accesses on fieldless receivers like `x.foo` where `x::Nothing` are reported as well.
 
 - Updated JuliaSyntax.jl and JuliaLowering.jl revisions, bringing in JuliaLowering bugfixes for various lowering edge cases found in real-world packages ([JuliaLang/julia#62862](https://github.com/JuliaLang/julia/pull/62862)).

--- a/Compiler/snapshots.toml
+++ b/Compiler/snapshots.toml
@@ -3,13 +3,13 @@ repository = "https://github.com/JuliaLang/julia.git"
 subdir = "Compiler"
 
 [snapshots."1.12"]
-commit = "a4b756b6b41910c7284a8114bc5d7eb9b700c152"
-source-branch = "avi/JETLS-Compiler-head-v1.12-2026-07-31"
+commit = "571a09836c95c73989daf8e468a724919a12a480"
+source-branch = "avi/JETLS-Compiler-head-v1.12-2026-09-01"
 runtime = { lower = "1.12.2", upper = "1.13-" }
 destination = "snapshots/v1.12"
 
 [snapshots."1.13"]
-commit = "039fbdb19f067ffca3b53719d751a4311ce375e7"
-source-branch = "avi/JETLS-Compiler-head-v1.13-2026-07-31"
+commit = "caa034a63c03aa98dd2c5b6e94f77f43ce7ad98c"
+source-branch = "avi/JETLS-Compiler-head-v1.13-2026-09-01"
 runtime = { lower = "1.13-", upper = "1.14-" }
 destination = "snapshots/v1.13"

--- a/Compiler/snapshots/v1.12/src/methodtable.jl
+++ b/Compiler/snapshots/v1.12/src/methodtable.jl
@@ -42,7 +42,9 @@ end
 struct MethodMatchKey
     sig # ::Type
     limit::Int
-    MethodMatchKey(@nospecialize(sig), limit::Int) = new(sig, limit)
+    include_ambiguous::Bool
+    MethodMatchKey(@nospecialize(sig), limit::Int, include_ambiguous::Bool) =
+        new(sig, limit, include_ambiguous)
 end
 
 """
@@ -58,20 +60,23 @@ end
 CachedMethodTable(table::T) where T = CachedMethodTable{T}(IdDict{MethodMatchKey, Union{Nothing,MethodLookupResult}}(), table)
 
 """
-    findall(sig::Type, view::MethodTableView; limit::Int=-1) ->
+    findall(sig::Type, view::MethodTableView;
+            limit::Int=-1, include_ambiguous::Bool=false) ->
         matches::MethodLookupResult or nothing
 
-Find all methods in the given method table `view` that are applicable to the given signature `sig`.
-If no applicable methods are found, an empty result is returned.
-If the number of applicable methods exceeded the specified `limit`, `nothing` is returned.
-Note that the default setting `limit=-1` does not limit the number of applicable methods.
-`overlayed` indicates if any of the matching methods comes from an overlayed method table.
+Find all methods in `view` that are applicable to `sig`. If no applicable methods
+are found, an empty result is returned. If the number of applicable methods exceeds
+`limit`, `nothing` is returned. The default `limit=-1` does not limit the number of
+applicable methods. `include_ambiguous=true` retains fully ambiguous matches that are
+normally filtered out of the result.
 """
-findall(@nospecialize(sig::Type), table::InternalMethodTable; limit::Int=-1) =
-    _findall(sig, nothing, table.world, limit)
+findall(@nospecialize(sig::Type), table::InternalMethodTable;
+        limit::Int=-1, include_ambiguous::Bool=false) =
+    _findall(sig, nothing, table.world, limit, include_ambiguous)
 
-function findall(@nospecialize(sig::Type), table::OverlayMethodTable; limit::Int=-1)
-    result = _findall(sig, table.mt, table.world, limit)
+function findall(@nospecialize(sig::Type), table::OverlayMethodTable;
+                 limit::Int=-1, include_ambiguous::Bool=false)
+    result = _findall(sig, table.mt, table.world, limit, include_ambiguous)
     result === nothing && return nothing
     nr = length(result)
     if nr ≥ 1 && result[nr].fully_covers
@@ -79,7 +84,7 @@ function findall(@nospecialize(sig::Type), table::OverlayMethodTable; limit::Int
         return result
     end
     # fall back to the internal method table
-    fallback_result = _findall(sig, nothing, table.world, limit)
+    fallback_result = _findall(sig, nothing, table.world, limit, include_ambiguous)
     fallback_result === nothing && return nothing
     # merge the fallback match results with the internal method table,
     # filtering out base methods that are fully covered by overlay methods
@@ -98,25 +103,27 @@ function findall(@nospecialize(sig::Type), table::OverlayMethodTable; limit::Int
         result.ambig | fallback_result.ambig)
 end
 
-function _findall(@nospecialize(sig::Type), mt::Union{Nothing,MethodTable}, world::UInt, limit::Int)
+function _findall(@nospecialize(sig::Type), mt::Union{Nothing,MethodTable}, world::UInt,
+                  limit::Int, include_ambiguous::Bool)
     _min_val = RefValue{UInt}(typemin(UInt))
     _max_val = RefValue{UInt}(typemax(UInt))
     _ambig = RefValue{Int32}(0)
-    ms = _methods_by_ftype(sig, mt, limit, world, false, _min_val, _max_val, _ambig)
+    ms = _methods_by_ftype(sig, mt, limit, world, include_ambiguous, _min_val, _max_val, _ambig)
     isa(ms, Vector) || return nothing
     return MethodLookupResult(ms, WorldRange(_min_val[], _max_val[]), _ambig[] != 0)
 end
 
-function findall(@nospecialize(sig::Type), table::CachedMethodTable; limit::Int=-1)
+function findall(@nospecialize(sig::Type), table::CachedMethodTable;
+                 limit::Int=-1, include_ambiguous::Bool=false)
     if isconcretetype(sig)
         # as for concrete types, we cache result at on the next level
-        return findall(sig, table.table; limit)
+        return findall(sig, table.table; limit, include_ambiguous)
     end
-    key = MethodMatchKey(sig, limit)
+    key = MethodMatchKey(sig, limit, include_ambiguous)
     if haskey(table.cache, key)
         return table.cache[key]
     else
-        return table.cache[key] = findall(sig, table.table; limit)
+        return table.cache[key] = findall(sig, table.table; limit, include_ambiguous)
     end
 end
 

--- a/Compiler/snapshots/v1.12/test/AbstractInterpreter.jl
+++ b/Compiler/snapshots/v1.12/test/AbstractInterpreter.jl
@@ -33,6 +33,41 @@ end
 @MethodTable OVERLAY_MT
 Compiler.method_table(interp::MTOverlayInterp) = Compiler.OverlayMethodTable(Compiler.get_inference_world(interp), OVERLAY_MT)
 
+# `include_ambiguous` preserves ambiguous matches across method-table views and cache modes.
+ambiguous_lookup(x::Integer, y) = 1
+ambiguous_lookup(x, y::Integer) = 2
+ambiguous_overlay(x, y) = 0
+@overlay OVERLAY_MT ambiguous_overlay(x::Integer, y) = 1
+@overlay OVERLAY_MT ambiguous_overlay(x, y::Integer) = 2
+
+@testset "ambiguous method lookup" begin
+    world = Base.get_world_counter()
+    sig = Tuple{typeof(ambiguous_lookup),Integer,Integer}
+    internal = Compiler.InternalMethodTable(world)
+    filtered = Compiler.findall(sig, internal)
+    inclusive = Compiler.findall(sig, internal; include_ambiguous=true)
+    @test filtered !== nothing
+    @test Compiler.length(filtered) == 0
+    @test inclusive !== nothing
+    @test inclusive.ambig
+    @test Compiler.length(inclusive) == 2
+    @test Set(match.method for match in inclusive) == Set(methods(ambiguous_lookup))
+
+    cached = Compiler.CachedMethodTable(internal)
+    @test Compiler.length(Compiler.findall(sig, cached)) == 0
+    @test Compiler.length(Compiler.findall(sig, cached; include_ambiguous=true)) == 2
+    @test length(cached.cache) == 2
+
+    overlay_sig = Tuple{typeof(ambiguous_overlay),Integer,Integer}
+    overlay = Compiler.OverlayMethodTable(world, OVERLAY_MT)
+    overlay_matches = Compiler.findall(overlay_sig, overlay; include_ambiguous=true)
+    @test overlay_matches !== nothing
+    @test overlay_matches.ambig
+    @test Compiler.length(overlay_matches) == 2
+    base_method = only(methods(ambiguous_overlay))
+    @test all(match -> match.method !== base_method, overlay_matches)
+end
+
 function Compiler.add_remark!(interp::MTOverlayInterp, ::Compiler.InferenceState, remark)
     if interp.meta !== nothing
         # Core.println(remark)

--- a/Compiler/snapshots/v1.13/src/methodtable.jl
+++ b/Compiler/snapshots/v1.13/src/methodtable.jl
@@ -42,7 +42,9 @@ end
 struct MethodMatchKey
     sig # ::Type
     limit::Int
-    MethodMatchKey(@nospecialize(sig), limit::Int) = new(sig, limit)
+    include_ambiguous::Bool
+    MethodMatchKey(@nospecialize(sig), limit::Int, include_ambiguous::Bool) =
+        new(sig, limit, include_ambiguous)
 end
 
 """
@@ -58,20 +60,23 @@ end
 CachedMethodTable(table::T) where T = CachedMethodTable{T}(IdDict{MethodMatchKey, Union{Nothing,MethodLookupResult}}(), table)
 
 """
-    findall(sig::Type, view::MethodTableView; limit::Int=-1) ->
+    findall(sig::Type, view::MethodTableView;
+            limit::Int=-1, include_ambiguous::Bool=false) ->
         matches::MethodLookupResult or nothing
 
-Find all methods in the given method table `view` that are applicable to the given signature `sig`.
-If no applicable methods are found, an empty result is returned.
-If the number of applicable methods exceeded the specified `limit`, `nothing` is returned.
-Note that the default setting `limit=-1` does not limit the number of applicable methods.
-`overlayed` indicates if any of the matching methods comes from an overlayed method table.
+Find all methods in `view` that are applicable to `sig`. If no applicable methods
+are found, an empty result is returned. If the number of applicable methods exceeds
+`limit`, `nothing` is returned. The default `limit=-1` does not limit the number of
+applicable methods. `include_ambiguous=true` retains fully ambiguous matches that are
+normally filtered out of the result.
 """
-findall(@nospecialize(sig::Type), table::InternalMethodTable; limit::Int=-1) =
-    _findall(sig, nothing, table.world, limit)
+findall(@nospecialize(sig::Type), table::InternalMethodTable;
+        limit::Int=-1, include_ambiguous::Bool=false) =
+    _findall(sig, nothing, table.world, limit, include_ambiguous)
 
-function findall(@nospecialize(sig::Type), table::OverlayMethodTable; limit::Int=-1)
-    result = _findall(sig, table.mt, table.world, limit)
+function findall(@nospecialize(sig::Type), table::OverlayMethodTable;
+                 limit::Int=-1, include_ambiguous::Bool=false)
+    result = _findall(sig, table.mt, table.world, limit, include_ambiguous)
     result === nothing && return nothing
     nr = length(result)
     if nr ≥ 1 && result[nr].fully_covers
@@ -79,7 +84,7 @@ function findall(@nospecialize(sig::Type), table::OverlayMethodTable; limit::Int
         return result
     end
     # fall back to the internal method table
-    fallback_result = _findall(sig, nothing, table.world, limit)
+    fallback_result = _findall(sig, nothing, table.world, limit, include_ambiguous)
     fallback_result === nothing && return nothing
     # merge the fallback match results with the internal method table,
     # filtering out base methods that are fully covered by overlay methods
@@ -98,25 +103,27 @@ function findall(@nospecialize(sig::Type), table::OverlayMethodTable; limit::Int
         result.ambig | fallback_result.ambig)
 end
 
-function _findall(@nospecialize(sig::Type), mt::Union{Nothing,MethodTable}, world::UInt, limit::Int)
+function _findall(@nospecialize(sig::Type), mt::Union{Nothing,MethodTable}, world::UInt,
+                  limit::Int, include_ambiguous::Bool)
     _min_val = RefValue{UInt}(typemin(UInt))
     _max_val = RefValue{UInt}(typemax(UInt))
     _ambig = RefValue{Int32}(0)
-    ms = _methods_by_ftype(sig, mt, limit, world, false, _min_val, _max_val, _ambig)
+    ms = _methods_by_ftype(sig, mt, limit, world, include_ambiguous, _min_val, _max_val, _ambig)
     isa(ms, Vector) || return nothing
     return MethodLookupResult(ms, WorldRange(_min_val[], _max_val[]), _ambig[] != 0)
 end
 
-function findall(@nospecialize(sig::Type), table::CachedMethodTable; limit::Int=-1)
+function findall(@nospecialize(sig::Type), table::CachedMethodTable;
+                 limit::Int=-1, include_ambiguous::Bool=false)
     if isconcretetype(sig)
         # as for concrete types, we cache result at on the next level
-        return findall(sig, table.table; limit)
+        return findall(sig, table.table; limit, include_ambiguous)
     end
-    key = MethodMatchKey(sig, limit)
+    key = MethodMatchKey(sig, limit, include_ambiguous)
     if haskey(table.cache, key)
         return table.cache[key]
     else
-        return table.cache[key] = findall(sig, table.table; limit)
+        return table.cache[key] = findall(sig, table.table; limit, include_ambiguous)
     end
 end
 

--- a/Compiler/snapshots/v1.13/test/AbstractInterpreter.jl
+++ b/Compiler/snapshots/v1.13/test/AbstractInterpreter.jl
@@ -34,6 +34,41 @@ end
 @MethodTable OVERLAY_MT
 Compiler.method_table(interp::MTOverlayInterp) = Compiler.OverlayMethodTable(Compiler.get_inference_world(interp), OVERLAY_MT)
 
+# `include_ambiguous` preserves ambiguous matches across method-table views and cache modes.
+ambiguous_lookup(x::Integer, y) = 1
+ambiguous_lookup(x, y::Integer) = 2
+ambiguous_overlay(x, y) = 0
+@overlay OVERLAY_MT ambiguous_overlay(x::Integer, y) = 1
+@overlay OVERLAY_MT ambiguous_overlay(x, y::Integer) = 2
+
+@testset "ambiguous method lookup" begin
+    world = Base.get_world_counter()
+    sig = Tuple{typeof(ambiguous_lookup),Integer,Integer}
+    internal = Compiler.InternalMethodTable(world)
+    filtered = Compiler.findall(sig, internal)
+    inclusive = Compiler.findall(sig, internal; include_ambiguous=true)
+    @test filtered !== nothing
+    @test Compiler.length(filtered) == 0
+    @test inclusive !== nothing
+    @test inclusive.ambig
+    @test Compiler.length(inclusive) == 2
+    @test Set(match.method for match in inclusive) == Set(methods(ambiguous_lookup))
+
+    cached = Compiler.CachedMethodTable(internal)
+    @test Compiler.length(Compiler.findall(sig, cached)) == 0
+    @test Compiler.length(Compiler.findall(sig, cached; include_ambiguous=true)) == 2
+    @test length(cached.cache) == 2
+
+    overlay_sig = Tuple{typeof(ambiguous_overlay),Integer,Integer}
+    overlay = Compiler.OverlayMethodTable(world, OVERLAY_MT)
+    overlay_matches = Compiler.findall(overlay_sig, overlay; include_ambiguous=true)
+    @test overlay_matches !== nothing
+    @test overlay_matches.ambig
+    @test Compiler.length(overlay_matches) == 2
+    base_method = only(methods(ambiguous_overlay))
+    @test all(match -> match.method !== base_method, overlay_matches)
+end
+
 function Compiler.add_remark!(interp::MTOverlayInterp, ::Compiler.InferenceState, remark)
     if interp.meta !== nothing
         # Core.println(remark)

--- a/docs/src/diagnostic.md
+++ b/docs/src/diagnostic.md
@@ -1278,14 +1278,15 @@ end
 
 **Default severity:** `Warning`
 
-Function calls where no matching method can be found for the inferred argument
-types. This diagnostic detects potential `MethodError`s that would occur at
-runtime.
+Function calls where no unique matching method can be found for the inferred
+argument types. This diagnostic detects potential `MethodError`s that would
+occur at runtime.
 
-Examples:
+When no method matches, the diagnostic includes up to three closest candidates:
 
 ```julia
-sin(1, 2)  # no matching method found `sin(::Int64, ::Int64)` (JETLS inference/method-error)
+sin('4')  # MethodError: no matching method found `sin(::Char)`
+          # (JETLS inference/method-error)
 ```
 
 When multiple union-split signatures fail to find matches, the diagnostic will
@@ -1295,7 +1296,8 @@ report all failed signatures:
 only_int(x::Int) = 2x
 
 function union_split_method_error(x::Union{Int,String})
-    return only_int(x)  # no matching method found `only_int(::String)` (1/2 union split)
+    return only_int(x)  # MethodError: no matching method found
+                        # `only_int(::String)` (1/2 union split)
                         # (JETLS inference/method-error)
 end
 ```
@@ -1309,6 +1311,20 @@ kwfunc(; kw1=nothing, kw2=nothing) = (kw1, kw2)
 kwfunc(; kw3=42)  # unsupported keyword argument `kw3` in `kwfunc(; kw3::Int64)`
                   # (JETLS inference/method-error)
 ```
+
+Ambiguous calls are identified separately and include the conflicting methods
+and a possible disambiguating signature:
+
+```julia
+ambiguous(x, y::Int) = x + y
+ambiguous(x::Int, y) = x - y
+
+ambiguous(1, 2)  # MethodError: `ambiguous(::Int64, ::Int64)` is ambiguous.
+                 # (JETLS inference/method-error)
+```
+
+Within a union-split call, ambiguous branches are reported separately from
+branches where no method matches.
 
 #### [Undefined keyword (`inference/undef-keyword`)](@id diagnostic/reference/inference/undef-keyword)
 

--- a/src/analysis/Analyzer.jl
+++ b/src/analysis/Analyzer.jl
@@ -4,8 +4,8 @@ export LSAnalyzer
 export inference_error_report_related_frames, inference_error_report_related_stack,
     inference_error_report_severity, inference_error_report_stack,
     reset_report_target_modules!
-export BoundsErrorReport, FieldErrorReport, KeywordTypeErrorReport, MethodErrorReport,
-    NoMethodMatchReport, NonBooleanCondErrorReport, TypeAssertErrorReport,
+export AmbiguousMethodReport, BoundsErrorReport, FieldErrorReport, KeywordTypeErrorReport,
+    MethodErrorReport, NoMethodMatchReport, NonBooleanCondErrorReport, TypeAssertErrorReport,
     TypeErrorReport, UndefKeywordErrorReport, UndefVarErrorReport,
     UnsupportedKeywordArgReport
 export RelatedEntryFrame, RelatedFrame, RelatedFrameKind, RelatedOriginFrame, RelatedViaFrame
@@ -422,19 +422,17 @@ end
 
 function after_abstract_call_gf_by_type(
         analyzer::LSAnalyzer, ret::CC.Future, @nospecialize(func), arginfo::CC.ArgInfo,
-        @nospecialize(atype), sv::CC.InferenceState, max_methods::Int
+        sv::CC.InferenceState, max_methods::Int
     )
     if !should_analyze(analyzer, sv)
         return nothing
     end
-    atype_ref = Ref{Any}(atype)
     func_ref = Ref{Any}(func)
     function _after_abstract_call_gf_by_type(analyzer′::LSAnalyzer, sv′::CC.InferenceState)
         ret′ = ret[]
-        atype′ = atype_ref[]
         func′ = func_ref[]
-        report_method_error!(analyzer′, sv′, ret′, arginfo, atype′)
-        report_unsupported_kwarg_error!(analyzer′, sv′, func′, ret′, arginfo, max_methods)
+        kwarg_reported = report_unsupported_kwarg_error!(analyzer′, sv′, func′, ret′, arginfo, max_methods)
+        report_method_error!(analyzer′, sv′, ret′, arginfo, kwarg_reported, max_methods)
         report_keyword_typeerror!(analyzer′, sv′, func′, ret′, arginfo, max_methods)
         return true
     end
@@ -458,7 +456,7 @@ function CC.abstract_call_gf_by_type(
         analyzer::ToplevelAbstractAnalyzer, func::Any, arginfo::CC.ArgInfo,
         si::CC.StmtInfo, atype::Any, vtypes::Union{Vector{CC.VarState},Nothing},
         sv::CC.InferenceState, max_methods::Int)
-    after_abstract_call_gf_by_type(analyzer, ret, func, arginfo, atype, sv, max_methods)
+    after_abstract_call_gf_by_type(analyzer, ret, func, arginfo, sv, max_methods)
     return ret
 end
 else
@@ -469,7 +467,7 @@ function CC.abstract_call_gf_by_type(
     ret = @invoke CC.abstract_call_gf_by_type(
         analyzer::ToplevelAbstractAnalyzer, func::Any, arginfo::CC.ArgInfo,
         si::CC.StmtInfo, atype::Any, sv::CC.InferenceState, max_methods::Int)
-    after_abstract_call_gf_by_type(analyzer, ret, func, arginfo, atype, sv, max_methods)
+    after_abstract_call_gf_by_type(analyzer, ret, func, arginfo, sv, max_methods)
     return ret
 end
 end
@@ -614,6 +612,7 @@ Subtypes:
 - `BoundsErrorReport`: Out-of-bounds field access by index (corresponding to `BoundsError`)
 - `MethodErrorReport`: Errors that raise `MethodError` at runtime
   * `NoMethodMatchReport`: No matching method for a call (a dispatch failure)
+  * `AmbiguousMethodReport`: Multiple applicable methods without a unique match
   * `UnsupportedKeywordArgReport`: Keyword arguments the method does not accept
     (raised via `Base.kwerr`)
 - `UndefKeywordErrorReport`: Missing required keyword arguments
@@ -903,11 +902,19 @@ end
 @jetreport struct NoMethodMatchReport <: MethodErrorReport
     @nospecialize t # ::Union{Type, Vector{Type}}
     union_split::Int
+    world::UInt
 end
-function JETInterface.print_report_message(io::IO, report::NoMethodMatchReport)
-    print(io, "no matching method found ")
+JETInterface.print_report_message(io::IO, report::NoMethodMatchReport) =
+    print_no_method_match_report(io, report)
+inference_error_report_stack_impl(r::NoMethodMatchReport) = length(r.vst):-1:1
+inference_error_report_severity_impl(::NoMethodMatchReport) = DiagnosticSeverity.Warning
+
+function print_no_method_match_report(io::IO, report::NoMethodMatchReport)
+    print(io, "MethodError: no matching method found ")
     if report.union_split == 0
-        print_callsig(io, report.t)
+        t = report.t
+        print_callsig(io, t)
+        print_no_method_hint(io, t, report.world)
     else
         ts = report.t::Vector{Any}
         nts = length(ts)
@@ -916,63 +923,377 @@ function JETInterface.print_report_message(io::IO, report::NoMethodMatchReport)
             i == nts || print(io, ", ")
         end
         print(io, " (", nts, '/', report.union_split, " union split)")
+        for t in ts
+            print_no_method_hint(io, t, report.world; labeled = nts > 1)
+        end
     end
 end
+
 function print_callsig(io, @nospecialize(t))
     print(io, '`')
     Base.show_tuple_as_call(io, Symbol(""), t)
     print(io, '`')
 end
-inference_error_report_stack_impl(r::NoMethodMatchReport) = length(r.vst):-1:1
-inference_error_report_severity_impl(::NoMethodMatchReport) = DiagnosticSeverity.Warning
+
+# The hint printers feed arbitrary inference signatures into `Base` printing internals
+# that were designed for runtime values, so guard against unexpected inputs here to
+# avoid breaking the whole diagnostics generation.
+function print_no_method_hint(
+        io::IO, @nospecialize(t), world::UInt; labeled::Bool = false
+    )
+    hint = try
+        sprint(print_no_method_hint_impl, t, world, labeled; context=io)
+    catch
+        JETLS_DEV_MODE && rethrow()
+        return
+    end
+    print(io, hint)
+end
+
+function print_no_method_hint_impl(
+        io::IO, @nospecialize(t), world::UInt, labeled::Bool
+    )
+    t′ = Base.unwrap_unionall(t)
+    t′ isa DataType && t′ <: Tuple || return
+    params = t′.parameters
+    isempty(params) && return
+    Base.isvarargtype(params[1]) && return
+    ftype = Base.rewrap_unionall(params[1], t)
+    f = CC.singleton_type(ftype)
+    if f === nothing
+        ftype′ = Base.unwrap_unionall(ftype)
+        if ftype′ isa DataType && CC.isType(ftype)
+            typ = ftype′.parameters[1]
+            typ isa Type && (f = typ)
+        end
+    end
+    argparams = params[2:end]
+    # `Base.show_method_candidates` and `method_candidate_score` cannot handle `Vararg`
+    # in the argument types, so use the fixed-length prefix of the signature
+    if !isempty(argparams) && Base.isvarargtype(argparams[end])
+        argparams = argparams[1:end-1]
+    end
+    arg_types = Base.rewrap_unionall(Tuple{argparams...}, t)
+    f isa Core.Builtin && return
+    # keyword no-match calls surface as `Core.kwcall` signatures, for which candidates
+    # from `kwcall`'s own method table would be meaningless
+    f === Core.kwcall && return
+    if labeled
+        print(io, "\n\nFor ")
+        print_callsig(io, t)
+        print(io, ':')
+    end
+    if f isa Function
+        print(io, "\n\nThe function `", f,
+            "` exists, but no method is defined for this combination of argument types.")
+    elseif f isa Type
+        if f isa DataType && isabstracttype(f) && !has_methods_at_world(f, world)
+            print(io, "\n\nNo constructors have been defined for `", f, "`.")
+            return
+        end
+        print(io, "\n\nThe type `", f,
+            "` exists, but no method is defined for this combination of argument types ",
+            "when trying to construct it.")
+    elseif f === nothing
+        candidates = find_callable_candidate_methods(ftype)
+        if candidates !== nothing && isempty(candidates)
+            print(io, "\n\nObjects of type `", ftype, "` are not callable.")
+            return
+        end
+        print(io, "\n\nThe object of type `", ftype,
+            "` exists, but no method is defined for this combination of argument types ",
+            "when trying to treat it as a callable object.")
+        if candidates !== nothing
+            print_callable_method_candidates(io, candidates, arg_types, world)
+        end
+        return
+    else
+        if !has_methods_at_world(f, world)
+            print(io, "\n\nObjects of type `", typeof(f), "` are not callable.")
+            return
+        end
+        print(io, "\n\nThe object of type `", typeof(f),
+            "` exists, but no method is defined for this combination of argument types ",
+            "when trying to treat it as a callable object.")
+    end
+    exception = MethodError(f, arg_types, world)
+    candidates = sprint(Base.show_method_candidates, exception; context=io)
+    print_bulleted_method_candidates(io, candidates)
+    return nothing
+end
+
+function has_methods_at_world(@nospecialize(f), world::UInt)
+    matches = Base._methods(f, Tuple{Vararg{Any}}, -1, world)::Vector
+    return !isempty(matches)
+end
+
+function print_callable_method_candidates(
+        io::IO, methods::Vector{Method}, @nospecialize(arg_types), world::UInt
+    )
+    arg_types′ = Base.unwrap_unionall(arg_types)
+    arg_types′ isa DataType && arg_types′ <: Tuple || return nothing
+    params = Any[Base.rewrap_unionall(param, arg_types) for param in arg_types′.parameters]
+    scores = Int[method_candidate_score(method, params) for method in methods]
+    order = sortperm(scores)
+    print(io, "\n\nClosest candidates are:")
+    ncandidates = min(3, length(order))
+    for i = 1:ncandidates
+        print(io, '\n')
+        print_method_candidate(io, methods[order[i]]; world)
+    end
+    length(order) > ncandidates && print(io, "\n- ...")
+    return nothing
+end
+
+# Returns `nothing` when the applicable methods cannot be enumerated (too broad a
+# callable type or too many matches), and an empty vector when `ftype` has no methods
+# at all, i.e. its instances are not callable.
+function find_callable_candidate_methods(@nospecialize(ftype))
+    ftype′ = Base.unwrap_unionall(ftype)
+    ftype′ isa DataType || return nothing
+    ftype′ === Any && return nothing
+    ftype′ === Function && return nothing
+    callsig = Tuple{ftype,Vararg{Any}}
+    matches = Base._methods_by_ftype(callsig, nothing, 100, Base.get_world_counter())
+    matches isa Vector || return nothing
+    methods = Method[]
+    for match in matches
+        match = match::Core.MethodMatch
+        match.method ∈ methods || push!(methods, match.method)
+    end
+    return methods
+end
+
+function method_candidate_score(method::Method, arg_types::Vector{Any})
+    sig = Base.unwrap_unionall(method.sig)::DataType
+    sigtypes = sig.parameters[2:end]
+    input_types = copy(arg_types)
+    right_matches = 0
+    for i = 1:min(length(input_types), length(sigtypes))
+        j = Base.isvarargtype(sigtypes[i]) ? length(input_types) : i
+        method_prefix = Base.rewrap_unionall(Tuple{sigtypes[1:i]...}, method.sig)
+        input_prefix = Base.rewrap_unionall(Tuple{input_types[1:j]...}, method.sig)
+        if typeintersect(method_prefix, input_prefix) === Union{}
+            input_types[i] = sigtypes[i]
+        else
+            right_matches += j == i
+        end
+    end
+    if length(input_types) > length(sigtypes) &&
+       !isempty(sigtypes) && Base.isvarargtype(sigtypes[end])
+        vararg_type = Base.rewrap_unionall(Base.unwrapva(Base.unwrap_unionall(sigtypes[end])), method.sig)
+        # iterate the original `arg_types` here: `input_types` may contain `Vararg`
+        # entries written from `sigtypes` above, which `<:` cannot handle
+        for input_type in arg_types[length(sigtypes):end]
+            input_type <: vararg_type && (right_matches += 1)
+        end
+    end
+    return -(right_matches * 2 + (length(arg_types) < 2 ? 1 : 0))
+end
+
+function print_bulleted_method_candidates(io::IO, candidates::String)
+    lines = split(rstrip(candidates, '\n'), '\n'; keepempty=true)
+    for (i, line) in enumerate(lines)
+        if startswith(line, "   @")
+            print(io, "  ", line[4:end])
+        elseif startswith(line, "  ...")
+            print(io, "- ...")
+        elseif startswith(line, "  ") && !startswith(line, "   ")
+            print(io, "- `", line[3:end], '`')
+        else
+            print(io, line)
+        end
+        i == length(lines) || print(io, '\n')
+    end
+    return nothing
+end
+
+# AmbiguousMethodReport
+# ---------------------
+
+@jetreport struct AmbiguousMethodReport <: MethodErrorReport
+    @nospecialize t # ::Union{Type, Vector{Type}}
+    union_split::Int
+    methods::Union{Vector{Method},Vector{Vector{Method}}} # parallel to `t`
+end
+JETInterface.print_report_message(io::IO, report::AmbiguousMethodReport) =
+    print_ambiguous_method_report(io, report)
+inference_error_report_stack_impl(r::AmbiguousMethodReport) = length(r.vst):-1:1
+inference_error_report_severity_impl(::AmbiguousMethodReport) = DiagnosticSeverity.Warning
+
+function print_ambiguous_method_report(io::IO, report::AmbiguousMethodReport)
+    print(io, "MethodError: ")
+    if report.union_split == 0
+        print_callsig(io, report.t)
+        print(io, " is ambiguous.")
+        print_ambiguity_candidates(io, report.methods::Vector{Method}, report.t)
+    else
+        ts = report.t::Vector{Any}
+        nts = length(ts)
+        for i = 1:nts
+            print_callsig(io, ts[i])
+            i == nts || print(io, ", ")
+        end
+        print(io, nts == 1 ? " is" : " are", " ambiguous.")
+        print(io, " (", nts, '/', report.union_split, " union split)")
+        methodss = report.methods::Vector{Vector{Method}}
+        for i = 1:nts
+            if nts > 1
+                print(io, "\n\nFor ")
+                print_callsig(io, ts[i])
+                print(io, ':')
+            end
+            print_ambiguity_candidates(io, methodss[i], ts[i])
+        end
+    end
+    return nothing
+end
+
+function print_ambiguity_candidates(
+        io::IO, methods::Vector{Method}, @nospecialize(t)
+    )
+    print(io, "\n\nCandidates:")
+    for method in methods
+        print(io, '\n')
+        print_method_candidate(io, method)
+    end
+    t′ = Base.unwrap_unionall(t)
+    is_kwcall = t′ isa DataType && !isempty(t′.parameters) &&
+        t′.parameters[1] === typeof(Core.kwcall)
+    sigfix = mapfoldl(m -> m.sig, typeintersect, methods; init=Any)
+    if Base.unwrap_unionall(sigfix) isa DataType && sigfix <: Tuple
+        if !is_kwcall && t <: sigfix && all(m -> Base.morespecific(sigfix, m.sig), methods)
+            print(io, "\n\nPossible fix, define: ")
+            print_callsig(io, sigfix)
+        else
+            print(io, "\n\nTo resolve the ambiguity, try making one of the methods more ",
+                "specific, or adding a new method more specific than any of the existing ",
+                "applicable methods.")
+        end
+    end
+    return nothing
+end
+
+function print_method_candidate(
+        io::IO, method::Method; world::Union{Nothing,UInt} = nothing
+    )
+    description = sprint(method; context=io) do candidate_io, method
+        Base.show_method(candidate_io, method; digit_align_width=0)
+    end
+    parts = split(description, '\n'; limit=2, keepempty=true)
+    print(io, "- `", parts[1], '`')
+    if world !== nothing && world < reinterpret(UInt, method.primary_world)
+        print(io, " (method too new to be called from this world context.)")
+    end
+    if length(parts) == 2
+        print(io, "\n  ", lstrip(parts[2]))
+    end
+    return nothing
+end
 
 function report_method_error!(
-        analyzer::LSAnalyzer, sv::CC.InferenceState, call::CC.CallMeta,
-        arginfo::CC.ArgInfo, @nospecialize(atype)
+        analyzer::LSAnalyzer, sv::CC.InferenceState, call::CC.CallMeta, arginfo::CC.ArgInfo,
+        kwarg_reported::Bool, max_methods::Int
     )
     info = call.info
     if isa(info, CC.ConstCallInfo)
         info = info.call
     end
     if isa(info, CC.MethodMatchInfo)
-        report_method_error!(analyzer, sv, info, atype)
+        report_method_error!(analyzer, sv, info, kwarg_reported)
     elseif isa(info, CC.UnionSplitInfo)
-        report_method_error_for_union_split!(analyzer, sv, info, arginfo)
+        report_method_error_for_union_split!(analyzer, sv, info, arginfo, kwarg_reported,
+            max_methods)
     end
 end
 
 function report_method_error!(
         analyzer::LSAnalyzer, sv::CC.InferenceState, info::CC.MethodMatchInfo,
-        @nospecialize(atype)
+        kwarg_reported::Bool
     )
     if CC.isempty(info.results)
-        report = NoMethodMatchReport(sv, atype, 0)
+        world = CC.get_inference_world(analyzer)
+        atype = info.atype
+        methods = find_ambiguous_methods(atype, CC.method_table(analyzer))
+        if methods !== nothing
+            report = AmbiguousMethodReport(sv, atype, 0, methods)
+        elseif kwarg_reported
+            # the unsupported keyword diagnostic already covers this call site:
+            # `report_unsupported_kwarg_error!` requires the positional signature to have
+            # matching methods, so the raw `Core.kwcall` no-match report is redundant.
+            # For a statically-unknown-length `Vararg` signature the matches may cover
+            # only some arities, but the uncovered arities are below the reporting bar
+            # anyway: their keyword-free analog is not reported either
+            return
+        else
+            report = NoMethodMatchReport(sv, atype, 0, world)
+        end
         add_new_report!(analyzer, sv.result, report)
     end
 end
 
 function report_method_error_for_union_split!(
         analyzer::LSAnalyzer, sv::CC.InferenceState, info::CC.UnionSplitInfo,
-        arginfo::CC.ArgInfo
+        arginfo::CC.ArgInfo, kwarg_reported::Bool, max_methods::Int
     )
-    # check each match for union-split signature
-    split_argtypes = empty_matches = nothing
+    world = CC.get_inference_world(analyzer)
+    union_split = length(info.split)
+    split_argtypes = empty_matches = ambiguous_matches = nothing
     for (i, matchinfo) in enumerate(info.split)
         if CC.isempty(matchinfo.results)
-            if isnothing(split_argtypes)
-                split_argtypes = CC.switchtupleunion(CC.typeinf_lattice(analyzer), arginfo.argtypes)
+            sig_n = matchinfo.atype
+            methods = find_ambiguous_methods(sig_n, CC.method_table(analyzer))
+            if methods === nothing
+                # suppress the raw `Core.kwcall` no-match only for branches whose
+                # positional signature has matching methods, i.e. whose failure the
+                # unsupported keyword diagnostic covers (for the `Vararg` arity caveat,
+                # see the corresponding comment in `report_method_error!`); branches
+                # without any positional method are independent errors and must be kept
+                if kwarg_reported
+                    split_argtypes = @something split_argtypes CC.switchtupleunion(
+                        CC.typeinf_lattice(analyzer), arginfo.argtypes)
+                    argtypes′ = split_argtypes[i]::Vector{Any}
+                    if length(argtypes′) ≥ 3 && find_call_method_matches(
+                            analyzer, CC.widenconst(argtypes′[3]), argtypes′, 4, max_methods
+                        ) !== nothing
+                        continue
+                    end
+                end
+                empty_matches = @something empty_matches (Any[], union_split)
+                push!(empty_matches[1], sig_n)
+            else
+                ambiguous_matches = @something ambiguous_matches (Any[], Vector{Method}[])
+                push!(ambiguous_matches[1], sig_n)
+                push!(ambiguous_matches[2], methods)
             end
-            argtypes′ = split_argtypes[i]::Vector{Any}
-            if empty_matches === nothing
-                empty_matches = (Any[], length(info.split))
-            end
-            sig_n = CC.argtypes_to_type(argtypes′)
-            push!(empty_matches[1], sig_n)
         end
     end
     if empty_matches !== nothing
-        add_new_report!(analyzer, sv.result, NoMethodMatchReport(sv, empty_matches...))
+        report = NoMethodMatchReport(sv, empty_matches..., world)
+        add_new_report!(analyzer, sv.result, report)
     end
+    if ambiguous_matches !== nothing
+        report = AmbiguousMethodReport(sv, ambiguous_matches[1], union_split, ambiguous_matches[2])
+        add_new_report!(analyzer, sv.result, report)
+    end
+end
+
+function find_ambiguous_methods(
+        @nospecialize(t), method_table::CC.MethodTableView
+    )
+    matches = @something CC.findall(t, method_table; include_ambiguous=true) return nothing
+    matches.ambig || return nothing
+    coverage = Union{}
+    methods = Method[]
+    for match in matches
+        match = match::Core.MethodMatch
+        coverage = Union{coverage,match.spec_types}
+        match.method ∈ methods || push!(methods, match.method)
+    end
+    # The ambiguity flag may describe only part of an abstract query signature.
+    # Require the applicable match regions to cover the complete query signature.
+    t <: coverage || return nothing
+    return methods
 end
 
 # UnsupportedKeywordArgReport
@@ -983,16 +1304,24 @@ end
 # `MethodError` via `Base.kwerr` for the surplus keyword. Since this is an explicit
 # `throw` rather than a dispatch failure, `NoMethodMatchReport` does not fire; we detect
 # the statically-determined surplus keyword here instead.
+# When `f` has no keyword-accepting method at all, the `Core.kwcall` dispatch itself
+# fails instead; this report then supersedes the raw no-match report
+# (see `after_abstract_call_gf_by_type`).
 @jetreport struct UnsupportedKeywordArgReport <: MethodErrorReport
     @nospecialize ftype
     posargtypes::Vector{Any}
     @nospecialize kwt
     unsupported::Vector{Symbol}
+    combination::Bool
 end
 function JETInterface.print_report_message(io::IO, r::UnsupportedKeywordArgReport)
     unsupported = r.unsupported
-    print(io, "unsupported keyword argument")
-    isone(length(unsupported)) || print(io, 's')
+    if r.combination
+        print(io, "unsupported combination of keyword arguments")
+    else
+        print(io, "unsupported keyword argument")
+        isone(length(unsupported)) || print(io, 's')
+    end
     print(io, ' ')
     for (i, name) in enumerate(unsupported)
         i == 1 || print(io, ", ")
@@ -1049,19 +1378,27 @@ function report_unsupported_kwarg_error!(
     ftype = CC.widenconst(argtypes[3])
     posargtypes, matches = @something find_call_method_matches(
         analyzer, ftype, argtypes, 4, max_methods) return false
-    supported = Set{Symbol}()
+    world = CC.get_inference_world(analyzer)
+    always_unsupported = trues(length(kwnames))
+    ever_unsupported = falses(length(kwnames))
     for match in matches
-        for name in Base.kwarg_decl(match.method)
-            # a slurping `kwargs...` shows up as a name ending with `...` and accepts anything
-            endswith(String(name), "...") && return false
-            push!(supported, name)
+        decls = kwarg_decl(match.method, world)
+        # a slurping `kwargs...` shows up as a name ending with `...` and accepts anything
+        any(name -> endswith(String(name), "..."), decls) && return false
+        rejects_call = false
+        for i in eachindex(kwnames)
+            unsupported = kwnames[i] ∉ decls
+            always_unsupported[i] &= unsupported
+            ever_unsupported[i] |= unsupported
+            rejects_call |= unsupported
         end
+        rejects_call || return false
     end
 
-    unsupported = Symbol[name for name in kwnames if name ∉ supported]
-    isempty(unsupported) && return false
-
-    report = UnsupportedKeywordArgReport(sv, ftype, posargtypes, kwt, unsupported)
+    combination = !any(always_unsupported)
+    unsupported_flags = combination ? ever_unsupported : always_unsupported
+    unsupported = Symbol[kwnames[i] for i in eachindex(kwnames) if unsupported_flags[i]]
+    report = UnsupportedKeywordArgReport(sv, ftype, posargtypes, kwt, unsupported, combination)
     add_new_report!(analyzer, sv.result, report)
     return true
 end
@@ -1127,18 +1464,23 @@ end
 inference_error_report_stack_impl(r::KeywordTypeErrorReport) = length(r.vst):-1:1
 inference_error_report_severity_impl(::KeywordTypeErrorReport) = DiagnosticSeverity.Warning
 
-# Recover the declared keyword types of `m` as `name => type` pairs (declaration order),
-# skipping the slurp (`kws...`). The keyword sorter forwards the sorted keywords to the body
-# function as leading positional arguments, so the body method's argument types are exactly the
-# declared keyword types in `Base.kwarg_decl` order.
-function keyword_arg_types(m::Method)
-    decls = Base.kwarg_decl(m)
+function kwarg_decl(m::Method, world::UInt)
+    @static if :world in Base.kwarg_decl(only(methods(Base.kwarg_decl, (Method,))))
+        return Base.kwarg_decl(m; world)
+    else
+        return Base.kwarg_decl(m)
+    end
+end
+
+function keyword_arg_types(m::Method, world::UInt)
+    decls = kwarg_decl(m, world)
     isempty(decls) && return nothing
     bf = Base.bodyfunction(m)
     bf === nothing && return nothing
-    bms = methods(bf)
+    bms = Base._methods(bf, Tuple{Vararg{Any}}, -1, world)
+    bms isa Vector || return nothing
     length(bms) == 1 || return nothing
-    bsig = Base.unwrap_unionall((first(bms)).sig)
+    bsig = Base.unwrap_unionall((first(bms)::Core.MethodMatch).method.sig)
     bsig isa DataType || return nothing
     params = bsig.parameters
     length(params) ≥ 1 + length(decls) || return nothing
@@ -1169,21 +1511,37 @@ function report_keyword_typeerror!(
     ftype = CC.widenconst(argtypes[3])
     _, matches = @something find_call_method_matches(
         analyzer, ftype, argtypes, 4, max_methods) return false
+    world = CC.get_inference_world(analyzer)
+    mismatches = Dict{Symbol,Any}[]
     for match in matches
-        kwtypes = @something keyword_arg_types(match.method) continue
+        kwtypes = @something keyword_arg_types(match.method, world) return false
+        mismatch = Dict{Symbol,Any}()
         for (name, expected) in kwtypes
-            idx = findfirst(==(name), names)
-            idx === nothing && continue # this typed keyword was not provided
+            idx = @something findfirst(==(name), names) continue # this typed keyword was not provided
             got = fieldtype(kwt, idx)
             # report only a definite mismatch: no value of `got` can satisfy the keyword's
-            # `isa expected` assertion (the `call.rt === Union{}` gate already ensures the call
-            # always throws, so this picks the offending keyword)
+            # `isa expected` assertion
             typeintersect(got, expected) === Union{} || continue
-            add_new_report!(analyzer, sv.result, KeywordTypeErrorReport(sv, name, expected, got))
-            return true
+            mismatch[name] = expected
         end
+        isempty(mismatch) && return false
+        push!(mismatches, mismatch)
     end
-    return false
+
+    common_names = Set{Symbol}(keys(first(mismatches)))
+    for mismatch in @view mismatches[2:end]
+        intersect!(common_names, keys(mismatch))
+        isempty(common_names) && return false
+    end
+    idx = @something findfirst(∈(common_names), names) return false
+    name = names[idx]
+    expected = Union{}
+    for mismatch in mismatches
+        expected = Union{expected,mismatch[name]}
+    end
+    got = fieldtype(kwt, idx)
+    add_new_report!(analyzer, sv.result, KeywordTypeErrorReport(sv, name, expected, got))
+    return true
 end
 
 # NonBooleanCondErrorReport
@@ -1230,9 +1588,7 @@ function report_non_boolean_cond!(analyzer::LSAnalyzer, sv::CC.InferenceState, @
         uts = Base.uniontypes(t)
         for ut in uts
             if !(check_uncovered ? ut ⊑ Bool : CC.hasintersect(ut, Bool))
-                if info === nothing
-                    info = Any[], length(uts)
-                end
+                info = @something info Any[], length(uts)
                 push!(info[1], ut)
             end
         end

--- a/src/app/cli-check.jl
+++ b/src/app/cli-check.jl
@@ -518,6 +518,29 @@ end
 count_label(n::Int, singular::AbstractString, plural::AbstractString = singular * "s") =
     string(n, ' ', n == 1 ? singular : plural)
 
+# `JS.highlight`'s `note` rendering assumes a single-line message: continuation lines
+# would be interleaved with the source context lines. Show only the first line inline
+# and print the remaining lines as a separate block after the highlighted snippet.
+function split_diagnostic_message(message::String)
+    nl = findfirst('\n', message)
+    nl === nothing && return message, nothing
+    summary = message[1:prevind(message, nl)]
+    details = strip(message[nl:end], '\n')
+    isempty(details) && return summary, nothing
+    return summary, String(details)
+end
+
+function print_diagnostic_details(io::IO, details::String)
+    printstyled(io, "#\n"; color=:light_black)
+    for line in eachsplit(details, '\n')
+        if isempty(line)
+            printstyled(io, "#\n"; color=:light_black)
+        else
+            printstyled(io, "# ", line, '\n'; color=:light_black)
+        end
+    end
+end
+
 function print_diagnostics(
         uri2diagnostics::URI2Diagnostics, root_path::String,
         context_lines::Int, exit_severity::DiagnosticSeverity.Ty,
@@ -564,7 +587,8 @@ function print_diagnostics(
 
             start_byte = _xy_to_offset(textbuf, diagnostic.range.start, PositionEncodingKind.UTF16, line_starts)
             end_byte = _xy_to_offset(textbuf, diagnostic.range.var"end", PositionEncodingKind.UTF16, line_starts)
-            note = get_raw_message(diagnostic)
+            summary, details = split_diagnostic_message(get_raw_message(diagnostic))
+            note = summary
             if diagnostic.code !== nothing
                 note *= " [$severity_str:$(diagnostic.code)]"
             else
@@ -582,6 +606,7 @@ function print_diagnostics(
                 end
             end
             println(stdout, strip(output, '\n'))
+            details === nothing || print_diagnostic_details(stdout, details)
         end
     end
 

--- a/src/signature-help.jl
+++ b/src/signature-help.jl
@@ -577,12 +577,10 @@ function fixup_argtypes!(argtypes::Vector{Any}, fntyp::Core.Const)
 end
 
 function find_all_matches(
-        argtypes::Vector{Any};
-        world::UInt = Base.get_world_counter(),
-        limit::Int = -1
+        argtypes::Vector{Any}; world::UInt = Base.get_world_counter(), limit::Int = -1
     )
     atype = Tuple{argtypes...}
-    return CC._findall(atype, nothing, world, limit)
+    return CC.findall(atype, CC.InternalMethodTable(world); limit)
 end
 
 function cursor_siginfos(

--- a/test/analysis/test_Analyzer.jl
+++ b/test/analysis/test_Analyzer.jl
@@ -256,8 +256,89 @@ only_int(x::Int) = 2x
 nested_only_int_inner(x) = only_int(x)
 nested_only_int_outer(x) = nested_only_int_inner(x)
 call_nested_only_int(x) = nested_only_int_outer(x)
+ambiguous_func(x, y::Int) = x + y
+ambiguous_func(x::Int, y) = x - y
+union_ambiguous_func(x::Number, y::Int) = x + y
+union_ambiguous_func(x::Int, y::Number) = x - y
+world_age_func(x::Int) = x
+struct MethodErrorCallable
+    value::Int
+end
+(::MethodErrorCallable)(x::Int) = x
+call_method_error_callable(f::MethodErrorCallable) = f("x")
+function call_captured_method_error()
+    captured = 1
+    f = (x::Int) -> x + captured
+    return f("x")
+end
+struct MethodErrorParametricCallable{T}
+    value::T
+end
+(::MethodErrorParametricCallable)(x::Int) = x
+call_method_error_parametric_callable(f::MethodErrorParametricCallable) = f("x")
+abstract type AbstractMethodErrorCallable end
+(::AbstractMethodErrorCallable)(x::Int) = x
+call_abstract_method_error_callable(f::AbstractMethodErrorCallable) = f("x")
+struct MethodErrorWorldAgeCallable
+    value::Int
+end
+call_method_error_world_age_callable(f::MethodErrorWorldAgeCallable) = f("x")
+struct MethodErrorConstructor{T} end
+MethodErrorConstructor(x::Int) = MethodErrorConstructor{Int}()
+call_method_error_constructor() = MethodErrorConstructor("x")
+abstract type MethodErrorNoConstructor end
+call_method_error_no_constructor() = MethodErrorNoConstructor(1)
+struct MethodErrorNotCallable
+    value::Int
+end
+call_method_error_not_callable(f::MethodErrorNotCallable) = f(1)
+struct MethodErrorNotCallableSingleton end
+call_method_error_not_callable_singleton() = MethodErrorNotCallableSingleton()(1)
+struct MethodErrorVarargCallable
+    value::Int
+end
+(::MethodErrorVarargCallable)(xs::Int...) = xs
+call_method_error_vararg_callable(f::MethodErrorVarargCallable) = f("x", "y")
+vararg_only_int(xs::Int...) = xs
+call_vararg_splat_method_error(xs::Vector{String}) = vararg_only_int("x", xs...)
+nokw_func(x::Int) = x
+call_kwcall_method_error(x::Int) = nokw_func(x; kw=1)
+call_kwcall_no_match_method_error(x::String) = nokw_func(x; kw=1)
+kwambig_func(x, y::Int; a=1) = 1
+kwambig_func(x::Int, y; b=1) = 2
+kwambig_func(x::Int, y::Int) = 3
+call_kwambig_method_error(x::Int, y::Int) = kwambig_func(x, y; z=1)
+kwsplit_func(x::Int; a=1) = x
+call_kwsplit_method_error(x::Union{Int,String}) = kwsplit_func(x; z=1)
+nokw_union_func(x::Int) = x
+nokw_union_func(x::String) = x
+call_kwcall_union_explained(x::Union{Int,String}) = nokw_union_func(x; kw=1)
+vararg_ambiguous_func(x, y::Int) = 1
+vararg_ambiguous_func(x::Int, y) = 2
+call_vararg_ambiguous(xs::Tuple{Vararg{Int}}) = vararg_ambiguous_func(xs...)
+partial_ambiguous_func(x, y::Int, z::Int) = 1
+partial_ambiguous_func(x::Int, y, z::Int) = 2
+call_partial_ambiguous(z::Number) = partial_ambiguous_func(1, 1, z)
+full_vararg_ambiguous_func(x, y::Int, zs::Int...) = 1
+full_vararg_ambiguous_func(x::Int, y, zs::Int...) = 2
+function call_full_vararg_ambiguous(xs::Tuple{Int,Int,Vararg{Int}})
+    return full_vararg_ambiguous_func(xs...)
+end
+changing_vararg_ambiguous_func(x, y::Int, zs::Int...) = 1
+changing_vararg_ambiguous_func(x::Int, y, zs::Int...) = 2
+changing_vararg_ambiguous_func(x::Int, y::Number) = 3
+function call_changing_vararg_ambiguous(xs::Tuple{Int,Int,Vararg{Int}})
+    return changing_vararg_ambiguous_func(xs...)
+end
+
+multi_ambiguous_func(x::Number, y::Int) = x + y
+multi_ambiguous_func(x::Int, y::Number) = x - y
+multi_ambiguous_func(x::AbstractString, y::String) = x * y
+multi_ambiguous_func(x::String, y::AbstractString) = y * x
 
 kwfunc(; code::String="code", message::String="message", data=nothing) = (code, message, data)
+kwdispatch(x::Int; a=1) = x
+kwdispatch(x::String; b=1) = x
 kwslurp(; a=1, kwargs...) = (a, kwargs)
 kwpos(x::Int; y=1) = (x, y)
 kwvaropt(pos...; y=1) = (pos, y) # optional keyword + positional vararg
@@ -275,12 +356,313 @@ struct KwCallable end
 
         # basic method error
         let result = analyze_call() do
-                sin(1, 2)
+                sin('4')
             end
             reports = get_reports(result)
             @test length(reports) == 1
             r = only(reports)
             @test r isa NoMethodMatchReport && r.union_split == 0
+            message = sprint(JET.print_report_message, r)
+            @test startswith(message, "MethodError: no matching method found `sin(::Char)`")
+            @test occursin("The function `sin` exists, but no method is defined", message)
+            @test occursin("Closest candidates are:", message)
+            @test occursin("\n- `sin(!Matched::", message)
+            @test occursin("\n  @ Base", message)
+            @test occursin("\n- ...", message)
+        end
+
+        let result = analyze_call(call_method_error_callable, (MethodErrorCallable,))
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa NoMethodMatchReport && r.union_split == 0
+            message = sprint(JET.print_report_message, r)
+            @test startswith(message, "MethodError: no matching method found `(::")
+            @test occursin("MethodErrorCallable)(::String)`", message)
+            @test occursin("The object of type `", message)
+            @test occursin("MethodErrorCallable` exists", message)
+            @test occursin("Closest candidates are:", message)
+            @test occursin("MethodErrorCallable)(x::$Int)`\n  @", message)
+        end
+
+        let result = analyze_call(call_captured_method_error, ())
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa NoMethodMatchReport && r.union_split == 0
+            message = sprint(JET.print_report_message, r)
+            @test occursin("The object of type `", message)
+            @test occursin("Closest candidates are:", message)
+            @test occursin("(x::$Int)`\n  @", message)
+        end
+
+        let result = analyze_call(
+                call_method_error_parametric_callable, (MethodErrorParametricCallable,))
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa NoMethodMatchReport && r.union_split == 0
+            message = sprint(JET.print_report_message, r)
+            @test occursin("The object of type `", message)
+            @test occursin("Closest candidates are:", message)
+            @test occursin("MethodErrorParametricCallable)(x::$Int)`", message)
+        end
+
+        let result = analyze_call(
+                call_abstract_method_error_callable, (AbstractMethodErrorCallable,))
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa NoMethodMatchReport && r.union_split == 0
+            message = sprint(JET.print_report_message, r)
+            @test occursin("The object of type `", message)
+            @test occursin("Closest candidates are:", message)
+            @test occursin("AbstractMethodErrorCallable)(x::$Int)`", message)
+        end
+
+        let result = analyze_call(
+                call_method_error_world_age_callable, (MethodErrorWorldAgeCallable,))
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa NoMethodMatchReport && r.union_split == 0
+            @eval (::MethodErrorWorldAgeCallable)(x::String) = x
+            message = sprint(JET.print_report_message, r)
+            @test occursin("Closest candidates are:", message)
+            @test occursin("MethodErrorWorldAgeCallable)(x::String)`", message)
+            @test occursin("method too new to be called from this world context", message)
+        end
+
+        let result = analyze_call(call_method_error_constructor, ())
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa NoMethodMatchReport && r.union_split == 0
+            message = sprint(JET.print_report_message, r)
+            @test startswith(message, "MethodError: no matching method found `")
+            @test occursin("MethodErrorConstructor(::String)`", message)
+            @test occursin("The type `", message)
+            @test occursin("MethodErrorConstructor` exists", message)
+            @test occursin("Closest candidates are:", message)
+            @test occursin("MethodErrorConstructor(!Matched::$Int)`", message)
+        end
+
+        # abstract type without any constructor
+        let result = analyze_call(call_method_error_no_constructor, ())
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa NoMethodMatchReport && r.union_split == 0
+            @eval MethodErrorNoConstructor(x::Int) = x
+            message = sprint(JET.print_report_message, r)
+            @test occursin("No constructors have been defined for `", message)
+            @test occursin("MethodErrorNoConstructor`.", message)
+            @test !occursin("exists", message)
+            @test !occursin("Closest candidates are:", message)
+        end
+
+        # object without any callable method
+        let result = analyze_call(
+                call_method_error_not_callable, (MethodErrorNotCallable,))
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa NoMethodMatchReport && r.union_split == 0
+            message = sprint(JET.print_report_message, r)
+            @test occursin("MethodErrorNotCallable` are not callable.", message)
+            @test !occursin("exists", message)
+            @test !occursin("Closest candidates are:", message)
+        end
+
+        # singleton object without any callable method
+        let result = analyze_call(call_method_error_not_callable_singleton, ())
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa NoMethodMatchReport && r.union_split == 0
+            @eval (::MethodErrorNotCallableSingleton)(x::Int) = x
+            message = sprint(JET.print_report_message, r)
+            @test occursin("MethodErrorNotCallableSingleton` are not callable.", message)
+            @test !occursin("exists", message)
+        end
+
+        # vararg method of a callable object: candidate scoring must not crash
+        let result = analyze_call(
+                call_method_error_vararg_callable, (MethodErrorVarargCallable,))
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa NoMethodMatchReport && r.union_split == 0
+            message = sprint(JET.print_report_message, r)
+            @test occursin("The object of type `", message)
+            @test occursin("Closest candidates are:", message)
+            @test occursin("(xs::$Int...)`", message)
+            @test !endswith(message, '\n')
+        end
+
+        # splat call with `Vararg` argument types: hint must not crash `Base` printing
+        let result = analyze_call(call_vararg_splat_method_error, (Vector{String},))
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa NoMethodMatchReport && r.union_split == 0
+            message = sprint(JET.print_report_message, r)
+            @test startswith(message,
+                "MethodError: no matching method found `vararg_only_int(::String")
+            @test occursin("The function `vararg_only_int` exists", message)
+            @test occursin("Closest candidates are:", message)
+            @test !endswith(message, '\n')
+        end
+
+        # `Core.kwcall` signatures get no misleading candidate hints
+        let result = analyze_call(call_kwcall_no_match_method_error, (String,))
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa NoMethodMatchReport && r.union_split == 0
+            message = sprint(JET.print_report_message, r)
+            @test startswith(message, "MethodError: no matching method found `kwcall(")
+            @test !occursin("exists", message)
+            @test !occursin("Closest candidates are:", message)
+        end
+
+        # ambiguous `Core.kwcall` dispatch is reported alongside the keyword diagnostic
+        let result = analyze_call(call_kwambig_method_error, (Int, Int))
+            reports = get_reports(result)
+            @test length(reports) == 2
+            ambiguity = only(r for r in reports if r isa AmbiguousMethodReport)
+            kwarg = only(r for r in reports if r isa UnsupportedKeywordArgReport)
+            @test kwarg.unsupported == [:z]
+            message = sprint(JET.print_report_message, ambiguity)
+            @test startswith(message, "MethodError: `kwcall(")
+            # Defining an internal `Core.kwcall` method is not a source-level fix.
+            @test !occursin("Possible fix, define:", message)
+            @test occursin("To resolve the ambiguity", message)
+        end
+
+        # keyword suppression is per-branch: a union-split branch without any positional
+        # method keeps its no-match report
+        let result = analyze_call(call_kwsplit_method_error, (Union{Int,String},))
+            reports = get_reports(result)
+            @test length(reports) == 2
+            kwarg = only(r for r in reports if r isa UnsupportedKeywordArgReport)
+            no_match = only(r for r in reports if r isa NoMethodMatchReport)
+            @test kwarg.unsupported == [:z]
+            @test no_match.union_split == 2 && length(no_match.t) == 1
+            message = sprint(JET.print_report_message, no_match)
+            @test startswith(message, "MethodError: no matching method found `kwcall(")
+            @test occursin("::String", message)
+        end
+
+        # while branches explained by the keyword diagnostic are still suppressed
+        let result = analyze_call(call_kwcall_union_explained, (Union{Int,String},))
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa UnsupportedKeywordArgReport
+            @test r.unsupported == [:kw]
+        end
+
+        # open-ended `Vararg` signatures are not classified by the ambiguity flag alone
+        let result = analyze_call(call_vararg_ambiguous, (Tuple{Vararg{Int}},))
+            r = only(get_reports(result))
+            @test r isa NoMethodMatchReport && r.union_split == 0
+            message = sprint(JET.print_report_message, r)
+            @test startswith(message, "MethodError: no matching method found `vararg_ambiguous_func(")
+            @test occursin("The function `vararg_ambiguous_func` exists", message)
+        end
+
+        # fixed-length abstract signatures can also mix ambiguity and no-match regions
+        let result = analyze_call(call_partial_ambiguous, (Number,))
+            @test only(get_reports(result)) isa NoMethodMatchReport
+        end
+
+        # every arity represented by this open-ended `Vararg` is ambiguous
+        let result = analyze_call(
+                call_full_vararg_ambiguous, (Tuple{Int,Int,Vararg{Int}},))
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa AmbiguousMethodReport && r.union_split == 0
+            @test length(r.methods) == 2
+            message = sprint(JET.print_report_message, r)
+            @test startswith(message, "MethodError: `full_vararg_ambiguous_func(")
+            @test occursin("::Vararg{$Int})` is ambiguous.", message)
+        end
+
+        # the conflicting candidates may change between represented arities
+        let result = analyze_call(
+                call_changing_vararg_ambiguous, (Tuple{Int,Int,Vararg{Int}},))
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa AmbiguousMethodReport && length(r.methods) == 3
+            message = sprint(JET.print_report_message, r)
+            @test !occursin("Possible fix, define:", message)
+            @test occursin("To resolve the ambiguity", message)
+        end
+
+        # ambiguous method error
+        let result = analyze_call() do
+                ambiguous_func(1, 2)
+            end
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa AmbiguousMethodReport && r.union_split == 0
+            @test length(r.methods) == 2
+            message = sprint(JET.print_report_message, r)
+            @test startswith(message, "MethodError: `ambiguous_func(::$Int, ::$Int)` is ambiguous.")
+            @test occursin("\n\nCandidates:\n", message)
+            @test occursin("\n- `ambiguous_func(x::$Int, y)`\n  @", message)
+            @test occursin("\n- `ambiguous_func(x, y::$Int)`\n  @", message)
+            @test occursin("\n\nPossible fix, define: `ambiguous_func(::$Int, ::$Int)`", message)
+        end
+
+        # union split case: ambiguity and no-match branches
+        let result = analyze_call((Union{Int,String},)) do x
+                union_ambiguous_func(x, 1)
+            end
+            reports = get_reports(result)
+            @test length(reports) == 2
+            no_match = only(r for r in reports if r isa NoMethodMatchReport)
+            ambiguity = only(r for r in reports if r isa AmbiguousMethodReport)
+            @test no_match.union_split == ambiguity.union_split == 2
+            @test length(no_match.t) == 1
+            @test length(ambiguity.t::Vector{Any}) == 1
+            @test length(only(ambiguity.methods::Vector{Vector{Method}})) == 2
+            no_match_message = sprint(JET.print_report_message, no_match)
+            ambiguity_message = sprint(JET.print_report_message, ambiguity)
+            @test startswith(no_match_message, "MethodError: no matching method found `union_ambiguous_func(::String, ::$Int)`")
+            @test occursin(" (1/2 union split)\n\nThe function `union_ambiguous_func` exists", no_match_message)
+            @test occursin("Closest candidates are:", no_match_message)
+            @test startswith(ambiguity_message, "MethodError: `union_ambiguous_func(::$Int, ::$Int)` is ambiguous. ")
+            @test occursin("(1/2 union split)\n\nCandidates:\n- `", ambiguity_message)
+            @test !endswith(ambiguity_message, '\n')
+        end
+
+        # union split case: multiple ambiguous branches are aggregated into one report
+        let result = analyze_call((Union{Int,String}, Union{Int,String})) do x, y
+                multi_ambiguous_func(x, y)
+            end
+            reports = get_reports(result)
+            @test length(reports) == 2
+            no_match = only(r for r in reports if r isa NoMethodMatchReport)
+            ambiguity = only(r for r in reports if r isa AmbiguousMethodReport)
+            @test no_match.union_split == ambiguity.union_split == 4
+            @test length(no_match.t) == 2
+            ts = ambiguity.t::Vector{Any}
+            methodss = ambiguity.methods::Vector{Vector{Method}}
+            @test length(ts) == 2 && length(methodss) == 2
+            @test all(methods -> length(methods) == 2, methodss)
+            message = sprint(JET.print_report_message, ambiguity)
+            @test startswith(message, "MethodError: `multi_ambiguous_func(::")
+            @test occursin("` are ambiguous. (2/4 union split)", message)
+            @test occursin("For `multi_ambiguous_func(::$Int, ::$Int)`:", message)
+            @test occursin("For `multi_ambiguous_func(::String, ::String)`:", message)
+            @test length(findall("Candidates:", message)) == 2
+            @test occursin("Possible fix, define: `multi_ambiguous_func(::$Int, ::$Int)`", message)
+            @test occursin("Possible fix, define: `multi_ambiguous_func(::String, ::String)`", message)
         end
 
         # union split case: only one branch fails
@@ -291,6 +673,11 @@ struct KwCallable end
             @test length(reports) == 1
             r = only(reports)
             @test r isa NoMethodMatchReport && r.union_split == 2 && length(r.t) == 1
+            message = sprint(JET.print_report_message, r)
+            @test startswith(message, "MethodError: no matching method found `only_int(::String)`")
+            @test occursin(" (1/2 union split)\n\nThe function `only_int` exists", message)
+            @test occursin("Closest candidates are:", message)
+            @test occursin("\n- `only_int(!Matched::$Int)`", message)
         end
 
         let result = analyze_call(call_nested_only_int, (String,); report_target_modules=(@__MODULE__,))
@@ -316,6 +703,10 @@ struct KwCallable end
             @test length(reports) == 1
             r = only(reports)
             @test r isa NoMethodMatchReport && r.union_split == 2 && length(r.t) == 2
+            message = sprint(JET.print_report_message, r)
+            @test occursin("For `only_int(::String)`:", message)
+            @test occursin("For `only_int(::Symbol)`:", message)
+            @test length(findall("Closest candidates are:", message)) == 2
         end
     end
 
@@ -330,6 +721,17 @@ struct KwCallable end
             @test r isa UnsupportedKeywordArgReport
             @test r.ftype === typeof(kwfunc)
             @test r.unsupported == [:result]
+        end
+
+        # a callee without any keyword-accepting method: the keyword diagnostic
+        # supersedes the no-match report on the raw `Core.kwcall` signature
+        let result = analyze_call(call_kwcall_method_error, (Int,))
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa UnsupportedKeywordArgReport
+            @test r.ftype === typeof(nokw_func)
+            @test r.unsupported == [:kw]
         end
 
         # only the unsupported keywords are reported, supported ones are ignored
@@ -347,6 +749,17 @@ struct KwCallable end
                 kwfunc(; code="c", data=42)
             end
             @test isempty(get_reports(result))
+        end
+
+        # every positional branch rejects the keyword combination, but for different names
+        let result = analyze_call((Union{Int,String},)) do x
+                kwdispatch(x; a=1, b=1)
+            end
+            r = only(get_reports(result))
+            @test r isa UnsupportedKeywordArgReport
+            @test r.combination && r.unsupported == [:a, :b]
+            message = sprint(JET.print_report_message, r)
+            @test startswith(message, "unsupported combination of keyword arguments `a`, `b` in `kwdispatch(")
         end
 
         # no report when the method slurps `kwargs...` (accepts any keyword)
@@ -626,6 +1039,8 @@ end
 
 kwtyped(a::Int; kw::Int=42) = a * kw       # typed keyword with a default, plus a positional
 kwtyped2(; x::Int, y::String="s") = (x, y) # required typed x, optional typed y
+kwtyped_dispatch(x::Int; kw::Int=1) = x
+kwtyped_dispatch(x::String; kw::String="s") = x
 kwtypedfwd(; kws...) = kwtyped(1; kws...)   # forwards slurped keywords
 kwtypedbad(; _kws...) = kwtyped(1; kw=2.0)   # slurps but hardcodes a mismatching call
 module KeywordTypeExternalModule
@@ -643,6 +1058,15 @@ end
             r = only(reports)
             @test r isa KeywordTypeErrorReport
             @test r.var === :kw && r.expected === Int && r.got === Float64
+        end
+
+        # expectations from different positional branches are combined deterministically
+        let result = analyze_call((Union{Int,String},)) do x
+                kwtyped_dispatch(x; kw=1.0)
+            end
+            r = only(get_reports(result))
+            @test r isa KeywordTypeErrorReport
+            @test r.var === :kw && r.expected === Union{Int,String} && r.got === Float64
         end
 
         # mismatch on a required typed keyword (routed through the keyword sorter)

--- a/test/app/test_jetls_check.jl
+++ b/test/app/test_jetls_check.jl
@@ -15,6 +15,7 @@ To run this test independently:
 
 using Test
 using JETLS
+using JETLS.LSP
 
 const JULIA_CMD = normpath(Sys.BINDIR, "julia")
 const JETLS_DIR = pkgdir(JETLS)
@@ -144,6 +145,34 @@ end
         result = run_jetls_check(["test.jl"]; root=dir)
         @test occursin("lowering/unused-local", result.stdout)
         @test occursin("test.jl", result.stdout)
+    end
+end
+
+@testset "multi-line diagnostic message rendering" begin
+    mktempdir() do dir
+        filepath = write_test_file(dir, "test.jl", "func(1, 2)\n")
+        uri = JETLS.filepath2uri(filepath)
+        message = "MethodError: no matching method found `func(::Int64, ::Int64)`\n\n" *
+            "The function `func` exists.\n\nClosest candidates are:\n- `func(::Int64)`"
+        diagnostic = Diagnostic(;
+            range = Range(;
+                start = Position(; line=0, character=0),
+                var"end" = Position(; line=0, character=10)),
+            severity = DiagnosticSeverity.Warning,
+            message,
+            code = "inference/method-error")
+        uri2diagnostics = JETLS.URI2Diagnostics(uri => [diagnostic])
+        result = capture_jetls_check() do
+            JETLS.print_diagnostics(uri2diagnostics, dir, 1,
+                DiagnosticSeverity.Error, DiagnosticSeverity.Information)
+        end
+        # the summary line carries the severity tag inline
+        @test occursin("`func(::Int64, ::Int64)` [warn:inference/method-error]", result.stdout)
+        # continuation lines form a separate `#`-prefixed block
+        @test occursin("# The function `func` exists.", result.stdout)
+        @test occursin("# Closest candidates are:", result.stdout)
+        @test occursin("# - `func(::Int64)`", result.stdout)
+        @test !occursin("exists. [warn", result.stdout)
     end
 end
 


### PR DESCRIPTION
`inference/method-error` reported ambiguous calls as missing methods and provided incomplete candidate context for ordinary dispatch failures, especially for callable objects and failed union-split branches. Keyword calls to functions without keyword support were also double-reported, as both a raw `Core.kwcall` dispatch failure and an unsupported keyword argument.

Distinguish ambiguous dispatch from no-match failures using the analysis world, preserve conflicting methods in a dedicated `AmbiguousMethodReport`, and render Markdown candidate lists with signatures and possible fixes. No-match reports now include Julia-style closest-candidate hints for functions, constructors, callable objects, and each failed union-split signature. Callees without any method use Base's dedicated phrasings instead ("no constructors have been defined", "not callable").

Ambiguous union-split branches are aggregated into a single report that follows the same `(k/N union split)` labeling as `NoMethodMatchReport`. Abstract signatures are classified as ambiguous only when applicable match regions cover the entire quer ,
since the ambiguity flag may describe only part of it. Disambiguating signatures are likewise suggested only when they cover the complete query. Ambiguous `Core.kwcall` dispatch uses generic source-level advice rather than suggesting a method on the internal keyword sorter.

Unsupported keyword diagnostics supersede redundant raw `Core.kwcall` no-match reports only for branches whose positional signature has matching methods. They retain ambiguity and independent positional no-match failures. Keyword support is evaluated per applicable positional method, so calls whose branches reject different keywords are reported as unsupported keyword combinations. Typed keyword diagnostics combine differing expectations across positional branches instead of selecting an arbitrary method.

Since inference signatures may contain `Vararg` from splatted calls, which neither `Base.show_method_candidates` nor the candidate scorer can handle, hints are computed on the fixed-length prefix of the argument types. Raw `Core.kwcall` no-match signatures get no closest- candidate hints, because candidates from the internal keyword sorter would be meaningless. Hint generation is wrapped in a fail-safe that drops the hint (rethrowing in `JETLS_DEV_MODE`) instead of breaking the whole diagnostics generation.

The multi-line messages also affect `jetls check`, whose rendering via `JuliaSyntax.highlight` assumes a single-line note. The CLI now shows only the first line of a message inline and prints the remaining lines as a `#`-prefixed block below the highlighted snippet. This also fixes the previously interleaved rendering of other multi-line messages, such as the missing-concretization instructions.

The ambiguity lookup runs only for failed dispatch branches. Synthetic benchmarks measured about 0.5% overhead for 1,000 no-match sites and about 1.1% for 1,000 ambiguous sites; JETLS self-analysis performed no extra ambiguity lookups.