### PR TITLE
ast: Avoid invalidation from redundant iterator traits

### DIFF
--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -935,9 +935,7 @@ end
     out = (s_pos + 1, s_byte + tc.tokens[s_pos + 1].byte_span)
     return TokenCursor(tc.tokens, out...), out
 end
-Base.IteratorEltype(::Type{TokenCursor}) = Base.HasEltype()
 Base.eltype(::Type{TokenCursor}) = TokenCursor
-Base.IteratorSize(::Type{TokenCursor}) = Base.HasLength()
 Base.length(tc::TokenCursor) = length(tc.tokens)
 function Base.show(io::IO, tc::TokenCursor)
     print(io, "TokenCursor at position ", tc.position, " ")


### PR DESCRIPTION
`TokenCursor` redundantly specialized `Base.IteratorSize`, invalidating cached iterator and lowering code when JETLS was loaded.

This change uses Base's existing `HasLength()` fallback instead and also removes the redundant `IteratorEltype` specialization in favor of the `HasEltype()` fallback. The `eltype` specialization is preserved.

Removing `IteratorSize` reduced measured invalidated MethodInstances from 80 to zero on Julia 1.13.0 and from 84 to zero on Julia 1.12.7, with dependencies preloaded. The AST tests pass on both versions, and self diagnostics are clean.