### PR TITLE
full-analysis: Stream Pkg output during environment instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 >
 > Note: Path glob patterns use `/` as the separator on all platforms, including Windows; backslashes are not supported as separators.
 
+### Added
+
+- Added live Pkg output to progress messages for environment instantiation triggered by [`full_analysis.auto_instantiate`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/full_analysis/auto_instantiate), showing the latest activity while resolving and installing dependencies.
+
 ### Fixed
 
 - Fixed a race during background analysis that could cause diagnostics and other language features to use outdated document contents after an edit.

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -134,6 +134,7 @@ using .Interpreter
 
 include("document-synchronization.jl")
 include("notebook.jl")
+include("analysis/instantiation-progress.jl")
 include("analysis/full-analysis.jl")
 include("registration.jl")
 include("apply-edit.jl")

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -1596,23 +1596,26 @@ function should_request_instantiation_progress(server::Server, env_path::String)
          instantiation_decision(server, env_path) === :accepted)
 end
 
-function do_instantiation(server::Server, uri::URI, ins_request::InstantiationRequest)
+function do_instantiation(
+        server::Server, uri::URI, ins_request::InstantiationRequest;
+        progress_io::Union{Nothing,InstantiationProgressIO} = nothing
+    )
     (; env_path, pkgname, filekind, filedir, isnotebook) = ins_request
     if pkgname === nothing
-        ensure_instantiated_if_requested!(server, env_path)
+        ensure_instantiated_if_requested!(server, env_path; progress_io)
         return ScriptInEnvAnalysisEntry(env_path, uri, isnotebook)
     elseif pkgname isa Base.PkgId
         pkgid = pkgname
         envpkgname = find_pkg_name(env_path)
         if envpkgname === nothing
-            ensure_instantiated_if_requested!(server, env_path)
+            ensure_instantiated_if_requested!(server, env_path; progress_io)
         else
-            instantiate_package_environment!(server, env_path, envpkgname)
+            instantiate_package_environment!(server, env_path, envpkgname; progress_io)
         end
         return NewAnalysisEntry(pkgid, env_path)
     else
         pkgid, pkgfile = @something(
-            instantiate_package_environment!(server, env_path, pkgname),
+            instantiate_package_environment!(server, env_path, pkgname; progress_io),
             return ScriptInEnvAnalysisEntry(env_path, uri, isnotebook))
         if filekind === :src
             return PackageSourceAnalysisEntry(env_path, filepath2uri(pkgfile), pkgid)
@@ -1623,13 +1626,16 @@ function do_instantiation(server::Server, uri::URI, ins_request::InstantiationRe
     end
 end
 
-function ensure_instantiated_if_requested!(server::Server, env_path::String)
+function ensure_instantiated_if_requested!(
+        server::Server, env_path::String;
+        progress_io::Union{Nothing,InstantiationProgressIO} = nothing
+    )
     instantiated_envs = server.state.analysis_manager.instantiated_envs
     activate_do(env_path) do
         if haskey(load(instantiated_envs), env_path)
             return
         end
-        ensure_instantiated!(server, env_path)
+        ensure_instantiated!(server, env_path; progress_io)
         store!(instantiated_envs) do cache
             if haskey(cache, env_path)
                 cache, nothing
@@ -1642,14 +1648,17 @@ function ensure_instantiated_if_requested!(server::Server, env_path::String)
     end
 end
 
-function instantiate_package_environment!(server::Server, env_path::String, pkgname::String)
+function instantiate_package_environment!(
+        server::Server, env_path::String, pkgname::String;
+        progress_io::Union{Nothing,InstantiationProgressIO} = nothing
+    )
     instantiated_envs = server.state.analysis_manager.instantiated_envs
     activate_do(env_path) do
         cached = get(load(instantiated_envs), env_path, missing)
         if cached !== missing
             return cached
         end
-        ensure_instantiated!(server, env_path)
+        ensure_instantiated!(server, env_path; progress_io)
         pkgenv = @lock Base.require_lock @something Base.identify_package_env(pkgname) begin
             @warn "Failed to identify package environment" env_path pkgname
             return store!(instantiated_envs) do cache
@@ -1675,7 +1684,10 @@ function instantiate_package_environment!(server::Server, env_path::String, pkgn
     end
 end
 
-function ensure_instantiated!(server::Server, env_path::String)
+function ensure_instantiated!(
+        server::Server, env_path::String;
+        progress_io::Union{Nothing,InstantiationProgressIO} = nothing
+    )
     needs = inspect_instantiation_needs(env_path)
     if !needs.instantiate
         @static JETLS_DEV_MODE && @info "Package environment is already instantiated" env_path
@@ -1693,7 +1705,9 @@ function ensure_instantiated!(server::Server, env_path::String)
     end
     if auto_instantiate == AUTO_INSTANTIATE_ALWAYS
         verbose = server.state.cli_mode || JETLS_DEV_MODE
-        io = IOBuffer()
+        io = @something progress_io IOBuffer()
+        start_time = time_ns()
+        successed = false
         try
             if needs.resolve
                 verbose && @info "Resolving package environment" env_path
@@ -1701,13 +1715,14 @@ function ensure_instantiated!(server::Server, env_path::String)
             end
             verbose && @info "Instantiating package environment" env_path
             Pkg.instantiate(; io)
+            successed = true
         catch e
             @error """Failed to instantiate package environment;
             Unable to instantiate the environment of the target package for analysis,
             so this package will be analyzed as a script instead.
             This may cause various features such as diagnostics to not function properly.
             It is recommended to fix the problem by referring to the following error""" env_path
-            print(stderr, String(take!(io)))
+            println(stderr, String(take!(io)))
             Base.showerror(stderr, e, catch_backtrace())
             if !server.state.cli_mode
                 show_warning_message(server, """
@@ -1717,6 +1732,11 @@ function ensure_instantiated!(server::Server, env_path::String)
                     It is recommended to fix your package environment setup and restart the language server.""")
             end
         finally
+            if successed && verbose
+                elapsed = format_duration((time_ns() - start_time) / 1e9)
+                @info "Package environment instantiation finished" env_path elapsed
+                print(stderr, String(take!(io)))
+            end
             clear_pkg_registry_cache!()
         end
     else
@@ -1858,15 +1878,7 @@ function do_instantiation_with_progress(
         server::Server, uri::URI, ins_request::InstantiationRequest, token::ProgressToken
     )
     message_path = instantiation_message_path(ins_request)
-    send_progress(server, token,
-        WorkDoneProgressBegin(;
-            title = "Instantiating environment",
-            message = message_path,
-            cancellable = false))
-    entry = try
-        do_instantiation(server, uri, ins_request)
-    finally
-        send_progress(server, token, WorkDoneProgressEnd())
+    return with_instantiation_progress(server, token, message_path) do progress_io
+        do_instantiation(server, uri, ins_request; progress_io)
     end
-    return entry
 end

--- a/src/analysis/instantiation-progress.jl
+++ b/src/analysis/instantiation-progress.jl
@@ -1,0 +1,116 @@
+const INSTANTIATION_PROGRESS_INTERVAL = 0.1
+const INSTANTIATION_PROGRESS_LINE_LIMIT = 100
+
+mutable struct InstantiationProgressIO <: IO
+    const output::IOBuffer
+    const pending::IOBuffer
+    const lock::ReentrantLock
+    latest::String
+    reported::String
+end
+
+InstantiationProgressIO() =
+    InstantiationProgressIO(IOBuffer(), IOBuffer(), ReentrantLock(), "", "")
+
+Base.isopen(io::InstantiationProgressIO) = isopen(io.output)
+Base.iswritable(io::InstantiationProgressIO) = iswritable(io.output)
+Base.isreadable(::InstantiationProgressIO) = false
+Base.lock(io::InstantiationProgressIO) = lock(io.lock)
+Base.unlock(io::InstantiationProgressIO) = unlock(io.lock)
+Base.flush(::InstantiationProgressIO) = nothing
+Base.take!(io::InstantiationProgressIO) = @lock io.lock take!(io.output)
+
+function finish_instantiation_progress_line!(io::InstantiationProgressIO)
+    line = String(take!(io.pending))
+    # Pkg can emit color/cursor controls (CSI) and hyperlinks (OSC).
+    line = replace(line,
+        r"\e\][^\a\e]*(?:\a|\e\\)|\e\[[0-?]*[ -/]*[@-~]|\e[@-_]" => "",
+        '\t' => ' ')
+    line = strip(filter(c -> isvalid(c) && !iscntrl(c), line))
+    isempty(line) && return nothing
+    limit = INSTANTIATION_PROGRESS_LINE_LIMIT
+    io.latest = length(line) > limit ? first(line, limit - 1) * "…" : String(line)
+    return nothing
+end
+
+function write_instantiation_progress_byte!(io::InstantiationProgressIO, byte::UInt8)
+    if byte == UInt8('\r') || byte == UInt8('\n')
+        finish_instantiation_progress_line!(io)
+    else
+        write(io.pending, byte)
+    end
+    return nothing
+end
+
+function Base.write(io::InstantiationProgressIO, byte::UInt8)
+    @lock io.lock begin
+        write(io.output, byte)
+        write_instantiation_progress_byte!(io, byte)
+    end
+    return 1
+end
+
+function Base.unsafe_write(io::InstantiationProgressIO, ptr::Ptr{UInt8}, n::UInt)
+    @lock io.lock begin
+        Base.unsafe_write(io.output, ptr, n)
+        for i in 1:n
+            write_instantiation_progress_byte!(io, unsafe_load(ptr, i))
+        end
+    end
+    return Int(n)
+end
+
+function instantiation_progress_message!(io::InstantiationProgressIO; finish::Bool=false)
+    @lock io.lock begin
+        finish && finish_instantiation_progress_line!(io)
+        io.latest == io.reported && return nothing
+        io.reported = io.latest
+        return io.latest
+    end
+end
+
+function report_instantiation_progress!(
+        server::Server, token::ProgressToken, message_path::String,
+        io::InstantiationProgressIO; finish::Bool=false
+    )
+    line = @something instantiation_progress_message!(io; finish) return nothing
+    send_progress(server, token,
+        WorkDoneProgressReport(; message = message_path * " — " * line, cancellable = false))
+    return nothing
+end
+
+function with_instantiation_progress(
+        f, server::Server, token::ProgressToken, message_path::String
+    )
+    send_progress(server, token,
+        WorkDoneProgressBegin(;
+            title = "Instantiating environment",
+            message = message_path,
+            cancellable = false))
+    io = InstantiationProgressIO()
+    interval = INSTANTIATION_PROGRESS_INTERVAL
+    timer = Timer(interval; interval)
+    reporter = Threads.@spawn :default begin
+        while true
+            try
+                wait(timer)
+            catch err
+                err isa EOFError || rethrow()
+                break
+            end
+            report_instantiation_progress!(server, token, message_path, io)
+        end
+    end
+    try
+        return f(io)
+    finally
+        close(timer)
+        try
+            # Join before flushing so a queued timer tick cannot report after End.
+            wait(reporter)
+            report_instantiation_progress!(server, token, message_path, io; finish=true)
+        finally
+            send_progress(server, token, WorkDoneProgressEnd())
+        end
+    end
+end

--- a/test/analysis/test_full_analysis.jl
+++ b/test/analysis/test_full_analysis.jl
@@ -197,6 +197,82 @@ end
     end
 end
 
+@testset "do_instantiation_with_progress with offline Pkg" begin
+    offline = Pkg.OFFLINE_MODE[]
+    Pkg.offline(true)
+    try
+        withenv("JULIA_PKG_PRECOMPILE_AUTO" => "0") do
+            @testset "$filekind" for filekind in (:script, :src)
+                pkgname = "TestInstantiationProgress"
+                withpackage(pkgname, "module $pkgname end";
+                    pkg_setup = Returns(nothing)) do pkgpath
+                    env_path = joinpath(pkgpath, "Project.toml")
+                    manifest_path = joinpath(pkgpath, "Manifest.toml")
+                    deps = "\n[deps]\nTest = \"8dfed614-e22c-5e08-85e1-65c5234f0b40\"\n"
+                    if filekind === :script
+                        write(env_path, deps)
+                        script_path = joinpath(pkgpath, "script.jl")
+                        write(script_path, "using Test\n")
+                        uri = filepath2uri(script_path)
+                        request = JETLS.InstantiationRequest(env_path, pkgpath)
+                    else
+                        open(env_path, "a") do io
+                            print(io, deps)
+                        end
+                        uri = filepath2uri(joinpath(pkgpath, "src", "$pkgname.jl"))
+                        request = JETLS.InstantiationRequest(
+                            env_path, pkgname, :src, joinpath(pkgpath, "src"), pkgpath)
+                    end
+                    sent_queue = Channel{Any}(Inf)
+                    server = JETLS.Server(;
+                        callback = JETLS.ServerMessageRecorder(Channel{Any}(Inf), sent_queue))
+                    JETLS.store!(server.state.config_manager) do old_data
+                        lsp_config = JETLS.JETLSConfig(;
+                            full_analysis = JETLS.FullAnalysisConfig(;
+                                auto_instantiate = JETLS.AUTO_INSTANTIATE_ALWAYS))
+                        return JETLS.ConfigManagerData(old_data; lsp_config), nothing
+                    end
+                    token = "pkg-instantiation-$filekind"
+                    @test !isfile(manifest_path)
+                    entry = JETLS.do_instantiation_with_progress(server, uri, request, token)
+                    @test isfile(manifest_path)
+                    @test JETLS.instantiation_needs(env_path) == (; resolve=false, instantiate=false)
+                    @test entry.env_path == env_path
+                    if filekind === :script
+                        @test entry isa JETLS.ScriptInEnvAnalysisEntry
+                        @test entry.uri == uri
+                    else
+                        @test entry isa JETLS.PackageSourceAnalysisEntry
+                        @test entry.pkgfileuri == uri
+                        @test entry.pkgid.name == "TestInstantiationProgress"
+                    end
+                    messages = Any[]
+                    while isready(sent_queue)
+                        push!(messages, take!(sent_queue))
+                    end
+                    @test all(msg -> msg isa ProgressNotification, messages)
+                    @test all(msg -> msg.params.token == token, messages)
+                    @test first(messages).params.value isa WorkDoneProgressBegin
+                    @test last(messages).params.value isa WorkDoneProgressEnd
+                    begin_value = first(messages).params.value
+                    @test begin_value.title == "Instantiating environment"
+                    @test begin_value.message == joinpath("TestInstantiationProgress", "Project.toml")
+                    @test begin_value.cancellable === false
+                    reports = messages[2:end-1]
+                    @test !isempty(reports)
+                    @test all(msg -> msg.params.value isa WorkDoneProgressReport, reports)
+                    @test all(reports) do msg
+                        message = msg.params.value.message
+                        message isa String && !isempty(message)
+                    end
+                end
+            end
+        end
+    finally
+        Pkg.offline(offline)
+    end
+end
+
 @testset "auto_instantiate = \"prompt\"" begin
     settings = Dict{String,Any}(
         "full_analysis" => Dict{String,Any}(

--- a/test/analysis/test_instantiation_progress.jl
+++ b/test/analysis/test_instantiation_progress.jl
@@ -1,0 +1,147 @@
+module test_instantiation_progress
+
+using Test
+using JETLS: JETLS
+
+include(normpath(pkgdir(JETLS), "test", "setup.jl"))
+
+@testset "InstantiationProgressIO" begin
+    @testset "partial lines and finish" begin
+        let io = JETLS.InstantiationProgressIO()
+            @test io isa IO
+            @test JETLS.instantiation_progress_message!(io) === nothing
+            @test JETLS.instantiation_progress_message!(io; finish=true) === nothing
+            print(io, "Resolving ", 1)
+            flush(io)
+            @test JETLS.instantiation_progress_message!(io) === nothing
+            println(io, " package")
+            @test JETLS.instantiation_progress_message!(io) == "Resolving 1 package"
+            print(io, "Final output")
+            flush(io)
+            @test JETLS.instantiation_progress_message!(io) === nothing
+            @test JETLS.instantiation_progress_message!(io; finish=true) == "Final output"
+            @test JETLS.instantiation_progress_message!(io; finish=true) === nothing
+            raw = take!(io)
+            @test raw isa Vector{UInt8}
+            @test raw == codeunits("Resolving 1 package\nFinal output")
+        end
+    end
+
+    @testset "coalescing and deduplication" begin
+        let io = JETLS.InstantiationProgressIO(), chunks = (
+                "old\nnewer\rlatest\r\n\r \t\n\e[0m\n",
+                "\e[32mlatest\e[0m\n",
+                "intermediate\nlatest\n",
+                "next\r",
+                "latest\n",
+                "latest")
+            for (chunk, expected) in zip(chunks,
+                    ("latest", nothing, nothing, "next", "latest", nothing))
+                @test write(io, chunk) == ncodeunits(chunk)
+                @test JETLS.instantiation_progress_message!(io) == expected
+                @test JETLS.instantiation_progress_message!(io) === nothing
+            end
+            @test JETLS.instantiation_progress_message!(io; finish=true) === nothing
+            @test take!(io) == codeunits(join(chunks))
+        end
+    end
+
+    @testset "sanitization" begin
+        for (raw, expected) in (
+                (" \e[31mResolving\e[0m\tpackages \r\n", "Resolving packages"),
+                ("\e[2K\e[1GUpdating \e]8;;https://example.invalid\aPackage\e]8;;\e\\\n",
+                    "Updating Package"),
+                (" \0\x01ready\b\x7f\u0085\t now \n", "ready  now"),
+                (String(UInt8[0x61, 0xff, 0x62, 0xc0, 0x80, 0x63, 0x0a]), "abc"),
+                ("\r\n \t\e[0m\0\r\n", nothing))
+            io = JETLS.InstantiationProgressIO()
+            write(io, raw)
+            @test JETLS.instantiation_progress_message!(io) == expected
+            @test JETLS.instantiation_progress_message!(io; finish=true) === nothing
+            @test take!(io) == codeunits(raw)
+        end
+        for n in (99, 100, 101)
+            io = JETLS.InstantiationProgressIO()
+            raw = repeat("🙂", n) * "\n"
+            write(io, raw)
+            message = JETLS.instantiation_progress_message!(io)
+            @test message == (n > 100 ? repeat("🙂", 99) * "…" : repeat("🙂", n))
+            @test length(message) == min(n, 100)
+            @test take!(io) == codeunits(raw)
+        end
+    end
+
+    @testset "fragmented UTF-8 and unsafe_write" begin
+        let raw = collect(codeunits("λ🙂 ready\n"))
+            for split in 1:length(raw)-1
+                io = JETLS.InstantiationProgressIO()
+                for byte in @view raw[1:split]
+                    @test write(io, byte) == 1
+                end
+                flush(io)
+                @test JETLS.instantiation_progress_message!(io) === nothing
+                remaining = length(raw) - split
+                GC.@preserve raw begin
+                    @test Base.unsafe_write(io, pointer(raw, split + 1),
+                        UInt(remaining)) == remaining
+                end
+                @test JETLS.instantiation_progress_message!(io) == "λ🙂 ready"
+                @test JETLS.instantiation_progress_message!(io; finish=true) === nothing
+                @test take!(io) == raw
+            end
+        end
+    end
+end
+
+@testset "with_instantiation_progress" begin
+    @testset "$outcome" for outcome in (:return, :throw)
+        sent_queue = Channel{Any}(Inf)
+        server = JETLS.Server(;
+            callback = JETLS.ServerMessageRecorder(Channel{Any}(Inf), sent_queue))
+        token = outcome === :return ? "instantiation-stream" : 42
+        message_path = "environment/Project.toml"
+        expected = outcome === :return ? Ref(:result) : ErrorException("instantiation failed")
+        captured_io = Ref{JETLS.InstantiationProgressIO}()
+        result = try
+            JETLS.with_instantiation_progress(server, token, message_path) do io
+                captured_io[] = io
+                msg = take_with_timeout!(sent_queue; interval=0.01, limit=500)
+                @test msg isa ProgressNotification
+                @test msg.params.token == token
+                @test msg.params.value isa WorkDoneProgressBegin
+                @test msg.params.value.title == "Instantiating environment"
+                @test msg.params.value.message == message_path
+                @test msg.params.value.cancellable === false
+
+                println(io, "Resolving dependencies")
+                # The callback cannot finish until the worker reports this line.
+                msg = take_with_timeout!(sent_queue; interval=0.01, limit=500)
+                @test msg isa ProgressNotification
+                @test msg.params.token == token
+                @test msg.params.value isa WorkDoneProgressReport
+                @test msg.params.value.message == "$message_path — Resolving dependencies"
+                print(io, "Final output")
+                outcome === :throw && throw(expected)
+                return expected
+            end
+        catch err
+            err
+        end
+        @test result === expected
+        messages = Any[]
+        while isready(sent_queue)
+            push!(messages, take!(sent_queue))
+        end
+        @test all(msg -> msg isa ProgressNotification, messages)
+        @test all(msg -> msg.params.token == token, messages)
+        @test [typeof(msg.params.value) for msg in messages] == [WorkDoneProgressReport, WorkDoneProgressEnd]
+        report = only(msg for msg in messages if msg.params.value isa WorkDoneProgressReport)
+        @test report.params.value.message == "$message_path — Final output"
+        @test take!(captured_io[]) == codeunits("Resolving dependencies\nFinal output")
+
+        println(captured_io[], "After End")
+        @test timedwait(() -> isready(sent_queue), 0.3; pollint=0.01) == :timed_out
+    end
+end
+
+end # module test_instantiation_progress

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,7 @@ end
     end
     @testset "analysis" verbose=true begin
         @testset "full analysis" include("analysis/test_full_analysis.jl")
+        @testset "instantiation progress" include("analysis/test_instantiation_progress.jl")
         @testset "occurrence" include("analysis/test_occurrence_analysis.jl")
         @testset "cfg" include("analysis/test_cfg_analysis.jl")
         @testset "LSAnalyzer" include("analysis/test_Analyzer.jl")


### PR DESCRIPTION
Environment instantiation previously displayed only a static progress message while Pkg resolved and installed dependencies, leaving users without feedback during lengthy setup.

This change streams the latest sanitized Pkg output line through LSP work-done progress. A synchronized IO wrapper retains raw output, while a periodic reporter coalesces updates and flushes before progress ends. Verbose CLI and development logs include a readable elapsed duration and the captured output.

Focused tests cover output parsing, progress lifecycle, and offline Pkg instantiation.