### PR TITLE
diagnostic: Long-poll `workspace/diagnostic` requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed diagnostics disappearing prematurely during reanalysis.
+
+- Fixed stale diagnostics not being cleared when a file is closed with `diagnostic.all_files=false`.
+
 - Fixed a race during background analysis that could cause diagnostics and other language features to use outdated document contents after an edit.
 
 - Fixed errors logged when in-flight requests or progress notifications finished during language server shutdown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added live Pkg output to progress messages for environment instantiation triggered by [`full_analysis.auto_instantiate`](https://aviatesk.github.io/JETLS.jl/release/configuration/#config/full_analysis/auto_instantiate), showing the latest activity while resolving and installing dependencies.
 
+### Changed
+
+- `workspace/diagnostic` now long-polls: when nothing has changed since the client's last pull, the server keeps the request open instead of answering it, and answers as soon as workspace diagnostics may have changed (full-analysis completion, edits, watched-file or configuration changes). Clients that re-pull workspace diagnostics on a fixed interval (Zed, VS Code) no longer make the server rescan the workspace while idle, and diagnostics of unopened files update without waiting for the next poll.
+
+- Pull diagnostics (`textDocument/diagnostic` and `workspace/diagnostic`) are now refreshed as soon as full-analysis has resolved module contexts, before signature analysis finishes, instead of after the whole analysis completes.
+
 ### Fixed
 
 - Fixed a race during background analysis that could cause diagnostics and other language features to use outdated document contents after an edit.
@@ -90,8 +96,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [`jetls check`](https://aviatesk.github.io/JETLS.jl/release/cli-check/) is unaffected: it has no client to ask, so `"prompt"` instantiates like `"always"` there, as the CLI already did before.
   For backward compatibility, the legacy values `true` and `false` are still accepted at runtime as aliases of `"always"` and `"never"`.
   Configuration schemas intentionally reject these legacy boolean values to prompt migration to the string form.
-
-- `workspace/diagnostic` now uses less CPU while the workspace is unchanged, especially in clients that poll workspace diagnostics continuously.
 
 ### Fixed
 

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -371,6 +371,7 @@ function handler_concurrent_message(server::Server, @nospecialize msg)
             return # Request was already handled, ignore cancellation
         end
         cancel!(get!(()->CancelFlag(true), server.state.currently_handled, msg.params.id))
+        cancel_parked_workspace_diagnostic_request!(server, msg.params.id)
     elseif msg isa WorkDoneProgressCancelNotification
         if msg.params.token in server.state.handled_history
             return # Token was already handled, ignore cancellation
@@ -381,6 +382,10 @@ function handler_concurrent_message(server::Server, @nospecialize msg)
         push!(server.state.handled_history, msg.id) # Add to handled history to prevent dead IDs from accumulating
         # @info "Remaining requests" length(server.state.currently_handled) Base.summarysize(server.state.currently_handled)
         # @info "Handled history" length(server.state.handled_history) Base.summarysize(server.state.handled_history)
+    elseif msg isa WorkspaceDiagnosticParkToken
+        park_workspace_diagnostic_request!(server, msg.request)
+    elseif msg isa WorkspaceDiagnosticWakeToken
+        resume_parked_workspace_diagnostic_request!(server)
     # Handle regular messages concurrently
     elseif msg isa Dict{Symbol,Any} # ResponseMessage or untyped message
         request_caller = let id = get(msg, :id, nothing)
@@ -400,6 +405,7 @@ function handler_concurrent_message(server::Server, @nospecialize msg)
             @warn "[handler_concurrent_message] Unhandled message" msg _id=_id maxlog=1
         end
     elseif isdefined(msg, :id) && (id = msg.id; id isa String || id isa Int)
+        prepare_request_message!(server, msg)
         let cancel_flag = get!(()->CancelFlag(false), server.state.currently_handled, id)
             Threads.@spawn :default @tryinvokelatest handle_request_message(server, msg, cancel_flag)
         end
@@ -460,6 +466,15 @@ function handle_response_message(
         # nothing to do
     else
         error("Unknown request caller type")
+    end
+    nothing
+end
+
+# Runs on the concurrent message worker right before a request is dispatched, for
+# bookkeeping that has to stay serialized with the worker's other state updates.
+function prepare_request_message!(server::Server, @nospecialize(msg))
+    if msg isa WorkspaceDiagnosticRequest
+        begin_workspace_diagnostic_request!(server, msg)
     end
     nothing
 end

--- a/src/analysis/Interpreter.jl
+++ b/src/analysis/Interpreter.jl
@@ -197,6 +197,12 @@ function cache_intermediate_analysis_result!(interp::LSInterpreter)
     result = JET.JETToplevelResult(interp.analyzer, interp.state.res, "LSInterpreter (intermediate result)", ())
     intermediate_result, _ = JETLS.new_analysis_result(interp, result)
     JETLS.update_analysis_cache!(interp.server.state, intermediate_result)
+    # Module contexts are complete at this point, which is all pull diagnostics need,
+    # so refresh them now rather than after signature analysis.
+    JETLS.request_diagnostic_refresh!(interp.server)
+    JETLS.request_codelens_refresh!(interp.server)
+    interp.execution.context_refreshed = true
+    nothing
 end
 
 function JET.analyze_from_definitions!(interp::LSInterpreter, config::JET.ToplevelConfig)

--- a/src/analysis/Interpreter.jl
+++ b/src/analysis/Interpreter.jl
@@ -195,7 +195,7 @@ end
 
 function cache_intermediate_analysis_result!(interp::LSInterpreter)
     result = JET.JETToplevelResult(interp.analyzer, interp.state.res, "LSInterpreter (intermediate result)", ())
-    intermediate_result, _ = JETLS.new_analysis_result(interp, result)
+    intermediate_result, _ = JETLS.new_analysis_result(interp, result; intermediate=true)
     JETLS.update_analysis_cache!(interp.server.state, intermediate_result)
     # Module contexts are complete at this point, which is all pull diagnostics need,
     # so refresh them now rather than after signature analysis.

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -926,7 +926,22 @@ function update_analyzer_world(analyzer::LSAnalyzer, world::UInt = Base.get_worl
     return JET.AbstractAnalyzer(analyzer, newstate)
 end
 
-function new_analysis_result(interp::LSInterpreter, result::JET.JETToplevelResult)
+# Publishing a new context must not discard completed diagnostics while analysis is pending.
+function intermediate_analysis_diagnostics(
+        execution::AnalysisExecution, analyzed_file_infos::Dict{URI,JET.AnalyzedFileInfo}
+    )
+    prev_result = execution.prev_result
+    uri2diagnostics = URI2Diagnostics()
+    for uri in keys(analyzed_file_infos)
+        diagnostics = prev_result === nothing ? nothing : get(prev_result.uri2diagnostics, uri, nothing)
+        uri2diagnostics[uri] = diagnostics === nothing ? Diagnostic[] : copy(diagnostics)
+    end
+    return uri2diagnostics
+end
+
+function new_analysis_result(
+        interp::LSInterpreter, result::JET.JETToplevelResult; intermediate::Bool = false
+    )
     execution = interp.execution
     request = execution.request
     analyzed_file_infos = Dict{URI,JET.AnalyzedFileInfo}(
@@ -936,10 +951,15 @@ function new_analysis_result(interp::LSInterpreter, result::JET.JETToplevelResul
 
     result_world = Base.get_world_counter()
 
-    uri2diagnostics = URI2Diagnostics(uri => Diagnostic[] for uri in keys(analyzed_file_infos))
-    postprocessor = JET.PostProcessor(result.res.actual2virtual)
-    toplevel_warning_reports_to_diagnostics!(uri2diagnostics, interp.warning_reports, interp.server, postprocessor)
-    jet_result_to_diagnostics!(uri2diagnostics, result, result_world, postprocessor)
+    uri2diagnostics = if intermediate
+        intermediate_analysis_diagnostics(execution, analyzed_file_infos)
+    else
+        diagnostics = URI2Diagnostics(uri => Diagnostic[] for uri in keys(analyzed_file_infos))
+        postprocessor = JET.PostProcessor(result.res.actual2virtual)
+        toplevel_warning_reports_to_diagnostics!(diagnostics, interp.warning_reports, interp.server, postprocessor)
+        jet_result_to_diagnostics!(diagnostics, result, result_world, postprocessor)
+        diagnostics
+    end
 
     entry = request.entry
     prev_result = execution.prev_result
@@ -1234,7 +1254,7 @@ function analyze_package_with_revise(
 
     # Module contexts are known at this point, which is all pull diagnostics need, so
     # expose them before signature analysis, like `cache_intermediate_analysis_result!`.
-    let uri2diagnostics = URI2Diagnostics(uri => Diagnostic[] for uri in keys(analyzed_file_infos))
+    let uri2diagnostics = intermediate_analysis_diagnostics(execution, analyzed_file_infos)
         intermediate_result = AnalysisResult(request.entry, uri2diagnostics, analyzer,
             analyzed_file_infos, pkgmod => pkgmod, world)
         update_analysis_cache!(server.state, intermediate_result)

--- a/src/analysis/full-analysis.jl
+++ b/src/analysis/full-analysis.jl
@@ -575,15 +575,11 @@ function resolve_analysis_request(server::Server, request::AnalysisRequest)
     update_analysis_cache!(server.state, analysis_result)
     mark_analyzed_generation!(manager, request)
     request.notify_diagnostics && notify_diagnostics!(server)
-
-    # Request diagnostic refresh for full-analysis completion.
-    # This ensures that clients using pull diagnostics (textDocument/diagnostic) will
-    # re-request diagnostics now that new module context is available, allowing
-    # lowering/macro-expansion-error and lowering/undef-global-var diagnostics
-    # to be properly reported.
-    request_diagnostic_refresh!(server)
-    # Also request code lens for references recalculation
-    request_codelens_refresh!(server)
+    # Top-level errors can skip signature analysis and its intermediate context refresh.
+    if !execution.context_refreshed
+        request_diagnostic_refresh!(server)
+        request_codelens_refresh!(server)
+    end
 
     @label next_request
 
@@ -841,10 +837,10 @@ function execute_analysis(server::Server, execution::AnalysisExecution)
     if entry isa NewAnalysisEntry
         env_path = entry.env_path
         result = if env_path === nothing
-            analyze_package_with_revise(server, request, entry.pkgid)
+            analyze_package_with_revise(server, execution, entry.pkgid)
         else
             activate_with_early_release(env_path) do activation_done::Base.Event
-                analyze_package_with_revise(server, request, entry.pkgid, activation_done)
+                analyze_package_with_revise(server, execution, entry.pkgid, activation_done)
             end::AnalysisResult
         end
         return result, false
@@ -1174,9 +1170,10 @@ function get_lines_in_src(filepath::AbstractString, src::Core.CodeInfo)
 end
 
 function analyze_package_with_revise(
-        server::Server, request::AnalysisRequest, pkgid::Base.PkgId,
+        server::Server, execution::AnalysisExecution, pkgid::Base.PkgId,
         activation_done::Union{Nothing,Base.Event} = nothing
     )
+    request = execution.request
     pkgmod = get(Base.loaded_modules, pkgid, nothing)
     pkgmod = try
         pkgmod === nothing ? Base.require(pkgid)::Module : pkgmod
@@ -1233,6 +1230,17 @@ function analyze_package_with_revise(
         analyzer = LSAnalyzer(request.entry; report_target_modules, reuse_native_inference)
         newstate = JET.AnalyzerState(JET.AnalyzerState(analyzer); world)
         JET.AbstractAnalyzer(analyzer, newstate)
+    end
+
+    # Module contexts are known at this point, which is all pull diagnostics need, so
+    # expose them before signature analysis, like `cache_intermediate_analysis_result!`.
+    let uri2diagnostics = URI2Diagnostics(uri => Diagnostic[] for uri in keys(analyzed_file_infos))
+        intermediate_result = AnalysisResult(request.entry, uri2diagnostics, analyzer,
+            analyzed_file_infos, pkgmod => pkgmod, world)
+        update_analysis_cache!(server.state, intermediate_result)
+        request_diagnostic_refresh!(server)
+        request_codelens_refresh!(server)
+        execution.context_refreshed = true
     end
 
     # Detect method overwrites

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -2449,9 +2449,14 @@ function postprocess_pull_diagnostics(
     return diagnostics
 end
 
-# Full reports stream as partial results when the client supports them, while unchanged
-# reports only travel in the final response, so a pull that changes nothing sends nothing
-# before it gets parked.
+# Full reports are streamed as partial results when the client offers a token, so they
+# show up while the scan is still running, and they are repeated in the final response.
+# The repetition matters: Zed clears the request token as soon as the response arrives
+# and drops partial results it processes afterwards, which would leave it with stale
+# result ids and make it re-pull until they converge one file per answer. The spec allows
+# reporting the same URI more than once, with the last report winning. Unchanged reports
+# only travel in the final response, so a pull that changes nothing sends nothing before
+# it gets parked.
 mutable struct WorkspaceDiagnosticReporter
     const partial_token::Union{Nothing,ProgressToken}
     const items::Vector{WorkspaceDocumentDiagnosticReport}
@@ -2474,10 +2479,9 @@ function report_full!(
         item::WorkspaceFullDocumentDiagnosticReport
     )
     reporter.changed = true
+    push!(reporter.items, item)
     partial_token = reporter.partial_token
-    if partial_token === nothing
-        push!(reporter.items, item)
-    else
+    if partial_token !== nothing
         send_partial_result(server, partial_token,
             WorkspaceDiagnosticReportPartialResult(;
                 items = WorkspaceDocumentDiagnosticReport[item]))
@@ -2494,6 +2498,7 @@ function report_cleared!(server::Server, reporter::WorkspaceDiagnosticReporter, 
     report_full!(server, reporter,
         WorkspaceFullDocumentDiagnosticReport(;
             uri, version = null, items = empty_diagnostics))
+    nothing
 end
 
 function report_stale_results!(

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -2165,15 +2165,17 @@ function merge_diagnostics!(uri2diagnostics::URI2Diagnostics, other_uri2diagnost
 end
 
 """
-    notify_diagnostics!(server::Server; ensure_cleared::Union{Nothing,URI} = nothing)
+    notify_diagnostics!(server::Server; ensure_cleared::Union{Bool,URI} = false)
 
 Send `textDocument/publishDiagnostics` notifications to the client. This combines
 diagnostics from full-analysis with extra diagnostics provided by sources like the
 test runner.
 
-When `ensure_cleared` is specified, guarantees that a notification is sent for that URI
+When `ensure_cleared` is a URI, guarantees that a notification is sent for that URI
 even if it no longer has any diagnostics, ensuring the client clears any previously
-displayed diagnostics for that URI.
+displayed diagnostics for that URI. With `ensure_cleared=true`, also clears diagnostics
+for unopened files suppressed by `diagnostic.all_files=false`, but skips files whose
+cached diagnostics are empty.
 """
 function notify_diagnostics!(server::Server; ensure_cleared::Union{Bool,URI} = false)
     notify_diagnostics!(server, get_full_diagnostics(server; ensure_cleared); ensure_cleared)
@@ -2185,8 +2187,8 @@ function notify_diagnostics!(server::Server, uri2diagnostics::URI2Diagnostics; e
     root_path = isdefined(state, :root_path) ? state.root_path : nothing
     for (uri, diagnostics) in uri2diagnostics
         if !all_files && !is_synchronized(state, uri)
-            if ((ensure_cleared isa URI && uri == ensure_cleared) ||
-                ensure_cleared === true) && !isempty(diagnostics)
+            if (ensure_cleared isa URI && uri == ensure_cleared) ||
+                (ensure_cleared === true && !isempty(diagnostics))
                 send(server, PublishDiagnosticsNotification(;
                     params = PublishDiagnosticsParams(;
                         uri,

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -2317,16 +2317,32 @@ end
 
 # workspace/diagnostic
 # ====================
+#
+# Long-polling: a pull that has nothing to report (every file unchanged, nothing to clear)
+# is parked instead of answered. Change points call `mark_workspace_diagnostics_changed!`,
+# which resumes the parked request; it then answers only if something actually changed.
+# Both Zed and VS Code re-pull after every answer (Zed immediately when it has pending
+# edits, otherwise after 2s), so server-driven wakeups replace their fixed-interval polling.
+
+# Workspace scans are spaced by at least this many seconds. Without it every keystroke
+# would rescan through the wake-up path (a bump that turns out to change nothing still
+# costs a full scan), and Zed's immediate re-pull after each answer would do the same
+# through the request path.
+const WORKSPACE_DIAGNOSTIC_MIN_INTERVAL = 1.0
 
 function handle_WorkspaceDiagnosticRequest(
         server::Server, msg::WorkspaceDiagnosticRequest, cancel_flag::CancelFlag
     )
+    longpoll = server.state.workspace_diagnostic_longpoll
+    wait_workspace_diagnostic_interval(longpoll)
+    is_cancelled(cancel_flag) && return send_workspace_diagnostic_cancelled(server, msg.id)
+    revision = @atomic longpoll.revision
     uris_to_search = collect_workspace_uris(server)
     try
         if get_config(server, :diagnostic, :all_files)
-            send_workspace_diagnostics(server, msg, uris_to_search, cancel_flag)
+            send_workspace_diagnostics(server, msg, uris_to_search, cancel_flag, revision)
         else
-            send_empty_workspace_diagnostics(server, msg, uris_to_search, cancel_flag)
+            send_empty_workspace_diagnostics(server, msg, uris_to_search, cancel_flag, revision)
         end
     catch err
         send(server,
@@ -2339,6 +2355,21 @@ function handle_WorkspaceDiagnosticRequest(
                     data = DiagnosticServerCancellationData(; retriggerRequest = true))))
         rethrow(err)
     end
+end
+
+function wait_workspace_diagnostic_interval(longpoll::WorkspaceDiagnosticLongPoll)
+    elapsed = time() - (@atomic longpoll.last_run_time)
+    remaining = WORKSPACE_DIAGNOSTIC_MIN_INTERVAL - elapsed
+    remaining > 0 && sleep(remaining)
+    nothing
+end
+
+function send_workspace_diagnostic_cancelled(server::Server, id::MessageId)
+    return send(server,
+        WorkspaceDiagnosticResponse(;
+            id,
+            result = nothing,
+            error = request_cancelled_error()))
 end
 
 # Derives the `resultId` sent back for `textDocument/diagnostic` and `workspace/diagnostic`.
@@ -2418,28 +2449,103 @@ function postprocess_pull_diagnostics(
     return diagnostics
 end
 
+# Full reports stream as partial results when the client supports them, while unchanged
+# reports only travel in the final response, so a pull that changes nothing sends nothing
+# before it gets parked.
+mutable struct WorkspaceDiagnosticReporter
+    const partial_token::Union{Nothing,ProgressToken}
+    const items::Vector{WorkspaceDocumentDiagnosticReport}
+    changed::Bool
+end
+WorkspaceDiagnosticReporter(partial_token::Union{Nothing,ProgressToken}) =
+    WorkspaceDiagnosticReporter(partial_token, WorkspaceDocumentDiagnosticReport[], false)
+
+function report_unchanged!(
+        reporter::WorkspaceDiagnosticReporter, uri::URI, result_id::String
+    )
+    push!(reporter.items,
+        WorkspaceUnchangedDocumentDiagnosticReport(;
+            uri, version = null, resultId = result_id))
+    nothing
+end
+
+function report_full!(
+        server::Server, reporter::WorkspaceDiagnosticReporter,
+        item::WorkspaceFullDocumentDiagnosticReport
+    )
+    reporter.changed = true
+    partial_token = reporter.partial_token
+    if partial_token === nothing
+        push!(reporter.items, item)
+    else
+        send_partial_result(server, partial_token,
+            WorkspaceDiagnosticReportPartialResult(;
+                items = WorkspaceDocumentDiagnosticReport[item]))
+    end
+    nothing
+end
+
+const empty_diagnostics = Diagnostic[]
+
+# The client holds a result for `uri` but no report can be produced for it anymore
+# (deleted, unreadable, or no longer part of any analysis unit): an empty report without
+# a `resultId` clears its diagnostics and makes the client drop the stale id.
+function report_cleared!(server::Server, reporter::WorkspaceDiagnosticReporter, uri::URI)
+    report_full!(server, reporter,
+        WorkspaceFullDocumentDiagnosticReport(;
+            uri, version = null, items = empty_diagnostics))
+end
+
+function report_stale_results!(
+        server::Server, reporter::WorkspaceDiagnosticReporter,
+        previous_result_ids::Dict{URI,String}, uris_to_search::Set{URI}
+    )
+    state = server.state
+    for uri in keys(previous_result_ids)
+        uri in uris_to_search && continue
+        # Open documents belong to `textDocument/diagnostic`, whose result ids clients may
+        # echo back here; notebook cell ids never originate from this endpoint either.
+        is_synchronized(state, uri) && continue
+        get_notebook_uri_for_cell(state, uri) === nothing || continue
+        report_cleared!(server, reporter, uri)
+    end
+    nothing
+end
+
+function finish_workspace_diagnostics!(
+        server::Server, msg::WorkspaceDiagnosticRequest,
+        reporter::WorkspaceDiagnosticReporter, cancel_flag::CancelFlag, revision::Int
+    )
+    @atomic server.state.workspace_diagnostic_longpoll.last_run_time = time()
+    if reporter.partial_token !== nothing && !reporter.changed
+        enqueue_message!(server, WorkspaceDiagnosticParkToken(
+            ParkedWorkspaceDiagnosticRequest(msg, cancel_flag, revision)))
+        return nothing
+    end
+    return send(server,
+        WorkspaceDiagnosticResponse(;
+            id = msg.id,
+            result = WorkspaceDiagnosticReport(; items = reporter.items)))
+end
+
 function send_workspace_diagnostics(
         server::Server, msg::WorkspaceDiagnosticRequest, uris_to_search::Set{URI},
-        cancel_flag::CancelFlag
+        cancel_flag::CancelFlag, revision::Int
     )
     state = server.state
     previous_result_ids = Dict{URI,String}()
     for prev in msg.params.previousResultIds
         previous_result_ids[prev.uri] = prev.value
     end
-    partial_token = msg.params.partialResultToken
-    items = WorkspaceDocumentDiagnosticReport[]
+    reporter = WorkspaceDiagnosticReporter(msg.params.partialResultToken)
     root_path = isdefined(state, :root_path) ? state.root_path : nothing
     result_id_cache = DiagnosticResultIdCache()
     debuginfo = nothing
     # debuginfo = (; synced = URI[], analyzed = URI[], skipped = URI[], failed = URI[])
     def_used_names_cache = DefUsedNamesCache()
     for uri in uris_to_search
-        is_cancelled(cancel_flag) && return send(server,
-            WorkspaceDiagnosticResponse(;
-                id = msg.id,
-                result = nothing,
-                error = request_cancelled_error()))
+        is_cancelled(cancel_flag) &&
+            return send_workspace_diagnostic_cancelled(server, msg.id)
 
         if is_synchronized(state, uri)
             isnothing(debuginfo) || push!(debuginfo.synced, uri)
@@ -2447,6 +2553,7 @@ function send_workspace_diagnostics(
         end
 
         fi = @something get_unsynced_file_info!(state, uri) begin
+            haskey(previous_result_ids, uri) && report_cleared!(server, reporter, uri)
             isnothing(debuginfo) || push!(debuginfo.failed, uri)
             continue
         end
@@ -2454,99 +2561,148 @@ function send_workspace_diagnostics(
         result_id = compute_diagnostic_result_id(server, uri; result_id_cache)
         prev_result_id = get(previous_result_ids, uri, nothing)
         if prev_result_id !== nothing && prev_result_id == result_id
-            item = WorkspaceUnchangedDocumentDiagnosticReport(;
-                uri,
-                version = null,
-                resultId = result_id)
-            if partial_token !== nothing
-                send_partial_result(server, partial_token,
-                    WorkspaceDiagnosticReportPartialResult(; items = WorkspaceDocumentDiagnosticReport[item]))
-            else
-                push!(items, item)
-            end
+            report_unchanged!(reporter, uri, result_id)
             isnothing(debuginfo) || push!(debuginfo.skipped, uri)
             continue
         end
 
         diagnostics = compute_pull_diagnostics!(def_used_names_cache, server, uri, fi, cancel_flag)
-        is_cancelled(cancel_flag) && return send(server,
-            WorkspaceDiagnosticResponse(;
-                id = msg.id,
-                result = nothing,
-                error = request_cancelled_error()))
+        is_cancelled(cancel_flag) &&
+            return send_workspace_diagnostic_cancelled(server, msg.id)
         diagnostics = postprocess_pull_diagnostics(server, uri, diagnostics, root_path)
 
-        item = WorkspaceFullDocumentDiagnosticReport(;
-            uri,
-            version = null,
-            resultId = result_id,
-            items = diagnostics)
-        if partial_token !== nothing
-            send_partial_result(server, partial_token,
-                WorkspaceDiagnosticReportPartialResult(; items = WorkspaceDocumentDiagnosticReport[item]))
-        else
-            push!(items, item)
-        end
+        report_full!(server, reporter,
+            WorkspaceFullDocumentDiagnosticReport(;
+                uri,
+                version = null,
+                resultId = result_id,
+                items = diagnostics))
         isnothing(debuginfo) || push!(debuginfo.analyzed, uri)
     end
+    report_stale_results!(server, reporter, previous_result_ids, uris_to_search)
 
-    partial_token === nothing ||
-        @assert isempty(items) "The final result should be empty when using partial token"
     if !isnothing(debuginfo)
         debugshow = (x) -> Text(sprint(show, MIME("text/plain"), x; context=:limit=>true))
         @info "workspace/diagnostic" analyzed=debugshow(debuginfo.analyzed) synced=debugshow(debuginfo.synced) skipped=debugshow(debuginfo.skipped) failed=debugshow(debuginfo.failed)
     end
-    return send(server,
-        WorkspaceDiagnosticResponse(;
-            id = msg.id,
-            result = WorkspaceDiagnosticReport(; items)))
+    return finish_workspace_diagnostics!(server, msg, reporter, cancel_flag, revision)
 end
 
 const ALL_FILES_DISABLED_RESULT_ID = "workspace/diagnostic-disabled"
-const empty_diagnostics = Diagnostic[]
 
 function send_empty_workspace_diagnostics(
         server::Server, msg::WorkspaceDiagnosticRequest, uris_to_search::Set{URI},
-        cancel_flag::CancelFlag
+        cancel_flag::CancelFlag, revision::Int
     )
+    state = server.state
     previous_result_ids = Dict{URI,String}()
     for prev in msg.params.previousResultIds
         previous_result_ids[prev.uri] = prev.value
     end
-    partial_token = msg.params.partialResultToken
-    items = WorkspaceDocumentDiagnosticReport[]
+    reporter = WorkspaceDiagnosticReporter(msg.params.partialResultToken)
     for uri in uris_to_search
-        is_cancelled(cancel_flag) && return send(server,
-            WorkspaceDiagnosticResponse(;
-                id = msg.id,
-                result = nothing,
-                error = request_cancelled_error()))
-        is_synchronized(server.state, uri) && continue
+        is_cancelled(cancel_flag) &&
+            return send_workspace_diagnostic_cancelled(server, msg.id)
+        is_synchronized(state, uri) && continue
         if get(previous_result_ids, uri, nothing) == ALL_FILES_DISABLED_RESULT_ID
-            item = WorkspaceUnchangedDocumentDiagnosticReport(;
-                uri,
-                version = null,
-                resultId = ALL_FILES_DISABLED_RESULT_ID)
+            report_unchanged!(reporter, uri, ALL_FILES_DISABLED_RESULT_ID)
         else
-            item = WorkspaceFullDocumentDiagnosticReport(;
-                uri,
-                version = null,
-                resultId = ALL_FILES_DISABLED_RESULT_ID,
-                items = empty_diagnostics)
-        end
-        if partial_token !== nothing
-            send_partial_result(server, partial_token,
-                WorkspaceDiagnosticReportPartialResult(; items = WorkspaceDocumentDiagnosticReport[item]))
-        else
-            push!(items, item)
+            report_full!(server, reporter,
+                WorkspaceFullDocumentDiagnosticReport(;
+                    uri,
+                    version = null,
+                    resultId = ALL_FILES_DISABLED_RESULT_ID,
+                    items = empty_diagnostics))
         end
     end
-    partial_token === nothing ||
-        @assert isempty(items) "The final result should be empty when using partial token"
+    report_stale_results!(server, reporter, previous_result_ids, uris_to_search)
+    return finish_workspace_diagnostics!(server, msg, reporter, cancel_flag, revision)
+end
+
+# Long-polling bookkeeping
+# ------------------------
+#
+# Everything below except `mark_workspace_diagnostics_changed!` runs on the concurrent
+# message worker (`handler_concurrent_message`), which serializes it against
+# `$/cancelRequest` handling and the dispatch of new `workspace/diagnostic` requests.
+
+# Queue the wake token unconditionally: checking `parked` here could miss a revision bump
+# between the park handler's revision check and its store to `parked`. Park and wake
+# handlers run serially on the same concurrent message worker, so a wake queued in that
+# window is handled after the park completes. If a wake is handled before the park,
+# the park handler detects the revision mismatch and re-runs the request instead.
+function mark_workspace_diagnostics_changed!(server::Server)
+    longpoll = server.state.workspace_diagnostic_longpoll
+    @atomic longpoll.revision += 1
+    enqueue_message!(server, WorkspaceDiagnosticWakeToken())
+    nothing
+end
+
+function begin_workspace_diagnostic_request!(
+        server::Server, msg::WorkspaceDiagnosticRequest
+    )
+    close_parked_workspace_diagnostic_request!(server)
+    @atomic server.state.workspace_diagnostic_longpoll.current_id = msg.id
+    nothing
+end
+
+function park_workspace_diagnostic_request!(
+        server::Server, request::ParkedWorkspaceDiagnosticRequest
+    )
+    longpoll = server.state.workspace_diagnostic_longpoll
+    if is_cancelled(request.cancel_flag)
+        send_workspace_diagnostic_cancelled(server, request.msg.id)
+    elseif request.msg.id != (@atomic longpoll.current_id)
+        send_empty_workspace_diagnostic_report(server, request.msg.id)
+    elseif request.revision != (@atomic longpoll.revision)
+        # something changed while this run was computing: re-run instead of parking
+        rerun_workspace_diagnostic_request(server, request)
+    else
+        @atomic longpoll.parked = request
+    end
+    nothing
+end
+
+function resume_parked_workspace_diagnostic_request!(server::Server)
+    longpoll = server.state.workspace_diagnostic_longpoll
+    request = @something (@atomic longpoll.parked) return nothing
+    request.revision == (@atomic longpoll.revision) && return nothing
+    @atomic longpoll.parked = nothing
+    rerun_workspace_diagnostic_request(server, request)
+    nothing
+end
+
+function rerun_workspace_diagnostic_request(
+        server::Server, request::ParkedWorkspaceDiagnosticRequest
+    )
+    Threads.@spawn :default @tryinvokelatest handle_request_message(
+        server, request.msg, request.cancel_flag)
+    nothing
+end
+
+function cancel_parked_workspace_diagnostic_request!(server::Server, id::MessageId)
+    longpoll = server.state.workspace_diagnostic_longpoll
+    request = @something (@atomic longpoll.parked) return nothing
+    request.msg.id == id || return nothing
+    @atomic longpoll.parked = nothing
+    send_workspace_diagnostic_cancelled(server, id)
+    nothing
+end
+
+# A new pull arriving while one is parked (a client that polls without cancelling)
+# supersedes the parked one; an empty report leaves the client's state untouched.
+function close_parked_workspace_diagnostic_request!(server::Server)
+    longpoll = server.state.workspace_diagnostic_longpoll
+    request = @something (@atomic longpoll.parked) return nothing
+    @atomic longpoll.parked = nothing
+    send_empty_workspace_diagnostic_report(server, request.msg.id)
+    nothing
+end
+
+function send_empty_workspace_diagnostic_report(server::Server, id::MessageId)
+    items = WorkspaceDocumentDiagnosticReport[]
     return send(server,
-        WorkspaceDiagnosticResponse(;
-            id = msg.id,
-            result = WorkspaceDiagnosticReport(; items)))
+        WorkspaceDiagnosticResponse(; id, result = WorkspaceDiagnosticReport(; items)))
 end
 
 # workspace/diagnostic/refresh
@@ -2554,13 +2710,13 @@ end
 
 struct DiagnosticRefreshRequestCaller <: RequestCaller end
 
-# This function is currently used to refresh `textDocument/diagnostic`.
-# The LSP specification states that clients receiving `workspace/diagnostic/refresh`
-# should refresh both document and workspace diagnostics, but client implementations
-# vary. As of now (2025-12-19), VSCode refreshes `textDocument/diagnostic` when it
-# receives `workspace/diagnostic/refresh`, but Zed handles this request without
-# refreshing `textDocument/diagnostic`.
+# Resumes a parked `workspace/diagnostic` pull and asks the client to re-pull
+# `textDocument/diagnostic` for its open documents. The refresh request only matters for
+# the latter: VS Code re-pulls open documents and never touches its workspace pull loop,
+# and Zed leaves an in-flight workspace pull open as well (it re-pulls once the server
+# answers), so the parked request has to be resumed on the server side.
 function request_diagnostic_refresh!(server::Server)
+    mark_workspace_diagnostics_changed!(server)
     supports(server, :workspace, :diagnostics, :refreshSupport) || return nothing
     id = String(gensym(:WorkspaceDiagnosticRefreshRequest))
     addrequest!(server, id=>DiagnosticRefreshRequestCaller())

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -255,9 +255,6 @@ function handle_DidCloseTextDocumentNotification(server::Server, msg::DidCloseTe
     clear_extra_diagnostics!(server, uri)
     # Republish textDocument/publishDiagnostics for cases with `diagnostic.all_files === false`,
     # where diagnostics for this file must be suppressed.
-    # This must run before `cleanup_analysis_state!` below, since the suppression
-    # branch in `notify_diagnostics!` only emits the clearing notification when the
-    # analysis cache still reports non-empty diagnostics for this URI.
     notify_diagnostics!(server; ensure_cleared=uri)
     if isunsaveduri(uri)
         cleanup_analysis_state!(server, uri)

--- a/src/document-synchronization.jl
+++ b/src/document-synchronization.jl
@@ -134,6 +134,7 @@ function cache_file_info!(
     end
 
     invalidate_per_file_caches!(state, uri)
+    mark_workspace_diagnostics_changed!(server)
 
     any_deleted && notify_diagnostics!(server; ensure_cleared=uri)
 

--- a/src/notebook.jl
+++ b/src/notebook.jl
@@ -81,6 +81,7 @@ function cache_notebook_file_info!(server::Server, notebook_uri::URI, notebook_i
         Base.PersistentDict(cache, notebook_uri => fi), fi
     end
     invalidate_per_file_caches!(state, notebook_uri)
+    mark_workspace_diagnostics_changed!(server)
     return fi
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -339,9 +339,12 @@ the whole run: it is not a live view of the latest analysis cache. This keeps
 intermediate and final results consistent even if the run itself updates the
 cache before completion.
 """
-struct AnalysisExecution
-    request::AnalysisRequest
-    prev_result::Union{Nothing,AnalysisResult}
+mutable struct AnalysisExecution
+    const request::AnalysisRequest
+    const prev_result::Union{Nothing,AnalysisResult}
+    context_refreshed::Bool
+    AnalysisExecution(request::AnalysisRequest, prev_result::Union{Nothing,AnalysisResult}) =
+        new(request, prev_result, false)
 end
 
 abstract type AbstractSignatureAnalysisJob end
@@ -976,6 +979,40 @@ struct HandledToken
     id::MessageId
 end
 
+"""
+    ParkedWorkspaceDiagnosticRequest
+
+A `workspace/diagnostic` request whose last run found nothing to report. Its response
+is withheld (long-polling) until `WorkspaceDiagnosticLongPoll.revision` moves past
+`revision`, at which point the request is re-run with its original parameters.
+"""
+struct ParkedWorkspaceDiagnosticRequest
+    msg::WorkspaceDiagnosticRequest
+    cancel_flag::CancelFlag
+    revision::Int
+end
+
+"""
+    WorkspaceDiagnosticLongPoll
+
+Long-polling state for `workspace/diagnostic`. `revision` is bumped by
+`mark_workspace_diagnostics_changed!` whenever workspace diagnostics may have changed.
+Parking, resumption, cancellation and supersession of `parked` are serialized on the
+concurrent message worker (see `handler_concurrent_message`).
+"""
+mutable struct WorkspaceDiagnosticLongPoll
+    @atomic revision::Int
+    @atomic last_run_time::Float64
+    @atomic parked::Union{Nothing,ParkedWorkspaceDiagnosticRequest}
+    @atomic current_id::Union{Nothing,MessageId}
+    WorkspaceDiagnosticLongPoll() = new(0, 0.0, nothing, nothing)
+end
+
+struct WorkspaceDiagnosticParkToken
+    request::ParkedWorkspaceDiagnosticRequest
+end
+struct WorkspaceDiagnosticWakeToken end
+
 mutable struct ServerState
     const file_cache::FileCache # syntactic analysis cache (synced with `textDocument/didChange`)
     const saved_file_cache::SavedFileCache # syntactic analysis cache (synced with `textDocument/didSave`)
@@ -1002,6 +1039,7 @@ mutable struct ServerState
     const extra_diagnostics::ExtraDiagnostics
     const currently_handled::CurrentlyHandled
     const handled_history::HandledHistory
+    const workspace_diagnostic_longpoll::WorkspaceDiagnosticLongPoll
     const currently_requested::CurrentlyRequested
     const currently_registered::CurrentlyRegistered
     const config_manager::ConfigManager
@@ -1036,6 +1074,7 @@ mutable struct ServerState
             #=extra_diagnostics=# ExtraDiagnostics(),
             #=currently_handled=# CurrentlyHandled(),
             #=handled_history=# HandledHistory(128),
+            #=workspace_diagnostic_longpoll=# WorkspaceDiagnosticLongPoll(),
             #=currently_requested=# CurrentlyRequested(),
             #=currently_registered=# CurrentlyRegistered(),
             #=config_manager=# ConfigManager(),

--- a/test/test_diagnostic.jl
+++ b/test/test_diagnostic.jl
@@ -1454,6 +1454,8 @@ end
             end
             return items
         end
+        full_report_keys(items) = Set((item.uri, item.resultId) for item in items
+            if item isa WorkspaceFullDocumentDiagnosticReport)
         find_response(messages) =
             only(msg for msg in messages if msg isa WorkspaceDiagnosticResponse)
         has_unused_import(item) =
@@ -1466,13 +1468,17 @@ end
                 @test all(msg -> msg isa PublishDiagnosticsNotification, raw_res)
             end
 
-            # Initial pull: main.jl streams as a partial result and the stale id is cleared
-            # with an empty report, so the response follows immediately.
+            # Initial pull: main.jl gets a full report and the stale id is cleared with an
+            # empty report. Both are streamed as partial results and repeated in the
+            # response; see `WorkspaceDiagnosticReporter`.
             local main_id::String
             let id = id_counter[] += 1
                 (; raw_res) = writereadmsg(make_request(id, PreviousResultId[
                     PreviousResultId(; uri = stale_uri, value = "stale")]); read = 3)
-                items = partial_items(raw_res)
+                response = find_response(raw_res)
+                @test response.id == id
+                items = response.result.items
+                @test full_report_keys(partial_items(raw_res)) == full_report_keys(items)
                 main_item = only(item for item in items if item.uri == main_uri)
                 @test main_item isa WorkspaceFullDocumentDiagnosticReport
                 @test has_unused_import(main_item)
@@ -1481,9 +1487,6 @@ end
                 @test stale_item isa WorkspaceFullDocumentDiagnosticReport
                 @test stale_item.resultId === nothing
                 @test isempty(stale_item.items)
-                response = find_response(raw_res)
-                @test response.id == id
-                @test isempty(response.result.items)
             end
 
             # Re-pull with the matching id: nothing to report, so the request is parked.
@@ -1499,14 +1502,14 @@ end
                 writemsg(make_DidChangeTextDocumentNotification(
                     util_uri, "y = sum([1, 2, 3])\n", #=version=#2); check = false)
                 messages = readmsg(; read = 2).raw_msg
-                main_item = only(partial_items(messages))
+                response = find_response(messages)
+                @test response.id == id
+                main_item = only(response.result.items)
+                @test full_report_keys(partial_items(messages)) == full_report_keys([main_item])
                 @test main_item isa WorkspaceFullDocumentDiagnosticReport
                 @test main_item.uri == main_uri
                 @test main_item.resultId != main_id
                 @test !has_unused_import(main_item)
-                response = find_response(messages)
-                @test response.id == id
-                @test isempty(response.result.items)
                 main_id = main_item.resultId
             end
 
@@ -1524,13 +1527,14 @@ end
                 messages = readmsg(; read = 4).raw_msg
                 @test count(msg -> msg isa ShowMessageNotification, messages) == 1
                 @test count(msg -> msg isa PublishDiagnosticsNotification, messages) == 1
-                main_item = only(partial_items(messages))
+                response = find_response(messages)
+                @test response.id == id
+                main_item = only(response.result.items)
+                @test full_report_keys(partial_items(messages)) == full_report_keys([main_item])
                 @test main_item isa WorkspaceFullDocumentDiagnosticReport
                 @test main_item.uri == main_uri
                 @test main_item.resultId == JETLS.ALL_FILES_DISABLED_RESULT_ID
                 @test isempty(main_item.items)
-                response = find_response(messages)
-                @test response.id == id
                 main_id = main_item.resultId
             end
 

--- a/test/test_diagnostic.jl
+++ b/test/test_diagnostic.jl
@@ -1399,4 +1399,203 @@ end
     end
 end
 
+function wait_for_parked_workspace_diagnostic(
+        state::JETLS.ServerState, id::Union{Int,String}; timeout::Float64 = 10.0
+    )
+    deadline = time() + timeout
+    while time() < deadline
+        parked = @atomic state.workspace_diagnostic_longpoll.parked
+        parked !== nothing && parked.msg.id == id && return parked
+        sleep(0.01)
+    end
+    error("Timed out waiting for workspace/diagnostic request $id to be parked")
+end
+
+function wait_for_no_handled_requests(state::JETLS.ServerState; timeout::Float64 = 10.0)
+    deadline = time() + timeout
+    while time() < deadline
+        isempty(state.currently_handled) && return
+        sleep(0.01)
+    end
+    error("Timed out waiting for `currently_handled` to drain")
+end
+
+@testset "workspace/diagnostic long-polling" begin
+    pkg_code = """
+    module TestWorkspaceDiagnosticLongPoll
+    using Base: sum
+    include("util.jl")
+    end # module TestWorkspaceDiagnosticLongPoll
+    """
+    util_code_initial = ""
+
+    pkg_setup = function ()
+        pkg_dir = dirname(Pkg.project().path)
+        write(normpath(pkg_dir, "src", "util.jl"), util_code_initial)
+    end
+    withpackage("TestWorkspaceDiagnosticLongPoll", pkg_code; pkg_setup) do pkg_path
+        util_uri = filepath2uri(normpath(pkg_path, "src", "util.jl"))
+        main_path = normpath(pkg_path, "src", "TestWorkspaceDiagnosticLongPoll.jl")
+        main_uri = filepath2uri(main_path)
+        stale_uri = filepath2uri(normpath(pkg_path, "src", "gone.jl"))
+        rootUri = filepath2uri(pkg_path)
+        token = "workspace-diagnostic-long-poll"
+        make_request(id, previousResultIds) = WorkspaceDiagnosticRequest(;
+            id,
+            params = WorkspaceDiagnosticParams(;
+                previousResultIds,
+                partialResultToken = token))
+        function partial_items(messages)
+            items = WorkspaceDocumentDiagnosticReport[]
+            for msg in messages
+                msg isa ProgressNotification || continue
+                @test msg.params.token == token
+                append!(items, msg.params.value.items)
+            end
+            return items
+        end
+        find_response(messages) =
+            only(msg for msg in messages if msg isa WorkspaceDiagnosticResponse)
+        has_unused_import(item) =
+            any(d -> d.code == JETLS.LOWERING_UNUSED_IMPORT_CODE, item.items)
+        withserver(; rootUri) do (; server, writemsg, readmsg, writereadmsg, id_counter)
+            longpoll = server.state.workspace_diagnostic_longpoll
+            let (; raw_res) = writereadmsg(
+                    make_DidOpenTextDocumentNotification(util_uri, util_code_initial);
+                    read = 2)
+                @test all(msg -> msg isa PublishDiagnosticsNotification, raw_res)
+            end
+
+            # Initial pull: main.jl streams as a partial result and the stale id is cleared
+            # with an empty report, so the response follows immediately.
+            local main_id::String
+            let id = id_counter[] += 1
+                (; raw_res) = writereadmsg(make_request(id, PreviousResultId[
+                    PreviousResultId(; uri = stale_uri, value = "stale")]); read = 3)
+                items = partial_items(raw_res)
+                main_item = only(item for item in items if item.uri == main_uri)
+                @test main_item isa WorkspaceFullDocumentDiagnosticReport
+                @test has_unused_import(main_item)
+                main_id = main_item.resultId
+                stale_item = only(item for item in items if item.uri == stale_uri)
+                @test stale_item isa WorkspaceFullDocumentDiagnosticReport
+                @test stale_item.resultId === nothing
+                @test isempty(stale_item.items)
+                response = find_response(raw_res)
+                @test response.id == id
+                @test isempty(response.result.items)
+            end
+
+            # Re-pull with the matching id: nothing to report, so the request is parked.
+            let id = id_counter[] += 1
+                writemsg(make_request(id, PreviousResultId[
+                    PreviousResultId(; uri = main_uri, value = main_id)]))
+                parked = wait_for_parked_workspace_diagnostic(server.state, id)
+                @test !JETLS.is_cancelled(parked.cancel_flag)
+                @test haskey(server.state.currently_handled, id)
+
+                # Editing the synchronized sibling resumes it: `sum` is now used, so main.jl
+                # gets a fresh report and the response follows.
+                writemsg(make_DidChangeTextDocumentNotification(
+                    util_uri, "y = sum([1, 2, 3])\n", #=version=#2); check = false)
+                messages = readmsg(; read = 2).raw_msg
+                main_item = only(partial_items(messages))
+                @test main_item isa WorkspaceFullDocumentDiagnosticReport
+                @test main_item.uri == main_uri
+                @test main_item.resultId != main_id
+                @test !has_unused_import(main_item)
+                response = find_response(messages)
+                @test response.id == id
+                @test isempty(response.result.items)
+                main_id = main_item.resultId
+            end
+
+            # A configuration change resumes a parked request as well: with
+            # `diagnostic.all_files` disabled, main.jl is reported with empty items.
+            let id = id_counter[] += 1
+                writemsg(make_request(id, PreviousResultId[
+                    PreviousResultId(; uri = main_uri, value = main_id)]))
+                wait_for_parked_workspace_diagnostic(server.state, id)
+                settings_off = Dict{String,Any}(
+                    "diagnostic" => Dict{String,Any}("all_files" => false))
+                writemsg(DidChangeConfigurationNotification(;
+                    params = DidChangeConfigurationParams(; settings = settings_off));
+                    check = false)
+                messages = readmsg(; read = 4).raw_msg
+                @test count(msg -> msg isa ShowMessageNotification, messages) == 1
+                @test count(msg -> msg isa PublishDiagnosticsNotification, messages) == 1
+                main_item = only(partial_items(messages))
+                @test main_item isa WorkspaceFullDocumentDiagnosticReport
+                @test main_item.uri == main_uri
+                @test main_item.resultId == JETLS.ALL_FILES_DISABLED_RESULT_ID
+                @test isempty(main_item.items)
+                response = find_response(messages)
+                @test response.id == id
+                main_id = main_item.resultId
+            end
+
+            # A second pull arriving while one is parked supersedes it with an empty report,
+            # and `$/cancelRequest` closes a parked request with `RequestCancelled`.
+            let id1 = id_counter[] += 1
+                writemsg(make_request(id1, PreviousResultId[
+                    PreviousResultId(; uri = main_uri, value = main_id)]))
+                wait_for_parked_workspace_diagnostic(server.state, id1)
+                id2 = id_counter[] += 1
+                writemsg(make_request(id2, PreviousResultId[
+                    PreviousResultId(; uri = main_uri, value = main_id)]); check = false)
+                response = readmsg().raw_msg
+                @test response isa WorkspaceDiagnosticResponse
+                @test response.id == id1
+                @test isempty(response.result.items)
+                wait_for_parked_workspace_diagnostic(server.state, id2)
+
+                writemsg(CancelRequestNotification(; params = CancelParams(; id = id2)); check = false)
+                response = readmsg().raw_msg
+                @test response isa WorkspaceDiagnosticResponse
+                @test response.id == id2
+                @test isnothing(response.result)
+                @test response.error isa ResponseError
+                @test response.error.code == ErrorCodes.RequestCancelled
+                @test (@atomic longpoll.parked) === nothing
+                wait_for_no_handled_requests(server.state)
+            end
+        end
+    end
+
+    # A revision bump landing between the revision check and the `parked` store of
+    # `park_workspace_diagnostic_request!` must still leave a wake token in the queue.
+    let server = JETLS.Server()
+        longpoll = server.state.workspace_diagnostic_longpoll
+        msg = WorkspaceDiagnosticRequest(;
+            id = 1,
+            params = WorkspaceDiagnosticParams(;
+                previousResultIds = PreviousResultId[],
+                partialResultToken = "wake-up-token"))
+        @atomic longpoll.current_id = msg.id
+        cancel_flag = JETLS.CancelFlag(false)
+        function drain_wake_tokens!(queue::Channel)
+            woken = false
+            while isready(queue)
+                woken |= take!(queue) isa JETLS.WorkspaceDiagnosticWakeToken
+            end
+            return woken
+        end
+        lost = 0
+        for _ in 1:500
+            @atomic longpoll.parked = nothing
+            drain_wake_tokens!(server.message_queue)
+            request = JETLS.ParkedWorkspaceDiagnosticRequest(msg, cancel_flag, (@atomic longpoll.revision))
+            park = Threads.@spawn JETLS.park_workspace_diagnostic_request!(server, request)
+            mark = Threads.@spawn JETLS.mark_workspace_diagnostics_changed!(server)
+            wait(park); wait(mark)
+            woken = drain_wake_tokens!(server.message_queue)
+            parked = @atomic longpoll.parked
+            if parked !== nothing && parked.revision != (@atomic longpoll.revision) && !woken
+                lost += 1
+            end
+        end
+        @test lost == 0
+    end
+end
+
 end # module test_diagnostics

--- a/test/test_unsaved_buffer.jl
+++ b/test/test_unsaved_buffer.jl
@@ -36,9 +36,7 @@ function any_entry_for(manager::JETLS.AnalysisManager, uri::URI, field::Symbol)
     return any(entry -> JETLS.entryuri(entry) == uri, keys(dict))
 end
 
-# Disable `diagnostic.all_files` so didClose doesn't emit the empty
-# `PublishDiagnosticsNotification` triggered by `notify_diagnostics!(; ensure_cleared=uri)`.
-# Keeps these tests focused on cleanup state.
+# Exercise diagnostic clearing on close with reporting limited to open files.
 const SETTINGS = Dict{String,Any}(
     "diagnostic" => Dict{String,Any}(
         "all_files" => false,
@@ -68,13 +66,7 @@ const SETTINGS = Dict{String,Any}(
         @test JETLS.entryuri(entry) == untitled_uri
         @test haskey(JETLS.load(manager.analyzed_generations), entry)
 
-        # didClose must publish an empty `PublishDiagnosticsNotification` to
-        # clear the previously published `unused-argument` diagnostic, and
-        # then drop the per-entry analysis state. This exercises the ordering
-        # of `notify_diagnostics!` before `cleanup_analysis_state!` in
-        # `handle_DidCloseTextDocumentNotification`: if `cleanup_analysis_state!`
-        # ran first the clearing notification path in `notify_diagnostics!`
-        # would have nothing to publish under `all_files=false`.
+        # Closing the buffer clears its previously published inference diagnostic.
         let (; raw_res) = writereadmsg(make_DidCloseTextDocumentNotification(untitled_uri))
             @test raw_res isa PublishDiagnosticsNotification
             @test raw_res.params.uri == untitled_uri
@@ -96,6 +88,7 @@ end
         let text = "f(x) = x + 1"
             (; raw_res) = writereadmsg(make_DidOpenTextDocumentNotification(untitled_uri, text))
             @test raw_res isa PublishDiagnosticsNotification
+            @test isempty(raw_res.params.diagnostics)
         end
 
         manager = server.state.analysis_manager
@@ -114,11 +107,12 @@ end
         # didClose must cancel the timer along with the rest of the per-entry
         # state. Without the cancellation the timer would fire 3s later and the
         # original "Unsupported URI" error would surface in the analysis worker.
-        # Note: unlike the first @testset, no clearing `PublishDiagnosticsNotification`
-        # is emitted here because the cached diagnostics for `f(x) = x + 1` are empty,
-        # so the `!isempty(diagnostics)` guard in `notify_diagnostics!`'s suppression
-        # branch (under `all_files=false`) skips the send.
-        writemsg(make_DidCloseTextDocumentNotification(untitled_uri))
+        # An explicit clearing notification is sent even when cached diagnostics are empty.
+        let (; raw_res) = writereadmsg(make_DidCloseTextDocumentNotification(untitled_uri))
+            @test raw_res isa PublishDiagnosticsNotification
+            @test raw_res.params.uri == untitled_uri
+            @test isempty(raw_res.params.diagnostics)
+        end
         wait_for_analysis_uncached(manager, untitled_uri)
 
         @test JETLS.get_analysis_info(manager, untitled_uri) === nothing


### PR DESCRIPTION
Zed and VS Code pull `workspace/diagnostic` on a fixed interval: once the server answers, the next request arrives about two seconds later. JETLS answered every pull immediately, so an idle workspace still paid for a full URI scan, `resultId` computation, and one partial result per unchanged file every two seconds, and changes to unopened files were only picked up on the next poll.

This change makes the handler long-poll in the style of the ty language server. A pull whose scan finds nothing to report (every file unchanged and nothing to clear) is parked in `ServerState.workspace_diagnostic_longpoll` instead of answered. Change points call `mark_workspace_diagnostics_changed!`, which bumps a revision counter and queues a wake-up token; the concurrent message worker then re-runs the parked request, which answers only if something actually changed and parks again otherwise. Both clients re-pull after every answer, so the server never has to track what the client currently holds. The parked request's `CancelFlag` stays in `currently_handled`, so `$/cancelRequest` answers it with `RequestCancelled`, and a new pull arriving while one is parked closes the parked one with an empty report. Requests without a `partialResultToken` are answered immediately as before.

Parking, resumption, cancellation and supersession all run on the concurrent message worker via `message_queue` tokens, so they are serialized against each other. The wake-up token is queued unconditionally: gating it on the parked slot would race with the revision check in `park_workspace_diagnostic_request!` and lose the wake-up. Scans are spaced by `WORKSPACE_DIAGNOSTIC_MIN_INTERVAL`, measured from the end of the previous scan whether it answered or parked, because Zed re-pulls immediately after each answer while the user is typing and every keystroke bumps the revision.

The change points are the existing `request_diagnostic_refresh!` callers (full-analysis results, configuration and watched-file changes, `didClose`), content changes of synchronized files and notebooks, and the intermediate analysis result cached before signature analysis. Pull-diagnostic and code-lens refresh requests now go out at that intermediate point in both the interpreter-based and Revise-based analysis paths rather than after signature analysis, since module contexts are all they need.

Unchanged reports now travel only in the final response instead of one partial result each, and a URI the client still holds a `resultId` for but that no longer yields a report is cleared with an empty report without a `resultId`.