### PR TITLE
ci: Enable JET on patch-release nightlies

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -25,7 +25,10 @@ jobs:
           - version: "1" # current stable
             os: ubuntu-latest
             arch: x64
-          - version: "1.12" # minimum version supported
+          - version: "1.12" # 1.12
+            os: ubuntu-latest
+            arch: x64
+          - version: "1.12.2" # the minimum version supported
             os: ubuntu-latest
             arch: x64
           - version: "1" # x86 ubuntu
@@ -68,7 +71,10 @@ jobs:
       fail-fast: false # don't stop CI even when one of them fails
       matrix:
         include:
-          - version: "1.13-nightly" # next release
+          - version: "1.12-nightly" # next patch release for 1.12
+            os: ubuntu-latest
+            arch: x64
+          - version: "1.13-nightly" # next patch release for 1.13
             os: ubuntu-latest
             arch: x64
           # - version: "nightly" # dev
@@ -81,13 +87,13 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
-      # - name: allow JET to be loaded on nightly
-      #   if: matrix.version == 'nightly'
-      #   run: |
-      #     echo '
-      #     [JET]
-      #     JET_DEV_MODE = true
-      #     ' > LocalPreferences.toml
+      - name: allow JET to be loaded on nightly
+        run: |
+          echo '
+          [JET]
+          JET_DEV_MODE = true
+          use_fixed_world = true
+          ' > LocalPreferences.toml
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
         with:


### PR DESCRIPTION
The 1.13 nightly now reports 1.13.1-DEV, which makes JET load its empty stubs by default. JETLS consequently fails to load because those stubs lack `JETInterface`.

The nightly jobs now enable `JET_DEV_MODE` while explicitly keeping `use_fixed_world = true`. The matrix also covers 1.12 patch-release nightlies alongside 1.13.