### PR TITLE
diagnostic: Align workspace diagnostic support with `all_files`

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -260,6 +260,13 @@ analysis is usually pretty fast). For `JETLS/save`, full analysis still runs;
 only reporting is suppressed. Disabling this can be useful to reduce noise when
 there are many warnings across the workspace.
 
+Not all clients support live diagnostics for unopened files. Depending on the
+client, changing this setting may require updating
+[`.JETLSConfig.toml`](@ref config/file-based-config) and restarting JETLS.
+Some clients may also retain existing diagnostics after this setting is disabled.
+
+Push-based `JETLS/save` reporting follows setting changes without a restart.
+
 ```toml
 [diagnostic]
 all_files = false  # Disable diagnostics for unopened files

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -386,6 +386,8 @@ function handler_concurrent_message(server::Server, @nospecialize msg)
         park_workspace_diagnostic_request!(server, msg.request)
     elseif msg isa WorkspaceDiagnosticWakeToken
         resume_parked_workspace_diagnostic_request!(server)
+    elseif msg isa DiagnosticRegistrationUpdateToken
+        update_diagnostic_registration!(server)
     # Handle regular messages concurrently
     elseif msg isa Dict{Symbol,Any} # ResponseMessage or untyped message
         request_caller = let id = get(msg, :id, nothing)

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -2452,20 +2452,25 @@ function postprocess_pull_diagnostics(
 end
 
 # Full reports are streamed as partial results when the client offers a token, so they
-# show up while the scan is still running, and they are repeated in the final response.
-# The repetition matters: Zed clears the request token as soon as the response arrives
-# and drops partial results it processes afterwards, which would leave it with stale
-# result ids and make it re-pull until they converge one file per answer. The spec allows
-# reporting the same URI more than once, with the last report winning. Unchanged reports
-# only travel in the final response, so a pull that changes nothing sends nothing before
-# it gets parked.
+# show up while the scan is still running. The spec then requires the final response to
+# carry no result values, so they are not repeated there, except for Zed: it clears the
+# request token as soon as the response arrives and drops partial results it processes
+# afterwards, which would leave it with stale result ids and make it re-pull until they
+# converge one file per answer. Zed applies the same URI reported twice with the last
+# report winning. Unchanged reports only travel in the final response, so a pull that
+# changes nothing sends nothing before it gets parked.
 mutable struct WorkspaceDiagnosticReporter
     const partial_token::Union{Nothing,ProgressToken}
+    const repeat_full_in_response::Bool
     const items::Vector{WorkspaceDocumentDiagnosticReport}
     changed::Bool
 end
-WorkspaceDiagnosticReporter(partial_token::Union{Nothing,ProgressToken}) =
-    WorkspaceDiagnosticReporter(partial_token, WorkspaceDocumentDiagnosticReport[], false)
+function WorkspaceDiagnosticReporter(server::Server, partial_token::Union{Nothing,ProgressToken})
+    repeat_full_in_response = partial_token === nothing ||
+        getobjpath(server.state, :init_params, :clientInfo, :name) ∈ ("Zed", "Zed Dev")
+    return WorkspaceDiagnosticReporter(
+        partial_token, repeat_full_in_response, WorkspaceDocumentDiagnosticReport[], false)
+end
 
 function report_unchanged!(
         reporter::WorkspaceDiagnosticReporter, uri::URI, result_id::String
@@ -2481,7 +2486,7 @@ function report_full!(
         item::WorkspaceFullDocumentDiagnosticReport
     )
     reporter.changed = true
-    push!(reporter.items, item)
+    reporter.repeat_full_in_response && push!(reporter.items, item)
     partial_token = reporter.partial_token
     if partial_token !== nothing
         send_partial_result(server, partial_token,
@@ -2544,7 +2549,7 @@ function send_workspace_diagnostics(
     for prev in msg.params.previousResultIds
         previous_result_ids[prev.uri] = prev.value
     end
-    reporter = WorkspaceDiagnosticReporter(msg.params.partialResultToken)
+    reporter = WorkspaceDiagnosticReporter(server, msg.params.partialResultToken)
     root_path = isdefined(state, :root_path) ? state.root_path : nothing
     result_id_cache = DiagnosticResultIdCache()
     debuginfo = nothing
@@ -2606,7 +2611,7 @@ function send_empty_workspace_diagnostics(
     for prev in msg.params.previousResultIds
         previous_result_ids[prev.uri] = prev.value
     end
-    reporter = WorkspaceDiagnosticReporter(msg.params.partialResultToken)
+    reporter = WorkspaceDiagnosticReporter(server, msg.params.partialResultToken)
     for uri in uris_to_search
         is_cancelled(cancel_flag) &&
             return send_workspace_diagnostic_cancelled(server, msg.id)

--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -2257,15 +2257,16 @@ end
 const DIAGNOSTIC_REGISTRATION_ID = "jetls-diagnostic"
 const DIAGNOSTIC_REGISTRATION_METHOD = "textDocument/diagnostic"
 
-function diagnostic_options()
+function diagnostic_options(workspace_diagnostics::Bool = true)
     return DiagnosticOptions(;
         identifier = "JETLS/diagnostic",
         interFileDependencies = true,
-        workspaceDiagnostics = true)
+        workspaceDiagnostics = workspace_diagnostics)
 end
 
-function diagnostic_registration()
-    (; identifier, interFileDependencies, workspaceDiagnostics) = diagnostic_options()
+function diagnostic_registration(server::Server)
+    (; identifier, interFileDependencies, workspaceDiagnostics) =
+        diagnostic_options(get_config(server, :diagnostic, :all_files))
     return Registration(;
         id = DIAGNOSTIC_REGISTRATION_ID,
         method = DIAGNOSTIC_REGISTRATION_METHOD,
@@ -2277,11 +2278,32 @@ function diagnostic_registration()
     )
 end
 
-# # For dynamic registrations during development
-# unregister(currently_running, Unregistration(;
-#     id = DIAGNOSTIC_REGISTRATION_ID,
-#     method = DIAGNOSTIC_REGISTRATION_METHOD))
-# register(currently_running, diagnostic_registration())
+struct DiagnosticRegistrationUpdateToken end
+
+function update_diagnostic_registration!(
+        server::Server, tracker::ConfigChangeTracker; on_init::Bool = false
+    )
+    supports(server, :textDocument, :diagnostic, :dynamicRegistration) || return nothing
+    load(server.state.config_manager).initialized || return nothing
+    if !on_init && !any(c -> c.path == "diagnostic.all_files", tracker.changed_settings)
+        return nothing
+    end
+    enqueue_message!(server, DiagnosticRegistrationUpdateToken())
+    nothing
+end
+
+# Run the replacement on the message worker so concurrent config handlers cannot
+# interleave unregister/register. Read the current config, not the queued update's value.
+function update_diagnostic_registration!(server::Server)
+    registered = Registered(DIAGNOSTIC_REGISTRATION_ID, DIAGNOSTIC_REGISTRATION_METHOD)
+    if registered in load(server.state.currently_registered)
+        unregister(server, Unregistration(;
+            id = DIAGNOSTIC_REGISTRATION_ID,
+            method = DIAGNOSTIC_REGISTRATION_METHOD))
+    end
+    register(server, diagnostic_registration(server))
+    nothing
+end
 
 function handle_DocumentDiagnosticRequest(
         server::Server, msg::DocumentDiagnosticRequest, cancel_flag::CancelFlag)

--- a/src/did-change-watched-files.jl
+++ b/src/did-change-watched-files.jl
@@ -77,6 +77,7 @@ function handle_config_file_change!(
     source = "[.JETLSConfig.toml] $(dirname(changed_path)) ($kind)"
     notify_config_changes(server, tracker, source)
     apply_auto_instantiate_change!(server)
+    update_diagnostic_registration!(server, tracker)
     if tracker.diagnostic_setting_changed
         clear_per_file_diagnostics_cache!(server.state)
         notify_diagnostics!(server; ensure_cleared = true)

--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -101,6 +101,10 @@ function handle_InitializeRequest(
     if isdefined(state, :root_path)
         config_path = joinpath(state.root_path, ".JETLSConfig.toml")
         load_file_init_options!(server, config_path)
+        # Loaded before the `InitializeResponse` so statically registered capabilities
+        # can reflect file settings; LSP configuration only becomes available after
+        # `InitializedNotification`. Null callback: don't notify initially loaded values.
+        load_file_config!(Returns(nothing), server, config_path)
     end
 
     start_signature_analysis_workers!(server)
@@ -170,9 +174,11 @@ function handle_InitializeRequest(
     end
 
     if supports(server, :textDocument, :diagnostic, :dynamicRegistration)
-        diagnosticProvider = nothing # will be registered dynamically
+        diagnosticProvider = nothing # registered after loading the initial configuration
     else
-        diagnosticProvider = diagnostic_options()
+        # Static clients cannot be re-registered, so only the file configuration
+        # (already loaded above) can disable workspace diagnostics for them.
+        diagnosticProvider = diagnostic_options(get_config(server, :diagnostic, :all_files))
         @static JETLS_DEV_MODE && @info "Registering 'textDocument/diagnostic' with `InitializeResponse`"
     end
 
@@ -364,18 +370,8 @@ function handle_InitializedNotification(server::Server)
 
     isdefined(state, :init_params) || error("Initialization process not completed") # to exit the server loop
 
-    # Load configurations: This needs to be done after the `InitializedNotification` is sent from the client
-    # - Load .JETLSConfig.toml configuration
-    if !isdefined(state, :root_path)
-        @static JETLS_DEV_MODE && @info "`server.state.root_path` is not defined, skip config registration at startup."
-    else
-        config_path = joinpath(state.root_path, ".JETLSConfig.toml")
-        if isfile(config_path)
-            # Null callback: Don't notify even if values different from defaults are loaded initially
-            load_file_config!(Returns(nothing), server, config_path)
-        end
-    end
-    # - Load LSP configuration
+    # Load LSP configuration: This needs to be done after the `InitializedNotification`
+    # is sent from the client (`.JETLSConfig.toml` is loaded in `handle_InitializeRequest`)
     load_lsp_config!(server, nothing, "[LSP] initialize"; on_init=true)
 
     registrations = Registration[]
@@ -458,11 +454,6 @@ function handle_InitializedNotification(server::Server)
         # NOTE If hover's `dynamicRegistration` is not supported,
         # it needs to be registered along with initialization in the `InitializeResponse`,
         # since `HoverRegistrationOptions` does not extend `StaticRegistrationOptions`.
-    end
-
-    if supports(server, :textDocument, :diagnostic, :dynamicRegistration)
-        push!(registrations, diagnostic_registration())
-        @static JETLS_DEV_MODE && @info "Dynamically registering 'textDocument/diagnostic' upon `InitializedNotification`"
     end
 
     if supports(server, :textDocument, :codeLens, :dynamicRegistration)

--- a/src/workspace-configuration.jl
+++ b/src/workspace-configuration.jl
@@ -48,6 +48,11 @@ function handle_workspace_configuration_response(
     else
         show_error_message(server, "Unexpected response from workspace/configuration request")
     end
+    # Complete initialization with existing settings so a failed or empty response
+    # does not leave diagnostics unregistered.
+    if caller.handler.on_init && !load(server.state.config_manager).initialized
+        handle_lsp_config_change!(server, ConfigChangeTracker(), caller.handler.source, true)
+    end
 end
 
 function load_lsp_config!(server::Server, source::AbstractString; on_init::Bool=false)
@@ -116,6 +121,7 @@ function handle_lsp_config_change!(server::Server, tracker::ConfigChangeTracker,
         notify_config_changes(server, tracker, source)
     end
     apply_auto_instantiate_change!(server)
+    update_diagnostic_registration!(server, tracker; on_init)
     if tracker.diagnostic_setting_changed
         clear_per_file_diagnostics_cache!(server.state)
         notify_diagnostics!(server; ensure_cleared = true)

--- a/test/test_diagnostic.jl
+++ b/test/test_diagnostic.jl
@@ -1454,8 +1454,6 @@ end
             end
             return items
         end
-        full_report_keys(items) = Set((item.uri, item.resultId) for item in items
-            if item isa WorkspaceFullDocumentDiagnosticReport)
         find_response(messages) =
             only(msg for msg in messages if msg isa WorkspaceDiagnosticResponse)
         has_unused_import(item) =
@@ -1469,16 +1467,16 @@ end
             end
 
             # Initial pull: main.jl gets a full report and the stale id is cleared with an
-            # empty report. Both are streamed as partial results and repeated in the
-            # response; see `WorkspaceDiagnosticReporter`.
+            # empty report. Both are streamed as partial results only; see
+            # `WorkspaceDiagnosticReporter`.
             local main_id::String
             let id = id_counter[] += 1
                 (; raw_res) = writereadmsg(make_request(id, PreviousResultId[
                     PreviousResultId(; uri = stale_uri, value = "stale")]); read = 3)
                 response = find_response(raw_res)
                 @test response.id == id
-                items = response.result.items
-                @test full_report_keys(partial_items(raw_res)) == full_report_keys(items)
+                @test isempty(response.result.items)
+                items = partial_items(raw_res)
                 main_item = only(item for item in items if item.uri == main_uri)
                 @test main_item isa WorkspaceFullDocumentDiagnosticReport
                 @test has_unused_import(main_item)
@@ -1504,8 +1502,8 @@ end
                 messages = readmsg(; read = 2).raw_msg
                 response = find_response(messages)
                 @test response.id == id
-                main_item = only(response.result.items)
-                @test full_report_keys(partial_items(messages)) == full_report_keys([main_item])
+                @test isempty(response.result.items)
+                main_item = only(partial_items(messages))
                 @test main_item isa WorkspaceFullDocumentDiagnosticReport
                 @test main_item.uri == main_uri
                 @test main_item.resultId != main_id
@@ -1529,8 +1527,8 @@ end
                 @test count(msg -> msg isa PublishDiagnosticsNotification, messages) == 1
                 response = find_response(messages)
                 @test response.id == id
-                main_item = only(response.result.items)
-                @test full_report_keys(partial_items(messages)) == full_report_keys([main_item])
+                @test isempty(response.result.items)
+                main_item = only(partial_items(messages))
                 @test main_item isa WorkspaceFullDocumentDiagnosticReport
                 @test main_item.uri == main_uri
                 @test main_item.resultId == JETLS.ALL_FILES_DISABLED_RESULT_ID

--- a/test/test_registration.jl
+++ b/test/test_registration.jl
@@ -33,4 +33,240 @@ let capabilities = ClientCapabilities(;
     end
 end
 
+function with_diagnostic_registration_server(
+        f;
+        configuration::Bool = true,
+        dynamicRegistration::Bool = true,
+        recorder::JETLS.ServerMessageRecorder = JETLS.ServerMessageRecorder(),
+    )
+    server = Server(; callback=recorder)
+    server.state.workspaceFolders = URI[]
+    server.state.init_params = InitializeParams(;
+        processId = nothing,
+        rootUri = nothing,
+        capabilities = ClientCapabilities(;
+            workspace = WorkspaceClientCapabilities(; configuration),
+            textDocument = TextDocumentClientCapabilities(;
+                diagnostic = DiagnosticClientCapabilities(; dynamicRegistration))))
+    try
+        return f(server, recorder)
+    finally
+        close(server.endpoint)
+    end
+end
+
+function recorded_messages!(recorder::JETLS.ServerMessageRecorder)
+    messages = Any[]
+    while isready(recorder.sent_queue)
+        push!(messages, take!(recorder.sent_queue))
+    end
+    return messages
+end
+
+function diagnostic_requests!(server::Server, recorder::JETLS.ServerMessageRecorder)
+    while isready(server.message_queue)
+        JETLS.handler_concurrent_message(server, take!(server.message_queue))
+    end
+    return filter(recorded_messages!(recorder)) do msg
+        if msg isa RegisterCapabilityRequest
+            return any(r -> r.method == JETLS.DIAGNOSTIC_REGISTRATION_METHOD,
+                msg.params.registrations)
+        elseif msg isa UnregisterCapabilityRequest
+            return any(r -> r.method == JETLS.DIAGNOSTIC_REGISTRATION_METHOD,
+                msg.params.unregisterations)
+        end
+        return false
+    end
+end
+
+function wait_for_recorded_message(recorder::JETLS.ServerMessageRecorder)
+    timedwait(() -> isready(recorder.sent_queue), 10.0) === :ok ||
+        error("Timed out waiting for a server message")
+end
+
+function test_diagnostic_requests(
+        messages::Vector{Any}, all_files::Bool; replacement::Bool=false
+    )
+    @test length(messages) == (replacement ? 2 : 1)
+    registration = only((last(messages)::RegisterCapabilityRequest).params.registrations)
+    if replacement
+        unregistration = only(
+            (first(messages)::UnregisterCapabilityRequest).params.unregisterations)
+        @test unregistration.id == registration.id
+    end
+    @test registration.registerOptions.workspaceDiagnostics === all_files
+    return registration
+end
+
+diagnostic_settings(all_files::Bool) = Dict{String,Any}(
+    "diagnostic" => Dict{String,Any}("all_files" => all_files))
+
+# Runs `initialize` for a client without dynamic diagnostic registration and returns
+# the statically advertised `diagnosticProvider`.
+function static_diagnostic_provider(dir::AbstractString)
+    recorder = JETLS.ServerMessageRecorder()
+    server = Server(; callback=recorder)
+    request = InitializeRequest(;
+        id = 1,
+        params = InitializeParams(;
+            processId = getpid(),
+            capabilities = ClientCapabilities(;
+                textDocument = TextDocumentClientCapabilities(;
+                    diagnostic = DiagnosticClientCapabilities(; dynamicRegistration=false))),
+            rootUri = nothing,
+            workspaceFolders = [WorkspaceFolder(; uri=filepath2uri(dir), name="workspace")]))
+    try
+        JETLS.handle_InitializeRequest(server, request; client_process_id = Int(getpid()))
+        response = only(msg for msg in recorded_messages!(recorder) if msg isa InitializeResponse)
+        return response.result.capabilities.diagnosticProvider
+    finally
+        JETLS.stop_analysis_worker(server)
+        JETLS.stop_signature_analysis_workers(server)
+        close(server.endpoint)
+    end
+end
+
+@testset "diagnostic registration" begin
+    @testset "initial client configuration selects document-only diagnostics" begin
+        with_diagnostic_registration_server() do server, recorder
+            JETLS.handle_InitializedNotification(server)
+            messages = recorded_messages!(recorder)
+            @test all(r.method != JETLS.DIAGNOSTIC_REGISTRATION_METHOD
+                for msg in messages if msg isa RegisterCapabilityRequest
+                for r in msg.params.registrations)
+            request = only(msg for msg in messages if msg isa ConfigurationRequest)
+            caller = JETLS.poprequest!(server, request.id)
+            JETLS.handle_workspace_configuration_response(server,
+                Dict{Symbol,Any}(
+                    :id => request.id,
+                    :result => Any[diagnostic_settings(false)]), caller)
+            registration = test_diagnostic_requests(diagnostic_requests!(server, recorder), false)
+            @test registration.registerOptions.identifier == "JETLS/diagnostic"
+            @test registration.registerOptions.interFileDependencies
+            @test registration.registerOptions.documentSelector == JETLS.DEFAULT_DOCUMENT_SELECTOR
+        end
+    end
+
+    @testset "configuration changes update workspace diagnostics" begin
+        with_diagnostic_registration_server(; configuration=false) do server, recorder
+            JETLS.handle_InitializedNotification(server)
+            test_diagnostic_requests(diagnostic_requests!(server, recorder), true)
+            for all_files in (false, true)
+                JETLS.load_lsp_config!(server, diagnostic_settings(all_files), "test")
+                test_diagnostic_requests(
+                    diagnostic_requests!(server, recorder), all_files; replacement=true)
+            end
+            settings = diagnostic_settings(true)
+            JETLS.load_lsp_config!(server, settings, "test")
+            @test isempty(diagnostic_requests!(server, recorder))
+            settings["diagnostic"]["enabled"] = false
+            JETLS.load_lsp_config!(server, settings, "test")
+            @test isempty(diagnostic_requests!(server, recorder))
+        end
+    end
+
+    @testset "overlapping updates leave the latest configuration registered" begin
+        recorder = JETLS.ServerMessageRecorder(Channel{Any}(Inf), Channel{Any}(0))
+        with_diagnostic_registration_server(; configuration=false, recorder) do server, recorder
+            JETLS.initialize_config!(server.state.config_manager)
+            queue, worker = JETLS.start_concurrent_message_worker(server)
+            updates = Task[]
+            try
+                push!(updates, Threads.@spawn JETLS.update_diagnostic_registration!(
+                    server, JETLS.ConfigChangeTracker(); on_init=true))
+                wait_for_recorded_message(recorder)
+                initial = only((take!(recorder.sent_queue)::RegisterCapabilityRequest).params.registrations)
+                messages = Any[]
+                for all_files in (false, true)
+                    tracker = JETLS.ConfigChangeTracker()
+                    JETLS.store_lsp_config!(
+                        tracker, server, diagnostic_settings(all_files), "test")
+                    push!(updates, Threads.@spawn(
+                        JETLS.update_diagnostic_registration!(server, tracker)))
+                    if !all_files
+                        wait_for_recorded_message(recorder)
+                        push!(messages, take!(recorder.sent_queue))
+                        # Leave the document-only registration's send pending during re-enable.
+                        wait_for_recorded_message(recorder)
+                    end
+                end
+                reader = @async collect(recorder.sent_queue)
+                timedwait(() -> all(istaskdone, updates), 10.0) === :ok || error("Timed out waiting for registration updates")
+                foreach(fetch, updates)
+                put!(queue, nothing)
+                timedwait(() -> istaskdone(worker), 10.0) === :ok || error("Timed out waiting for the message worker")
+                fetch(worker)
+                close(recorder.sent_queue)
+                registrations = Dict(initial.id => initial)
+                append!(messages, fetch(reader))
+                for msg in messages
+                    if msg isa UnregisterCapabilityRequest
+                        for r in msg.params.unregisterations
+                            delete!(registrations, r.id)
+                        end
+                    elseif msg isa RegisterCapabilityRequest
+                        for r in msg.params.registrations
+                            registrations[r.id] = r
+                        end
+                    end
+                end
+                registration = only(values(registrations))
+                @test registration.registerOptions.workspaceDiagnostics ===
+                    JETLS.get_config(server, :diagnostic, :all_files)
+            finally
+                close(recorder.sent_queue)
+                put!(queue, nothing)
+                @test timedwait(() -> istaskdone(worker) && all(istaskdone, updates), 10.0) === :ok
+                close(queue)
+            end
+        end
+    end
+
+    @testset "file configuration initialization and updates" begin
+        mktempdir() do dir
+            config_path = joinpath(dir, JETLS.CONFIG_FILE)
+            write(config_path, "[diagnostic]\nall_files = false\n")
+            with_diagnostic_registration_server(; configuration=false) do server, recorder
+                server.state.root_path = dir
+                JETLS.load_file_config!(Returns(nothing), server, config_path)
+                JETLS.handle_InitializedNotification(server)
+                test_diagnostic_requests(diagnostic_requests!(server, recorder), false)
+                write(config_path, "[diagnostic]\nall_files = true\n")
+                JETLS.handle_config_file_change!(server, config_path, FileChangeType.Changed)
+                test_diagnostic_requests(diagnostic_requests!(server, recorder), true; replacement=true)
+            end
+        end
+    end
+
+    @testset "static clients follow the file configuration at startup" begin
+        @test JETLS.diagnostic_options().workspaceDiagnostics
+        mktempdir() do dir
+            @test static_diagnostic_provider(dir).workspaceDiagnostics
+            write(joinpath(dir, JETLS.CONFIG_FILE), "[diagnostic]\nall_files = false\n")
+            @test !static_diagnostic_provider(dir).workspaceDiagnostics
+        end
+        with_diagnostic_registration_server(;
+            dynamicRegistration=false, configuration=false) do server, recorder
+            JETLS.handle_InitializedNotification(server)
+            @test isempty(diagnostic_requests!(server, recorder))
+            JETLS.load_lsp_config!(server, diagnostic_settings(false), "test")
+            @test isempty(diagnostic_requests!(server, recorder))
+        end
+    end
+
+    @testset "configuration failure does not disable diagnostics" begin
+        with_diagnostic_registration_server() do server, recorder
+            JETLS.handle_InitializedNotification(server)
+            request = only(msg for msg in recorded_messages!(recorder) if msg isa ConfigurationRequest)
+            response = Dict{Symbol,Any}(
+                :id => request.id,
+                :error => Dict{String,Any}(
+                    "code" => -32603, "message" => "unavailable"))
+            caller = JETLS.poprequest!(server, request.id)
+            JETLS.handle_workspace_configuration_response(server, response, caller)
+            test_diagnostic_requests(diagnostic_requests!(server, recorder), true)
+        end
+    end
+end
+
 end # module test_registration


### PR DESCRIPTION
Clients can retain pull diagnostics after `didClose` when `diagnostic.all_files=false` but workspace diagnostic support remains advertised. Repeated empty reports would keep workspace pulls from becoming idle instead of fixing the client-side retention policy.

JETLS now matches `workspaceDiagnostics` to the effective `all_files` setting. Dynamic registration waits for initial configuration loading, and setting changes replace the fixed-ID registration on the message worker so concurrent configuration handlers cannot interleave updates. An initial configuration error or empty response completes registration with the existing settings.

File configuration is loaded before `InitializeResponse` so clients without dynamic registration can also start without workspace pulls. Their capability is fixed from `.JETLSConfig.toml` at startup: changing it requires updating that file and restarting the server. Push-based diagnostic reporting still follows runtime configuration changes.

The registration, configuration, and full lifecycle tests pass.