### PR TITLE
deps: Update Compiler snapshots

### DIFF
--- a/Compiler/snapshots.toml
+++ b/Compiler/snapshots.toml
@@ -3,13 +3,13 @@ repository = "https://github.com/JuliaLang/julia.git"
 subdir = "Compiler"
 
 [snapshots."1.12"]
-commit = "4772d66f0fcfbd5bdb350398a913353250718241"
-source-branch = "avi/JETLS-Compiler-head-v1.12-2026-09-01"
+commit = "6d7250ae04fd2f9ee943b576fa63596beacc72cf"
+source-branch = "avi/JETLS-Compiler-head-v1.12-2026-09-11"
 runtime = { lower = "1.12.2", upper = "1.13-" }
 destination = "snapshots/v1.12"
 
 [snapshots."1.13"]
-commit = "dfbaee4f4b1f134d8c0312405ef9086ad3a28f3f"
-source-branch = "avi/JETLS-Compiler-head-v1.13-2026-09-02"
+commit = "6cfdf95353dec6f7326038d5bb3b4b67977323ca"
+source-branch = "avi/JETLS-Compiler-head-v1.13-2026-09-11"
 runtime = { lower = "1.13-", upper = "1.14-" }
 destination = "snapshots/v1.13"

--- a/Compiler/snapshots/v1.12/src/optimize.jl
+++ b/Compiler/snapshots/v1.12/src/optimize.jl
@@ -143,16 +143,46 @@ struct InliningState{Interp<:AbstractInterpreter}
     edges::Vector{Any}
     world::UInt
     interp::Interp
+    opt_cache::IdDict{MethodInstance,CodeInstance}
 end
-function InliningState(sv::InferenceState, interp::AbstractInterpreter)
-    return InliningState(sv.edges, frame_world(sv), interp)
+function InliningState(sv::InferenceState, interp::AbstractInterpreter,
+                       opt_cache::IdDict{MethodInstance,CodeInstance}=IdDict{MethodInstance,CodeInstance}())
+    return InliningState(sv.edges, frame_world(sv), interp, opt_cache)
 end
-function InliningState(interp::AbstractInterpreter)
-    return InliningState(Any[], get_inference_world(interp), interp)
+function InliningState(interp::AbstractInterpreter,
+                       opt_cache::IdDict{MethodInstance,CodeInstance}=IdDict{MethodInstance,CodeInstance}())
+    return InliningState(Any[], get_inference_world(interp), interp, opt_cache)
+end
+
+struct OptimizerCache{CodeCache}
+    wvc::WorldView{CodeCache}
+    owner
+    opt_cache::IdDict{MethodInstance,CodeInstance}
+    function OptimizerCache(
+        wvc::WorldView{CodeCache},
+        @nospecialize(owner),
+        opt_cache::IdDict{MethodInstance,CodeInstance}) where CodeCache
+        new{CodeCache}(wvc, owner, opt_cache)
+    end
+end
+function get((; wvc, owner, opt_cache)::OptimizerCache, mi::MethodInstance, default)
+    if haskey(opt_cache, mi)
+        codeinst = opt_cache[mi]
+        @assert codeinst.min_world ≤ wvc.worlds.min_world &&
+                wvc.worlds.max_world ≤ codeinst.max_world &&
+                codeinst.owner === owner
+        @assert isdefined(codeinst, :inferred) && codeinst.inferred === nothing
+        return codeinst
+    end
+    return get(wvc, mi, default)
 end
 
 # get `code_cache(::AbstractInterpreter)` from `state::InliningState`
-code_cache(state::InliningState) = WorldView(code_cache(state.interp), state.world)
+function code_cache(state::InliningState)
+    cache = WorldView(code_cache(state.interp), state.world)
+    owner = cache_owner(state.interp)
+    return OptimizerCache(cache, owner, state.opt_cache)
+end
 
 mutable struct OptimizationState{Interp<:AbstractInterpreter}
     linfo::MethodInstance
@@ -168,13 +198,15 @@ mutable struct OptimizationState{Interp<:AbstractInterpreter}
     bb_vartables::Vector{Union{Nothing,VarTable}}
     insert_coverage::Bool
 end
-function OptimizationState(sv::InferenceState, interp::AbstractInterpreter)
-    inlining = InliningState(sv, interp)
+function OptimizationState(sv::InferenceState, interp::AbstractInterpreter,
+                           opt_cache::IdDict{MethodInstance,CodeInstance}=IdDict{MethodInstance,CodeInstance}())
+    inlining = InliningState(sv, interp, opt_cache)
     return OptimizationState(sv.linfo, sv.src, nothing, sv.stmt_info, sv.mod,
                              sv.sptypes, sv.slottypes, inlining, sv.cfg,
                              sv.unreachable, sv.bb_vartables, sv.insert_coverage)
 end
-function OptimizationState(mi::MethodInstance, src::CodeInfo, interp::AbstractInterpreter)
+function OptimizationState(mi::MethodInstance, src::CodeInfo, interp::AbstractInterpreter,
+                           opt_cache::IdDict{MethodInstance,CodeInstance}=IdDict{MethodInstance,CodeInstance}())
     # prepare src for running optimization passes if it isn't already
     nssavalues = src.ssavaluetypes
     if nssavalues isa Int
@@ -194,7 +226,7 @@ function OptimizationState(mi::MethodInstance, src::CodeInfo, interp::AbstractIn
     mod = isa(def, Method) ? def.module : def
     # Allow using the global MI cache, but don't track edges.
     # This method is mostly used for unit testing the optimizer
-    inlining = InliningState(interp)
+    inlining = InliningState(interp, opt_cache)
     cfg = compute_basic_blocks(src.code)
     unreachable = BitSet()
     bb_vartables = Union{VarTable,Nothing}[]

--- a/Compiler/snapshots/v1.12/src/typeinfer.jl
+++ b/Compiler/snapshots/v1.12/src/typeinfer.jl
@@ -105,6 +105,7 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState, validation
     #@assert last(result.valid_worlds) <= get_world_counter() || isempty(caller.edges)
     if isdefined(result, :ci)
         ci = result.ci
+        mi = result.linfo
         # if we aren't cached, we don't need this edge
         # but our caller might, so let's just make it anyways
         if last(result.valid_worlds) >= validation_world
@@ -127,7 +128,7 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState, validation
                 end
                 di = inferred_result.debuginfo
                 uncompressed = inferred_result
-                inferred_result = maybe_compress_codeinfo(interp, result.linfo, inferred_result)
+                inferred_result = maybe_compress_codeinfo(interp, mi, inferred_result)
                 result.is_src_volatile = false
             elseif ci.owner === nothing
                 # The global cache can only handle objects that codegen understands
@@ -135,14 +136,19 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState, validation
             end
         end
         if !@isdefined di
-            di = DebugInfo(result.linfo)
+            di = DebugInfo(mi)
         end
+        min_world, max_world = first(result.valid_worlds), last(result.valid_worlds)
+        ipo_effects = encode_effects(result.ipo_effects)
         time_now = _time_ns()
         time_self_ns = caller.time_self_ns + (time_now - time_before)
         time_total = (time_now - caller.time_start - caller.time_paused) * 1e-9
         ccall(:jl_update_codeinst, Cvoid, (Any, Any, Int32, UInt, UInt, UInt32, Any, Float64, Float64, Float64, Any, Any),
-            ci, inferred_result, const_flag, first(result.valid_worlds), last(result.valid_worlds), encode_effects(result.ipo_effects),
+            ci, inferred_result, const_flag, min_world, max_world, ipo_effects,
             result.analysis_results, time_total, caller.time_caches, time_self_ns * 1e-9, di, edges)
+        if is_cached(caller) # CACHE_MODE_GLOBAL
+            cache_result!(interp, result, ci)
+        end
         engine_reject(interp, ci)
         codegen = codegen_cache(interp)
         if !discard_src && codegen !== nothing && uncompressed isa CodeInfo
@@ -152,7 +158,6 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState, validation
                 # This is necessary to get decent bootstrapping performance
                 # when compiling the compiler to inject everything eagerly
                 # where codegen can start finding and using it right away
-                mi = result.linfo
                 if mi.def isa Method && isa_compileable_sig(mi) && is_cached(caller)
                     ccall(:jl_add_codeinst_to_jit, Cvoid, (Any, Any), ci, uncompressed)
                 end
@@ -160,6 +165,11 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState, validation
         end
     end
     return nothing
+end
+
+function cache_result!(interp::AbstractInterpreter, result::InferenceResult, ci::CodeInstance)
+    mi = result.linfo
+    code_cache(interp)[mi] = ci
 end
 
 function finish!(interp::AbstractInterpreter, mi::MethodInstance, ci::CodeInstance, src::CodeInfo)
@@ -196,11 +206,13 @@ function finish!(interp::AbstractInterpreter, mi::MethodInstance, ci::CodeInstan
 end
 
 function finish_nocycle(::AbstractInterpreter, frame::InferenceState, time_before::UInt64)
-    finishinfer!(frame, frame.interp, frame.cycleid)
+    opt_cache = IdDict{MethodInstance,CodeInstance}()
+    finishinfer!(frame, frame.interp, frame.cycleid, opt_cache)
     opt = frame.result.src
     if opt isa OptimizationState # implies `may_optimize(caller.interp) === true`
         optimize(frame.interp, opt, frame.result)
     end
+    empty!(opt_cache)
     validation_world = get_world_counter()
     finish!(frame.interp, frame, validation_world, time_before)
     if isdefined(frame.result, :ci)
@@ -230,10 +242,11 @@ function finish_cycle(::AbstractInterpreter, frames::Vector{AbsIntState}, cyclei
         cycle_valid_worlds = intersect(cycle_valid_worlds, caller.world.valid_worlds)
         cycle_valid_effects = merge_effects(cycle_valid_effects, caller.ipo_effects)
     end
+    opt_cache = IdDict{MethodInstance,CodeInstance}()
     for frameid = cycleid:length(frames)
         caller = frames[frameid]::InferenceState
         adjust_cycle_frame!(caller, cycle_valid_worlds, cycle_valid_effects)
-        finishinfer!(caller, caller.interp, cycleid)
+        finishinfer!(caller, caller.interp, cycleid, opt_cache)
         time_now = _time_ns()
         caller.time_self_ns += (time_now - time_before)
         time_before = time_now
@@ -254,6 +267,7 @@ function finish_cycle(::AbstractInterpreter, frames::Vector{AbsIntState}, cyclei
         caller.time_paused = UInt64(0)
         caller.time_caches = 0.0
     end
+    empty!(opt_cache)
     cycletop = frames[cycleid]::InferenceState
     time_start = cycletop.time_start
     validation_world = get_world_counter()
@@ -317,22 +331,6 @@ function maybe_compress_codeinfo(interp::AbstractInterpreter, mi::MethodInstance
     else
         return nothing
     end
-end
-
-function cache_result!(interp::AbstractInterpreter, result::InferenceResult, ci::CodeInstance)
-    @assert isdefined(ci, :inferred)
-    # check if the existing linfo metadata is also sufficient to describe the current inference result
-    # to decide if it is worth caching this right now
-    mi = result.linfo
-    cache = WorldView(code_cache(interp), result.valid_worlds)
-    if haskey(cache, mi)
-        ci = cache[mi]
-        # n.b.: accurate edge representation might cause the CodeInstance for this to be constructed later
-        @assert isdefined(ci, :inferred)
-        return false
-    end
-    code_cache(interp)[mi] = ci
-    return true
 end
 
 function cycle_fix_limited(@nospecialize(typ), sv::InferenceState, cycleid::Int)
@@ -464,7 +462,8 @@ const empty_edges = Core.svec()
 
 # inference completed on `me`
 # update the MethodInstance
-function finishinfer!(me::InferenceState, interp::AbstractInterpreter, cycleid::Int)
+function finishinfer!(me::InferenceState, interp::AbstractInterpreter, cycleid::Int,
+                      opt_cache::IdDict{MethodInstance, CodeInstance})
     # prepare to run optimization passes on fulltree
     @assert isempty(me.ip)
     # inspect whether our inference had a limited result accuracy,
@@ -522,7 +521,7 @@ function finishinfer!(me::InferenceState, interp::AbstractInterpreter, cycleid::
                 # disable optimization if we've already obtained very accurate result
                 !result_is_constabi(interp, result)
         if doopt
-            result.src = OptimizationState(me, interp)
+            result.src = OptimizationState(me, interp, opt_cache)
         else
             result.src = me.src # for reflection etc.
         end
@@ -557,21 +556,38 @@ function finishinfer!(me::InferenceState, interp::AbstractInterpreter, cycleid::
             rettype_const = nothing
             const_flags = 0x0
         end
+
         di = nothing
         edges = empty_edges # `edges` will be updated within `finish!`
         ci = result.ci
+        min_world, max_world = first(result.valid_worlds), last(result.valid_worlds)
         ccall(:jl_fill_codeinst, Cvoid, (Any, Any, Any, Any, Int32, UInt, UInt, UInt32, Any, Any, Any),
             ci, widenconst(result_type), widenconst(result.exc_result), rettype_const, const_flags,
-            first(result.valid_worlds), last(result.valid_worlds),
+            min_world, max_world,
             encode_effects(result.ipo_effects), result.analysis_results, di, edges)
         if is_cached(me) # CACHE_MODE_GLOBAL
-            cached_result = cache_result!(me.interp, result, ci)
-            if !cached_result
+            already_cached = is_already_cached(me.interp, result, ci)
+            if already_cached
                 me.cache_mode = CACHE_MODE_VOLATILE
+            else
+                opt_cache[result.linfo] = ci
             end
         end
     end
     nothing
+end
+
+function is_already_cached(interp::AbstractInterpreter, result::InferenceResult, ci::CodeInstance)
+    # check if the existing linfo metadata is also sufficient to describe the current inference result
+    # to decide if it is worth caching this right now
+    mi = result.linfo
+    cache = WorldView(code_cache(interp), result.valid_worlds)
+    if haskey(cache, mi)
+        # n.b.: accurate edge representation might cause the CodeInstance for this to be constructed later
+        @assert isdefined(cache[mi], :inferred)
+        return true
+    end
+    return false
 end
 
 # Iterate a series of back-edges that need registering, based on the provided forward edge list.
@@ -1350,7 +1366,7 @@ function collectinvokes!(workqueue::CompilationQueue, ci::CodeInfo, sptypes::Vec
             !applicable(argextype, farg, ci, sptypes) && continue # TODO: Why is this failing during bootstrap
             ftyp = widenconst(argextype(farg, ci, sptypes))
 
-            if ftyp === typeof(Core.finalizer) && length(stmt.args) == 3
+            if ftyp === typeof(Core.finalizer) && 3 <= length(stmt.args) <= 5
                 finalizer = argextype(stmt.args[2], ci, sptypes)
                 obj = argextype(stmt.args[3], ci, sptypes)
                 atype = argtypes_to_type(Any[finalizer, obj])

--- a/Compiler/snapshots/v1.12/src/verifytrim.jl
+++ b/Compiler/snapshots/v1.12/src/verifytrim.jl
@@ -219,7 +219,7 @@ function verify_codeinstance!(interp::NativeInterpreter, codeinst::CodeInstance,
                         end
                     end
                 elseif Core.finalizer isa ftyp
-                    if length(stmt.args) == 3
+                    if 3 <= length(stmt.args) <= 5
                         finalizer = argextype(stmt.args[2], codeinfo, sptypes)
                         obj = argextype(stmt.args[3], codeinfo, sptypes)
                         atype = argtypes_to_type(Any[finalizer, obj])
@@ -229,9 +229,8 @@ function verify_codeinstance!(interp::NativeInterpreter, codeinst::CodeInstance,
                             ci = get(caches, mi, nothing)
                             ci isa CodeInstance && continue
                         end
-
-                        error = "unresolved finalizer registered"
                     end
+                    error = "unresolved finalizer registered"
                 elseif Core._apply isa ftyp
                     error = "trim verification not yet implemented for builtin `Core._apply`"
                 elseif Core._call_in_world_total isa ftyp

--- a/Compiler/snapshots/v1.13/src/reinfer.jl
+++ b/Compiler/snapshots/v1.13/src/reinfer.jl
@@ -578,11 +578,6 @@ function verify_call(@nospecialize(sig), expecteds::Core.SimpleVector, i::Int, n
         empty!(matches)
         maxworld[] = 0
     else
-        # FIXME: the edge format does not encode whether or not this ambiguity was accounted
-        # for in inference / optimizer / etc. so we are forced to invalidate conservatively.
-        if has_ambig[] != 0
-            maxworld[] = 0
-        end
         # setdiff!(result, expected)
         if length(result) ≠ n
             maxworld[] = 0

--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
 Compiler = {path = "Compiler"}
-JET = {rev = "b955cc5057", url = "https://github.com/aviatesk/JET.jl"}
+JET = {rev = "538fd4e763", url = "https://github.com/aviatesk/JET.jl"}
 JuliaLowering = {rev = "537a4c16f1", subdir = "JuliaLowering", url = "https://github.com/JuliaLang/julia"}
 JuliaSyntax = {rev = "537a4c16f1", subdir = "JuliaSyntax", url = "https://github.com/JuliaLang/julia"}
 LSP = {path = "LSP"}

--- a/src/analysis/TypeAnnotation.jl
+++ b/src/analysis/TypeAnnotation.jl
@@ -855,7 +855,6 @@ function finish_type_annotation!(frame::CC.InferenceState, interp::ASTTypeAnnota
     return nothing
 end
 
-@static if VERSION ≥ v"1.13.0-DEV.565"
 function CC.finishinfer!(
         frame::CC.InferenceState, interp::ASTTypeAnnotator, cycleid::Int,
         opt_cache::IdDict{Core.MethodInstance,Core.CodeInstance}
@@ -865,14 +864,6 @@ function CC.finishinfer!(
         opt_cache::IdDict{Core.MethodInstance,Core.CodeInstance})
     finish_type_annotation!(frame, interp)
     return ret
-end
-else
-function CC.finishinfer!(frame::CC.InferenceState, interp::ASTTypeAnnotator, cycleid::Int)
-    ret = @invoke CC.finishinfer!(
-        frame::CC.InferenceState, interp::CC.AbstractInterpreter, cycleid::Int)
-    finish_type_annotation!(frame, interp)
-    return ret
-end
 end
 
 # The pending `def` entry marks the dynamic extent of the eager `check=false`


### PR DESCRIPTION
Compiler snapshot updates backport the four-argument `finishinfer!` API to Julia 1.12. The runtime-version guard would then bypass the `ASTTypeAnnotator` completion hook and leave type annotations empty.

This change refreshes the Julia 1.12 and 1.13 snapshots and uses the four-argument hook unconditionally, matching both pinned APIs.