### PR TITLE
deps: Update v1.13 Compiler snapshot to avoid invalidations

### DIFF
--- a/Compiler/snapshots.toml
+++ b/Compiler/snapshots.toml
@@ -9,7 +9,7 @@ runtime = { lower = "1.12.2", upper = "1.13-" }
 destination = "snapshots/v1.12"
 
 [snapshots."1.13"]
-commit = "6cfdf95353dec6f7326038d5bb3b4b67977323ca"
-source-branch = "avi/JETLS-Compiler-head-v1.13-2026-09-11"
+commit = "7eaea029fea4d9f048b310b0a6bde6d612cc9d6a"
+source-branch = "avi/JETLS-Compiler-head-v1.13-2026-09-12"
 runtime = { lower = "1.13-", upper = "1.14-" }
 destination = "snapshots/v1.13"

--- a/Compiler/snapshots/v1.13/src/abstractinterpretation.jl
+++ b/Compiler/snapshots/v1.13/src/abstractinterpretation.jl
@@ -66,6 +66,7 @@ any_ambig(info::MethodMatchInfo) = any_ambig(info.results)
 any_ambig(m::MethodMatches) = any_ambig(m.info)
 fully_covering(info::MethodMatchInfo) = info.fullmatch
 fully_covering(m::MethodMatches) = fully_covering(m.info)
+multiple_methods(m::MethodMatches) = length(m.applicable) > 1
 
 struct UnionSplitMethodMatches
     applicable::Vector{MethodMatchTarget}
@@ -77,6 +78,17 @@ any_ambig(info::UnionSplitInfo) = any(any_ambig, info.split)
 any_ambig(m::UnionSplitMethodMatches) = any_ambig(m.info)
 fully_covering(info::UnionSplitInfo) = all(fully_covering, info.split)
 fully_covering(m::UnionSplitMethodMatches) = fully_covering(m.info)
+function multiple_methods(m::UnionSplitMethodMatches)
+    first_method = nothing
+    for target in m.applicable
+        if first_method === nothing
+            first_method = target.match.method
+        elseif target.match.method !== first_method
+            return true
+        end
+    end
+    return false
+end
 
 nmatches(info::MethodMatchInfo) = length(info.results)
 function nmatches(info::UnionSplitInfo)
@@ -158,7 +170,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
     # split the for loop off into a function, so that we can pause and restart it at will
     function infercalls(interp, sv)
         local napplicable = length(applicable)
-        local multiple_matches = napplicable > 1
+        local multiple_matches = multiple_methods(matches)
         while state.inferidx <= napplicable
             (; match, edges, edge_idx) = applicable[state.inferidx]
             local method = match.method
@@ -320,7 +332,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(fun
             inferidx = SafeBox{Int}(1)
             function infercalls2(interp, sv)
                 local napplicable = length(applicable)
-                local multiple_matches = napplicable > 1
+                local multiple_matches = multiple_methods(matches)
                 while inferidx[] <= napplicable
                     (; match) = applicable[inferidx[]]
                     inferidx[] += 1

--- a/Compiler/snapshots/v1.13/src/typeinfer.jl
+++ b/Compiler/snapshots/v1.13/src/typeinfer.jl
@@ -902,17 +902,10 @@ function type_annotate!(::AbstractInterpreter, sv::InferenceState)
 end
 
 function merge_call_chain!(::AbstractInterpreter, parent::InferenceState, child::InferenceState)
-    # add backedge of parent <- child
-    # then add all backedges of parent <- parent.parent
+    # update all cycleid to be in the same group
     frames = parent.callstack::Vector{AbsIntState}
     @assert child.callstack === frames
     ancestorid = child.cycleid
-    while true
-        add_cycle_backedge!(parent, child)
-        parent.cycleid === ancestorid && break
-        child = parent
-        parent = cycle_parent(child)::InferenceState
-    end
     # ensure that walking the callstack has the same cycleid (DAG)
     for frameid = reverse(ancestorid:length(frames))
         frame = frames[frameid]::InferenceState
@@ -923,7 +916,6 @@ function merge_call_chain!(::AbstractInterpreter, parent::InferenceState, child:
 end
 
 function add_cycle_backedge!(caller::InferenceState, frame::InferenceState)
-    update_valid_age!(caller, frame.world.valid_worlds)
     backedge = (caller, caller.currpc)
     contains_is(frame.cycle_backedges, backedge) || push!(frame.cycle_backedges, backedge)
     return frame
@@ -942,9 +934,8 @@ end
 # frame matching `mi` is encountered, then there is a cycle in the call graph
 # (i.e. `mi` is a descendant callee of itself). Upon encountering this cycle,
 # we "resolve" it by merging the call chain, which entails updating each intermediary
-# frame's `cycleid` field and adding the appropriate backedges. Finally,
-# we return `mi`'s pre-existing frame. If no cycles are found, `nothing` is
-# returned instead.
+# frame's `cycleid` field. Finally, we return `mi`'s pre-existing frame.
+# If no cycles are found, `nothing` is returned instead.
 function resolve_call_cycle!(interp::AbstractInterpreter, mi::MethodInstance, parent::AbsIntState)
     # TODO (#48913) implement a proper recursion handling for irinterp:
     # This works most of the time currently just because the irinterp code doesn't get used much with
@@ -1128,6 +1119,7 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
                     result.ci_as_edge = edge_ci # set the edge for the inliner usage
                     VolatileInferenceResult(result)
                 end
+                isinferred || add_cycle_backedge!(caller, frame)
                 mresult[] = MethodCallResult(interp, caller, method, bestguess, exc_bestguess, effects,
                     edge, edgecycle, edgelimited, volatile_inf_result)
                 return true
@@ -1145,6 +1137,7 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
     effects = adjust_effects(effects_for_cycle(frame.ipo_effects), method)
     bestguess = frame.bestguess
     exc_bestguess = refine_exception_type(frame.exc_bestguess, effects)
+    add_cycle_backedge!(caller, frame)
     return Future(MethodCallResult(interp, caller, method, bestguess, exc_bestguess, effects, nothing, edgecycle, edgelimited))
 end
 

--- a/Compiler/snapshots/v1.13/src/typelattice.jl
+++ b/Compiler/snapshots/v1.13/src/typelattice.jl
@@ -773,13 +773,13 @@ end
 # type.
 
 # Legacy constructor
-function Core.PartialStruct(𝕃::AbstractLattice, @nospecialize(typ), fields::Vector{Any})
+function Core.PartialStruct(𝕃::AbstractLattice, @nospecialize(typ::Type), fields::Vector{Any})
     undefs = partialstruct_init_undefs(typ, fields)
     undefs === nothing && error("This object never exists at runtime")
     return PartialStruct(𝕃, typ, undefs, fields)
 end
 
-function Core.PartialStruct(::AbstractLattice, @nospecialize(typ), undefs::Vector{Union{Nothing,Bool}}, fields::Vector{Any})
+function Core.PartialStruct(::AbstractLattice, @nospecialize(typ::Type), undefs::Vector{Union{Nothing,Bool}}, fields::Vector{Any})
     for i = 1:length(fields)
         assert_nested_slotwrapper(fields[i])
     end

--- a/Compiler/snapshots/v1.13/test/effects.jl
+++ b/Compiler/snapshots/v1.13/test/effects.jl
@@ -1533,3 +1533,25 @@ let f = (x) -> Core.Intrinsics.trunc_int(Int16, x)
     @test Compiler.is_nothrow(Base.infer_effects(f, (Int32,)))
     @test catch_error_61435(f, Int16(0)) === :caught
 end
+
+# issue #57324
+module Issue57324
+struct T <: AbstractVector{Float64}
+    m::Memory{UInt64}
+end
+function f(w)
+    r = Base.OneTo(w.m[1])
+    setindex!(w, 0.0, r[1])
+end
+Base.setindex!(w::T, v, i::Int) = _setindex!(w, i)
+function _setindex!(w, i)
+    w.m[w.m[1]] = 0 > i ? nothing : 0
+    w
+end
+Base.size(::T) = (0,)
+end
+let effects = Base.infer_effects(Issue57324.f, (Issue57324.T,))
+    @test Compiler.is_terminates(effects)
+    @test Compiler.is_notaskstate(effects)
+    @test Compiler.is_nortcall(effects)
+end


### PR DESCRIPTION
Loading the Julia 1.13 `Compiler` snapshot invalidates cached `Base.Compiler` inference code. The legacy lattice-aware `PartialStruct` wrapper accepts any second argument, overlapping inferred core-constructor calls whose second argument is an `undefs` vector.

This update constrains `typ` to `Type` in both lattice-aware wrappers, removing that overlap (cherry-picked from JuliaLang/julia#63107). The snapshot also includes upstream fixes to union-split method counting and inference-cycle backedge handling.

Earlier isolated measurements of the constructor fix on Julia 1.13.0 reduced unique invalidated MethodInstances for `using JETLS` from 1,068 to 504 (564 fewer, about 53%). The `PartialStruct` cause tree fell from 768 to zero, and `using Compiler` alone fell from 728 to zero. Cause trees overlap, so their sizes are not additive. Remaining invalidations come from dependencies, notably `REPL.REPLCompletions`.

The Julia 1.12 snapshot is unchanged. On Julia 1.12.7, the constructor restriction removed no invalidations: `using Compiler` was already at zero, and `using JETLS` remained at 903. With dependencies preloaded, `using JETLS` caused zero additional invalidations on both versions.