### PR TITLE
server: Respond with `MethodNotFound` to unsupported requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed errors logged when in-flight requests or progress notifications finished during language server shutdown.
 
+- Fixed requests for methods the server does not support being left unanswered; they now receive a `MethodNotFound` error response.
+
 ## 2026-09-06
 
 - Commit: [`2b51ac0`](https://github.com/aviatesk/JETLS.jl/commit/2b51ac0)

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -261,7 +261,7 @@ function runserver(
             elseif !initialize_requested
                 if isdefined(msg, :id)
                     send(server, ResponseMessage(;
-                        id = msg.id,
+                        id = getfield(msg, :id),
                         result = nothing,
                         error = ResponseError(;
                             code = ErrorCodes.ServerNotInitialized,
@@ -270,7 +270,7 @@ function runserver(
             elseif shutdown_requested
                 if isdefined(msg, :id)
                     send(server, ResponseMessage(;
-                        id = msg.id,
+                        id = getfield(msg, :id),
                         result = nothing,
                         error = ResponseError(;
                             code = ErrorCodes.InvalidRequest,
@@ -385,9 +385,8 @@ function handler_concurrent_message(server::Server, @nospecialize msg)
         update_diagnostic_registration!(server)
     # Handle regular messages concurrently
     elseif msg isa Dict{Symbol,Any} # ResponseMessage or untyped message
-        request_caller = let id = get(msg, :id, nothing)
-            id !== nothing ? poprequest!(server, id) : nothing
-        end
+        id = get(msg, :id, nothing)
+        request_caller = id !== nothing ? poprequest!(server, id) : nothing
         if request_caller !== nothing
             # NOTE: The `get!` call to `server.state.currently_handled` MUST happen here
             # to avoid race conditions. Only after getting the flag can we spawn the actual dispatcher.
@@ -396,12 +395,21 @@ function handler_concurrent_message(server::Server, @nospecialize msg)
                     get!(()->CancelFlag(false), server.state.currently_handled, token)
                 Threads.@spawn :default @tryinvokelatest handle_response_message(server, msg, request_caller, cancel_flag)
             end
-        elseif @static JETLS_DEV_MODE ? true : false
-            # Not a response to our request, or untyped message - log if in dev mode
-            _id = get(()->get(msg, :id, nothing), msg, :method)
-            @warn "[handler_concurrent_message] Unhandled message" msg _id=_id maxlog=1
+        else
+            method = get(msg, :method, nothing)
+            @static if JETLS_DEV_MODE
+                # Not a response to our request, or untyped message - log if in dev mode
+                _id = something(method, Some(id))
+                @warn "[handler_concurrent_message] Unhandled message" msg _id=_id maxlog=1
+            end
+            if method isa String && (id isa String || id isa Int)
+                send(server, ResponseMessage(;
+                    id,
+                    result = nothing,
+                    error = method_not_found_error(method)))
+            end
         end
-    elseif isdefined(msg, :id) && (id = msg.id; id isa String || id isa Int)
+    elseif isdefined(msg, :id) && (id = getfield(msg, :id); id isa String || id isa Int)
         prepare_request_message!(server, msg)
         let cancel_flag = get!(()->CancelFlag(false), server.state.currently_handled, id)
             Threads.@spawn :default @tryinvokelatest handle_request_message(server, msg, cancel_flag)
@@ -539,13 +547,21 @@ function handle_request_message(server::Server, @nospecialize(msg), cancel_flag:
         handle_ExecuteCommandRequest(server, msg)
     elseif msg isa TextDocumentContentRequest
         handle_TextDocumentContentRequest(server, msg)
-    elseif @static JETLS_DEV_MODE ? true : false
-        if isdefined(msg, :method)
-            _id = getfield(msg, :method)
-        else
-            _id = typeof(msg)
+    else
+        isdefined(msg, :id) || error(lazy"Request message without id: $(typeof(msg))")
+        id = getfield(msg, :id)
+        id isa Int || id isa String || error(lazy"Invalid request id $(repr(id)) in $(typeof(msg))")
+        method = isdefined(msg, :method) ? getfield(msg, :method) : nothing
+        @static if JETLS_DEV_MODE
+            _id = something(method, typeof(msg))
+            @warn "[handle_request_message] Unhandled message" msg _id=_id maxlog=1
         end
-        @warn "[handle_request_message] Unhandled message" msg _id=_id maxlog=1
+        if method isa String
+            send(server, ResponseMessage(;
+                id,
+                result = nothing,
+                error = method_not_found_error(method)))
+        end
     end
     nothing
 end
@@ -555,13 +571,12 @@ function handle_notification_message(server::Server, @nospecialize msg)
         handle_DidChangeWatchedFilesNotification(server, msg)
     elseif msg isa DidChangeConfigurationNotification
         handle_DidChangeConfigurationNotification(server, msg)
-    elseif @static JETLS_DEV_MODE ? true : false
-        if isdefined(msg, :method)
-            _id = getfield(msg, :method)
-        else
-            _id = typeof(msg)
+    else
+        @static if JETLS_DEV_MODE
+            method = isdefined(msg, :method) ? getfield(msg, :method) : nothing
+            _id = something(method, typeof(msg))
+            @warn "[handle_notification_message] Unhandled message" msg _id=_id maxlog=1
         end
-        @warn "[handle_notification_message] Unhandled message" msg _id=_id maxlog=1
     end
     nothing
 end

--- a/src/utils/lsp.jl
+++ b/src/utils/lsp.jl
@@ -131,6 +131,12 @@ function request_cancelled_error(message::AbstractString="Request was cancelled"
         data)
 end
 
+function method_not_found_error(method::AbstractString)
+    return ResponseError(;
+        code = ErrorCodes.MethodNotFound,
+        message = "Method not found: $method")
+end
+
 function show_message(server::Server, message::AbstractString, type::MessageType.Ty)
     if server.state.cli_mode
         # `jetls check` has no client to show the message; log it instead, so that `--quiet`

--- a/test/test_full_lifecycle.jl
+++ b/test/test_full_lifecycle.jl
@@ -225,6 +225,43 @@ end # @testset "full completion cycle" begin
     end
 end
 
+@testset "unsupported request methods" begin
+    uri = URI("file:///unsupported.jl")
+
+    withserver() do (; server, writereadmsg, id_counter)
+        # Typed by LSP.jl but not handled by the server
+        let id = id_counter[] += 1
+            (; raw_msg, raw_res) = writereadmsg(FoldingRangeRequest(;
+                id,
+                params = FoldingRangeParams(;
+                    textDocument = TextDocumentIdentifier(; uri))))
+            @test raw_msg isa FoldingRangeRequest
+            @test raw_res isa ResponseMessage
+            @test raw_res.id == id
+            @test isnothing(raw_res.result)
+            @test raw_res.error isa ResponseError
+            @test raw_res.error.code == ErrorCodes.MethodNotFound
+            wait_for_handled_request(server.state, id)
+        end
+
+        # Unknown to LSP.jl, so it arrives untyped
+        let id = id_counter[] += 1
+            (; raw_msg, raw_res) = writereadmsg(Dict{String,Any}(
+                "jsonrpc" => "2.0",
+                "id" => id,
+                "method" => "textDocument/unknownMethod",
+                "params" => Dict{String,Any}()))
+            @test raw_msg isa Dict{Symbol,Any}
+            @test raw_res isa ResponseMessage
+            @test raw_res.id == id
+            @test isnothing(raw_res.result)
+            @test raw_res.error isa ResponseError
+            @test raw_res.error.code == ErrorCodes.MethodNotFound
+            wait_for_handled_request(server.state, id)
+        end
+    end
+end
+
 # Regression test: `textDocument/references` previously returned stale
 # results after script-mode reanalysis because the cached occurrences kept
 # `binfo.mod` from the previous virtual module while the new target binding


### PR DESCRIPTION
Requests for methods the server does not handle were dropped without a response. That covered both requests LSP.jl parses into typed messages but the server has no handler for (e.g. `textDocument/foldingRange`, which the server never advertises) and requests for methods unknown to LSP.jl, which arrive as untyped `Dict`s. Clients that send such requests regardless of the advertised capabilities waited until their own timeout, and the only trace on the server side was a warning emitted in `JETLS_DEV_MODE`.

This change makes both fallbacks respond with a `MethodNotFound` (-32601) error, as the LSP specification requires for unsupported methods. The typed fallback in `handle_request_message` answers with the message's `method`, and the untyped branch in
`handler_concurrent_message` answers when the `Dict` carries a string `method` and a request `id`. Untyped notifications and responses to unknown requests are still dropped. The `JETLS_DEV_MODE` warnings are kept in both places, with the untyped one keyed on the method (falling back to the id) so `maxlog` deduplicates per method.

`method_not_found_error` in `src/utils/lsp.jl` builds the error next to the other `ResponseError` helpers. A new "unsupported request methods" testset in `test/test_full_lifecycle.jl` covers both the typed and the untyped path end-to-end through `withserver`.