### PR TITLE
lsp: Add structural `==`/`hash` for `Diagnostic` and `Location`

### DIFF
--- a/src/declaration.jl
+++ b/src/declaration.jl
@@ -97,7 +97,7 @@ function find_global_binding_declarations(
     )
     state = server.state
     uris_to_search = collect_search_uris(server, uri)
-    seen_locations = Set{Tuple{URI,Range}}()
+    seen_locations = Set{Location}()
     for search_uri in uris_to_search
         fi = @something begin
             get_file_info(state, search_uri)
@@ -108,14 +108,10 @@ function find_global_binding_declarations(
             occurrence.kind === :decl || continue
             range, adjusted_uri =
                 unadjust_range(state, search_uri, jsobj_to_range(occurrence.tree, fi))
-            push!(seen_locations, (adjusted_uri, range))
+            push!(seen_locations, Location(; uri = adjusted_uri, range))
         end
     end
-    locations = Location[]
-    for (loc_uri, range) in seen_locations
-        push!(locations, Location(; uri = loc_uri, range))
-    end
-    return locations
+    return collect(seen_locations)
 end
 
 function find_local_binding_declarations(
@@ -125,15 +121,13 @@ function find_local_binding_declarations(
     locations = Location[]
     binding_occurrences = compute_binding_occurrences(ctx3, st3, world)
     haskey(binding_occurrences, binfo) || return locations
-    seen_locations = Set{Tuple{URI,Range}}()
+    seen_locations = Set{Location}()
     for occurrence in binding_occurrences[binfo]
         occurrence.kind === :decl || continue
         range, adjusted_uri =
             unadjust_range(state, uri, jsobj_to_range(occurrence.tree, fi))
-        push!(seen_locations, (adjusted_uri, range))
+        push!(seen_locations, Location(; uri = adjusted_uri, range))
     end
-    for (loc_uri, range) in seen_locations
-        push!(locations, Location(; uri = loc_uri, range))
-    end
+    append!(locations, seen_locations)
     return locations
 end

--- a/src/definition.jl
+++ b/src/definition.jl
@@ -280,7 +280,7 @@ function find_global_binding_definitions(
     locations = Location[]
     state = server.state
     uris_to_search = collect_search_uris(server, uri)
-    seen_locations = Set{Tuple{URI,Range}}()
+    seen_locations = Set{Location}()
     for search_uri in uris_to_search
         fi = @something begin
             get_file_info(state, search_uri)
@@ -290,13 +290,11 @@ function find_global_binding_definitions(
         for occurrence in find_global_binding_occurrences!(state, search_uri, fi, binfo)
             if is_definition_occurrence(occurrence)
                 range, adjusted_uri = unadjust_range(state, search_uri, jsobj_to_range(occurrence.tree, fi))
-                push!(seen_locations, (adjusted_uri, range))
+                push!(seen_locations, Location(; uri = adjusted_uri, range))
             end
         end
     end
-    for (loc_uri, range) in seen_locations
-        push!(locations, Location(; uri = loc_uri, range))
-    end
+    append!(locations, seen_locations)
     return locations
 end
 

--- a/src/references.jl
+++ b/src/references.jl
@@ -115,7 +115,7 @@ function find_global_references!(
         send_progress(server, token,
             WorkDoneProgressBegin(; title = "Finding references", cancellable = true, percentage = 0))
     end
-    seen_locations = Set{Tuple{URI,Range}}()
+    seen_locations = Set{Location}()
     local completed = errored = false
     try
         completed = collect_global_references!(
@@ -138,14 +138,12 @@ function find_global_references!(
     elseif !completed
         return request_cancelled_error("find_global_references! cancelled")
     end
-    for (loc_uri, range) in seen_locations
-        push!(locations, Location(; uri = loc_uri, range))
-    end
+    append!(locations, seen_locations)
     return nothing
 end
 
 function collect_global_references!(
-        seen_locations::Set{Tuple{URI,Range}}, server::Server,
+        seen_locations::Set{Location}, server::Server,
         uris_to_search::Set{URI}, binfo::JL.BindingInfo;
         include_declaration::Bool = true,
         token::Union{Nothing,ProgressToken} = nothing,
@@ -178,14 +176,14 @@ function collect_global_references!(
 end
 
 function global_find_references_in_file!(
-        seen_locations::Set{Tuple{URI,Range}}, state::ServerState, uri::URI, fi::FileInfo,
+        seen_locations::Set{Location}, state::ServerState, uri::URI, fi::FileInfo,
         binfo::JL.BindingInfo;
         include_declaration::Bool = true,
     )
     for occurrence in find_global_binding_occurrences!(state, uri, fi, binfo)
         if include_declaration || occurrence.kind === :use
             range, adjusted_uri = unadjust_range(state, uri, jsobj_to_range(occurrence.tree, fi))
-            push!(seen_locations, (adjusted_uri, range))
+            push!(seen_locations, Location(; uri = adjusted_uri, range))
         end
     end
     return seen_locations
@@ -196,18 +194,16 @@ function find_local_references!(
         ctx3, st3, binfo::JL.BindingInfo, world::UInt;
         include_declaration::Bool = true,
     )
-    seen_locations = Set{Tuple{URI,Range}}()
+    seen_locations = Set{Location}()
     binding_occurrences = compute_binding_occurrences(ctx3, st3, world)
     if haskey(binding_occurrences, binfo)
         for occurrence in binding_occurrences[binfo]
             if include_declaration || occurrence.kind === :use
                 range, adjusted_uri = unadjust_range(server.state, uri, jsobj_to_range(occurrence.tree, fi))
-                push!(seen_locations, (adjusted_uri, range))
+                push!(seen_locations, Location(; uri = adjusted_uri, range))
             end
         end
     end
-    for (loc_uri, range) in seen_locations
-        push!(locations, Location(; uri = loc_uri, range))
-    end
+    append!(locations, seen_locations)
     return locations
 end

--- a/src/rename.jl
+++ b/src/rename.jl
@@ -233,15 +233,15 @@ function get_local_binding_rename(
             error = ResponseError(;
                 code = ErrorCodes.RequestFailed,
                 message = "Could not compute information for this local binding."))
-    seen_locations = Set{Tuple{URI,Range}}()
+    seen_locations = Set{Location}()
     for occurrence in binding_occurrences[binfo]
         range, adjusted_uri = unadjust_range(state, uri, jsobj_to_range(occurrence.tree, fi))
-        push!(seen_locations, (adjusted_uri, range))
+        push!(seen_locations, Location(; uri = adjusted_uri, range))
     end
     edits_by_uri = Dict{URI,Vector{TextEdit}}()
-    for (loc_uri, range) in seen_locations
-        edit = TextEdit(; range, newText = newName)
-        push!(get!(Vector{TextEdit}, edits_by_uri, loc_uri), edit)
+    for loc in seen_locations
+        edit = TextEdit(; range = loc.range, newText = newName)
+        push!(get!(Vector{TextEdit}, edits_by_uri, loc.uri), edit)
     end
 
     if supports(server, :workspace, :workspaceEdit, :documentChanges)
@@ -341,7 +341,7 @@ function collect_global_rename_edits!(
     )
     state = server.state
     n_files = length(uris_to_search)
-    seen_edits = Set{Tuple{URI,Range,String}}()
+    seen_edits = Set{Tuple{URI,TextEdit}}()
     for (i, uri) in enumerate(uris_to_search)
         if is_cancelled(cancel_flag)
             return false
@@ -370,8 +370,7 @@ function collect_global_rename_edits!(
 
         # Group edits by URI (for notebooks, occurrences may map to different cell URIs)
         edits_by_uri = Dict{URI,Vector{TextEdit}}()
-        for (loc_uri, range, newText) in seen_edits
-            edit = TextEdit(; range, newText)
+        for (loc_uri, edit) in seen_edits
             push!(get!(Vector{TextEdit}, edits_by_uri, loc_uri), edit)
         end
         if changes isa Vector{TextDocumentEdit}
@@ -390,7 +389,7 @@ function collect_global_rename_edits!(
 end
 
 function collect_global_rename_edits_in_file!(
-        seen_edits::Set{Tuple{URI,Range,String}}, state::ServerState, uri::URI, fi::FileInfo,
+        seen_edits::Set{Tuple{URI,TextEdit}}, state::ServerState, uri::URI, fi::FileInfo,
         st0_top::SyntaxTree, binfo::JL.BindingInfo, newName::String
     )
     ismacro = startswith(binfo.name, '@')
@@ -404,7 +403,7 @@ function collect_global_rename_edits_in_file!(
             insert_range, adjusted_uri =
                 unadjust_range(state, uri, Range(; start=full_range.var"end", var"end"=full_range.var"end"))
             newText = ismacro ? " as @$newName" : " as $newName"
-            push!(seen_edits, (adjusted_uri, insert_range, newText))
+            push!(seen_edits, (adjusted_uri, TextEdit(; range = insert_range, newText)))
         elseif classification === :alias && begin
                 collapse = collapse_alias_to_source(st0_top, id_byte_range, fi, newName, ismacro)
                 collapse !== nothing
@@ -412,11 +411,11 @@ function collect_global_rename_edits_in_file!(
             # Renaming an alias back to its source name — drop the ` as <alias>` suffix
             # so the import simplifies to `using M: <source>` instead of `<source> as <source>`.
             collapse_range, adjusted_uri = unadjust_range(state, uri, collapse)
-            push!(seen_edits, (adjusted_uri, collapse_range, ""))
+            push!(seen_edits, (adjusted_uri, TextEdit(; range = collapse_range, newText = "")))
         else
             adjust_first = ismacro && is_macrocall_use_site(fi, occurrence.tree) ? 1 : 0
             range, adjusted_uri = unadjust_range(state, uri, jsobj_to_range(occurrence.tree, fi; adjust_first))
-            push!(seen_edits, (adjusted_uri, range, newName))
+            push!(seen_edits, (adjusted_uri, TextEdit(; range, newText = newName)))
         end
     end
     return seen_edits

--- a/src/utils/lsp.jl
+++ b/src/utils/lsp.jl
@@ -19,6 +19,12 @@ overlap(rng1::Range, rng2::Range) = max(rng1.start, rng2.start) <= min(rng1.var"
 @define_override_constructor LSP.InlayHint
 @define_override_constructor LSP.TextEdit
 
+# LSP objects compare with `===` by default. `Diagnostic` needs structural equality so
+# recomputed diagnostics of an unchanged file are recognized as such (its `tags` vector
+# defeats egal), and `Location` so `Set{Location}` honors the custom `==`/`hash` of `URI`.
+@define_eq_overloads LSP.Diagnostic
+@define_eq_overloads LSP.Location
+
 const DEFAULT_DOCUMENT_SELECTOR = DocumentFilter[
     TextDocumentFilterLanguage(; language = "julia", scheme = "file"),
     [TextDocumentFilterLanguage(; language = "julia", scheme) for scheme in UNSAVED_DOCUMENT_SCHEMES]...,

--- a/test/utils/test_lsp.jl
+++ b/test/utils/test_lsp.jl
@@ -244,4 +244,27 @@ end
     end
 end
 
+@testset "Diagnostic and Location structural equality" begin
+    make_tagged(character) = Diagnostic(;
+        range = Range(;
+            start = Position(; line = 1, character),
+            var"end" = Position(; line = 1, character = character + 3)),
+        severity = DiagnosticSeverity.Warning,
+        message = "unused argument `xxx`",
+        source = JETLS.DIAGNOSTIC_SOURCE_LIVE,
+        code = JETLS.LOWERING_UNUSED_ARGUMENT_CODE,
+        tags = DiagnosticTag.Ty[DiagnosticTag.Unnecessary])
+    # separately built objects are not egal because of the `tags` vector
+    a = make_tagged(4); b = make_tagged(4)
+    @test a !== b
+    @test a == b && hash(a) == hash(b)
+    @test a != make_tagged(5)
+    @test [a] == [b]
+    uri = filepath2uri(@__FILE__)
+    loc1 = Location(; uri, range = a.range)
+    loc2 = Location(; uri, range = b.range)
+    @test loc1 == loc2 && hash(loc1) == hash(loc2)
+    @test length(Set([loc1, loc2])) == 1
+end
+
 end # module test_lsp


### PR DESCRIPTION
LSP objects have no `==` of their own, so comparisons fall back to `===`. Julia's egal compares immutable fields by content, which is why fully immutable objects such as `Position` and `Range` already compare structurally, but a `Vector`-valued field makes two separately built objects unequal. JETLS's `lowering/unused-*` diagnostics carry `tags = [DiagnosticTag.Unnecessary]`, so diagnostics recomputed for an unchanged file could never be recognized as equal to the ones already published, which is what skipping redundant `textDocument/publishDiagnostics` for unopened files needs. `Location` had the related problem that its default `hash` and `==` bypass the custom `==`/`hash` of `URI`, which is why the definition, declaration, references and rename handlers deduplicated through `Set{Tuple{URI,Range}}` (and rename edits through `Set{Tuple{URI,Range,String}}`) and rebuilt the `Location`/`TextEdit` objects afterwards.

`src/utils/lsp.jl` now applies `@define_eq_overloads`, the macro already used for the configuration structs, to `LSP.Diagnostic` and `LSP.Location`. The dedup sets hold `Location` and `Tuple{URI,TextEdit}` directly.

Generating `==`/`hash` for every `@interface` type in the LSP package was measured as an alternative: 435 methods each, no additional invalidations, but about 1 MiB more pkgimage for types nothing compares. The two targeted methods leave the invalidation profile of loading JETLS unchanged (24 trees, 2533 method instances before and after). `test/utils/test_lsp.jl` covers equality and hashing of separately built diagnostics and locations.