### PR TITLE
analysis: Report field errors for union-split property accesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 >
 > Note: Path glob patterns use `/` as the separator on all platforms, including Windows; backslashes are not supported as separators.
 
+### Added
+
+- Added `inference/field-error` diagnostics for field accesses whose receiver may be a type without the field: `x.regex` where `x::Union{Nothing,Regex}` now reports a `FieldError` for the `Nothing` case, and accesses on fieldless receivers like `x.foo` where `x::Nothing` are now reported as well.
+
 ### Changed
 
 - Updated JuliaSyntax.jl and JuliaLowering.jl revisions, bringing in JuliaLowering bugfixes for various lowering edge cases found in real-world packages ([JuliaLang/julia#62862](https://github.com/JuliaLang/julia/pull/62862)).

--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
 Compiler = {path = "Compiler"}
-JET = {rev = "2744e2ef", url = "https://github.com/aviatesk/JET.jl"}
+JET = {rev = "a5e6cd4a", url = "https://github.com/aviatesk/JET.jl"}
 JuliaLowering = {rev = "537a4c16f1", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
 JuliaSyntax = {rev = "537a4c16f1", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
 LSP = {path = "LSP"}

--- a/src/analysis/Analyzer.jl
+++ b/src/analysis/Analyzer.jl
@@ -321,6 +321,33 @@ non-concrete call sites in a toplevel frame created by `JET.virtual_process`.
 """
 CC.bail_out_toplevel_call(::LSAnalyzer, ::CC.InferenceState) = false
 
+"""
+    bail_out_const_call(analyzer::LSAnalyzer, ...)
+
+The native compiler bails out of constant propagation when the generic inference result is
+already proven to be `Bottom` (i.e. the call always throws), since const-prop' cannot
+improve the return type any further. For error analysis however, const-prop'ing such a call
+is exactly what analyzes the callee frame with the constant arguments and lets it create
+precise error reports (e.g. `FieldError` for an `x.field` access with the concrete field
+name, including each split of a union-split `getproperty` call), which then surface at the
+in-scope call site via `collect_callee_reports!`. This overload keeps const-prop' going in
+that case, while still respecting `@constprop :none` annotations and the
+`ipo_constant_propagation` inference parameter.
+"""
+function CC.bail_out_const_call(
+        analyzer::LSAnalyzer, result::CC.MethodCallResult, si::CC.StmtInfo,
+        match::CC.MethodMatch, sv::CC.InferenceState
+    )
+    ret = @invoke CC.bail_out_const_call(
+        analyzer::ToplevelAbstractAnalyzer, result::CC.MethodCallResult, si::CC.StmtInfo,
+        match::CC.MethodMatch, sv::CC.InferenceState)
+    if (ret && result.rt === Union{} && !CC.is_no_constprop(match.method) &&
+        CC.InferenceParams(analyzer).ipo_constant_propagation)
+        return false
+    end
+    return ret
+end
+
 function CC.concrete_eval_eligible(
         analyzer::LSAnalyzer, @nospecialize(f), result::CC.MethodCallResult,
         arginfo::CC.ArgInfo, sv::CC.InferenceState

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -918,6 +918,7 @@ function new_analysis_result(interp::LSInterpreter, result::JET.JETToplevelResul
     prev_result = execution.prev_result
     replace_analysis_result = isempty(result.res.toplevel_error_reports) || isnothing(prev_result)
     if !replace_analysis_result
+        prev_result = prev_result::AnalysisResult
         (; actual2virtual, analyzer, analyzed_file_infos) = prev_result
         cache_world = prev_result.world
     else

--- a/src/completions.jl
+++ b/src/completions.jl
@@ -881,7 +881,8 @@ function call_completions!(
             newText = if isnothing(base_text)
                 ""
             else
-                prefix = (num_existing_args > 0 && context.triggerCharacter == ",") ? " " : ""
+                triggerCharacter = (context::CompletionContext).triggerCharacter
+                prefix = (num_existing_args > 0 && triggerCharacter == ",") ? " " : ""
                 prefix * base_text
             end
             label = String(msig_label)

--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -948,7 +948,8 @@ next_tok(tc::TokenCursor) =
 prev_tok(tc::TokenCursor) = tc.position <= 1 ? nothing :
     TokenCursor(tc.tokens, tc.position - 1, tc.next_byte - tc.tokens[tc.position].byte_span)
 this(tc::TokenCursor) = tc.tokens[tc.position]
-JS.first_byte(tc::TokenCursor) = tc.position <= 1 ? 1 : Int(prev_tok(tc).next_byte)
+JS.first_byte(tc::TokenCursor) =
+    tc.position <= 1 ? 1 : Int((prev_tok(tc)::TokenCursor).next_byte)
 JS.last_byte(tc::TokenCursor) = Int(tc.next_byte) - 1
 JS.byte_range(tc::TokenCursor) = JS.first_byte(tc):JS.last_byte(tc)
 JS.kind(tc::TokenCursor) = JS.kind(this(tc))

--- a/src/utils/jl-syntax-macros.jl
+++ b/src/utils/jl-syntax-macros.jl
@@ -1479,7 +1479,7 @@ end
 # contract.
 function _static_eval_cond(ctx::JL.MacroContext, cond::SyntaxTree)
     sc = (ctx.macrocall::SyntaxTree).context::JS.SyntaxContext
-    base_mod = JS.base_layer(sc).mod
+    base_mod = (JS.base_layer(sc)::JS.ScopeLayer).mod
     eval_cond = JS.fill_context(cond, JS.SyntaxContext(base_mod, sc.version))
     val = try
         JL.eval(base_mod, eval_cond)

--- a/test/analysis/test_Analyzer.jl
+++ b/test/analysis/test_Analyzer.jl
@@ -189,6 +189,67 @@ helper_getproperty_error(o::HelperGetproperty) = o.missing
         r = only(reports)
         @test r isa FieldErrorReport && r.field === :val
     end
+
+    # the report must not depend on inference cache state:
+    # re-analyzing the same call with a warm cache must reproduce it
+    let kernel = function (x)
+            x.regex
+        end
+        for _ = 1:2
+            result = analyze_call(kernel, (Union{Nothing,Regex},))
+            reports = get_reports(result)
+            @test length(reports) == 1
+            r = only(reports)
+            @test r isa FieldErrorReport && r.type === Nothing && r.field === :regex
+        end
+    end
+    let result = analyze_call((Nothing,)) do x
+            x.foo
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa FieldErrorReport && r.type === Nothing && r.field === :foo
+    end
+    let NT = Union{@NamedTuple{regex::Int},@NamedTuple{regex::String}}
+        result = analyze_call((NT,)) do x
+            x.regex
+        end
+        @test isempty(get_reports(result))
+    end
+    let result = analyze_call((Union{@NamedTuple{alias::Int},TransparentGetproperty},)) do x
+            x.alias
+        end
+        @test isempty(get_reports(result))
+    end
+    # an erroring split whose receiver has other fields takes the same const-prop
+    # path as before: exactly one report, no duplicates
+    let result = analyze_call((Union{Some{Int},Regex},)) do x
+            x.value
+        end
+        reports = get_reports(result)
+        @test length(reports) == 1
+        r = only(reports)
+        @test r isa FieldErrorReport && r.type === Regex && r.field === :value
+    end
+    let result = analyze_call((Union{Nothing,Missing},)) do x
+            x.foo
+        end
+        reports = get_reports(result)
+        @test length(reports) == 2
+        @test any(reports) do r
+            r isa FieldErrorReport && r.type === Nothing && r.field === :foo
+        end
+        @test any(reports) do r
+            r isa FieldErrorReport && r.type === Missing && r.field === :foo
+        end
+    end
+    let result = analyze_call((Union{Nothing,Regex},)) do x
+            isnothing(x) && return nothing
+            return x.regex
+        end
+        @test isempty(get_reports(result))
+    end
 end
 
 only_int(x::Int) = 2x


### PR DESCRIPTION
Field accesses on small union receivers were not reported even when the access is guaranteed to fail for some union component: e.g. `x.regex` where `x::Union{Nothing,Regex}` produced no diagnostic for the `Nothing` case. The native compiler bails out of constant propagation when the generic return type of a call is already proven to be `Bottom`, so the erroring `getproperty` split was never analyzed with the constant field name and the existing `FieldError` reporting pipeline never fired. Plain always-erroring receivers such as `x.foo` where `x::Nothing` were missed for the same reason.

This commit adds a `CC.bail_out_const_call` overload for `LSAnalyzer` that keeps const-prop' going for such always-throwing calls (while respecting `@constprop :none` and `ipo_constant_propagation`). The callee frame is then analyzed with the constant arguments and creates precise `FieldError` reports through the existing
`report_fieldaccess!`/`collect_callee_reports!` pipeline, covering union-split and non-union receivers uniformly, cache-stably, and without duplicate reports for receivers that already worked.

The relaxation lets always-throwing calls reach concrete evaluation, where `JET`'s `concrete_eval_call` overload used to throw away the reports collected on the generic edge even when the const-prop' fallback that should re-derive them does not run. That is fixed on the JET side (aviatesk/JET.jl's `fda8b924`, backported as `a5e6cd4a`), so this commit also bumps the JET pin to `a5e6cd4a`.

Accesses guarded in ways inference cannot refine (e.g. through a generic `|` call) now produce a false positive; the known case is pinned as `@test_broken` and the few instances in the server sources are silenced with typeasserts. The analysis time cost measured via selfcheck is a few percent.