### PR TITLE
full-analysis: Skip Pkg operations for instantiated environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 >
 > Note: Path glob patterns use `/` as the separator on all platforms, including Windows; backslashes are not supported as separators.
 
+### Changed
+
+- `full_analysis.auto_instantiate` no longer runs `Pkg.resolve()` and `Pkg.instantiate()` on environments that are already instantiated.
+  JETLS now inspects the environment first and leaves it untouched when nothing is missing, so opening a project no longer rewrites its `Manifest.toml` (e.g. when it was written by another Julia version).
+  `Pkg.resolve()` is run only when the manifest is missing or `Project.toml` has changed since the manifest was last resolved; otherwise only `Pkg.instantiate()` runs.
+
+### Fixed
+
+- Fixed the "environment has not been instantiated" warning shown when `full_analysis.auto_instantiate` is disabled not appearing for environments without a `Manifest.toml`.
+  The warning now also covers environments whose manifest is out of date with respect to `Project.toml`.
+
 ## 2026-09-01
 
 - Commit: [`9cebe8b`](https://github.com/aviatesk/JETLS.jl/commit/9cebe8b)

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -1528,12 +1528,45 @@ function ensure_instantiated_if_requested!(server::Server, env_path::String)
     end
 end
 
+"""
+    instantiation_needs(env_path::String) -> (; resolve::Bool, instantiate::Bool)
+
+Inspect the environment at `env_path` without mutating it. `resolve` is `true` when the
+manifest is missing or `Project.toml` has changed since the manifest was last resolved.
+`instantiate` is `true` when `resolve` is, or when some dependency source or artifact has
+not been downloaded yet.
+"""
+function instantiation_needs(env_path::String)
+    env = Pkg.Types.EnvCache(env_path)
+    resolve = !isfile(env.manifest_file) || Pkg.Operations.is_manifest_current(env) === false
+    instantiate = resolve || !Pkg.Operations.is_instantiated(env)
+    return (; resolve, instantiate)
+end
+
 function ensure_instantiated!(server::Server, env_path::String)
+    needs = try
+        instantiation_needs(env_path)
+    catch e
+        @error "Failed to inspect package environment" env_path
+        Base.showerror(stderr, e, catch_backtrace())
+        (; resolve = true, instantiate = true)
+    finally
+        # HACK This is a terrible hack to reduce Pkg.jl's memory footprint:
+        # This behavior should really be implemented as an environment variable that Pkg.jl understands,
+        # or perhaps this cache itself should be optimized.
+        empty!(Pkg.Registry.REGISTRY_CACHE)
+    end
+    if !needs.instantiate
+        @static JETLS_DEV_MODE && @info "Package environment is already instantiated" env_path
+        return
+    end
     if get_config(server, :full_analysis, :auto_instantiate)
         io = IOBuffer()
         try
-            @static JETLS_DEV_MODE && @info "Resolving package environment" env_path
-            Pkg.resolve(; io)
+            if needs.resolve
+                @static JETLS_DEV_MODE && @info "Resolving package environment" env_path
+                Pkg.resolve(; io)
+            end
             @static JETLS_DEV_MODE && @info "Instantiating package environment" env_path
             Pkg.instantiate(; io)
         catch e
@@ -1550,31 +1583,14 @@ function ensure_instantiated!(server::Server, env_path::String)
                 See the language server log for details.
                 It is recommended to fix your package environment setup and restart the language server.""")
         finally
-            # HACK This is a terrible hack to reduce Pkg.jl's memory footprint:
-            # This behavior should really be implemented as an environment variable that Pkg.jl understands,
-            # or perhaps this cache itself should be optimized.
             empty!(Pkg.Registry.REGISTRY_CACHE)
         end
     else
-        is_instantiated = try
-            Pkg.Operations.is_instantiated(Pkg.Types.EnvCache(env_path))
-        catch e
-            @error "Failed to create cache for package environment" env_path
-            Base.showerror(stderr, e, catch_backtrace())
-            false
-        finally
-            # HACK This is a terrible hack to reduce Pkg.jl's memory footprint:
-            # This behavior should really be implemented as an environment variable that Pkg.jl understands,
-            # or perhaps this cache itself should be optimized.
-            empty!(Pkg.Registry.REGISTRY_CACHE)
-        end
-        if !is_instantiated
-            show_warning_message(server, """
-                Package environment at $env_path has not been instantiated
-                (`full_analysis.auto_instantiate` is disabled).
-                The package will be analyzed as a script, which may result in incomplete diagnostics.
-                It is recommended to instantiate your package environment and restart the language server.""")
-        end
+        show_warning_message(server, """
+            Package environment at $env_path has not been instantiated or is out of date
+            (`full_analysis.auto_instantiate` is disabled).
+            The package will be analyzed as a script, which may result in incomplete diagnostics.
+            It is recommended to instantiate your package environment and restart the language server.""")
     end
 end
 

--- a/test/analysis/test_full_analysis.jl
+++ b/test/analysis/test_full_analysis.jl
@@ -4,6 +4,8 @@ using Test
 using JETLS: JETLS
 using JETLS.URIs2: filepath2uri
 
+include(normpath(pkgdir(JETLS), "test", "setup.jl"))
+
 @testset "immediate invalidation supersedes older requests" begin
     server = JETLS.Server()
     manager = server.state.analysis_manager
@@ -53,6 +55,84 @@ using JETLS.URIs2: filepath2uri
     @test JETLS.get_analysis_info(manager, script_uri) === nothing
     @test !haskey(JETLS.load(manager.analyzed_generations), entry)
     @test take!(manager.queue) === immediate_request
+end
+
+@testset "instantiation_needs" begin
+    withpackage("TestInstantiationNeeds", "module TestInstantiationNeeds end";
+                pkg_setup = Returns(nothing)) do pkgpath
+        env_path = joinpath(pkgpath, "Project.toml")
+        manifest_path = joinpath(pkgpath, "Manifest.toml")
+
+        @test !isfile(manifest_path)
+        @test JETLS.instantiation_needs(env_path) == (; resolve=true, instantiate=true)
+
+        withenv("JULIA_PKG_PRECOMPILE_AUTO" => "0") do
+            Pkg.activate(pkgpath) do
+                Pkg.instantiate(; io=devnull)
+            end
+        end
+        @test isfile(manifest_path)
+        @test JETLS.instantiation_needs(env_path) == (; resolve=false, instantiate=false)
+
+        # adding a dependency to `Project.toml` leaves the manifest stale
+        open(env_path, "a") do io
+            println(io, "\n[deps]\nTest = \"8dfed614-e22c-5e08-85e1-65c5234f0b40\"")
+        end
+        @test JETLS.instantiation_needs(env_path) == (; resolve=true, instantiate=true)
+
+        Pkg.activate(pkgpath) do
+            Pkg.resolve(; io=devnull)
+        end
+        @test JETLS.instantiation_needs(env_path) == (; resolve=false, instantiate=false)
+    end
+end
+
+@testset "ensure_instantiated!" begin
+    withpackage("TestEnsureInstantiated", "module TestEnsureInstantiated end";
+                pkg_setup = Returns(nothing)) do pkgpath
+        env_path = joinpath(pkgpath, "Project.toml")
+        manifest_path = joinpath(pkgpath, "Manifest.toml")
+        sent_queue = Channel{Any}(Inf)
+        server = JETLS.Server(;
+            callback = JETLS.ServerMessageRecorder(Channel{Any}(Inf), sent_queue))
+        function set_auto_instantiate!(auto_instantiate)
+            JETLS.store!(server.state.config_manager) do old_data
+                lsp_config = JETLS.JETLSConfig(;
+                    full_analysis = JETLS.FullAnalysisConfig(; auto_instantiate))
+                return JETLS.ConfigManagerData(old_data; lsp_config), nothing
+            end
+        end
+        ensure_instantiated!() = JETLS.activate_do(env_path) do
+            JETLS.ensure_instantiated!(server, env_path)
+        end
+
+        # disabled: only warn, never touch the environment
+        set_auto_instantiate!(false)
+        ensure_instantiated!()
+        @test !isfile(manifest_path)
+        let msg = take!(sent_queue)
+            @test msg isa ShowMessageNotification
+            @test msg.params.type == MessageType.Warning
+        end
+        @test isempty(sent_queue)
+
+        set_auto_instantiate!(true)
+        withenv("JULIA_PKG_PRECOMPILE_AUTO" => "0") do
+            ensure_instantiated!()
+        end
+        @test isfile(manifest_path)
+        @test isempty(sent_queue)
+
+        # An instantiated environment must be left untouched even when its manifest was
+        # written by another Julia version, which `Pkg.resolve` would rewrite.
+        manifest = read(manifest_path, String)
+        tampered = replace(manifest, r"julia_version = \"[^\"]*\"" => "julia_version = \"1.0.0\"")
+        @test tampered != manifest
+        write(manifest_path, tampered)
+        ensure_instantiated!()
+        @test read(manifest_path, String) == tampered
+        @test isempty(sent_queue)
+    end
 end
 
 end # module test_full_analysis


### PR DESCRIPTION
`ensure_instantiated!` unconditionally ran `Pkg.resolve()` and `Pkg.instantiate()` for every environment the first time a file in it was opened when `full_analysis.auto_instantiate` was enabled. For an already-instantiated environment this was pure side effect: opening a project could rewrite its `Manifest.toml` (e.g. when it was written by another Julia version), hit the network, and spawn precompilation without anything being missing.

This change adds `instantiation_needs`, which inspects the environment without mutating it and reports whether a resolve or an instantiate is actually required. `ensure_instantiated!` returns early when nothing is needed, runs `Pkg.resolve()` only when the manifest is missing or `Project.toml` has changed since the manifest was last resolved (via `Pkg.Operations.is_manifest_current`), and otherwise runs only `Pkg.instantiate()`.

The disabled-`auto_instantiate` branch now uses the same predicate. Its warning previously relied on `Pkg.Operations.is_instantiated` alone, which returns `true` for a package without a `Manifest.toml` because no dependency is recorded to check, so freshly cloned repositories never triggered the warning. The warning now also covers missing and out-of-date manifests.

Tests cover the predicate across the missing, instantiated, stale, and re-resolved states, and check that `ensure_instantiated!` leaves an instantiated environment untouched even when its manifest records a different Julia version.