### PR TITLE
full-analysis: Ask before instantiating environments by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 > [!note]
 > The VSCode extension (`jetls-client`) now lives in its own repository, [aviatesk/jetls-vscode](https://github.com/aviatesk/jetls-vscode).
-> The extension keeps its Marketplace identity (`aviatesk.jetls-client`) and updates continue as usual.
+> The extension keeps its Marketplace identity ([`aviatesk.jetls-client`](https://marketplace.visualstudio.com/items?itemName=aviatesk.jetls-client)) and updates continue as usual.
 > Since `v2026.8.29`, the extension has managed the JETLS installation automatically: it installs and updates the pinned JETLS release on its own, so VSCode users no longer need to run the installation command below or keep `jetls` up to date manually (still needed if you also use the `jetls` CLI, e.g. `jetls check`).
 > Please report extension-specific problems (installation, startup, extension UI) to [aviatesk/jetls-vscode issues](https://github.com/aviatesk/jetls-vscode/issues);
 > language-feature issues belong here as before.
@@ -59,18 +59,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- `workspace/diagnostic` now uses less CPU while the workspace is unchanged, especially in clients that poll workspace diagnostics continuously.
+- [`full_analysis.auto_instantiate`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/full_analysis/auto_instantiate) no longer runs `Pkg.resolve()` and `Pkg.instantiate()` on environments that are already instantiated with an up-to-date manifest.
+  JETLS now inspects the environment first and leaves it untouched when its manifest is up to date and nothing is missing, so opening a project whose `Manifest.toml` was written by a different Julia version no longer rewrites it just to update the recorded `julia_version`.
+  `Pkg.resolve()` is run only when the manifest is missing or out of date; otherwise only `Pkg.instantiate()` runs.
 
-- `full_analysis.auto_instantiate` no longer runs `Pkg.resolve()` and `Pkg.instantiate()` on environments that are already instantiated.
-  JETLS now inspects the environment first and leaves it untouched when nothing is missing, so opening a project no longer rewrites its `Manifest.toml` (e.g. when it was written by another Julia version).
-  `Pkg.resolve()` is run only when the manifest is missing or `Project.toml` has changed since the manifest was last resolved; otherwise only `Pkg.instantiate()` runs.
+- [`full_analysis.auto_instantiate`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/full_analysis/auto_instantiate) is now a string option taking `"always"`, `"prompt"`, or `"never"`, and its default changed from `true` to `"prompt"`.
+  With `"prompt"`, JETLS asks for confirmation via `window/showMessageRequest` before running `Pkg.resolve()` and `Pkg.instantiate()` on an environment that needs it, once per environment per server session.
+  Alternatively, the environment can be instantiated manually while the prompt is open; after the operation finishes, choosing "Skip" makes JETLS recheck and use the updated environment without running Pkg itself.
+  Choosing "Skip" while the environment is still incomplete analyzes the code with it as is.
+  `"always"` restores the previous behavior of instantiating without asking, and `"never"` only warns.
+  [`jetls check`](https://aviatesk.github.io/JETLS.jl/release/cli-check/) is unaffected: it has no client to ask, so `"prompt"` instantiates like `"always"` there, as the CLI already did before.
+  For backward compatibility, the legacy values `true` and `false` are still accepted at runtime as aliases of `"always"` and `"never"`.
+  Configuration schemas intentionally reject these legacy boolean values to prompt migration to the string form.
+
+- `workspace/diagnostic` now uses less CPU while the workspace is unchanged, especially in clients that poll workspace diagnostics continuously.
 
 ### Fixed
 
-- Fixed the "environment has not been instantiated" warning shown when `full_analysis.auto_instantiate` is disabled not appearing for environments without a `Manifest.toml`.
+- Fixed the "environment has not been instantiated" warning shown when [`full_analysis.auto_instantiate`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/full_analysis/auto_instantiate) is disabled not appearing for environments without a `Manifest.toml`.
   The warning now also covers environments whose manifest is out of date with respect to `Project.toml`.
 
-- `jetls check` now prints the messages that the language server would show in an editor (e.g. the warning about an uninstantiated environment, or configuration problems) to stderr as log messages instead of silently dropping them.
+- [`jetls check`](https://aviatesk.github.io/JETLS.jl/release/cli-check/) now prints the messages that the language server would show in an editor (e.g. the warning about an uninstantiated environment, or configuration problems) to stderr as log messages instead of silently dropping them.
   `--quiet` suppresses the info and warning ones, as it does for other log messages.
 
 ## 2026-09-01

--- a/docs/config-schema-block.jl
+++ b/docs/config-schema-block.jl
@@ -144,7 +144,7 @@ let rows = Union{Nothing, SchemaRow}[
         nothing,
         table_header("full_analysis"),
         default_entry(:full_analysis, :debounce; comment = "number (seconds)"),
-        default_entry(:full_analysis, :auto_instantiate; comment = "boolean"),
+        default_entry(:full_analysis, :auto_instantiate; comment = "\"always\"/\"prompt\"/\"never\""),
         default_entry(:full_analysis, :concretization_patterns; comment = "array of tables", validate = false),
         nothing,
         array_header("full_analysis.concretization_patterns"; comment = "table, an entry of the concretization patterns array above"),

--- a/docs/src/cli-check.md
+++ b/docs/src/cli-check.md
@@ -189,6 +189,13 @@ severity = "off"
 path = "test/**/*.jl"
 ```
 
+Package environments that are not instantiated yet (e.g. a fresh clone in CI)
+are resolved and instantiated before analysis. `jetls check` has no client to
+confirm with, so the default
+[`auto_instantiate = "prompt"`](@ref config/full_analysis/auto_instantiate)
+behaves like `"always"` here. Set it to `"never"` in `.JETLSConfig.toml` to
+analyze against the environment as is.
+
 For complete configuration options, see the [JETLS configuration](@ref config/schema) page.
 
 ## [GitHub Actions](@id cli-check/github-actions)

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -68,19 +68,49 @@ debounce = 2.0  # Wait 2 seconds after save before analyzing
 
 #### [`[full_analysis] auto_instantiate`](@id config/full_analysis/auto_instantiate)
 
-- **Type**: boolean
-- **Default**: `true`
+- **Type**: string (`"always"`, `"prompt"`, or `"never"`)
+- **Default**: `"prompt"`
 
-When enabled, JETLS automatically runs `Pkg.resolve()` and `Pkg.instantiate()` for
-packages that have not been instantiated yet (e.g., freshly cloned repositories).
-This allows full analysis to work immediately upon opening such packages.
-When no manifest file exists, JETLS first creates a
-[versioned manifest](https://pkgdocs.julialang.org/v1/toml-files/#Different-Manifests-for-Different-Julia-versions)
-(e.g., `Manifest-v1.12.toml`).
+Controls what JETLS does when the package environment of an analyzed file needs
+instantiation, i.e. when its manifest is missing or out of date, or some
+dependency has not been downloaded yet (e.g., freshly cloned repositories).
+Environments that are already instantiated with an up-to-date manifest are
+never touched.
+
+- `"prompt"` asks for confirmation before instantiating, once per environment
+  per server session. Clients that support work-done progress show
+  "Waiting for environment instantiation" until the prompt is answered.
+  Full analysis of the files in that environment is deferred until then, so
+  if the notification is left unanswered (e.g. tucked away in VSCode's
+  notification center), those files get no save-time diagnostics until you
+  respond.
+  Alternatively, you can resolve and instantiate the environment manually while
+  the prompt is open, then choose "Skip" after the operation finishes.
+  JETLS rechecks the environment before analysis and uses the updated
+  environment without running `Pkg.resolve()` or `Pkg.instantiate()` itself.
+  Choosing "Skip" while the environment still needs instantiation analyzes the
+  code against it as is, in which case package-loading failures show up as
+  [`toplevel` diagnostics](@ref diagnostic/reference/toplevel).
+- `"always"` runs `Pkg.resolve()` (only when the manifest is missing or out of
+  date) and `Pkg.instantiate()` without asking. This can download packages and
+  artifacts, run build scripts, precompile dependencies, and modify
+  `Manifest.toml`, so enable it only for projects you trust.
+- `"never"` leaves the environment untouched and shows a warning instead.
+
+!!! note "`jetls check`"
+    The CLI has no client to ask, so under `"prompt"` [`jetls check`](@ref cli-check)
+    resolves and instantiates the environment just like `"always"` does. Set
+    `auto_instantiate = "never"` in `.JETLSConfig.toml` to analyze against the
+    environment as is.
+
+For backward compatibility, JETLS still accepts the legacy values `true` and
+`false` at runtime as aliases of `"always"` and `"never"`. Configuration
+schemas intentionally accept only the string values above, so schema validation
+reports legacy booleans as invalid and prompts migration to the new form.
 
 ```toml
 [full_analysis]
-auto_instantiate = false  # Disable automatic instantiation
+auto_instantiate = "always"  # Instantiate without asking
 ```
 
 #### [`[full_analysis] concretization_patterns`](@id config/full_analysis/concretization_patterns)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,7 +19,11 @@ diagnostic, macro-aware go-to definition and such.
 !!! danger "Security"
     Do not run JETLS on code you do not trust. To analyze your project it
     runs your code — including the package dependencies it loads — which can
-    execute arbitrary code.
+    execute arbitrary code. Instantiating a package environment additionally
+    downloads packages and may run their build scripts; JETLS asks for
+    confirmation before doing so unless
+    [`auto_instantiate`](@ref config/full_analysis/auto_instantiate) says
+    otherwise.
 
 See the [Features](@ref features) page for a visual overview of the LSP
 features JETLS provides.

--- a/schemas/config-toml.schema.json
+++ b/schemas/config-toml.schema.json
@@ -178,9 +178,14 @@
       "description": "Configuration for full JET analysis. See [Full analysis configuration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/full_analysis).",
       "properties": {
         "auto_instantiate": {
-          "default": true,
-          "description": "Automatically run `Pkg.resolve()` and `Pkg.instantiate()` for uninstantiated packages (e.g., freshly cloned repos). Creates versioned manifest if needed.",
-          "type": "boolean"
+          "default": "prompt",
+          "description": "Controls how JETLS instantiates package environments when dependencies are missing, or when the manifest is missing or out of date (e.g., in freshly cloned repositories). `\"always\"` runs `Pkg.resolve()` and `Pkg.instantiate()` automatically. `\"prompt\"` asks for confirmation first. Alternatively, you can instantiate manually while the prompt is open and then choose `\"Skip\"`; JETLS rechecks the environment before analysis. `\"never\"` only warns. Legacy `true` and `false` settings remain supported at runtime for backward compatibility but are excluded from this schema.",
+          "enum": [
+            "always",
+            "prompt",
+            "never"
+          ],
+          "type": "string"
         },
         "concretization_patterns": {
           "default": [],

--- a/schemas/description.toml
+++ b/schemas/description.toml
@@ -23,7 +23,7 @@ path = "Optional glob pattern to restrict this configuration to specific files (
 
 [FullAnalysisConfig]
 debounce = "Debounce time in seconds before triggering full analysis after a file save. Higher values reduce analysis frequency but may delay diagnostic updates."
-auto_instantiate = "Automatically run `Pkg.resolve()` and `Pkg.instantiate()` for uninstantiated packages (e.g., freshly cloned repos). Creates versioned manifest if needed."
+auto_instantiate = "Controls how JETLS instantiates package environments when dependencies are missing, or when the manifest is missing or out of date (e.g., in freshly cloned repositories). `\"always\"` runs `Pkg.resolve()` and `Pkg.instantiate()` automatically. `\"prompt\"` asks for confirmation first. Alternatively, you can instantiate manually while the prompt is open and then choose `\"Skip\"`; JETLS rechecks the environment before analysis. `\"never\"` only warns. Legacy `true` and `false` settings remain supported at runtime for backward compatibility but are excluded from this schema."
 concretization_patterns = "Additional JET top-level concretization patterns. Each entry requires a Julia expression `pattern` and can use an optional `path` glob to restrict it to specific source files."
 
 [ConcretizationPattern]

--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -190,9 +190,14 @@
           "description": "Configuration for full JET analysis. See [Full analysis configuration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/full_analysis).",
           "properties": {
             "auto_instantiate": {
-              "$ref": "#/$defs/Core.Bool",
-              "default": true,
-              "description": "Automatically run `Pkg.resolve()` and `Pkg.instantiate()` for uninstantiated packages (e.g., freshly cloned repos). Creates versioned manifest if needed."
+              "default": "prompt",
+              "description": "Controls how JETLS instantiates package environments when dependencies are missing, or when the manifest is missing or out of date (e.g., in freshly cloned repositories). `\"always\"` runs `Pkg.resolve()` and `Pkg.instantiate()` automatically. `\"prompt\"` asks for confirmation first. Alternatively, you can instantiate manually while the prompt is open and then choose `\"Skip\"`; JETLS rechecks the environment before analysis. `\"never\"` only warns. Legacy `true` and `false` settings remain supported at runtime for backward compatibility but are excluded from this schema.",
+              "enum": [
+                "always",
+                "prompt",
+                "never"
+              ],
+              "type": "string"
             },
             "concretization_patterns": {
               "default": [],

--- a/schemas/vscode-configuration.json
+++ b/schemas/vscode-configuration.json
@@ -221,9 +221,14 @@
       "markdownDescription": "Configuration for full JET analysis. See [Full analysis configuration](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/full_analysis).",
       "properties": {
         "auto_instantiate": {
-          "default": true,
-          "markdownDescription": "Automatically run `Pkg.resolve()` and `Pkg.instantiate()` for uninstantiated packages (e.g., freshly cloned repos). Creates versioned manifest if needed.",
-          "type": "boolean"
+          "default": "prompt",
+          "enum": [
+            "always",
+            "prompt",
+            "never"
+          ],
+          "markdownDescription": "Controls how JETLS instantiates package environments when dependencies are missing, or when the manifest is missing or out of date (e.g., in freshly cloned repositories). `\"always\"` runs `Pkg.resolve()` and `Pkg.instantiate()` automatically. `\"prompt\"` asks for confirmation first. Alternatively, you can instantiate manually while the prompt is open and then choose `\"Skip\"`; JETLS rechecks the environment before analysis. `\"never\"` only warns. Legacy `true` and `false` settings remain supported at runtime for backward compatibility but are excluded from this schema.",
+          "type": "string"
         },
         "concretization_patterns": {
           "default": [],

--- a/scripts/schema/setup-schema-context.jl
+++ b/scripts/schema/setup-schema-context.jl
@@ -53,6 +53,10 @@ function setup_ctx!(ctx::SchemaContext)
         Dict("type" => "string", "pattern" => raw"\S")
     end
 
+    override_field!(ctx, JETLS.FullAnalysisConfig, :auto_instantiate) do _
+        Dict("type" => "string", "enum" => collect(JETLS.AUTO_INSTANTIATE_VALUES))
+    end
+
     override_field!(ctx, JETLS.DiagnosticPattern, :match_by) do _
         Dict("type" => "string", "enum" => ["code", "message"])
     end

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -411,8 +411,12 @@ function handle_response_message(
         server::Server, msg::Dict{Symbol,Any}, @nospecialize(request_caller::RequestCaller),
         cancel_flag::CancelFlag
     )
-    if request_caller isa InstantiationProgressCaller
+    if request_caller isa InstantiationPromptProgressCaller
+        handle_instantiation_prompt_progress_response(server, msg, request_caller)
+    elseif request_caller isa InstantiationProgressCaller
         handle_instantiation_progress_response(server, request_caller)
+    elseif request_caller isa InstantiationPromptCaller
+        handle_instantiation_prompt_response(server, msg, request_caller)
     elseif request_caller isa AnalysisProgressCaller
         handle_analysis_progress_response(server, request_caller, cancel_flag)
     elseif request_caller isa ShowTextDocumentContentCaller

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -133,6 +133,16 @@ struct InstantiationProgressCaller <: RequestCaller
     token::ProgressToken
 end
 
+struct InstantiationPromptProgressCaller <: RequestCaller
+    ins_request::InstantiationRequest
+    token::ProgressToken
+end
+
+struct InstantiationPromptCaller <: RequestCaller
+    ins_request::InstantiationRequest
+    progress_token::Union{Nothing,ProgressToken}
+end
+
 struct AnalysisProgressCaller <: RequestCaller
     uri::URI
     invalidate::Bool
@@ -164,6 +174,21 @@ function handle_instantiation_progress_response(
     # Now request a new progress token for the analysis phase
     request_analysis_progress!(
         server, uri, invalidate, entry, notify_diagnostics, debounce)
+end
+
+function handle_instantiation_prompt_progress_response(
+        server::Server, msg::Dict{Symbol,Any}, caller::InstantiationPromptProgressCaller
+    )
+    instantiation_decision(server, caller.ins_request.env_path) === :pending || return nothing
+    progress_token = haskey(msg, :error) ? nothing : caller.token
+    if progress_token !== nothing
+        send_progress(server, progress_token,
+            WorkDoneProgressBegin(;
+                title = "Waiting for environment instantiation",
+                message = instantiation_message_path(caller.ins_request),
+                cancellable = false))
+    end
+    send_instantiation_prompt!(server, caller.ins_request, progress_token)
 end
 
 function request_analysis_progress!(
@@ -335,7 +360,11 @@ function request_analysis!(
             cache_out_of_scope!(manager, uri, phase1_result)
             return nothing
         elseif phase1_result isa InstantiationRequest
-            if !wait && supports(server, :window, :workDoneProgress)
+            if !wait && request_instantiation_prompt!(
+                    server, uri, phase1_result, invalidate, notify_diagnostics, debounce)
+                return nothing
+            elseif (!wait && supports(server, :window, :workDoneProgress) &&
+                    should_request_instantiation_progress(server, phase1_result.env_path))
                 request_instantiation_progress!(
                     server, uri, phase1_result, invalidate, notify_diagnostics, debounce)
                 return nothing
@@ -656,8 +685,9 @@ function is_abandoned_analysis_target(server::Server, uri::URI, entry::AnalysisE
     if isunsaveduri(uri)
         return get_file_info(state, uri) === nothing
     end
-    if ((entry isa ScriptAnalysisEntry || entry isa ScriptInEnvAnalysisEntry) &&
-        entry.isnotebook)
+    if (is_notebook_uri(uri) ||
+        ((entry isa ScriptAnalysisEntry || entry isa ScriptInEnvAnalysisEntry) &&
+         entry.isnotebook))
         return !is_notebook_uri(state, uri)
     end
     return false
@@ -1460,6 +1490,112 @@ end
 # Environment instantiation
 # =========================
 
+const INSTANTIATE_ACTION_TITLE = "Instantiate"
+const SKIP_INSTANTIATION_ACTION_TITLE = "Skip"
+
+# Returns `true` when the analysis request has been deferred until the user answers the
+# `auto_instantiate = "prompt"` dialog for this environment; the request is then replayed
+# by `handle_instantiation_prompt_response`.
+function request_instantiation_prompt!(
+        server::Server, uri::URI, ins_request::InstantiationRequest,
+        invalidate::Bool, notify_diagnostics::Bool, debounce::Float64
+    )
+    effective_auto_instantiate(server) == AUTO_INSTANTIATE_PROMPT || return false
+    env_path = ins_request.env_path
+    prompts = server.state.analysis_manager.instantiation_prompts
+    haskey(load(prompts), env_path) || inspect_instantiation_needs(env_path).instantiate ||
+        return false
+    pending_request = PendingAnalysisRequest(uri, invalidate, notify_diagnostics, debounce)
+    action = store!(prompts) do d
+        prompt = get(d, env_path, nothing)
+        if prompt === nothing
+            new_d = copy(d)
+            new_d[env_path] = InstantiationPrompt(:pending, PendingAnalysisRequest[pending_request])
+            new_d, :send
+        elseif prompt.decision === :pending
+            new_d = copy(d)
+            waiters = upsert_pending_analysis_request(prompt.waiters, pending_request)
+            new_d[env_path] = InstantiationPrompt(:pending, waiters)
+            new_d, :wait
+        else
+            d, :proceed
+        end
+    end
+    action === :proceed && return false
+    action === :wait && return true
+    if supports(server, :window, :workDoneProgress)
+        request_instantiation_prompt_progress!(server, ins_request)
+    else
+        send_instantiation_prompt!(server, ins_request)
+    end
+    return true
+end
+
+# `"prompt"` needs a client to ask; `jetls check` has none, so it instantiates like `"always"`.
+function effective_auto_instantiate(server::Server)
+    auto_instantiate = get_config(server, :full_analysis, :auto_instantiate)
+    if auto_instantiate == AUTO_INSTANTIATE_PROMPT && server.state.cli_mode
+        return AUTO_INSTANTIATE_ALWAYS
+    end
+    return auto_instantiate
+end
+
+function upsert_pending_analysis_request(
+        waiters::Vector{PendingAnalysisRequest}, request::PendingAnalysisRequest
+    )
+    new_waiters = copy(waiters)
+    index = findfirst(waiter -> waiter.uri == request.uri, new_waiters)
+    if index === nothing
+        push!(new_waiters, request)
+    else
+        new_waiters[index] = request
+    end
+    return new_waiters
+end
+
+function request_instantiation_prompt_progress!(
+        server::Server, ins_request::InstantiationRequest
+    )
+    id = String(gensym(:WorkDoneProgressCreateRequest_instantiation_prompt))
+    token = String(gensym(:InstantiationPromptProgress))
+    caller = InstantiationPromptProgressCaller(ins_request, token)
+    addrequest!(server, id => caller)
+    params = WorkDoneProgressCreateParams(; token)
+    send(server, WorkDoneProgressCreateRequest(; id, params))
+end
+
+function send_instantiation_prompt!(
+        server::Server, ins_request::InstantiationRequest,
+        progress_token::Union{Nothing,ProgressToken} = nothing
+    )
+    id = String(gensym(:ShowMessageRequest_instantiation))
+    caller = InstantiationPromptCaller(ins_request, progress_token)
+    addrequest!(server, id => caller)
+    message = """
+        Package environment at $(instantiation_message_path(ins_request)) has not been
+        instantiated or is out of date.
+        Instantiate it now? This runs `Pkg.resolve()` and `Pkg.instantiate()`, which may
+        download packages, run build scripts, and modify the manifest.
+        Alternatively, you can resolve and instantiate it manually while this prompt is
+        open, then choose "Skip" after it finishes. JETLS will recheck the environment before
+        analysis.
+        Choosing "Skip" while the environment still needs instantiation analyzes the
+        code as is, so missing dependencies will be reported as errors."""
+    actions = MessageActionItem[
+        MessageActionItem(; title = INSTANTIATE_ACTION_TITLE)
+        MessageActionItem(; title = SKIP_INSTANTIATION_ACTION_TITLE)
+    ]
+    params = ShowMessageRequestParams(; type = MessageType.Info, message, actions)
+    send(server, ShowMessageRequest(; id, params))
+end
+
+function should_request_instantiation_progress(server::Server, env_path::String)
+    auto_instantiate = effective_auto_instantiate(server)
+    return auto_instantiate == AUTO_INSTANTIATE_ALWAYS ||
+        (auto_instantiate == AUTO_INSTANTIATE_PROMPT &&
+         instantiation_decision(server, env_path) === :accepted)
+end
+
 function do_instantiation(server::Server, uri::URI, ins_request::InstantiationRequest)
     (; env_path, pkgname, filekind, filedir, isnotebook) = ins_request
     if pkgname === nothing
@@ -1487,15 +1623,32 @@ function do_instantiation(server::Server, uri::URI, ins_request::InstantiationRe
     end
 end
 
+function ensure_instantiated_if_requested!(server::Server, env_path::String)
+    instantiated_envs = server.state.analysis_manager.instantiated_envs
+    activate_do(env_path) do
+        if haskey(load(instantiated_envs), env_path)
+            return
+        end
+        ensure_instantiated!(server, env_path)
+        store!(instantiated_envs) do cache
+            if haskey(cache, env_path)
+                cache, nothing
+            else
+                new_cache = copy(cache)
+                new_cache[env_path] = nothing
+                new_cache, nothing
+            end
+        end
+    end
+end
+
 function instantiate_package_environment!(server::Server, env_path::String, pkgname::String)
     instantiated_envs = server.state.analysis_manager.instantiated_envs
     activate_do(env_path) do
-        # Check cache inside lock to avoid race conditions
         cached = get(load(instantiated_envs), env_path, missing)
         if cached !== missing
             return cached
         end
-        # Cache miss - perform environment detection
         ensure_instantiated!(server, env_path)
         pkgenv = @lock Base.require_lock @something Base.identify_package_env(pkgname) begin
             @warn "Failed to identify package environment" env_path pkgname
@@ -1522,64 +1675,31 @@ function instantiate_package_environment!(server::Server, env_path::String, pkgn
     end
 end
 
-function ensure_instantiated_if_requested!(server::Server, env_path::String)
-    instantiated_envs = server.state.analysis_manager.instantiated_envs
-    activate_do(env_path) do
-        # Check if already processed (success or failure)
-        if haskey(load(instantiated_envs), env_path)
-            return
-        end
-        ensure_instantiated!(server, env_path)
-        # Mark as processed
-        store!(instantiated_envs) do cache
-            if haskey(cache, env_path)
-                cache, nothing
-            else
-                new_cache = copy(cache)
-                new_cache[env_path] = nothing
-                new_cache, nothing
-            end
-        end
-    end
-end
-
-"""
-    instantiation_needs(env_path::String) -> (; resolve::Bool, instantiate::Bool)
-
-Inspect the environment at `env_path` without mutating it. `resolve` is `true` when the
-manifest is missing or `Project.toml` has changed since the manifest was last resolved.
-`instantiate` is `true` when `resolve` is, or when some dependency source or artifact has
-not been downloaded yet.
-"""
-function instantiation_needs(env_path::String)
-    env = Pkg.Types.EnvCache(env_path)
-    resolve = !isfile(env.manifest_file) || Pkg.Operations.is_manifest_current(env) === false
-    instantiate = resolve || !Pkg.Operations.is_instantiated(env)
-    return (; resolve, instantiate)
-end
-
 function ensure_instantiated!(server::Server, env_path::String)
-    needs = try
-        instantiation_needs(env_path)
-    catch e
-        @error "Failed to inspect package environment" env_path
-        Base.showerror(stderr, e, catch_backtrace())
-        (; resolve = true, instantiate = true)
-    finally
-        clear_pkg_registry_cache!()
-    end
+    needs = inspect_instantiation_needs(env_path)
     if !needs.instantiate
         @static JETLS_DEV_MODE && @info "Package environment is already instantiated" env_path
         return
     end
-    if get_config(server, :full_analysis, :auto_instantiate)
+    auto_instantiate = effective_auto_instantiate(server)
+    if auto_instantiate == AUTO_INSTANTIATE_PROMPT
+        decision = instantiation_decision(server, env_path)
+        if decision === :accepted
+            auto_instantiate = AUTO_INSTANTIATE_ALWAYS
+        elseif decision === :declined
+            @static JETLS_DEV_MODE && @info "Skipping environment instantiation as requested" env_path
+            return
+        end
+    end
+    if auto_instantiate == AUTO_INSTANTIATE_ALWAYS
+        verbose = server.state.cli_mode || JETLS_DEV_MODE
         io = IOBuffer()
         try
             if needs.resolve
-                @static JETLS_DEV_MODE && @info "Resolving package environment" env_path
+                verbose && @info "Resolving package environment" env_path
                 Pkg.resolve(; io)
             end
-            @static JETLS_DEV_MODE && @info "Instantiating package environment" env_path
+            verbose && @info "Instantiating package environment" env_path
             Pkg.instantiate(; io)
         catch e
             @error """Failed to instantiate package environment;
@@ -1603,10 +1723,123 @@ function ensure_instantiated!(server::Server, env_path::String)
         rerun_hint = server.state.cli_mode ? "re-run `jetls check`" : "restart the language server"
         show_warning_message(server, """
             Package environment at $env_path has not been instantiated or is out of date
-            (`full_analysis.auto_instantiate` is disabled).
+            (`full_analysis.auto_instantiate` is "$auto_instantiate").
             The package will be analyzed as a script, which may result in incomplete diagnostics.
             It is recommended to instantiate your package environment and $rerun_hint.""")
     end
+end
+
+function inspect_instantiation_needs(env_path::String)
+    activate_do(env_path) do
+        try
+            instantiation_needs(env_path)
+        catch e
+            @error "Failed to inspect package environment" env_path
+            Base.showerror(stderr, e, catch_backtrace())
+            (; resolve = true, instantiate = true)
+        finally
+            clear_pkg_registry_cache!()
+        end
+    end
+end
+
+"""
+    instantiation_needs(env_path::String) -> (; resolve::Bool, instantiate::Bool)
+
+Inspect the environment at `env_path` without mutating it. `resolve` is `true` when the
+manifest is missing, has no recorded project hash, is known to be stale, or lacks a direct
+dependency from `Project.toml`. `instantiate` is `true` when `resolve` is, or when some
+dependency source or artifact has not been downloaded yet.
+"""
+function instantiation_needs(env_path::String)
+    env = Pkg.Types.EnvCache(env_path)
+    manifest_current = Pkg.Operations.is_manifest_current(env)
+    missing_direct_dep = any(uuid->!haskey(env.manifest,uuid), values(env.project.deps))
+    resolve = !isfile(env.manifest_file) || manifest_current !== true || missing_direct_dep
+    instantiate = resolve || !Pkg.Operations.is_instantiated(env)
+    return (; resolve, instantiate)
+end
+
+function instantiation_decision(server::Server, env_path::String)
+    prompts = server.state.analysis_manager.instantiation_prompts
+    prompt = get(load(prompts), env_path, nothing)
+    return prompt === nothing ? nothing : prompt.decision
+end
+
+instantiation_message_path(ins_request::InstantiationRequest) =
+    isnothing(ins_request.root_path) ? ins_request.env_path :
+    relpath(ins_request.env_path, dirname(ins_request.root_path))
+
+# Pending prompts are meaningless once `auto_instantiate` is no longer `"prompt"`: drop
+# them and replay their waiters under the new setting. A dialog that is still open cannot
+# be withdrawn, so `handle_instantiation_prompt_response` ignores its late answer.
+function apply_auto_instantiate_change!(server::Server)
+    effective_auto_instantiate(server) == AUTO_INSTANTIATE_PROMPT && return nothing
+    prompts = server.state.analysis_manager.instantiation_prompts
+    dropped = store!(prompts) do d
+        new_d = copy(d)
+        local dropped = InstantiationPrompt[]
+        for (env_path, prompt) in d
+            prompt.decision === :pending || continue
+            delete!(new_d, env_path)
+            push!(dropped, prompt)
+        end
+        new_d, dropped
+    end
+    for prompt in dropped
+        replay_pending_analysis_requests!(server, prompt.waiters)
+    end
+    return nothing
+end
+
+function replay_pending_analysis_requests!(
+        server::Server, waiters::Vector{PendingAnalysisRequest}
+    )
+    state = server.state
+    for waiter in waiters
+        uri = waiter.uri
+        # Documents closed while the prompt was open no longer need analysis
+        is_synchronized(state, uri) || is_notebook_uri(state, uri) || continue
+        request_analysis!(server, uri, waiter.invalidate;
+            notify_diagnostics = waiter.notify_diagnostics, debounce = waiter.debounce)
+    end
+end
+
+function handle_instantiation_prompt_response(
+        server::Server, msg::Dict{Symbol,Any}, caller::InstantiationPromptCaller
+    )
+    env_path = caller.ins_request.env_path
+    accepted = if handle_response_error(server, msg, "confirm environment instantiation")
+        false
+    else
+        result = get(msg, :result, nothing)
+        result isa Dict && get(result, "title", "") == INSTANTIATE_ACTION_TITLE
+    end
+    prompts = server.state.analysis_manager.instantiation_prompts
+    waiters = store!(prompts) do d
+        prompt = get(d, env_path, nothing)
+        if prompt === nothing || prompt.decision !== :pending
+            return d, nothing
+        end
+        new_d = copy(d)
+        new_d[env_path] =
+            InstantiationPrompt(accepted ? :accepted : :declined, PendingAnalysisRequest[])
+        new_d, prompt.waiters
+    end
+    if caller.progress_token !== nothing
+        message = if waiters === nothing
+            nothing
+        elseif accepted
+            "Environment instantiation approved"
+        elseif inspect_instantiation_needs(env_path).instantiate
+            "Continuing without environment instantiation"
+        else
+            "Using manually instantiated environment"
+        end
+        send_progress(server, caller.progress_token, WorkDoneProgressEnd(; message))
+    end
+    waiters === nothing && return nothing
+    replay_pending_analysis_requests!(server, waiters)
 end
 
 # Resolves the delayed environment instantiation with progress reporting.
@@ -1614,9 +1847,7 @@ end
 function do_instantiation_with_progress(
         server::Server, uri::URI, ins_request::InstantiationRequest, token::ProgressToken
     )
-    root_path = ins_request.root_path
-    message_path = isnothing(root_path) ? ins_request.env_path :
-        relpath(ins_request.env_path, dirname(root_path))
+    message_path = instantiation_message_path(ins_request)
     send_progress(server, token,
         WorkDoneProgressBegin(;
             title = "Instantiating environment",

--- a/src/config.jl
+++ b/src/config.jl
@@ -277,10 +277,31 @@ function parse_config_from_dict(
     for fname in fieldnames(T)
         sname = String(fname)
         haskey(d, sname) || continue
-        v = parse_config_dict_value(fieldtype(T, fname), d[sname], String[path; sname])
+        v = parse_config_field(T, fname, d[sname], String[path; sname])
         push!(kwargs, fname => v)
     end
     return T(; kwargs...)
+end
+
+function parse_config_field(
+        ::Type{T}, fname::Symbol, @nospecialize(x), path::Vector{String}
+    ) where T<:ConfigSection
+    if T === FullAnalysisConfig && fname === :auto_instantiate
+        return parse_auto_instantiate(x, path)
+    end
+    return parse_config_dict_value(fieldtype(T, fname), x, path)
+end
+
+function parse_auto_instantiate(@nospecialize(x), path::Vector{String})
+    x === nothing && return nothing
+    # `auto_instantiate` used to be a boolean; keep accepting `true`/`false` for
+    # backward compatibility, mapping them to `"always"`/`"never"`.
+    x === true && return AUTO_INSTANTIATE_ALWAYS
+    x === false && return AUTO_INSTANTIATE_NEVER
+    x isa String && x in AUTO_INSTANTIATE_VALUES && return x
+    parse_dict_error(path, string(
+        "expected one of ", join((repr(v) for v in AUTO_INSTANTIATE_VALUES), ", "),
+        " (or `true`/`false`), got ", repr(x)))
 end
 
 # Format an error message rooted at `path` (or unrooted at the top level). Messages

--- a/src/did-change-watched-files.jl
+++ b/src/did-change-watched-files.jl
@@ -76,6 +76,7 @@ function handle_config_file_change!(
 
     source = "[.JETLSConfig.toml] $(dirname(changed_path)) ($kind)"
     notify_config_changes(server, tracker, source)
+    apply_auto_instantiate_change!(server)
     if tracker.diagnostic_setting_changed
         clear_per_file_diagnostics_cache!(server.state)
         notify_diagnostics!(server; ensure_cleared = true)

--- a/src/types.jl
+++ b/src/types.jl
@@ -356,6 +356,22 @@ const AnalyzedGenerations = CASContainer{Dict{AnalysisEntry,Int}, CASStats}
 const DebouncedRequests = LWContainer{Dict{AnalysisEntry,Tuple{Timer,Base.Event}}, LWStats}
 const InstantiatedEnvs = LWContainer{Dict{String,Union{Nothing,Tuple{Base.PkgId,String}}}, LWStats}
 
+struct PendingAnalysisRequest
+    uri::URI
+    invalidate::Bool
+    notify_diagnostics::Bool
+    debounce::Float64
+end
+
+# `decision` is `:pending` while the `auto_instantiate = "prompt"` dialog is shown for the
+# environment, then `:accepted` or `:declined`; `waiters` retains the latest deferred
+# analysis request for each URI, including the request that opened the prompt.
+struct InstantiationPrompt
+    decision::Symbol
+    waiters::Vector{PendingAnalysisRequest}
+end
+const InstantiationPrompts = LWContainer{Dict{String,InstantiationPrompt}, LWStats}
+
 struct AnalysisManager
     cache::AnalysisCache
     pending_analyses::PendingAnalyses
@@ -366,6 +382,7 @@ struct AnalysisManager
     debounced::DebouncedRequests
     tracked_entries::TrackedAnalysisEntries
     instantiated_envs::InstantiatedEnvs
+    instantiation_prompts::InstantiationPrompts
     worker_task::Base.RefValue{Task}
     signature_worker_tasks::Vector{Task}
     function AnalysisManager()
@@ -379,6 +396,7 @@ struct AnalysisManager
             DebouncedRequests(),
             TrackedAnalysisEntries(),
             InstantiatedEnvs(),
+            InstantiationPrompts(),
             Ref{Task}(), # initialized by start_analysis_worker!
             Task[], # initialized by start_signature_analysis_workers!
         )
@@ -507,10 +525,19 @@ merge_key_value(pattern::ConcretizationPattern) = (pattern.path, pattern.__patte
 
 @kwdef struct FullAnalysisConfig <: ConfigSection
     debounce::Maybe{Float64} = nothing
-    auto_instantiate::Maybe{Bool} = nothing
+    auto_instantiate::Maybe{String} = nothing
     concretization_patterns::Maybe{Vector{ConcretizationPattern}} = nothing
 end
 @define_eq_overloads FullAnalysisConfig
+
+const AUTO_INSTANTIATE_ALWAYS = "always"
+const AUTO_INSTANTIATE_PROMPT = "prompt"
+const AUTO_INSTANTIATE_NEVER = "never"
+const AUTO_INSTANTIATE_VALUES = (
+    AUTO_INSTANTIATE_ALWAYS,
+    AUTO_INSTANTIATE_PROMPT,
+    AUTO_INSTANTIATE_NEVER,
+)
 
 @kwdef struct TestRunnerConfig <: ConfigSection
     executable::Maybe{String} = nothing
@@ -720,7 +747,9 @@ end
 const DEFAULT_CONFIG = JETLSConfig(;
     diagnostic = DiagnosticConfig(true, true, true, DiagnosticPattern[]),
     full_analysis = FullAnalysisConfig(
-        @static(JETLS_TEST_MODE ? 0.0 : 1.0), true, ConcretizationPattern[]),
+        @static(JETLS_TEST_MODE ? 0.0 : 1.0),
+        @static(JETLS_TEST_MODE ? AUTO_INSTANTIATE_ALWAYS : AUTO_INSTANTIATE_PROMPT),
+        ConcretizationPattern[]),
     testrunner = TestRunnerConfig(@static Sys.iswindows() ? "testrunner.bat" : "testrunner"),
     formatter = "Runic",
     completion = CompletionConfig(LaTeXEmojiConfig(missing)),

--- a/src/workspace-configuration.jl
+++ b/src/workspace-configuration.jl
@@ -115,6 +115,7 @@ function handle_lsp_config_change!(server::Server, tracker::ConfigChangeTracker,
         # and `workspace/didChangeConfiguration` may be handled before the initial `workspace/configuration`.
         notify_config_changes(server, tracker, source)
     end
+    apply_auto_instantiate_change!(server)
     if tracker.diagnostic_setting_changed
         clear_per_file_diagnostics_cache!(server.state)
         notify_diagnostics!(server; ensure_cleared = true)

--- a/test/analysis/test_full_analysis.jl
+++ b/test/analysis/test_full_analysis.jl
@@ -58,16 +58,16 @@ include(normpath(pkgdir(JETLS), "test", "setup.jl"))
 end
 
 @testset "instantiation_needs" begin
-    withpackage("TestInstantiationNeeds", "module TestInstantiationNeeds end";
-                pkg_setup = Returns(nothing)) do pkgpath
-        env_path = joinpath(pkgpath, "Project.toml")
-        manifest_path = joinpath(pkgpath, "Manifest.toml")
+    mktempdir() do env_dir
+        env_path = joinpath(env_dir, "Project.toml")
+        manifest_path = joinpath(env_dir, "Manifest.toml")
+        write(env_path, "")
 
         @test !isfile(manifest_path)
         @test JETLS.instantiation_needs(env_path) == (; resolve=true, instantiate=true)
 
         withenv("JULIA_PKG_PRECOMPILE_AUTO" => "0") do
-            Pkg.activate(pkgpath) do
+            Pkg.activate(env_dir) do
                 Pkg.instantiate(; io=devnull)
             end
         end
@@ -80,10 +80,40 @@ end
         end
         @test JETLS.instantiation_needs(env_path) == (; resolve=true, instantiate=true)
 
-        Pkg.activate(pkgpath) do
+        Pkg.activate(env_dir) do
             Pkg.resolve(; io=devnull)
         end
         @test JETLS.instantiation_needs(env_path) == (; resolve=false, instantiate=false)
+
+        manifest = read(manifest_path, String)
+        manifest_without_test = replace(manifest,
+            r"(?ms)^\[\[deps\.Test\]\]\n.*?(?=^\[\[deps\.|\z)" => "")
+        @test manifest_without_test != manifest
+        write(manifest_path, manifest_without_test)
+
+        env = Pkg.Types.EnvCache(env_path)
+        @test Pkg.Operations.is_manifest_current(env) === true
+        @test Pkg.Operations.is_instantiated(env)
+        @test JETLS.instantiation_needs(env_path) == (; resolve=true, instantiate=true)
+
+        Pkg.activate(env_dir) do
+            Pkg.resolve(; io=devnull)
+        end
+        @test JETLS.instantiation_needs(env_path) == (; resolve=false, instantiate=false)
+
+        manifest = read(manifest_path, String)
+        hashless_manifest = replace(manifest, r"(?m)^project_hash = .*\n" => "")
+        @test hashless_manifest != manifest
+        write(manifest_path, hashless_manifest)
+        @test JETLS.instantiation_needs(env_path) == (; resolve=true, instantiate=true)
+
+        Pkg.activate(env_dir) do
+            Pkg.resolve(; io=devnull)
+        end
+        @test JETLS.instantiation_needs(env_path) == (; resolve=false, instantiate=false)
+
+        write(manifest_path, "")
+        @test JETLS.instantiation_needs(env_path) == (; resolve=true, instantiate=true)
     end
 end
 
@@ -107,7 +137,7 @@ end
         end
 
         # disabled: only warn, never touch the environment
-        set_auto_instantiate!(false)
+        set_auto_instantiate!(JETLS.AUTO_INSTANTIATE_NEVER)
         ensure_instantiated!()
         @test !isfile(manifest_path)
         let msg = take!(sent_queue)
@@ -116,7 +146,14 @@ end
         end
         @test isempty(sent_queue)
 
-        set_auto_instantiate!(true)
+        # "prompt" without a client decision behaves like "never"
+        set_auto_instantiate!(JETLS.AUTO_INSTANTIATE_PROMPT)
+        ensure_instantiated!()
+        @test !isfile(manifest_path)
+        @test take!(sent_queue) isa ShowMessageNotification
+        @test isempty(sent_queue)
+
+        set_auto_instantiate!(JETLS.AUTO_INSTANTIATE_ALWAYS)
         withenv("JULIA_PKG_PRECOMPILE_AUTO" => "0") do
             ensure_instantiated!()
         end
@@ -132,6 +169,209 @@ end
         ensure_instantiated!()
         @test read(manifest_path, String) == tampered
         @test isempty(sent_queue)
+    end
+
+    # `jetls check` has no client to ask, so "prompt" instantiates like "always"
+    withpackage("TestEnsureInstantiatedCLI", "module TestEnsureInstantiatedCLI end";
+                pkg_setup = Returns(nothing)) do pkgpath
+        env_path = joinpath(pkgpath, "Project.toml")
+        manifest_path = joinpath(pkgpath, "Manifest.toml")
+        sent_queue = Channel{Any}(Inf)
+        server = JETLS.Server(; cli_mode = true,
+            callback = JETLS.ServerMessageRecorder(Channel{Any}(Inf), sent_queue))
+        JETLS.store!(server.state.config_manager) do old_data
+            lsp_config = JETLS.JETLSConfig(;
+                full_analysis = JETLS.FullAnalysisConfig(;
+                    auto_instantiate = JETLS.AUTO_INSTANTIATE_PROMPT))
+            return JETLS.ConfigManagerData(old_data; lsp_config), nothing
+        end
+        withenv("JULIA_PKG_PRECOMPILE_AUTO" => "0") do
+            @test_logs (:info, "Resolving package environment") (:info, "Instantiating package environment") match_mode=:any begin
+                JETLS.activate_do(env_path) do
+                    JETLS.ensure_instantiated!(server, env_path)
+                end
+            end
+        end
+        @test isfile(manifest_path)
+        @test isempty(sent_queue)
+    end
+end
+
+@testset "auto_instantiate = \"prompt\"" begin
+    settings = Dict{String,Any}(
+        "full_analysis" => Dict{String,Any}(
+            "auto_instantiate" => JETLS.AUTO_INSTANTIATE_PROMPT))
+    progress_capabilities = ClientCapabilities(;
+        window = WindowClientCapabilities(; workDoneProgress = true))
+    pkgname = "TestInstantiationPrompt"
+    pkgcode = "module $pkgname end"
+
+    # "Skip" leaves the environment untouched. Requests for the same environment share the
+    # prompt, and repeated requests for one URI are coalesced until it is answered.
+    withpackage(pkgname, pkgcode; pkg_setup = Returns(nothing)) do pkgpath
+        manifest_path = joinpath(pkgpath, "Manifest.toml")
+        pkg_uri = filepath2uri(joinpath(pkgpath, "src", "$pkgname.jl"))
+        script_code = "1 + 1\n"
+        script_path = joinpath(pkgpath, "script.jl")
+        write(script_path, script_code)
+        script_uri = filepath2uri(script_path)
+        withserver(; rootUri = filepath2uri(pkgpath), settings) do (;
+                server, writemsg, writereadmsg, readmsg)
+            (; raw_res) = writereadmsg(make_DidOpenTextDocumentNotification(pkg_uri, pkgcode))
+            @test raw_res isa ShowMessageRequest
+            @test raw_res.params.type == MessageType.Info
+            @test [action.title for action in raw_res.params.actions] == ["Instantiate", "Skip"]
+
+            writereadmsg(make_DidOpenTextDocumentNotification(script_uri, script_code); read = 0)
+            prompts = server.state.analysis_manager.instantiation_prompts
+            @test timedwait(5.0) do
+                length(only(values(JETLS.load(prompts))).waiters) == 2
+            end == :ok
+            @test only(values(JETLS.load(prompts))).decision === :pending
+
+            for debounce in (1.0, 2.0, 0.0)
+                JETLS.request_analysis!(server, script_uri, #=invalidate=#true; debounce)
+            end
+            waiters = only(values(JETLS.load(prompts))).waiters
+            @test length(waiters) == 2
+            script_waiter = only(waiter for waiter in waiters if waiter.uri == script_uri)
+            @test script_waiter.invalidate
+            @test script_waiter.debounce == 0.0
+
+            writemsg(ResponseMessage(; id = raw_res.id, result = Dict{String,Any}("title" => "Skip")); check = false)
+            # The first completed analysis publishes one URI; the second republishes both.
+            (; raw_msg) = readmsg(; read = 3)
+            @test all(msg -> msg isa PublishDiagnosticsNotification, raw_msg)
+            @test Set(msg.params.uri for msg in raw_msg) == Set([pkg_uri, script_uri])
+            @test only(values(JETLS.load(prompts))).decision === :declined
+            @test !isfile(manifest_path)
+        end
+    end
+
+    # Manual instantiation while the prompt is open is picked up after choosing "Skip".
+    withpackage(pkgname, pkgcode; pkg_setup = Returns(nothing)) do pkgpath
+        env_path = joinpath(pkgpath, "Project.toml")
+        manifest_path = joinpath(pkgpath, "Manifest.toml")
+        pkg_uri = filepath2uri(joinpath(pkgpath, "src", "$pkgname.jl"))
+        withenv("JULIA_PKG_PRECOMPILE_AUTO" => "0") do
+            withserver(;
+                    rootUri = filepath2uri(pkgpath), settings,
+                    capabilities = progress_capabilities
+                ) do (; server, writemsg, writereadmsg, readmsg)
+                (; raw_res) = writereadmsg(make_DidOpenTextDocumentNotification(pkg_uri, pkgcode))
+                waiting_progress_request = raw_res
+                @test waiting_progress_request isa WorkDoneProgressCreateRequest
+
+                response = ResponseMessage(; id = waiting_progress_request.id, result = null)
+                writemsg(response; check = false)
+                (; raw_msg) = readmsg(; read=2)
+                waiting_messages = raw_msg
+                waiting_progress = only(msg for msg in waiting_messages if msg isa ProgressNotification)
+                @test waiting_progress.params.token == waiting_progress_request.params.token
+                @test waiting_progress.params.value isa WorkDoneProgressBegin
+                @test waiting_progress.params.value.title == "Waiting for environment instantiation"
+                raw_res = only(msg for msg in waiting_messages if msg isa ShowMessageRequest)
+                @test first(waiting_messages) === waiting_progress
+                @test last(waiting_messages) === raw_res
+                @test occursin("Alternatively, you can resolve and instantiate it manually", raw_res.params.message)
+
+                Pkg.activate(pkgpath) do
+                    Pkg.instantiate(; io=devnull)
+                end
+                @test JETLS.instantiation_needs(env_path) ==
+                    (; resolve=false, instantiate=false)
+                manual_manifest = read(manifest_path, String)
+
+                response = ResponseMessage(; id = raw_res.id, result = Dict{String,Any}("title" => "Skip"))
+                writemsg(response; check = false)
+                (; raw_msg) = readmsg(; read=2)
+                post_prompt_messages = raw_msg
+                waiting_end = only(msg for msg in post_prompt_messages if msg isa ProgressNotification)
+                @test waiting_end.params.token == waiting_progress.params.token
+                @test waiting_end.params.value isa WorkDoneProgressEnd
+                @test waiting_end.params.value.message == "Using manually instantiated environment"
+                analysis_progress_request = only(msg for msg in post_prompt_messages if msg isa WorkDoneProgressCreateRequest)
+
+                response = ResponseMessage(; id = analysis_progress_request.id, result = null)
+                writemsg(response; check = false)
+                analysis_messages = Any[]
+                while true
+                    (; raw_msg) = readmsg(; check = false)
+                    push!(analysis_messages, raw_msg)
+                    raw_msg isa PublishDiagnosticsNotification && break
+                end
+                readmsg(; read=0)
+                @test any(analysis_messages) do msg
+                    msg isa ProgressNotification &&
+                        msg.params.value isa WorkDoneProgressBegin &&
+                        startswith(msg.params.value.title, "Analyzing ")
+                end
+                @test !any(analysis_messages) do msg
+                    msg isa ProgressNotification &&
+                        msg.params.value isa WorkDoneProgressBegin &&
+                        msg.params.value.title == "Instantiating environment"
+                end
+                diagnostic = only(msg for msg in analysis_messages if msg isa PublishDiagnosticsNotification)
+                @test diagnostic.params.uri == pkg_uri
+                prompts = server.state.analysis_manager.instantiation_prompts
+                @test only(values(JETLS.load(prompts))).decision === :declined
+                analysis_info = JETLS.get_analysis_info(server.state.analysis_manager, pkg_uri)::JETLS.AnalysisResult
+                @test analysis_info.entry isa JETLS.PackageSourceAnalysisEntry
+                @test read(manifest_path, String) == manual_manifest
+            end
+        end
+    end
+
+    # "Instantiate" instantiates the environment before the analysis
+    withpackage(pkgname, pkgcode; pkg_setup = Returns(nothing)) do pkgpath
+        manifest_path = joinpath(pkgpath, "Manifest.toml")
+        pkg_uri = filepath2uri(joinpath(pkgpath, "src", "$pkgname.jl"))
+        withenv("JULIA_PKG_PRECOMPILE_AUTO" => "0") do
+            withserver(; rootUri = filepath2uri(pkgpath), settings) do (; server, writemsg, writereadmsg, readmsg)
+                (; raw_res) = writereadmsg(make_DidOpenTextDocumentNotification(pkg_uri, pkgcode))
+                @test raw_res isa ShowMessageRequest
+                writemsg(ResponseMessage(; id = raw_res.id, result = Dict{String,Any}("title" => "Instantiate")); check = false)
+                (; raw_msg) = readmsg()
+                @test raw_msg isa PublishDiagnosticsNotification
+                @test raw_msg.params.uri == pkg_uri
+                prompts = server.state.analysis_manager.instantiation_prompts
+                @test only(values(JETLS.load(prompts))).decision === :accepted
+                @test isfile(manifest_path)
+            end
+        end
+    end
+
+    # Changing the setting away from "prompt" drops pending prompts and analyzes their
+    # waiters under the new setting; a late answer to the dropped prompt is ignored.
+    @testset "config change to $mode drains pending prompts" for mode in (
+            JETLS.AUTO_INSTANTIATE_ALWAYS, JETLS.AUTO_INSTANTIATE_NEVER)
+        withpackage(pkgname, pkgcode; pkg_setup = Returns(nothing)) do pkgpath
+            manifest_path = joinpath(pkgpath, "Manifest.toml")
+            pkg_uri = filepath2uri(joinpath(pkgpath, "src", "$pkgname.jl"))
+            withenv("JULIA_PKG_PRECOMPILE_AUTO" => "0") do
+                withserver(; rootUri = filepath2uri(pkgpath), settings) do (; server, writereadmsg)
+                    (; raw_res) = writereadmsg(make_DidOpenTextDocumentNotification(pkg_uri, pkgcode))
+                    @test raw_res isa ShowMessageRequest
+                    prompt_request = raw_res
+
+                    # the config change notification, the "never" warning, then the diagnostics
+                    nmsgs = mode == JETLS.AUTO_INSTANTIATE_NEVER ? 3 : 2
+                    changed = Dict{String,Any}(
+                        "full_analysis" => Dict{String,Any}("auto_instantiate" => mode))
+                    (; raw_res) = writereadmsg(DidChangeConfigurationNotification(;
+                            params = DidChangeConfigurationParams(; settings = changed));
+                        read = nmsgs)
+                    @test count(msg -> msg isa ShowMessageNotification, raw_res) == nmsgs - 1
+                    @test count(msg -> msg isa PublishDiagnosticsNotification, raw_res) == 1
+                    @test isempty(JETLS.load(server.state.analysis_manager.instantiation_prompts))
+                    @test isfile(manifest_path) == (mode == JETLS.AUTO_INSTANTIATE_ALWAYS)
+
+                    writereadmsg(ResponseMessage(; id = prompt_request.id,
+                        result = Dict{String,Any}("title" => "Instantiate")); read = 0)
+                    @test isfile(manifest_path) == (mode == JETLS.AUTO_INSTANTIATE_ALWAYS)
+                end
+            end
+        end
     end
 end
 

--- a/test/test_config.jl
+++ b/test/test_config.jl
@@ -592,4 +592,32 @@ end
     end
 end
 
+@testset "`full_analysis.auto_instantiate` values" begin
+    @test JETLS.get_default_config(:full_analysis, :auto_instantiate) ===
+        (JETLS.JETLS_TEST_MODE ? JETLS.AUTO_INSTANTIATE_ALWAYS : JETLS.AUTO_INSTANTIATE_PROMPT)
+    parse_auto_instantiate(value) = JETLS.parse_config_from_dict(JETLS.JETLSConfig, Dict{String,Any}(
+        "full_analysis" => Dict{String,Any}("auto_instantiate" => value)))
+    for value in JETLS.AUTO_INSTANTIATE_VALUES
+        @test parse_auto_instantiate(value).full_analysis.auto_instantiate === value
+    end
+    # booleans remain accepted as aliases for backward compatibility
+    @test parse_auto_instantiate(true).full_analysis.auto_instantiate === JETLS.AUTO_INSTANTIATE_ALWAYS
+    @test parse_auto_instantiate(false).full_analysis.auto_instantiate === JETLS.AUTO_INSTANTIATE_NEVER
+    @test parse_auto_instantiate(nothing).full_analysis.auto_instantiate === nothing
+    for value in ("yes", 1)
+        err = try
+            parse_auto_instantiate(value)
+            nothing
+        catch e; e; end
+        @test err isa ErrorException
+        @test occursin("Invalid value at `full_analysis.auto_instantiate`", err.msg)
+        @test occursin("expected one of", err.msg)
+    end
+    let manager = JETLS.ConfigManager(JETLS.ConfigManagerData())
+        @test Base.infer_return_type((typeof(manager),)) do manager
+            JETLS.get_config(manager, :full_analysis, :auto_instantiate)
+        end == String
+    end
+end
+
 end # test_config


### PR DESCRIPTION
`full_analysis.auto_instantiate` was a boolean that either ran `Pkg.resolve()` and `Pkg.instantiate()` silently on the first analysis of an environment or skipped it with a warning. Instantiation can download packages, run build scripts, precompile dependencies, and rewrite `Manifest.toml`, so doing it without confirmation merely because a file was opened is too aggressive for a default.

This change turns the option into a string enum: `"always"` keeps the previous behavior, `"never"` only warns, and the new default `"prompt"` asks for confirmation through `window/showMessageRequest` once per environment per server session. Analysis requests for the environment that arrive while the dialog is open are recorded per URI in `InstantiationPrompt.waiters` and replayed once it is answered, so the dialog is shown only once. Clients supporting work-done progress see a "Waiting for environment instantiation" item until then. Choosing "Skip" leaves the environment untouched; because `ensure_instantiated!` re-inspects the environment first, an environment instantiated manually while the prompt was open is picked up without running Pkg.

Since the config layering treats `nothing` as "inherit from the lower layer", the third mode could not be an absent value, hence the string enum. `parse_auto_instantiate` keeps accepting the legacy `true`/`false` as aliases of `"always"` and `"never"`, while the JSON schema lists only the string values so editors render a dropdown and flag the legacy booleans.

`instantiation_needs` now also requests a resolve when the manifest records no project hash or lacks a direct dependency. In `JETLS_TEST_MODE` the default remains `"always"` so the existing test suite keeps instantiating temporary packages without a client dialog. `jetls check` has no client to ask, so `effective_auto_instantiate` maps `"prompt"` to `"always"` there and logs the Pkg operations it runs; the CLI therefore keeps instantiating fresh clones as before, and `auto_instantiate = "never"` in `.JETLSConfig.toml` opts out.