### PR TITLE
inference: Widen slot-wrapped exception types

### DIFF
--- a/Compiler/snapshots.toml
+++ b/Compiler/snapshots.toml
@@ -3,13 +3,13 @@ repository = "https://github.com/JuliaLang/julia.git"
 subdir = "Compiler"
 
 [snapshots."1.12"]
-commit = "571a09836c95c73989daf8e468a724919a12a480"
+commit = "4772d66f0fcfbd5bdb350398a913353250718241"
 source-branch = "avi/JETLS-Compiler-head-v1.12-2026-09-01"
 runtime = { lower = "1.12.2", upper = "1.13-" }
 destination = "snapshots/v1.12"
 
 [snapshots."1.13"]
-commit = "caa034a63c03aa98dd2c5b6e94f77f43ce7ad98c"
+commit = "ffa7de3432e0ff98ab9b50b7fd89acfaa0a4b731"
 source-branch = "avi/JETLS-Compiler-head-v1.13-2026-09-01"
 runtime = { lower = "1.13-", upper = "1.14-" }
 destination = "snapshots/v1.13"

--- a/Compiler/snapshots/v1.12/src/abstractinterpretation.jl
+++ b/Compiler/snapshots/v1.12/src/abstractinterpretation.jl
@@ -4129,6 +4129,7 @@ end
 function update_exc_bestguess!(interp::AbstractInterpreter, @nospecialize(exct), frame::InferenceState)
     𝕃ₚ = ipo_lattice(interp)
     handler = gethandler(frame)
+    exct = widenslotwrapper(exct)
     if handler === nothing
         if !⊑(𝕃ₚ, exct, frame.exc_bestguess)
             frame.exc_bestguess = tmerge(𝕃ₚ, frame.exc_bestguess, exct)

--- a/Compiler/snapshots/v1.12/test/inference.jl
+++ b/Compiler/snapshots/v1.12/test/inference.jl
@@ -6405,3 +6405,8 @@ frec_rt_cycle(t::TreeRTCycle) =
 let rt = only(Base.return_types(map, (typeof(frec_rt_cycle), Vector{TreeRTCycle})))
     @test !any(T -> T === Vector{Union{}}, Compiler.uniontypes(rt))
 end
+
+throwconditional(c, x) = c ? throw(x isa Int) : throw(x isa Float64)
+@test Base.infer_exception_type((Bool, Any)) do c, x
+    throwconditional(c, x)
+end == Bool

--- a/Compiler/snapshots/v1.13/src/abstractinterpretation.jl
+++ b/Compiler/snapshots/v1.13/src/abstractinterpretation.jl
@@ -4113,6 +4113,7 @@ end
 function update_exc_bestguess!(interp::AbstractInterpreter, @nospecialize(exct), frame::InferenceState)
     𝕃ₚ = ipo_lattice(interp)
     handler = gethandler(frame)
+    exct = widenslotwrapper(exct)
     if handler === nothing
         if !⊑(𝕃ₚ, exct, frame.exc_bestguess)
             frame.exc_bestguess = tmerge(𝕃ₚ, frame.exc_bestguess, exct)

--- a/Compiler/snapshots/v1.13/test/inference.jl
+++ b/Compiler/snapshots/v1.13/test/inference.jl
@@ -6629,4 +6629,9 @@ let rt = only(Base.return_types(map, (typeof(frec_rt_cycle), Vector{TreeRTCycle}
     @test !any(T -> T === Vector{Union{}}, Compiler.uniontypes(rt))
 end
 
+throwconditional(c, x) = c ? throw(x isa Int) : throw(x isa Float64)
+@test Base.infer_exception_type((Bool, Any)) do c, x
+    throwconditional(c, x)
+end == Bool
+
 end # module inference

--- a/test/analysis/test_Analyzer.jl
+++ b/test/analysis/test_Analyzer.jl
@@ -54,6 +54,15 @@ function unpack_pair(pair::Pair{Any,Any})
     return nothing
 end
 
+# Adapted from JuliaLang/julia#61048
+throwconditional61048(c, x) = c ? throw(x isa Int) : throw(x isa Float64)
+function issue61048(c::Bool, x)
+    throwconditional61048(c, x)
+end
+@testset "aviatesk/JETLS#887" begin
+    @test isempty(analyze_signature(issue61048))
+end
+
 # test basic analysis abilities of `LSAnalyzer`
 function report_global_undef()
     return sin(undefvar)


### PR DESCRIPTION
Signature analysis could leave `Conditional` or `MustAlias` values in the accumulated exception type. A later merge through the IPO lattice then raised a `MethodError`, aborting `jetls check`.

Backport JuliaLang/julia#61048 to the Julia 1.12 and 1.13 Compiler snapshots so `update_exc_bestguess!` widens local slot wrappers before merging exception types. Update snapshot provenance and add native and `LSAnalyzer` regression coverage.

Closes aviatesk/JETLS.jl#887.