### PR TITLE
LSP: Fix interface inheritance and namespace constant typing

### DIFF
--- a/LSP/src/DSL/interface.jl
+++ b/LSP/src/DSL/interface.jl
@@ -252,7 +252,7 @@ function process_interface_def!(toplevelblk::Expr, structbody::Expr,
                                 __source__::LineNumberNode,
                                 Name::Union{Symbol,Nothing})
     method = _process_interface_def!(toplevelblk, structbody, omittable_fields, extended_fields, duplicated_fields, defex, __source__)
-    deleteat!(structbody.args, duplicated_fields)
+    deleteat!(structbody.args, sort!(duplicated_fields))
     is_anon = Name === nothing
     if is_anon
         # Name = Symbol("AnonymousInterface", string(__source__)) # XXX this doesn't work probably due to Julia internal bug

--- a/LSP/src/DSL/interface.jl
+++ b/LSP/src/DSL/interface.jl
@@ -1,4 +1,4 @@
-const _interface_defs_ = Dict{Symbol,Expr}()
+const _interface_defs_ = Dict{DataType,Expr}()
 
 # Register a fallback docstring (with field docs) for `name`, unless a top-level docstring
 # is already registered (e.g. via an outer `@doc`). Without it an `@interface` carrying
@@ -220,7 +220,7 @@ macro interface(exs...)
                                     omittable_fields,
                                     extended_fields,
                                     duplicated_fields,
-                                    extend,
+                                    getglobal(__module__, extend),
                                     __source__)
         end
     end
@@ -287,7 +287,7 @@ function process_interface_def!(toplevelblk::Expr, structbody::Expr,
         push!(toplevelblk.args, :(Base.convert(::Type{$Name}, nt::NamedTuple) = $Name(; nt...)))
     end
     if !is_anon
-        push!(toplevelblk.args, :($(GlobalRef(@__MODULE__, :_interface_defs_))[$(QuoteNode(Name))] = $(QuoteNode(structbody))))
+        push!(toplevelblk.args, :($(GlobalRef(@__MODULE__, :_interface_defs_))[$Name] = $(QuoteNode(structbody))))
     end
     return Name, method
 end
@@ -296,7 +296,7 @@ function add_extended_interface!(toplevelblk::Expr, structbody::Expr,
                                  omittable_fields::Set{Symbol},
                                  extended_fields::Dict{Symbol,Vector{Int}},
                                  duplicated_fields::Vector{Int},
-                                 extend::Symbol,
+                                 extend::DataType,
                                 __source__::LineNumberNode)
     return _process_interface_def!(toplevelblk, structbody,
                                    omittable_fields,

--- a/LSP/src/DSL/namespace.jl
+++ b/LSP/src/DSL/namespace.jl
@@ -6,6 +6,8 @@
 
 Creates a Julia module containing typed constants that correspond to TypeScript `namespace`
 definitions from the LSP specification.
+Constant values are converted to the declared type using Julia's typed global assignment
+semantics. Values that cannot be converted cause an error.
 
 # Type references
 
@@ -53,6 +55,9 @@ macro namespace(exs...)
     modex = Expr(:module, false, Name, modbody)
     push!(toplevelblk.args, modex)
     push!(toplevelblk.args, Expr(:macrocall, GlobalRef(Base, Symbol("@__doc__")), __source__, Name))
+    thismodname = nameof(__module__)
+    push!(modbody.args, :(using ..$thismodname: $Type))
+    push!(modbody.args, :(const Ty = $Type))
     curline = __source__
     for def in defs.args
         if def isa LineNumberNode
@@ -75,14 +80,11 @@ macro namespace(exs...)
         Meta.isexpr(def, :(=)) || error("Invalid `@namespace` syntax: ", def)
         name, val = def.args
         name isa Symbol || error("Invalid `@namespace` syntax: ", def)
-        push!(modbody.args, :(const $name = $val))
+        push!(modbody.args, :(const $name::Ty = $val))
         if doc !== nothing
             push!(modbody.args, Expr(:macrocall, GlobalRef(Core, Symbol("@doc")), curline, doc, name))
         end
     end
-    thismodname = nameof(__module__)
-    push!(modbody.args, :(using ..$thismodname: $Type))
-    push!(modbody.args, :(const Ty = $Type))
 
     push!(toplevelblk.args, :(push!($(GlobalRef(@__MODULE__, :exports)), $(QuoteNode(Name)))))
     push!(toplevelblk.args, :(return $Name))


### PR DESCRIPTION
This PR fixes three issues in the DSL used to mirror the LSP
specification:

- `@interface` could fail when inherited fields were overridden in a
  different order from their original declarations. The implementation
  now sorts the removal indices before passing them to `deleteat!`.
- Interface definitions were keyed by unqualified names, allowing
  same-named interfaces in different modules to overwrite each other.
  The registry now uses the generated `DataType` as its key and resolves
  parent names in the calling module.
- `@namespace` used its declared type only for the `Ty` alias, without
  enforcing it on constants. The macro now defines `Ty` first and
  generates typed constant bindings. Values are converted to the
  declared type, and incompatible values cause an error.

The changes are limited to the DSL implementation and its documentation.
The LSP definitions and DSL syntax remain unchanged.

No new tests are added; validation uses the existing LSP definitions
and test suite.