### PR TITLE
server: Reject untyped requests before initialize and after shutdown

### DIFF
--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -259,7 +259,7 @@ function runserver(
                 # Handle messages received before initialization (LSP 3.18 spec):
                 # - For requests: respond with error code -32002 (ServerNotInitialized)
                 # - For notifications: drop silently (exit already handled above)
-                id = client_request_id(msg)
+                id = valid_request_message_id(msg)
                 if id !== nothing
                     send(server, ResponseMessage(;
                         id,
@@ -273,7 +273,7 @@ function runserver(
                 # - For requests: respond with error code -32600 (InvalidRequest)
                 # - For notifications and responses to server requests: drop silently
                 #   (exit already handled above)
-                id = client_request_id(msg)
+                id = valid_request_message_id(msg)
                 if id !== nothing
                     send(server, ResponseMessage(;
                         id,
@@ -305,14 +305,24 @@ function runserver(
     return exit_code
 end
 
-function client_request_id(@nospecialize msg)
+function valid_request_message_id(@nospecialize msg)
     if msg isa Dict{Symbol,Any}
         haskey(msg, :method) || return nothing
         id = get(msg, :id, nothing)
-    elseif isdefined(msg, :id)
+    elseif isdefined(msg, :id) && isdefined(msg, :method)
         id = getfield(msg, :id)
     else
         return nothing
+    end
+    return valid_message_id(id)
+end
+
+function valid_message_id(@nospecialize id)
+    @static if Int === Int32
+        # JSON3 parses untyped integers as Int64 even on 32-bit Julia.
+        if id isa Int64 && typemin(Int32) <= id <= typemax(Int32)
+            id = Int32(id)
+        end
     end
     return id isa String || id isa Int ? id : nothing
 end
@@ -400,7 +410,7 @@ function handler_concurrent_message(server::Server, @nospecialize msg)
         update_diagnostic_registration!(server)
     # Handle regular messages concurrently
     elseif msg isa Dict{Symbol,Any} # ResponseMessage or untyped message
-        id = get(msg, :id, nothing)
+        id = valid_message_id(get(msg, :id, nothing))
         request_caller = id !== nothing ? poprequest!(server, id) : nothing
         if request_caller !== nothing
             # NOTE: The `get!` call to `server.state.currently_handled` MUST happen here
@@ -417,14 +427,14 @@ function handler_concurrent_message(server::Server, @nospecialize msg)
                 _id = something(method, Some(id))
                 @warn "[handler_concurrent_message] Unhandled message" msg _id=_id maxlog=1
             end
-            if method isa String && (id isa String || id isa Int)
+            if method isa String && id !== nothing
                 send(server, ResponseMessage(;
                     id,
                     result = nothing,
                     error = method_not_found_error(method)))
             end
         end
-    elseif isdefined(msg, :id) && (id = getfield(msg, :id); id isa String || id isa Int)
+    elseif isdefined(msg, :id) && (id = valid_message_id(getfield(msg, :id)); id !== nothing)
         prepare_request_message!(server, msg)
         let cancel_flag = get!(()->CancelFlag(false), server.state.currently_handled, id)
             Threads.@spawn :default @tryinvokelatest handle_request_message(server, msg, cancel_flag)
@@ -564,8 +574,8 @@ function handle_request_message(server::Server, @nospecialize(msg), cancel_flag:
         handle_TextDocumentContentRequest(server, msg)
     else
         isdefined(msg, :id) || error(lazy"Request message without id: $(typeof(msg))")
-        id = getfield(msg, :id)
-        id isa Int || id isa String || error(lazy"Invalid request id $(repr(id)) in $(typeof(msg))")
+        id = valid_message_id(getfield(msg, :id))
+        id === nothing && error(lazy"Invalid request id in $(typeof(msg))")
         method = isdefined(msg, :method) ? getfield(msg, :method) : nothing
         @static if JETLS_DEV_MODE
             _id = something(method, typeof(msg))

--- a/src/JETLS.jl
+++ b/src/JETLS.jl
@@ -255,29 +255,32 @@ function runserver(
             elseif msg === self_shutdown_token
                 exit_code = 1
                 break
-            # Handle messages received before initialization (LSP 3.17 spec):
-            # - For requests: respond with error code -32002 (ServerNotInitialized)
-            # - For notifications: drop silently (exit already handled above)
             elseif !initialize_requested
-                if isdefined(msg, :id)
+                # Handle messages received before initialization (LSP 3.18 spec):
+                # - For requests: respond with error code -32002 (ServerNotInitialized)
+                # - For notifications: drop silently (exit already handled above)
+                id = client_request_id(msg)
+                if id !== nothing
                     send(server, ResponseMessage(;
-                        id = getfield(msg, :id),
+                        id,
                         result = nothing,
                         error = ResponseError(;
                             code = ErrorCodes.ServerNotInitialized,
                             message = "Server has not been initialized")))
                 end
             elseif shutdown_requested
-                if isdefined(msg, :id)
+                # Handle messages received after a shutdown request (LSP 3.18 spec):
+                # - For requests: respond with error code -32600 (InvalidRequest)
+                # - For notifications and responses to server requests: drop silently
+                #   (exit already handled above)
+                id = client_request_id(msg)
+                if id !== nothing
                     send(server, ResponseMessage(;
-                        id = getfield(msg, :id),
+                        id,
                         result = nothing,
                         error = ResponseError(;
                             code = ErrorCodes.InvalidRequest,
                             message = "Received request after a shutdown request requested")))
-                else
-                    # This is the case where some notification was sent.
-                    # In this case, there is no way to inform the client side that it was unexpected.
                 end
             elseif is_sequential_msg(msg)
                 put!(seq_queue, msg)
@@ -300,6 +303,18 @@ function runserver(
     end
     @static JETLS_DEV_MODE && @info "Exited JETLS server loop"
     return exit_code
+end
+
+function client_request_id(@nospecialize msg)
+    if msg isa Dict{Symbol,Any}
+        haskey(msg, :method) || return nothing
+        id = get(msg, :id, nothing)
+    elseif isdefined(msg, :id)
+        id = getfield(msg, :id)
+    else
+        return nothing
+    end
+    return id isa String || id isa Int ? id : nothing
 end
 
 function is_sequential_msg(@nospecialize msg)


### PR DESCRIPTION
The `runserver` loop answers requests that arrive before `initialize` or after `shutdown` with `ServerNotInitialized` and `InvalidRequest` errors, but it detected requests with `isdefined(msg, :id)`. Requests for methods unknown to LSP.jl are parsed into untyped `Dict`s, for which that check is always false, so such requests were dropped without a response in both states.

This change introduces `client_request_id`, which returns the request id of a typed message or of an untyped `Dict` that carries a `method`, and uses it in both branches. Untyped messages without a `method` are responses to server-initiated requests (e.g. progress or configuration requests still in flight after `shutdown`) and are dropped as before, since answering them would send an error response to a response. The shutdown branch now documents its behavior in a header comment like the initialization branch instead of an empty `else`.

The situation is not expected from a well-behaved client, so no test is added; the behavior was verified manually by driving `runserver` over pipes with untyped requests in both states.