### PR TITLE
code-action: Add concrete `Ref` field quick fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 >
 > Note: Path glob patterns use `/` as the separator on all platforms, including Windows; backslashes are not supported as separators.
 
+### Added
+
+- Added a quick fix for `toplevel/abstract-field` diagnostics on `Ref{T}` fields that replaces `Ref` with `Base.RefValue`.
+
 ### Changed
 
 - `full_analysis.auto_instantiate` no longer runs `Pkg.resolve()` and `Pkg.instantiate()` on environments that are already instantiated.

--- a/LSP/src/basic-json-structures.jl
+++ b/LSP/src/basic-json-structures.jl
@@ -674,6 +674,11 @@ Structure to capture a description for an error code.
 end
 
 # JETLS specific data structures for `data` field of `Diagnostic`
+struct AbstractRefFieldData
+    ref_name_range::Range
+end
+export AbstractRefFieldData
+
 struct AmbiguousSoftScopeData
     name::String
     indent::String
@@ -719,6 +724,7 @@ end
 export MissingConcretizationData
 
 const DiagnosticData = Union{
+    AbstractRefFieldData,
     AmbiguousSoftScopeData,
     DeleteRangeData,
     UnsortedImportData,

--- a/src/code-action.jl
+++ b/src/code-action.jl
@@ -55,6 +55,7 @@ function handle_CodeActionRequest(
         delete_range_code_actions!(code_actions, uri, diagnostics)
         sort_imports_code_actions!(code_actions, uri, diagnostics)
         ambiguous_soft_scope_code_actions!(code_actions, uri, diagnostics)
+        abstract_ref_field_code_actions!(code_actions, uri, diagnostics)
         missing_concretization_code_actions!(code_actions, server, diagnostics)
     end
     if wants_kindless_actions
@@ -209,6 +210,27 @@ function delete_range_code_actions!(
                     uri => TextEdit[TextEdit(;
                         range = data.delete_range,
                         newText = "")]))))
+    end
+    return code_actions
+end
+
+function abstract_ref_field_code_actions!(
+        code_actions::Vector{Union{CodeAction,Command}}, uri::URI,
+        diagnostics::Vector{Diagnostic}
+    )
+    for diagnostic in diagnostics
+        diagnostic.code == TOPLEVEL_ABSTRACT_FIELD_CODE || continue
+        data = diagnostic.data
+        data isa AbstractRefFieldData || continue
+        push!(code_actions, CodeAction(;
+            title = "Replace `Ref` with `Base.RefValue`",
+            kind = CodeActionKind.QuickFix,
+            diagnostics = Diagnostic[diagnostic],
+            edit = WorkspaceEdit(;
+                changes = Dict{URI,Vector{TextEdit}}(
+                    uri => TextEdit[TextEdit(;
+                        range = data.ref_name_range,
+                        newText = "Base.RefValue")]))))
     end
     return code_actions
 end

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -591,6 +591,27 @@ end
 
 toplevel_warning_report_to_uri_impl(report::AbstractFieldReport) = to_valid_uri(report.filepath)
 
+function abstract_ref_field_data(report::AbstractFieldReport, sfi::SavedFileInfo)
+    fieldline = report.fieldline
+    fieldline isa JS.SyntaxNode || return nothing
+    report.ft isa DataType || return nothing
+    report.ft.name === Base.typename(Ref) || return nothing
+
+    field = fieldline
+    if JS.kind(field) === JS.K"const" && JS.numchildren(field) >= 1
+        field = field[1]
+    end
+    JS.kind(field) === JS.K"::" && JS.numchildren(field) >= 2 || return nothing
+    fieldtype_node = field[2]
+    JS.kind(fieldtype_node) === JS.K"curly" || return nothing
+    JS.numchildren(fieldtype_node) == 2 || return nothing
+    ref_name = fieldtype_node[1]
+    JS.kind(ref_name) === JS.K"Identifier" || return nothing
+    ref_name_data = ref_name.data
+    ref_name_data !== nothing && ref_name_data.val === :Ref || return nothing
+    return AbstractRefFieldData(jsobj_to_range(ref_name, sfi))
+end
+
 function toplevel_warning_report_to_diagnostic_impl(report::AbstractFieldReport, sfi::SavedFileInfo, postprocessor::JET.PostProcessor)
     typ_str = postprocessor(sprint(show, report.typ))
     ft_str = postprocessor(sprint(show, report.ft))
@@ -603,7 +624,8 @@ function toplevel_warning_report_to_diagnostic_impl(report::AbstractFieldReport,
         message,
         source = DIAGNOSTIC_SOURCE_SAVE,
         code = TOPLEVEL_ABSTRACT_FIELD_CODE,
-        codeDescription = diagnostic_code_description(TOPLEVEL_ABSTRACT_FIELD_CODE))
+        codeDescription = diagnostic_code_description(TOPLEVEL_ABSTRACT_FIELD_CODE),
+        data = abstract_ref_field_data(report, sfi))
 end
 
 # lowering diagnostic

--- a/src/notebook.jl
+++ b/src/notebook.jl
@@ -359,7 +359,9 @@ function localize_range(range::Range, concat::ConcatenatedNotebook)
 end
 
 function localize_diagnostic_data(@nospecialize(data), concat::ConcatenatedNotebook)
-    if data isa DeleteRangeData
+    if data isa AbstractRefFieldData
+        return AbstractRefFieldData(localize_range(data.ref_name_range, concat))
+    elseif data isa DeleteRangeData
         return DeleteRangeData(data.kind, localize_range(data.delete_range, concat))
     elseif data isa UnusedVariableData
         assignment_range = data.assignment_range

--- a/test/test_code_action.jl
+++ b/test/test_code_action.jl
@@ -514,6 +514,34 @@ end
     end
 end
 
+@testset "abstract Ref field code action" begin
+    _, positions = JETLS.get_text_and_positions("""
+        struct AAA
+            x::│Ref│{Int}
+        end
+        """)
+    ref_name_range = Range(; start = positions[1], var"end" = positions[2])
+    diagnostic = Diagnostic(;
+        range = JETLS.line_range(2),
+        severity = DiagnosticSeverity.Information,
+        message = "`AAA` has abstract field `x::Ref{Int64}`",
+        source = JETLS.DIAGNOSTIC_SOURCE_SAVE,
+        code = JETLS.TOPLEVEL_ABSTRACT_FIELD_CODE,
+        data = AbstractRefFieldData(ref_name_range))
+    uri = filepath2uri(abspath(pkgdir(JETLS), "test", "abstract-ref-field.jl"))
+    code_actions = Union{CodeAction,Command}[]
+    JETLS.abstract_ref_field_code_actions!(code_actions, uri, Diagnostic[diagnostic])
+
+    action = only(code_actions)
+    @test action.title == "Replace `Ref` with `Base.RefValue`"
+    @test action.kind == CodeActionKind.QuickFix
+    @test action.isPreferred === nothing
+    @test only(action.diagnostics) === diagnostic
+    edit = only(action.edit.changes[uri])
+    @test edit.range == ref_name_range
+    @test edit.newText == "Base.RefValue"
+end
+
 function missing_concretization_diagnostic(assignment_file::String)
     return Diagnostic(;
         range = JETLS.line_range(1),

--- a/test/test_diagnostic.jl
+++ b/test/test_diagnostic.jl
@@ -429,6 +429,15 @@ end
             xs::Vector{<:Integer}
         end
 
+        struct BadStruct3
+            x::Ref{Int}
+        end
+
+        const AbstractRefAlias = Ref{Int}
+        struct BadStruct4
+            x::AbstractRefAlias
+        end
+
         end # module TestAbstractField
         """) do pkg_path
         rootUri = filepath2uri(pkg_path)
@@ -463,6 +472,39 @@ end
                 end
             end
             @test found_diagnostic2
+
+            found_diagnostic3 = false
+            for diag in raw_res.params.diagnostics
+                if (diag.source == JETLS.DIAGNOSTIC_SOURCE_SAVE &&
+                    diag.code == JETLS.TOPLEVEL_ABSTRACT_FIELD_CODE &&
+                    occursin("BadStruct3", diag.message) &&
+                    occursin("x::Ref{$Int}", diag.message))
+                    found_diagnostic3 = true
+                    data = diag.data
+                    @test data isa AbstractRefFieldData
+                    if data isa AbstractRefFieldData
+                        @test data.ref_name_range.start.line == diag.range.start.line
+                        @test data.ref_name_range.var"end".line == diag.range.var"end".line
+                        @test data.ref_name_range.var"end".character -
+                            data.ref_name_range.start.character == 3
+                    end
+                    break
+                end
+            end
+            @test found_diagnostic3
+
+            found_diagnostic4 = false
+            for diag in raw_res.params.diagnostics
+                if (diag.source == JETLS.DIAGNOSTIC_SOURCE_SAVE &&
+                    diag.code == JETLS.TOPLEVEL_ABSTRACT_FIELD_CODE &&
+                    occursin("BadStruct4", diag.message) &&
+                    occursin("x::Ref{$Int}", diag.message))
+                    found_diagnostic4 = true
+                    @test diag.data === nothing
+                    break
+                end
+            end
+            @test found_diagnostic4
         end
     end
 end


### PR DESCRIPTION
`toplevel/abstract-field` reports fields declared as `Ref{T}`, but users previously had to replace this common abstract field type manually.

Attach the source range of standard `Ref{T}` annotations to each diagnostic and offer a quick fix that replaces `Ref` with `Base.RefValue`. The edit preserves the original type parameter and localizes the range for notebook cells.

The action is not preferred because narrowing `Ref{T}` can reject other concrete `Ref` implementations. Tests cover diagnostic data generation, aliases without fixes, and the resulting workspace edit.