### PR TITLE
cli-check: Log client messages instead of dropping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed the "environment has not been instantiated" warning shown when `full_analysis.auto_instantiate` is disabled not appearing for environments without a `Manifest.toml`.
   The warning now also covers environments whose manifest is out of date with respect to `Project.toml`.
 
+- `jetls check` now prints the messages that the language server would show in an editor (e.g. the warning about an uninstantiated environment, or configuration problems) to stderr as log messages instead of silently dropping them.
+  `--quiet` suppresses the info and warning ones, as it does for other log messages.
+
 ## 2026-09-01
 
 - Commit: [`9cebe8b`](https://github.com/aviatesk/JETLS.jl/commit/9cebe8b)

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -1585,20 +1585,23 @@ function ensure_instantiated!(server::Server, env_path::String)
             It is recommended to fix the problem by referring to the following error""" env_path
             print(stderr, String(take!(io)))
             Base.showerror(stderr, e, catch_backtrace())
-            show_warning_message(server, """
-                Failed to instantiate package environment at $env_path.
-                The package will be analyzed as a script, which may result in incomplete diagnostics.
-                See the language server log for details.
-                It is recommended to fix your package environment setup and restart the language server.""")
+            if !server.state.cli_mode
+                show_warning_message(server, """
+                    Failed to instantiate package environment at $env_path.
+                    The package will be analyzed as a script, which may result in incomplete diagnostics.
+                    See the language server log for details.
+                    It is recommended to fix your package environment setup and restart the language server.""")
+            end
         finally
             clear_pkg_registry_cache!()
         end
     else
+        rerun_hint = server.state.cli_mode ? "re-run `jetls check`" : "restart the language server"
         show_warning_message(server, """
             Package environment at $env_path has not been instantiated or is out of date
             (`full_analysis.auto_instantiate` is disabled).
             The package will be analyzed as a script, which may result in incomplete diagnostics.
-            It is recommended to instantiate your package environment and restart the language server.""")
+            It is recommended to instantiate your package environment and $rerun_hint.""")
     end
 end
 

--- a/src/init-options.jl
+++ b/src/init-options.jl
@@ -26,8 +26,10 @@ function load_file_init_options(server::Server, filepath::AbstractString)
     if parsed isa TOML.ParserError
         show_error_message(server,
             "Failed to parse .JETLSConfig.toml file at $filepath: $(sprint(Base.showerror, parsed))")
-        @error "Failed to parse .JETLSConfig.toml file" filepath
-        Base.showerror(stderr, parsed)
+        if !server.state.cli_mode
+            @error "Failed to parse .JETLSConfig.toml file" filepath
+            Base.showerror(stderr, parsed)
+        end
         return nothing
     end
     init_options_dict = get(parsed, "initialization_options", nothing)

--- a/src/utils/lsp.jl
+++ b/src/utils/lsp.jl
@@ -125,8 +125,17 @@ function request_cancelled_error(message::AbstractString="Request was cancelled"
         data)
 end
 
-show_message(server::Server, message::AbstractString, type::MessageType.Ty) =
+function show_message(server::Server, message::AbstractString, type::MessageType.Ty)
+    if server.state.cli_mode
+        # `jetls check` has no client to show the message; log it instead, so that `--quiet`
+        # (which disables info and warning logs) applies to it as well.
+        level = type == MessageType.Error ? Base.CoreLogging.Error :
+            type == MessageType.Warning ? Base.CoreLogging.Warn : Base.CoreLogging.Info
+        Base.CoreLogging.@logmsg level message _group=:client_message _file=nothing _line=nothing
+        return nothing
+    end
     send(server, ShowMessageNotification(; params = ShowMessageParams(; type, message)))
+end
 
 """
     show_error_message(server::Server, message::AbstractString)

--- a/test/utils/test_lsp.jl
+++ b/test/utils/test_lsp.jl
@@ -197,4 +197,27 @@ end
     @test JETLS.overlap(touch_start, touch_end)
 end
 
+@testset "show_message" begin
+    sent_queue = Channel{Any}(Inf)
+    recorder() = JETLS.ServerMessageRecorder(Channel{Any}(Inf), sent_queue)
+
+    # LSP mode: sent to the client as `window/showMessage`
+    let server = JETLS.Server(; callback = recorder())
+        @test_logs JETLS.show_warning_message(server, "careful")
+        msg = take!(sent_queue)
+        @test msg isa ShowMessageNotification
+        @test msg.params.type == MessageType.Warning
+        @test msg.params.message == "careful"
+        @test isempty(sent_queue)
+    end
+
+    # CLI mode: no client, so the message is logged instead
+    let server = JETLS.Server(; cli_mode = true, callback = recorder())
+        @test_logs (:info, "hello") JETLS.show_info_message(server, "hello")
+        @test_logs (:warn, "careful") JETLS.show_warning_message(server, "careful")
+        @test_logs (:error, "boom") JETLS.show_error_message(server, "boom")
+        @test isempty(sent_queue)
+    end
+end
+
 end # module test_lsp


### PR DESCRIPTION
`jetls check` runs the server with `Server(; cli_mode=true)`, whose endpoint is a pair of `IOBuffer`s. Every `window/showMessage` notification, e.g. the warning that a package environment is not instantiated or the errors about an invalid `.JETLSConfig.toml`, was therefore written into a buffer nobody reads, and the CLI user never learned why an analysis ran against an incomplete environment or why their configuration was ignored.

This change makes `show_message` emit the message through Julia's logging system when `server.state.cli_mode` is set, mapping the LSP message type to the `Info`/`Warn`/`Error` levels. Routing through logging means `--quiet`, which disables info and warning logs, applies to these messages as well, and the output lands on stderr alongside the other CLI logs. The record carries `_group=:client_message` and no file location, since the location of `show_message` itself would be misleading.

Two call sites paired such a message with a server-log entry for the same event, which would now print twice in the CLI: the `Pkg.instantiate` failure in `ensure_instantiated!` and the TOML parse failure in `load_file_init_options`. Each keeps only one of the two in CLI mode. The "environment not instantiated" warning also tells CLI users to re-run `jetls check` rather than to restart the language server.

`test/utils/test_lsp.jl` checks that CLI mode logs each message type and sends nothing, while LSP mode still sends the notification.