### PR TITLE
diagnostic: Repeat streamed workspace reports only for Zed

### DIFF
--- a/src/diagnostic.jl
+++ b/src/diagnostic.jl
@@ -2452,20 +2452,25 @@ function postprocess_pull_diagnostics(
 end
 
 # Full reports are streamed as partial results when the client offers a token, so they
-# show up while the scan is still running, and they are repeated in the final response.
-# The repetition matters: Zed clears the request token as soon as the response arrives
-# and drops partial results it processes afterwards, which would leave it with stale
-# result ids and make it re-pull until they converge one file per answer. The spec allows
-# reporting the same URI more than once, with the last report winning. Unchanged reports
-# only travel in the final response, so a pull that changes nothing sends nothing before
-# it gets parked.
+# show up while the scan is still running. The spec then requires the final response to
+# carry no result values, so they are not repeated there, except for Zed: it clears the
+# request token as soon as the response arrives and drops partial results it processes
+# afterwards, which would leave it with stale result ids and make it re-pull until they
+# converge one file per answer. Zed applies the same URI reported twice with the last
+# report winning. Unchanged reports only travel in the final response, so a pull that
+# changes nothing sends nothing before it gets parked.
 mutable struct WorkspaceDiagnosticReporter
     const partial_token::Union{Nothing,ProgressToken}
+    const repeat_full_in_response::Bool
     const items::Vector{WorkspaceDocumentDiagnosticReport}
     changed::Bool
 end
-WorkspaceDiagnosticReporter(partial_token::Union{Nothing,ProgressToken}) =
-    WorkspaceDiagnosticReporter(partial_token, WorkspaceDocumentDiagnosticReport[], false)
+function WorkspaceDiagnosticReporter(server::Server, partial_token::Union{Nothing,ProgressToken})
+    repeat_full_in_response = partial_token === nothing ||
+        getobjpath(server.state, :init_params, :clientInfo, :name) ∈ ("Zed", "Zed Dev")
+    return WorkspaceDiagnosticReporter(
+        partial_token, repeat_full_in_response, WorkspaceDocumentDiagnosticReport[], false)
+end
 
 function report_unchanged!(
         reporter::WorkspaceDiagnosticReporter, uri::URI, result_id::String
@@ -2481,7 +2486,7 @@ function report_full!(
         item::WorkspaceFullDocumentDiagnosticReport
     )
     reporter.changed = true
-    push!(reporter.items, item)
+    reporter.repeat_full_in_response && push!(reporter.items, item)
     partial_token = reporter.partial_token
     if partial_token !== nothing
         send_partial_result(server, partial_token,
@@ -2544,7 +2549,7 @@ function send_workspace_diagnostics(
     for prev in msg.params.previousResultIds
         previous_result_ids[prev.uri] = prev.value
     end
-    reporter = WorkspaceDiagnosticReporter(msg.params.partialResultToken)
+    reporter = WorkspaceDiagnosticReporter(server, msg.params.partialResultToken)
     root_path = isdefined(state, :root_path) ? state.root_path : nothing
     result_id_cache = DiagnosticResultIdCache()
     debuginfo = nothing
@@ -2606,7 +2611,7 @@ function send_empty_workspace_diagnostics(
     for prev in msg.params.previousResultIds
         previous_result_ids[prev.uri] = prev.value
     end
-    reporter = WorkspaceDiagnosticReporter(msg.params.partialResultToken)
+    reporter = WorkspaceDiagnosticReporter(server, msg.params.partialResultToken)
     for uri in uris_to_search
         is_cancelled(cancel_flag) &&
             return send_workspace_diagnostic_cancelled(server, msg.id)

--- a/test/test_diagnostic.jl
+++ b/test/test_diagnostic.jl
@@ -1454,8 +1454,6 @@ end
             end
             return items
         end
-        full_report_keys(items) = Set((item.uri, item.resultId) for item in items
-            if item isa WorkspaceFullDocumentDiagnosticReport)
         find_response(messages) =
             only(msg for msg in messages if msg isa WorkspaceDiagnosticResponse)
         has_unused_import(item) =
@@ -1469,16 +1467,16 @@ end
             end
 
             # Initial pull: main.jl gets a full report and the stale id is cleared with an
-            # empty report. Both are streamed as partial results and repeated in the
-            # response; see `WorkspaceDiagnosticReporter`.
+            # empty report. Both are streamed as partial results only; see
+            # `WorkspaceDiagnosticReporter`.
             local main_id::String
             let id = id_counter[] += 1
                 (; raw_res) = writereadmsg(make_request(id, PreviousResultId[
                     PreviousResultId(; uri = stale_uri, value = "stale")]); read = 3)
                 response = find_response(raw_res)
                 @test response.id == id
-                items = response.result.items
-                @test full_report_keys(partial_items(raw_res)) == full_report_keys(items)
+                @test isempty(response.result.items)
+                items = partial_items(raw_res)
                 main_item = only(item for item in items if item.uri == main_uri)
                 @test main_item isa WorkspaceFullDocumentDiagnosticReport
                 @test has_unused_import(main_item)
@@ -1504,8 +1502,8 @@ end
                 messages = readmsg(; read = 2).raw_msg
                 response = find_response(messages)
                 @test response.id == id
-                main_item = only(response.result.items)
-                @test full_report_keys(partial_items(messages)) == full_report_keys([main_item])
+                @test isempty(response.result.items)
+                main_item = only(partial_items(messages))
                 @test main_item isa WorkspaceFullDocumentDiagnosticReport
                 @test main_item.uri == main_uri
                 @test main_item.resultId != main_id
@@ -1529,8 +1527,8 @@ end
                 @test count(msg -> msg isa PublishDiagnosticsNotification, messages) == 1
                 response = find_response(messages)
                 @test response.id == id
-                main_item = only(response.result.items)
-                @test full_report_keys(partial_items(messages)) == full_report_keys([main_item])
+                @test isempty(response.result.items)
+                main_item = only(partial_items(messages))
                 @test main_item isa WorkspaceFullDocumentDiagnosticReport
                 @test main_item.uri == main_uri
                 @test main_item.resultId == JETLS.ALL_FILES_DISABLED_RESULT_ID


### PR DESCRIPTION
`workspace/diagnostic` streams Full reports as partial results and then repeated them in the final response for every client. The LSP partial-result contract requires the final response to carry no result values once partial results are used, so this deviated from the spec everywhere, while the repetition only exists to work around Zed: it dispatches responses ahead of earlier-queued `$/progress` notifications and clears the request token as soon as the response arrives, so partial results processed afterwards are dropped. Without the repetition Zed keeps stale result ids and re-pulls until they converge one file per answer.

`WorkspaceDiagnosticReporter` now takes the `Server` and records `repeat_full_in_response`, which is true when the client offered no partial-result token or when `clientInfo.name` is `"Zed"` or `"Zed Dev"`, matching the client detection used for completions. `report_full!` pushes into the response items only in that case; partial-result streaming itself is unchanged.

Unchanged reports still travel in the final response for every client. The Zed-side fix that delivers responses through the same ordered queue as notifications exists only in a local Zed branch so far; once it ships, this special case can be removed. The "workspace/diagnostic long-polling" test now reads Full reports from the partial results and asserts that the final response is empty.